### PR TITLE
Problem: finding endpoint query URL is inconvenient

### DIFF
--- a/assets/js/endpoint.js
+++ b/assets/js/endpoint.js
@@ -1,3 +1,19 @@
+import $ from "jquery"
+import {activateClipboardForSelector} from "./utils"
+
+export async function main() {
+  await initClipboards()
+  await initTooltips()
+}
+
+async function initTooltips() {
+  $(".logflare-tooltip").tooltip({delay: {show: 100, hide: 200}})
+}
+
+async function initClipboards() {
+  activateClipboardForSelector(".copy-token")
+}
+
 export async function query(query, params) {
   let queryResult = document.getElementById("queryResult")
   let url = new URL(`/endpoints/query/${query}`, window.location.origin)

--- a/lib/logflare_web/templates/endpoint/index.html.eex
+++ b/lib/logflare_web/templates/endpoint/index.html.eex
@@ -45,6 +45,13 @@
                 <span id="<%= endpoint_query.token %>">
                 </span>
               </div>
+              <div class="source-meta-data">
+                <small class="source-details">
+                  <% url = Routes.endpoint_url(@conn, :query, endpoint_query.token) %>
+                  <span class="pointer-cursor copy-token logflare-tooltip" data-toggle="tooltip" data-html=true data-placement="top" title="<span id=copy-tooltip>Copy this</span>" id="<%= String.replace(endpoint_query.token, ~r/[0-9]|-/, "") %>"
+                        data-clipboard-text="<%= url %>"><%=  url %></span>
+              </small>
+              </div>
             </div>
           </li>
           <% end %>
@@ -62,3 +69,9 @@
     </div>
   </div>
 </div>
+<script>
+  document.addEventListener("DOMContentLoaded", async () => {
+    await Endpoint.main()
+  })
+
+</script>


### PR DESCRIPTION
This requires extra steps, such as going into the detailed
view of an endpoint and selecting-copying the URL out of cURL example.

Solution: show copiable URL in the list of endpoints
(similarly to sources)