### PR TITLE
Problem: invalid HTML in endpoint query params form

### DIFF
--- a/lib/logflare_web/templates/endpoint/show.html.eex
+++ b/lib/logflare_web/templates/endpoint/show.html.eex
@@ -25,7 +25,7 @@
       <%= section_header("Parameters") %>
       <%= for parameter <- @parameters do %>
         <div>
-        <label ]for="param[<%= parameter %>">
+        <label for="param[<%= parameter %>]">
         <%= parameter %>
         </label>
         <input id="param[<%= parameter %>]">


### PR DESCRIPTION
Looks like the closing bracket went into an incorrect place.

Solution: make it valid