### PR TITLE
Problem: sql parser's error messages are somewhat cryptic

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/QueryParseError.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryParseError.kt
@@ -1,6 +1,37 @@
 package app.logflare.sql
 
-class QueryParseError(message: String) : Error(transformErrorMessage(message)) {
+import gudusoft.gsqlparser.TSyntaxError
+import java.lang.StringBuilder
+import kotlin.math.*
+
+class QueryParseError(private val sql: String, private val errors: ArrayList<TSyntaxError>) : Error() {
+
+    override val message: String
+        get() {
+            val error = errors.first()
+
+            val hint = if (error.hint.isEmpty()) {
+                "Syntax error"
+            } else {
+                // Remove useless ", state: NUMBER"
+                error.hint.replace(Regex(",\\sstate:(\\d)+"),"")
+            }
+
+            if (error.lineNo == 0L && error.columnNo == 0L) {
+               return transformErrorMessage(hint)
+            } else {
+                val line = sql.lines()[error.lineNo.toInt()-1]
+                val startIndex = max(error.columnNo - 10, 0).toInt()
+                val context = line.substring(
+                    startIndex,
+                    min(error.columnNo.toInt() + 10, line.length)
+                )
+                val sb = StringBuilder(context)
+                sb.insert(error.columnNo.toInt() - 1 - startIndex, "[")
+                sb.insert(min(error.columnNo.toInt() - startIndex + error.tokentext.length, line.length + 1), "]")
+                return "${transformErrorMessage(hint)} at line ${error.lineNo} column ${error.columnNo} near \"${error.tokentext}\" in \"$sb\""
+            }
+        }
 }
 
 internal fun transformErrorMessage(message: String): String =

--- a/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
@@ -29,7 +29,7 @@ class QueryProcessor(
 
     private fun parse() {
         if (parser.parse() != 0) {
-            throw QueryParseError(parser.errormessage)
+            throw QueryParseError(parser.sqltext, parser.syntaxErrors)
         }
         if (parser.sqlstatements.size() != 1) {
             throw SingularQueryRequired()


### PR DESCRIPTION
What does (x,y) mean there? what is in "near"?

Solution: rewrite error messages to provide more context

This change indicates line and column explicitly and tries
to extract more of the query's context surrounding the error.

It also removes some error messaging that is not very useful
for end users, such as "state: some_number".