### PR TITLE
Problem: Logflare.SQL handling of sources with dots in their names

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/ParserExt.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/ParserExt.kt
@@ -1,0 +1,13 @@
+package app.logflare.sql
+
+import gudusoft.gsqlparser.TBaseType
+import gudusoft.gsqlparser.nodes.TTable
+
+fun TTable.fullTableName(): String {
+  val fullName = this.fullName
+  return if (fullName != null) {
+    TBaseType.getTextWithoutQuoted(fullName)
+  } else {
+    this.name
+  }
+}

--- a/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
@@ -61,7 +61,7 @@ class QueryProcessor(
         val sources = mutableSetOf<Source>()
         statement.acceptChildren(object : TableVisitor() {
             override fun visit(table: TTable?, select: TSelectSqlStatement) {
-                sources.add(sourceResolver.resolve(table!!.name))
+                sources.add(sourceResolver.resolve(table!!.fullTableName()))
             }
         })
         return sources

--- a/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
@@ -22,7 +22,7 @@ internal class TransformerVisitor(
     }
 
     override fun visit(table: TTable?, select: TSelectSqlStatement) {
-        val name = table!!.tableName.tableString
+        val name = table!!.fullTableName()
         val source = sourceResolver.resolve(name)
         val newName = "`${projectId}.${datasetResolver.resolve(source)}.${tableResolver.resolve(source)}`"
         table.tableName.setString(newName)

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -224,4 +224,23 @@ internal class QueryProcessorTest {
         assert(exc.message!!.contains("tokenizing"))
     }
 
+    @Test
+    fun testSourceNamesWithDot() {
+        val qp = queryProcessor("SELECT count(id) FROM `dev.dev` WHERE a < 1")
+        assertEquals(qp.sources(), setOf(sourceResolver().resolve("dev.dev")))
+        assertEquals(
+            "SELECT count(id) FROM ${tableName("dev.dev")} WHERE a < 1",
+            qp.transformForExecution())
+    }
+
+    @Test
+    fun testSourceNamesWithDots() {
+        val qp = queryProcessor("SELECT count(id) FROM `dev.dev.dev` WHERE a < 1")
+        assertEquals(qp.sources(), setOf(sourceResolver().resolve("dev.dev.dev")))
+        assertEquals(
+            "SELECT count(id) FROM ${tableName("dev.dev.dev")} WHERE a < 1",
+            qp.transformForExecution())
+    }
+
+
 }


### PR DESCRIPTION
It treats `some.name` table name as a source named `name` and not `some.name`

Solution: make sure full table name is extracted