### PR TITLE
Problem: inconvenient editing of endpoints

### DIFF
--- a/lib/logflare_web/templates/endpoint/show.html.eex
+++ b/lib/logflare_web/templates/endpoint/show.html.eex
@@ -2,6 +2,14 @@
   <div class="container mx-auto">
 
     <h5>~/endpoints/<%= link @endpoint_query.name, to: Routes.endpoint_path(@conn, :show, @endpoint_query), class: "text-primary" %></h5>
+
+    <div class="log-settings">
+      <ul>
+        <li><%= link to: Routes.endpoint_path(@conn, :edit, @endpoint_query) do %><i class="fas fa-edit"></i><span class="hide-on-mobile"> edit</span> <% end %></li>
+        <li><a href="mailto:support@logflare.app?Subject=Logflare%20Help" target="_top"><i class="fas fa-question-circle"></i> <span class="hide-on-mobile">help</a></span></li>
+      </ul>
+    </div>
+
   </div>
 </div>
 <div class="container mx-auto">


### PR DESCRIPTION
When one is looking at endpoint details, it is not convenient
to edit it. One must go back to the list of endpoints, find it there
and click the edit icon.

Solution: add an edit icon in the sub-navigation
for detailed endpoint view.

This follows the design pattern used in Sources.