### PR TITLE
Add WebSocket to CSP

### DIFF
--- a/lib/logflare_web/endpoint.ex
+++ b/lib/logflare_web/endpoint.ex
@@ -59,4 +59,13 @@ defmodule LogflareWeb.Endpoint do
       {:ok, config}
     end
   end
+
+  @doc """
+  Generates the endpoint base websocket URL without any path information.
+  It uses the configuration under `:url` to generate such.
+  """
+  def socket_url() do
+    uri = struct_url()
+    "#{%{uri | scheme: String.replace(uri.scheme, "http", "ws")}}"
+  end
 end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -7,7 +7,7 @@ defmodule LogflareWeb.Router do
 
   @csp "\
   default-src 'self';\
-  connect-src 'self' https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com https://js.stripe.com;\
+  connect-src 'self' #{LogflareWeb.Endpoint.socket_url} https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com https://js.stripe.com;\
   script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://buttons.github.io https://platform.twitter.com https://cdnjs.cloudflare.com https://js.stripe.com;\
   style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com;\
   img-src 'self' https://*.googleusercontent.com https://www.gravatar.com https://avatars.githubusercontent.com;\


### PR DESCRIPTION
LogFlare dashboard fails to render on Safari 15, due to missing WebSocket in CSP.


<img width="1617" alt="Screen Shot 2021-09-22 at 12 58 54 PM" src="https://user-images.githubusercontent.com/10013742/134388368-eccc8887-ffc2-4306-b160-3880beebb95c.png">

<img width="1617" alt="Screen Shot 2021-09-22 at 12 58 42 PM" src="https://user-images.githubusercontent.com/10013742/134388381-25671ba8-e825-42c9-ac53-a9449a3cbb07.png">

`socket_url/0` will generate either `ws:://host:port` or `wss:://host:port` based on the environment configuration.

```js
[Error] Refused to connect to wss://logflare.app/socket/websocket?token=SFMyNTY.g2gDYgAAGDFuBgA0KlIOfAFiAAFRgA.K2P7lwsYysMAIktNAg2FdVma27bYJZIKCilzpGH_jLQ&public_token=undefined&vsn=2.0.0 because it does not appear in the connect-src directive of the Content Security Policy.
[Error] SecurityError: The operation is insecure.
	(anonymous function) (app-beb7b0b3b8e04009e6c08f252e55db3a.js:1:207092)
	value (app-beb7b0b3b8e04009e6c08f252e55db3a.js:1:207092)
	(anonymous function) (app-beb7b0b3b8e04009e6c08f252e55db3a.js:1:428541)
	(anonymous function) (app-beb7b0b3b8e04009e6c08f252e55db3a.js:1:725420)
	Global Code (app-beb7b0b3b8e04009e6c08f252e55db3a.js:1:725424)
```

I tried to start the server in dev, but it isn't really clear to me how I would generate the secrects needed to run the server.