### PR TITLE
Problem: Logflare SQL and endpoint caching in absence of Mix

### DIFF
--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -20,6 +20,7 @@ defmodule Logflare.Endpoint.Cache do
     @max_results 10_000
     @ttl_secs 60 # seconds until cache is invalidated
     @inactivity_minutes 60 # minutes until the Cache process is terminated
+    @env Application.get_env(:logflare, :env)
 
     import Ecto.Query, only: [from: 2]
 
@@ -129,7 +130,7 @@ defmodule Logflare.Endpoint.Cache do
 
 
     defp process_message(message, user_id) do
-      regex = ~r/#{@project_id}\.#{user_id}_#{Mix.env}\.(?<uuid>[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12})/
+      regex = ~r/#{@project_id}\.#{user_id}_#{@env}\.(?<uuid>[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12})/
       names = Regex.named_captures(regex, message)
       case names do
         %{"uuid" => uuid} ->

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -34,6 +34,7 @@ defmodule Logflare.SQL do
                        {"DATABASE_URL", db_url},
                        {"DB_USER", db_config[:username]},
                        {"DB_PASSWORD", db_config[:password]},
+                       {"LOGFLARE_ENV", Application.get_env(:logflare, :env) |> to_string() },
                        {"PROJECT_ID", Application.get_env(:logflare, Logflare.Google)[:project_id]}
                      ]}
                    ])

--- a/sql/src/main/kotlin/app/logflare/sql/Main.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/Main.kt
@@ -20,7 +20,7 @@ object Main {
         hikariConfig.password = System.getenv("DB_PASSWORD")
         val ds = HikariDataSource(hikariConfig)
 
-        val datasetResolver = EnvDatasetResolver(System.getenv("MIX_ENV") ?: "dev")
+        val datasetResolver = EnvDatasetResolver(System.getenv("LOGFLARE_ENV") ?: "dev")
 
         val node = OtpNode("logflare_sql")
         node.setCookie(System.getenv("COOKIE"))


### PR DESCRIPTION
When there's no Mix, these will fail as there is no Mix.env or MIX_ENV

Solution: don't rely on Mix, but logflare's own config