### PR TITLE
Clicking timestamp can search for surrounding lines

### DIFF
--- a/lib/logflare_web/templates/log/log_event_body.html.leex
+++ b/lib/logflare_web/templates/log/log_event_body.html.leex
@@ -6,7 +6,8 @@
         <div><%= Timex.to_datetime(@timestamp) %></div>
         <div>
           <%= if @user_local_timezone do %>
-            <%= Timex.to_datetime(@timestamp, @user_local_timezone) %>
+            <%= link Timex.to_datetime(@timestamp, @user_local_timezone), to: Routes.live_path(@socket, LogflareWeb.Source.SearchLV, @source,
+            querystring: "t:>#{Timex.format!(Timex.shift(@timestamp, seconds: -30), "{ISO:Extended:Z}")} t:<#{Timex.format!(Timex.shift(@timestamp, seconds: 30), "{ISO:Extended:Z}")} c:count(*) c:group_by(t::second)", tailing?: false) %>
           <% else %>
             <br/>
           <% end %>


### PR DESCRIPTION
One feature I have been deeply missing from our previous logging service is the ability to click the timestamp of a log line and have it show me the log lines immediately surrounding it.

I think I have the right idea here but didn't have a proper local setup to test it.  Might need some timezone adjustment in the `querystring` because I think the query expects local timezones.