### PR TITLE
Problem: UNNEST source name in endpoint queries

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
@@ -2,6 +2,7 @@ package app.logflare.sql
 
 import gudusoft.gsqlparser.EDbVendor
 import gudusoft.gsqlparser.TGSqlParser
+import gudusoft.gsqlparser.nodes.TParseTreeNode
 import gudusoft.gsqlparser.nodes.TTable
 import gudusoft.gsqlparser.stmt.TSelectSqlStatement
 import java.util.*
@@ -61,7 +62,7 @@ class QueryProcessor(
         val statement = parser.sqlstatements[0]
         val sources = mutableSetOf<Source>()
         statement.acceptChildren(object : TableVisitor() {
-            override fun visit(table: TTable?, select: TSelectSqlStatement) {
+            override fun visit(table: TTable?, node: TParseTreeNode) {
                 sources.add(sourceResolver.resolve(table!!.fullTableName()))
             }
         })

--- a/sql/src/main/kotlin/app/logflare/sql/SourceMappingVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SourceMappingVisitor.kt
@@ -9,7 +9,7 @@ internal class SourceMappingVisitor(
     private val sourceResolver: SourceResolver
 ) : TableVisitor() {
 
-    override fun visit(table: TTable?, select: TSelectSqlStatement) {
+    override fun visit(table: TTable?, node: TParseTreeNode) {
         val originalName = table!!.fullTableName()
         val newName = ensureValidName(sourceResolver.findByUUID(sourceMapping[originalName]!!).name)
         table.tableName.setString(newName)
@@ -20,10 +20,12 @@ internal class SourceMappingVisitor(
                 }
             }
         }
-        select.acceptChildren(tableRenamer)
+        node.acceptChildren(tableRenamer)
         // I don't know why, but GSP does not visit GROUP BY's
         // HAVING clause (or anything else beyond `items`, really)
-        select.groupByClause?.havingClause?.acceptChildren(tableRenamer)
+        if (node is TSelectSqlStatement) {
+            node.groupByClause?.havingClause?.acceptChildren(tableRenamer)
+        }
     }
 
     private fun ensureValidName(name: String): String {

--- a/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
@@ -21,7 +21,7 @@ internal class TransformerVisitor(
         super.postVisit(node)
     }
 
-    override fun visit(table: TTable?, select: TSelectSqlStatement) {
+    override fun visit(table: TTable?, node: TParseTreeNode) {
         val name = table!!.fullTableName()
         val source = sourceResolver.resolve(name)
         val newName = "`${projectId}.${datasetResolver.resolve(source)}.${tableResolver.resolve(source)}`"
@@ -33,10 +33,12 @@ internal class TransformerVisitor(
                 }
             }
         }
-        select.acceptChildren(tableRenamer)
+        node.acceptChildren(tableRenamer)
         // I don't know why, but GSP does not visit GROUP BY's
         // HAVING clause (or anything else beyond `items`, really)
-        select.groupByClause?.havingClause?.acceptChildren(tableRenamer)
+        if (node is TSelectSqlStatement) {
+            node.groupByClause?.havingClause?.acceptChildren(tableRenamer)
+        }
     }
 
     override fun postVisit(node: TFunctionCall?) {

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -246,5 +246,14 @@ internal class QueryProcessorTest {
             qp.transformForExecution())
     }
 
+    @Test
+    fun testTransformJoinUnnest() {
+        assertEquals("SELECT a FROM ${tableName("dev")} " +
+                "INNER JOIN UNNEST(${tableName("dev")}.metadata) AS f1 ON TRUE",
+            queryProcessor("SELECT a FROM dev INNER JOIN UNNEST(dev.metadata) AS f1 ON TRUE").transformForExecution())
+        assertEquals("SELECT a FROM ${tableName("dev")} AS dev1 " +
+                "INNER JOIN UNNEST(dev1.metadata) AS f1 ON TRUE",
+            queryProcessor("SELECT a FROM dev AS dev1 INNER JOIN UNNEST(dev1.metadata) AS f1 ON TRUE").transformForExecution())
+    }
 
 }


### PR DESCRIPTION
Source names used in UNNEST functions are not being translated
to their tokens. This makes queries unexecutable as BigQuery
won't get the rigth table to query.

Solution: handle UNNESTing by processing the unnesting clause

It definitely works well if the source name is an alias, but it might
be limited in types of (complex) expressions it will take if source name
is used as is.