### PR TITLE
Problem: running postgresql on a non-standard port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2.2'
+services:
+  lf-pg:
+    image: postgres:13.4
+    container_name: lf-pg
+    environment:
+      - POSTGRES_USER=chasegranberry
+      - POSTGRES_PASSWORD=
+    ports:
+      - ${POSTGRESQL_PORT:-15432}:5432
+    volumes:
+      - lf-pg:/var/lib/postgresql/data
+    networks:
+      - lf
+
+
+volumes:
+  lf-pg:
+    driver: local
+
+networks:
+  lf:
+    driver: bridge

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -20,6 +20,7 @@ defmodule Logflare.Application do
     username = Application.get_env(:logflare, Logflare.Repo)[:username]
     password = Application.get_env(:logflare, Logflare.Repo)[:password]
     database = Application.get_env(:logflare, Logflare.Repo)[:database]
+    port = Application.get_env(:logflare, Logflare.Repo)[:port]
     slot = Application.get_env(:logflare, Logflare.CacheBuster)[:replication_slot]
     publications = Application.get_env(:logflare, Logflare.CacheBuster)[:publications]
 
@@ -119,6 +120,7 @@ defmodule Logflare.Application do
         register: Logflare.PgPublisher,
         epgsql: %{
           host: hostname,
+          port: port,
           username: username,
           database: database,
           password: password

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -21,7 +21,7 @@ defmodule Logflare.SQL do
 
   def handle_continue(:run, state) do
     db_config = Logflare.Repo.config
-    db_url = "jdbc:pgsql://#{db_config[:hostname]}/#{db_config[:database]}"
+    db_url = "jdbc:pgsql://#{db_config[:hostname]}:#{db_config[:port] || 5432}/#{db_config[:database]}"
     :exec.run_link(:code.priv_dir(:logflare) |>
                    to_string() |>
                    Path.join("sql/bin/logflare_sql"),


### PR DESCRIPTION
I currently use docker compose to run different versions of postgresql
on my development machine. This means I have to use different ports.

Solution: ensure Logflare is able to handle :port config setting

I've also included docker-compose.yml if anybody wants to use this setup.