### PR TITLE
Problem: can't start application without distribution

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -6,6 +6,12 @@ defmodule Logflare.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
+    # Start distribution early so that both Cachex and Logflare.SQL
+    # can work with it.
+    unless Node.alive? do
+      {:ok, _} = Node.start(:logflare)
+    end
+
     # TODO: Set node status in GCP when sigterm is received
     :ok =
       :gen_event.swap_sup_handler(

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -16,10 +16,6 @@ defmodule Logflare.SQL do
   end
 
   def init(_) do
-    # Start networking if it isn't already
-    unless Node.alive? do
-      {:ok, _} = Node.start(:logflare)
-    end
     {:ok, %__MODULE__{}, {:continue, :run}}
   end
 


### PR DESCRIPTION
Cachex seem to fail starting up.

Logflare.SQL crashes with the {:EXIT, :nodistribution} error
in some cases.

Solution: ensure distribution is started before caches
and Logflare.SQL

Cachex doesn't accommodate distribution status changes after it has been
started.