### PR TITLE
BigQuery Table Schema Builder module

### DIFF
--- a/lib/logflare/table_bigquery_schema_builder.ex
+++ b/lib/logflare/table_bigquery_schema_builder.ex
@@ -1,0 +1,131 @@
+defmodule Logflare.BigQuery.TableSchemaBuilder do
+  require Logger
+  alias GoogleApi.BigQuery.V2.Model
+  alias Model.TableFieldSchema, as: TFS
+
+  @doc """
+  Builds table schema from event metadata and prev schema.
+
+  Arguments:
+
+  * metadata: event metadata
+  * old_schema: existing Model.TableFieldSchema,
+
+  Accepts both metadata map and metadata map wrapped in a list.
+  """
+  @spec build_table_schema([map], TFS.t()) :: TFS.t()
+  def build_table_schema([metadata], old_schema) do
+    build_table_schema(metadata, old_schema)
+  end
+
+  @spec build_table_schema(map, TFS.t()) :: TFS.t()
+  def build_table_schema(metadata, %{fields: old_fields}) do
+    old_metadata_schema = Enum.find(old_fields, &(&1.name == "metadata")) || %{}
+
+    %Model.TableSchema{
+      fields: [
+        %TFS{
+          description: nil,
+          fields: nil,
+          mode: "REQUIRED",
+          name: "timestamp",
+          type: "TIMESTAMP"
+        },
+        %TFS{
+          description: nil,
+          fields: nil,
+          mode: "NULLABLE",
+          name: "event_message",
+          type: "STRING"
+        },
+        build_metadata_fields_schemas(metadata, old_metadata_schema)
+      ]
+    }
+    |> deep_sort_by_fields_name()
+  end
+
+  @spec build_metadata_fields_schemas(map, TFS.t()) :: TFS.t()
+  defp build_metadata_fields_schemas(metadata, old_metadata_schema) do
+    new_metadata_schema = build_fields_schemas({"metadata", metadata})
+
+    old_metadata_schema
+    # DeepMerge resolver is implemented for Model.TableFieldSchema structs
+    |> DeepMerge.deep_merge(new_metadata_schema)
+  end
+
+  @spec build_fields_schemas({String.t(), map}) :: TFS.t()
+  defp build_fields_schemas({params_key, params_val}) when is_map(params_val) do
+    %TFS{
+      description: nil,
+      mode: "REPEATED",
+      name: params_key,
+      type: "RECORD",
+      fields: Enum.map(params_val, &build_fields_schemas/1)
+    }
+  end
+
+  defp build_fields_schemas({params_key, params_value}) do
+    case to_schema_type(params_value) do
+      "ARRAY" ->
+        %TFS{
+          name: params_key,
+          type: "STRING",
+          mode: "REPEATED"
+        }
+
+      type ->
+        %TFS{
+          name: params_key,
+          type: type,
+          mode: "NULLABLE"
+        }
+    end
+  end
+
+  @spec deep_sort_by_fields_name(TFS.t()) :: TFS.t()
+  def deep_sort_by_fields_name(%{fields: nil} = schema), do: schema
+
+  def deep_sort_by_fields_name(%{fields: fields} = schema) when is_list(fields) do
+    sorted_fields =
+      fields
+      |> Enum.sort_by(& &1.name)
+      |> Enum.map(&deep_sort_by_fields_name/1)
+
+    %{schema | fields: sorted_fields}
+  end
+
+  defp to_schema_type(literal_value) when is_map(literal_value), do: "RECORD"
+  defp to_schema_type(literal_value) when is_integer(literal_value), do: "INTEGER"
+  defp to_schema_type(literal_value) when is_binary(literal_value), do: "STRING"
+  defp to_schema_type(literal_value) when is_boolean(literal_value), do: "BOOLEAN"
+  defp to_schema_type(literal_value) when is_list(literal_value), do: "ARRAY"
+
+  defimpl DeepMerge.Resolver, for: Model.TableFieldSchema do
+    @doc """
+    Implements merge for schema key conflicts.
+    Overwrites fields schemas that are present BOTH in old and new TFS structs and keeps fields schemas present ONLY in old.
+    """
+    def resolve(
+          %TFS{fields: oldfs} = old,
+          %TFS{fields: newfs} = new,
+          resolver
+        )
+        when is_list(oldfs) and is_list(newfs) do
+      new_field_schemas_names = Enum.map(new.fields, & &1.name)
+
+      only_old_field_schemas =
+        for ofs <- old.fields, ofs.name not in new_field_schemas_names, do: ofs
+
+      new_with_all_field_schemas =
+        new
+        |> Map.from_struct()
+        |> Map.put(:fields, new.fields ++ only_old_field_schemas)
+
+      Map.merge(old, new_with_all_field_schemas, resolver)
+    end
+
+    def resolve(old, new, resolver) when is_map(new) do
+      Map.merge(old, new, resolver)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,8 @@ defmodule Logflare.Mixfile do
       {:google_api_big_query, "~> 0.0.1"},
       {:goth, "~> 0.8.0"},
       {:broadway, "~> 0.1.0"},
