### PR TITLE
Problem: which logging API should Erlang client use?

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -340,6 +340,7 @@ defmodule LogflareWeb.Router do
     post "/zeit", LogController, :vercel_ingest
     post "/vercel", LogController, :vercel_ingest
     post "/elixir/logger", LogController, :elixir_logger
+    post "/erlang/logger", LogController, :elixir_logger
     post "/typecasts", LogController, :create_with_typecasts
     post "/logplex", LogController, :syslog
     post "/syslogs", LogController, :syslog


### PR DESCRIPTION
There's one for Elixir, but is it suitable for Erlang?

Solution: designate /erlang/logger to Erlang logger

It is still the same handler, though (Elixir one)