### PR TITLE
Problem: endpoint query formatting in the UI

### DIFF
--- a/lib/logflare_web/templates/endpoint/show.html.eex
+++ b/lib/logflare_web/templates/endpoint/show.html.eex
@@ -9,7 +9,7 @@
     <%= section_header("Query") %>
 
     <code>
-      <%= @endpoint_query.query %>
+      <pre><%= @endpoint_query.query %></pre>
     </code>
 
     <%= unless Enum.empty?(@parameters) do %>


### PR DESCRIPTION
It is shown as a oneliner instead of what was entered by the user.

Solution: ensure formatting is respected (using pre tag)