-      {:google_api_cloud_resource_manager, "~> 0.0.1"}
+      {:google_api_cloud_resource_manager, "~> 0.0.1"},
+      {:deep_merge, "~> 1.0"}
     ]
   end
 
@@ -77,7 +78,7 @@ defmodule Logflare.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+      # test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 end

--- a/test/logflare/table_bigquery_schema_builder_test.exs
+++ b/test/logflare/table_bigquery_schema_builder_test.exs
@@ -1,0 +1,434 @@
+defmodule Logflare.TableBigQuerySchemaBuilderTest do
+  alias Logflare.BigQuery.TableSchemaBuilder, as: SchemaBuilder
+  use ExUnit.Case
+
+  describe "schema builder" do
+    test "correctly builds schema from first params metadata" do
+      new =
+        metadatas().first
+        |> SchemaBuilder.build_table_schema(schemas().initial)
+
+      expected = schemas().first
+      assert deep_schema_to_field_names(new) === deep_schema_to_field_names(expected)
+      assert new === expected
+    end
+
+    test "correctly builds schema from second params metadata" do
+      new =
+        metadatas().second
+        |> SchemaBuilder.build_table_schema(schemas().first)
+
+      expected = schemas().second
+      assert deep_schema_to_field_names(new) === deep_schema_to_field_names(expected)
+      assert new === expected
+    end
+
+    test "correctly builds schema from third params metadata" do
+      new =
+        metadatas().third
+        |> SchemaBuilder.build_table_schema(schemas().second)
+
+      expected = schemas().third
+
+      assert deep_schema_to_field_names(new) === deep_schema_to_field_names(expected)
+      assert new === expected
+    end
+  end
+
+  @doc """
+  Utility function for removing everything except schemas names from TableFieldSchema structs
+  for easier debugging of errors when not all fields schemas are present in the result
+  """
+  def deep_schema_to_field_names(%{fields: fields} = schema) when is_list(fields) do
+    %{
+      fields: Enum.map(fields, &deep_schema_to_field_names/1),
+      name: Map.get(schema, :name, :top_level_schema)
+    }
+  end
+
+  def deep_schema_to_field_names(%{name: name}) do
+    %{name: name}
+  end
+
+  @doc """
+  Utility function for a cleaner code
+  """
+  def schemas() do
+    for id <- ~w(initial first second third)a, into: Map.new() do
+      sorted_schema = id |> get_schema() |> SchemaBuilder.deep_sort_by_fields_name()
+      {id, sorted_schema}
+    end
+  end
+
+  @doc """
+  Utility function for a cleaner code
+  """
+  def metadatas() do
+    for id <- ~w(first second third)a, into: Map.new() do
+      {id, get_params(id)["metadata"]}
+    end
+  end
+
+  def get_params(:first) do
+    %{
+      "event_message" => "This is an example.",
+      "metadata" => [
+        %{
+          "datacenter" => "aws",
+          "ip_address" => "100.100.100.100",
+          "request_method" => "POST"
+        }
+      ],
+      "timestamp" => ~N[2019-04-12 16:38:37]
+    }
+  end
+
+  def get_params(:second) do
+    %{
+      "event_message" => "This is an example.",
+      "metadata" => [
+        %{
+          "datacenter" => "aws",
+          "ip_address" => "100.100.100.100",
+          "request_method" => "POST",
+          "user" => %{
+            "address" => %{
+              "city" => "New York",
+              "st" => "NY",
+              "street" => "123 W Main St"
+            },
+            "browser" => "Firefox",
+            "id" => 38,
+            "vip" => true
+          }
+        }
+      ],
+      "timestamp" => ~N[2019-04-12 16:41:56]
+    }
+  end
+
+  def get_params(:third) do
+    %{
+      "event_message" => "This is an example.",
+      "metadata" => [
+        %{
+          "ip_address" => "100.100.100.100",
+          "user" => %{
+            "address" => %{
+              "city" => "New York",
+              "st" => "NY",
+              "street" => "123 W Main St"
+            },
+            "browser" => "Firefox",
+            "company" => "Apple",
+            "id" => 38,
+            "login_count" => 154,
+            "vip" => true
+          }
+        }
+      ],
+      "timestamp" => ~N[2019-04-12 16:44:38]
+    }
+  end
+
+  def get_schema(:initial) do
+    %GoogleApi.BigQuery.V2.Model.TableSchema{
+      fields: [
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "REQUIRED",
+          name: "timestamp",
+          type: "TIMESTAMP"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "NULLABLE",
+          name: "event_message",
+          type: "STRING"
+        }
+      ]
+    }
+  end
+
+  def get_schema(:first) do
+    %GoogleApi.BigQuery.V2.Model.TableSchema{
+      fields: [
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "REQUIRED",
+          name: "timestamp",
+          type: "TIMESTAMP"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "NULLABLE",
+          name: "event_message",
+          type: "STRING"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: [
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "datacenter",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "ip_address",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "request_method",
+              type: "STRING"
+            }
+          ],
+          mode: "REPEATED",
+          name: "metadata",
+          type: "RECORD"
+        }
+      ]
+    }
+  end
+
+  def get_schema(:second) do
+    %GoogleApi.BigQuery.V2.Model.TableSchema{
+      fields: [
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "REQUIRED",
+          name: "timestamp",
+          type: "TIMESTAMP"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "NULLABLE",
+          name: "event_message",
+          type: "STRING"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: [
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "datacenter",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "ip_address",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "request_method",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: [
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "browser",
+                  type: "STRING"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "id",
+                  type: "INTEGER"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "vip",
+                  type: "BOOLEAN"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: [
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "street",
+                      type: "STRING"
+                    },
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "city",
+                      type: "STRING"
+                    },
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "st",
+                      type: "STRING"
+                    }
+                  ],
+                  mode: "REPEATED",
+                  name: "address",
+                  type: "RECORD"
+                }
+              ],
+              mode: "REPEATED",
+              name: "user",
+              type: "RECORD"
+            }
+          ],
+          mode: "REPEATED",
+          name: "metadata",
+          type: "RECORD"
+        }
+      ]
+    }
+  end
+
+  def get_schema(:third) do
+    %GoogleApi.BigQuery.V2.Model.TableSchema{
+      fields: [
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "REQUIRED",
+          name: "timestamp",
+          type: "TIMESTAMP"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: nil,
+          mode: "NULLABLE",
+          name: "event_message",
+          type: "STRING"
+        },
+        %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+          description: nil,
+          fields: [
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "datacenter",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "ip_address",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: nil,
+              mode: "NULLABLE",
+              name: "request_method",
+              type: "STRING"
+            },
+            %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+              description: nil,
+              fields: [
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "browser",
+                  type: "STRING"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "id",
+                  type: "INTEGER"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "vip",
+                  type: "BOOLEAN"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "company",
+                  type: "STRING"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: nil,
+                  mode: "NULLABLE",
+                  name: "login_count",
+                  type: "INTEGER"
+                },
+                %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                  description: nil,
+                  fields: [
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "street",
+                      type: "STRING"
+                    },
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "city",
+                      type: "STRING"
+                    },
+                    %GoogleApi.BigQuery.V2.Model.TableFieldSchema{
+                      description: nil,
+                      fields: nil,
+                      mode: "NULLABLE",
+                      name: "st",
+                      type: "STRING"
+                    }
+                  ],
+                  mode: "REPEATED",
+                  name: "address",
+                  type: "RECORD"
+                }
+              ],
+              mode: "REPEATED",
+              name: "user",
+              type: "RECORD"
+            }
+          ],
+          mode: "REPEATED",
+          name: "metadata",
+          type: "RECORD"
+        }
+      ]
+    }
+  end
+end


### PR DESCRIPTION
`Logflare.BigQuery.TableSchemaBuilder` implements the following features:

- creates new schema from event params metadata
- deep merges new table schema overwriting the fields schema values if a conflict happens and keeping fields schemas present only in the previously existing table schema
- deeply sorts all fields schemas by name

This pull request also includes tests and some utility functions for easier testing. 