### PR TITLE
Problem: endpoint queries keeping up with source renaming

### DIFF
--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -65,7 +65,7 @@ defmodule Logflare.Endpoint.Cache do
 
     defp do_query(params, state) do
         # Ensure latest version of the query is used
-        state = %{state | query: Logflare.Repo.reload(state.query),
+        state = %{state | query: Logflare.Repo.reload(state.query) |> Logflare.Endpoint.Query.map_query(),
                           last_update_at: DateTime.utc_now() }
         case Logflare.SQL.parameters(state.query.query) do
            {:ok, parameters} ->

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -22,7 +22,7 @@ defmodule LogflareWeb.EndpointController do
   def query(%{params: %{"token" => token}} = conn, _) do
     query = from q in Logflare.Endpoint.Query,
             where: q.token == ^token
-    endpoint_query = Logflare.Repo.one(query)
+    endpoint_query = Logflare.Repo.one(query) |> Logflare.Endpoint.Query.map_query()
     case Logflare.Endpoint.Cache.resolve(endpoint_query) |>
          Logflare.Endpoint.Cache.query(conn.query_params) do
       {:ok, result} ->
@@ -43,6 +43,7 @@ defmodule LogflareWeb.EndpointController do
     endpoint_query = (from q in Logflare.Endpoint.Query,
        where: q.user_id == ^user.id and q.id == ^id)
     |> Logflare.Repo.one()
+    |> Logflare.Endpoint.Query.map_query()
 
     parameters = case Logflare.SQL.parameters(endpoint_query.query) do
       {:ok, params} -> params
@@ -60,6 +61,7 @@ defmodule LogflareWeb.EndpointController do
     endpoint_query = (from q in Logflare.Endpoint.Query,
        where: q.user_id == ^user.id and q.id == ^id)
     |> Logflare.Repo.one() |> Logflare.Repo.preload(:user)
+    |> Logflare.Endpoint.Query.map_query()
 
     changeset = Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, %{})
 

--- a/priv/repo/migrations/20210715022534_add_source_mapping_to_endpoint_queries.exs
+++ b/priv/repo/migrations/20210715022534_add_source_mapping_to_endpoint_queries.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddSourceMappingToEndpointQueries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      add :source_mapping, :map, null: false, default: %{}
+    end
+  end
+end

--- a/sql/src/main/kotlin/app/logflare/sql/DatabaseSourceResolver.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/DatabaseSourceResolver.kt
@@ -13,9 +13,32 @@ class DatabaseSourceResolver(private val dataSource: HikariDataSource, private v
                    if (!resultSet.next()) {
                        throw SourceNotFound(source, userId)
                    }
-                   return Source(token = UUID.fromString(resultSet.getString(1)), userId = userId)
+                   return Source(
+                       name = source,
+                       token = UUID.fromString(resultSet.getString(1)),
+                       userId = userId
+                   )
                }
            }
+        }
+    }
+
+    override fun findByUUID(uuid: UUID): Source {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("SELECT name FROM sources WHERE user_id = ? AND token = ?").use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, uuid.toString())
+                stmt.executeQuery().use { resultSet ->
+                    if (!resultSet.next()) {
+                        throw SourceNotFound(uuid.toString(), userId)
+                    }
+                    return Source(
+                        name = resultSet.getString(1),
+                        token = uuid,
+                        userId = userId
+                    )
+                }
+            }
         }
     }
 }

