### PR TITLE
Problem: experiencing major slowdown upon node startup

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
-elixir 1.12.1-otp-24
-erlang 24.0.3
+elixir 1.12.3-otp-24
+erlang 24.1.6
 gradle 7.1.1
 kotlin 1.5.20
 nodejs 16.4.2


### PR DESCRIPTION
I noticed that when I have asset/node_modules installed, iex -S mix phx.server
takes close to forever to start.

Solution: update elixir and erlang

Not sure what's the cause of this but at this point, going for later versions
gets rid of the problem I experienced, and I don't want to spend too much time
trying to figure this out at this moment.