### PR TITLE
Problem: endpoint query URLs are static

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -146,6 +146,7 @@ defmodule LogflareWeb.Router do
     get "/:id", EndpointController, :show
     get "/:id/edit", EndpointController, :edit
     put "/:id", EndpointController, :update
+    put "/:id/reset_url", EndpointController, :reset_url
     delete "/:id", EndpointController, :delete
   end
 

--- a/lib/logflare_web/templates/endpoint/edit.html.eex
+++ b/lib/logflare_web/templates/endpoint/edit.html.eex
@@ -20,5 +20,14 @@
     </div>
     <%= submit "Update query", class: "btn btn-primary form-button" %>
     <% end %>
+
+    <%= section_header("Endpoint URL") %>
+    <div class="mb-2">
+      <%= Routes.endpoint_url(@conn, :query, @endpoint_query.token) %>
+    </div>
+    <%= form_for @changeset, Routes.endpoint_path(@conn, :reset_url, @endpoint_query), fn a -> %>
+    <%= submit "Reset", class: "btn btn-primary form-button" %>
+    <% end %>
+
   </div>
 </div>


### PR DESCRIPTION
There is no way to change them (for example, if we no longer want to
share them with somebody)

Solution: allow resetting the token

This exposes resetting functionality in the editing view. Cache
is preserved during the reset as the actual query doesn't change
and caches are named after unchangeable IDs rather than changeable
tokens.