--- a/sql/src/main/kotlin/app/logflare/sql/Main.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/Main.kt
@@ -4,6 +4,7 @@ import com.ericsson.otp.erlang.*
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory
+import java.util.*
 
 object Main {
 
@@ -49,18 +50,72 @@ object Main {
                                 sourceResolver = sourceResolver, datasetResolver = datasetResolver,
                                 projectId = projectId, query = query.binaryValue().decodeToString()
                             ).transformForExecution()
-                            mailbox.send(sender, OtpErlangTuple(listOf<OtpErlangObject>(
-                                OtpErlangAtom("ok"),
-                                ref,
-                                OtpErlangBinary(transformed.toByteArray())
-                            ).toTypedArray()))
+                            mailbox.send(
+                                sender, OtpErlangTuple(
+                                    listOf<OtpErlangObject>(
+                                        OtpErlangAtom("ok"),
+                                        ref,
+                                        OtpErlangBinary(transformed.toByteArray())
+                                    ).toTypedArray()
+                                )
+                            )
                         } catch (e: Throwable) {
-                            mailbox.send(sender,
-                                OtpErlangTuple(listOf<OtpErlangObject>(
-                                    OtpErlangAtom("error"),
-                                    ref,
-                                    OtpErlangBinary(e.message?.toByteArray() ?: "unknown error".toByteArray())
-                                ).toTypedArray()))
+                            mailbox.send(
+                                sender,
+                                OtpErlangTuple(
+                                    listOf<OtpErlangObject>(
+                                        OtpErlangAtom("error"),
+                                        ref,
+                                        OtpErlangBinary(e.message?.toByteArray() ?: "unknown error".toByteArray())
+                                    ).toTypedArray()
+                                )
+                            )
+                        }
+                    }
+                } else if (tag is OtpErlangAtom && tag.atomValue().equals("sourceMapping") &&
+                    msg.elements().size == 6) {
+                    val sender = msg.elementAt(1)
+                    val ref = msg.elementAt(2)
+                    val query = msg.elementAt(3)
+                    val userId = msg.elementAt(4)
+                    val map = msg.elementAt(5)
+
+                    if (sender is OtpErlangPid && query is OtpErlangBinary && userId is OtpErlangLong && map is OtpErlangMap) {
+                        val sourceResolver = DatabaseSourceResolver(dataSource = ds, userId = userId.longValue())
+                        val mapping = mutableMapOf<String, UUID>()
+                        map.entrySet().forEach {
+                            if (it.key is OtpErlangBinary && it.value is OtpErlangBinary) {
+                                mapping[(it.key as OtpErlangBinary).binaryValue().decodeToString()] =
+                                    UUID.fromString((it.value as OtpErlangBinary)
+                                        .binaryValue().decodeToString())
+                            }
+                        }
+
+                        try {
+                            val mapped = QueryProcessor(
+                                sourceResolver = sourceResolver, datasetResolver = datasetResolver,
+                                projectId = projectId, query = query.binaryValue().decodeToString()
+                            ).mapSources(mapping)
+                            mailbox.send(
+                                sender, OtpErlangTuple(
+                                    listOf<OtpErlangObject>(
+                                        OtpErlangAtom("ok"),
+                                        ref,
+                                        OtpErlangBinary(mapped.toByteArray())
+                                    ).toTypedArray()
+                                )
+                            )
+                        } catch (e: Throwable) {
+                            mailbox.send(
+                                sender,
+                                OtpErlangTuple(
+                                    listOf<OtpErlangObject>(
+                                        OtpErlangAtom("error"),
+                                        ref,
+                                        OtpErlangBinary(e.message?.toByteArray() ?: "unknown error".toByteArray())
+                                    ).toTypedArray()
+                                )
+                            )
                         }
                     }
                 } else if (tag is OtpErlangAtom && tag.atomValue().equals("parameters") &&
@@ -107,17 +162,21 @@ object Main {
                     if (sender is OtpErlangPid && query is OtpErlangBinary && userId is OtpErlangLong) {
                         val sourceResolver = DatabaseSourceResolver(dataSource = ds, userId = userId.longValue())
                         try {
-                            val parameters = QueryProcessor(
+                            val sources = QueryProcessor(
                                 sourceResolver = sourceResolver, datasetResolver = datasetResolver,
                                 projectId = projectId, query = query.binaryValue().decodeToString()
                             ).sources()
+                            val map = OtpErlangMap()
+                            sources.forEach {
+                                map.put(OtpErlangBinary(it.name.toByteArray()),
+                                    OtpErlangBinary(it.token.toString().toByteArray()))
+                            }
                             mailbox.send(
                                 sender, OtpErlangTuple(
                                     listOf<OtpErlangObject>(
                                         OtpErlangAtom("ok"),
                                         ref,
-                                        OtpErlangList(parameters.map { OtpErlangBinary(it.token.toString().toByteArray()) }
-                                            .toTypedArray<OtpErlangObject>())
+                                        map
                                     ).toTypedArray()
                                 )
                             )

--- a/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
@@ -4,6 +4,7 @@ import gudusoft.gsqlparser.EDbVendor
 import gudusoft.gsqlparser.TGSqlParser
 import gudusoft.gsqlparser.nodes.TTable
 import gudusoft.gsqlparser.stmt.TSelectSqlStatement
+import java.util.*
 
 /**
  * Main entry point to Logflare SQL functionality
@@ -65,5 +66,12 @@ class QueryProcessor(
             }
         })
         return sources
+    }
+
+    fun mapSources(mapping: Map<String, UUID>): String {
+        parse()
+        val statement = parser.sqlstatements[0]
+        statement.acceptChildren(SourceMappingVisitor(mapping, sourceResolver))
+        return statement.toString()
     }
 }

--- a/sql/src/main/kotlin/app/logflare/sql/Source.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/Source.kt
@@ -5,4 +5,4 @@ import java.util.*
 /**
  * Source representation
  */
-data class Source(val token: UUID, val userId: Long)
+data class Source(val token: UUID, val name: String, val userId: Long)

--- a/sql/src/main/kotlin/app/logflare/sql/SourceMappingVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SourceMappingVisitor.kt
@@ -1,0 +1,30 @@
+package app.logflare.sql
+
+import gudusoft.gsqlparser.nodes.*
+import gudusoft.gsqlparser.stmt.TSelectSqlStatement
+import java.util.*
+
+internal class SourceMappingVisitor(
+    private val sourceMapping: Map<String, UUID>,
+    private val sourceResolver: SourceResolver
+) : TableVisitor() {
+
+    override fun visit(table: TTable?, select: TSelectSqlStatement) {
+        val originalName = table!!.tableName.tableString
+        val newName = sourceResolver.findByUUID(sourceMapping[originalName]!!).name
+        table.tableName.setString(newName)
+        val tableRenamer = object : TParseTreeVisitor() {
+            override fun postVisit(node: TObjectName?) {
+                if (node?.objectToken != null && node.tableString == originalName) {
+                    node.objectToken.setString(newName)
+                }
+            }
+        }
+        select.acceptChildren(tableRenamer)
+        // I don't know why, but GSP does not visit GROUP BY's
+        // HAVING clause (or anything else beyond `items`, really)
+        select.groupByClause?.havingClause?.acceptChildren(tableRenamer)
+    }
+
+}
+

--- a/sql/src/main/kotlin/app/logflare/sql/SourceResolver.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SourceResolver.kt
@@ -1,8 +1,11 @@
 package app.logflare.sql
 
+import java.util.*
+
 /**
  * Resolves source name to a Source object
  */
 interface SourceResolver {
     fun resolve(source: String): Source
+    fun findByUUID(uuid: UUID): Source
 }

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -19,7 +19,7 @@ internal class QueryProcessorTest {
     private fun sourceResolver() =
         object : SourceResolver {
             override fun resolve(source: String): Source =
-                Source(token = UUID.nameUUIDFromBytes(source.toByteArray()), userId = userId)
+                Source(token = UUID.nameUUIDFromBytes(source.toByteArray()), name = source, userId = userId)
         }
 
     private fun tableName(sourceName: String): String  {


### PR DESCRIPTION
There is a problem with queries relying on names of sources, as those
can be easily renamed and the query will become erroneous as it won't
be possible to map them to sources anymore and they will need to be
manually updated.

Solution: record source name <-> token mapping when saving queries
and use it when loading query to ensure the query is up-to-date.

---

This will conflict with #880 upon its merge but I'll resolve it when we get there.