### PR TITLE
Problem: querying specific data from endpoints

### DIFF
--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -1,18 +1,18 @@
 defmodule Logflare.Endpoint.Cache do
-  def resolve(%Logflare.Endpoint.Query{id: id} = query) do
-    :global.set_lock({__MODULE__, id})
+  def resolve(%Logflare.Endpoint.Query{id: id} = query, params) do
+    :global.set_lock({__MODULE__, {id, params}})
 
     result =
-      case :global.whereis_name({__MODULE__, id}) do
+      case :global.whereis_name({__MODULE__, id, params}) do
         :undefined ->
-          {:ok, pid} = DynamicSupervisor.start_child(__MODULE__, {__MODULE__, query})
+          {:ok, pid} = DynamicSupervisor.start_child(__MODULE__, {__MODULE__, {query, params}})
           pid
 
         pid ->
           pid
       end
 
-    :global.del_lock({__MODULE__, id})
+    :global.del_lock({__MODULE__, {id, params}})
     result
   end
 
@@ -21,29 +21,29 @@ defmodule Logflare.Endpoint.Cache do
   @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
   @max_results 10_000
   # seconds until cache is invalidated
-  @ttl_secs 60
+  @ttl_secs 60 * 30
   # minutes until the Cache process is terminated
   @inactivity_minutes 60
   @env Application.get_env(:logflare, :env)
 
   import Ecto.Query, only: [from: 2]
 
-  def start_link(query) do
-    GenServer.start_link(__MODULE__, query, name: {:global, {__MODULE__, query.id}})
+  def start_link({query, params}) do
+    GenServer.start_link(__MODULE__, {query, params}, name: {:global, {__MODULE__, query.id, params}})
   end
 
-  defstruct query: nil, last_query_at: nil, last_update_at: nil, cached_result: nil
+  defstruct query: nil, params: %{}, last_query_at: nil, last_update_at: nil, cached_result: nil
 
-  def init(query) do
-    {:ok, %__MODULE__{query: query}}
+  def init({query, params}) do
+    {:ok, %__MODULE__{query: query, params: params}}
   end
 
-  def handle_call({:query, params}, _from, %__MODULE__{cached_result: nil} = state) do
+  def handle_call(:query, _from, %__MODULE__{cached_result: nil} = state) do
     state = %{state | last_query_at: DateTime.utc_now()}
-    do_query(params, state)
+    do_query(state)
   end
 
-  def handle_call({:query, %{}}, _from, %__MODULE__{} = state) do
+  def handle_call(:query, _from, %__MODULE__{} = state) do
     state = %{state | last_query_at: DateTime.utc_now()}
     {:reply, {:ok, state.cached_result}, state, timeout_until_fetching(state)}
   end
@@ -61,7 +61,7 @@ defmodule Logflare.Endpoint.Cache do
       {:ok, parameters} = Logflare.SQL.parameters(state.query.query)
 
       if Enum.empty?(parameters) do
-        {:reply, _, state, timeout} = do_query([], state)
+        {:reply, _, state, timeout} = do_query(state)
         {:noreply, state, timeout}
       else
         {:noreply, state}
@@ -73,7 +73,7 @@ defmodule Logflare.Endpoint.Cache do
     max(0, @ttl_secs - DateTime.diff(DateTime.utc_now(), state.last_update_at, :second)) * 1000
   end
 
-  defp do_query(params, state) do
+  defp do_query(state) do
     # Ensure latest version of the query is used
     state = %{
       state
@@ -84,9 +84,16 @@ defmodule Logflare.Endpoint.Cache do
         last_update_at: DateTime.utc_now()
     }
 
+    params = state.params
+
     case Logflare.SQL.parameters(state.query.query) do
       {:ok, parameters} ->
-        case Logflare.SQL.transform(state.query.query, state.query.user_id) do
+        query = if state.query.sandboxable && Map.get(params, "sql") do
+          {state.query.query, Map.get(params, "sql")}
+        else
+          state.query.query
+        end
+        case Logflare.SQL.transform(query, state.query.user_id) do
           {:ok, query} ->
             params =
               Enum.map(parameters, fn x ->
@@ -110,14 +117,9 @@ defmodule Logflare.Endpoint.Cache do
                    maxResults: @max_results
                  ) do
               {:ok, result} ->
-                if Enum.empty?(params) do
                   # Cache the result (no parameters)
                   state = %{state | cached_result: result}
                   {:reply, {:ok, result}, state, timeout_until_fetching(state)}
-                else
-                  # Uncacheable result
-                  {:reply, {:ok, result}, state}
-                end
 
               {:error, err} ->
                 error = Jason.decode!(err.body)["error"] |> process_error(state.query.user_id)
@@ -133,8 +135,8 @@ defmodule Logflare.Endpoint.Cache do
     end
   end
 
-  def query(cache, params) do
-    GenServer.call(cache, {:query, params}, :infinity)
+  def query(cache) do
+    GenServer.call(cache, :query, :infinity)
   end
 
   def invalidate(cache) do

--- a/lib/logflare/endpoint/query.ex
+++ b/lib/logflare/endpoint/query.ex
@@ -7,6 +7,7 @@ defmodule Logflare.Endpoint.Query do
     field :name, :string
     field :query, :string
     field :source_mapping, :map
+    field :sandboxable, :boolean
 
     belongs_to :user, Logflare.User
 
@@ -16,7 +17,7 @@ defmodule Logflare.Endpoint.Query do
   @doc false
   def changeset(query, attrs) do
     query
-    |> cast(attrs, [:name, :token, :query])
+    |> cast(attrs, [:name, :token, :query, :sandboxable])
     |> validate_required([:name, :token, :query])
   end
 
@@ -25,7 +26,8 @@ defmodule Logflare.Endpoint.Query do
     |> cast(attrs, [
       :name,
       :token,
-      :query
+      :query,
+      :sandboxable
     ])
     |> default_validations()
     |> update_source_mapping()

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -63,7 +63,7 @@ defmodule Logflare.SQL do
     {:noreply, put_in(state.requests[ref], from)}
   end
 
-def handle_call({:source_mapping, query, user_id, source_mapping}, from, state) do
+  def handle_call({:source_mapping, query, user_id, source_mapping}, from, state) do
     ref = make_ref()
     send(state.pid, {:sourceMapping, self(), ref, query, user_id, source_mapping})
     {:noreply, put_in(state.requests[ref], from)}

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -27,8 +27,8 @@ defmodule LogflareWeb.EndpointController do
 
     endpoint_query = Logflare.Repo.one(query) |> Logflare.Endpoint.Query.map_query()
 
-    case Logflare.Endpoint.Cache.resolve(endpoint_query)
-         |> Logflare.Endpoint.Cache.query(conn.query_params) do
+    case Logflare.Endpoint.Cache.resolve(endpoint_query, conn.query_params)
+         |> Logflare.Endpoint.Cache.query() do
       {:ok, result} ->
         render(conn, "query.json", result: result.rows)
 
@@ -117,7 +117,7 @@ defmodule LogflareWeb.EndpointController do
       |> Logflare.Repo.one()
       |> Logflare.Repo.preload(:user)
 
-    Logflare.Endpoint.Cache.resolve(endpoint_query) |> Logflare.Endpoint.Cache.invalidate()
+    Logflare.Endpoint.Cache.resolve(endpoint_query, %{}) |> Logflare.Endpoint.Cache.invalidate()
 
     Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, params)
     |> Logflare.Repo.update()

--- a/lib/logflare_web/templates/endpoint/new.html.eex
+++ b/lib/logflare_web/templates/endpoint/new.html.eex
@@ -25,6 +25,15 @@
       You can change the query later as well.
     </small>
 
+    <div class="form-control form-control-margin">
+      <%= checkbox f, :sandboxable, autofocus: true %>
+      <label for="query_sandboxable">Allow passing sandboxable queries</label>
+    </div>
+    <small class="form-text text-muted">
+      You can turn this on and off later.
+    </small>
+
+
   </div>
   <%= submit "Add endpoint", class: "btn btn-primary form-button" %>
   <% end %>

--- a/lib/logflare_web/templates/endpoint/show.html.eex
+++ b/lib/logflare_web/templates/endpoint/show.html.eex
@@ -20,6 +20,10 @@
       <pre><%= @endpoint_query.query %></pre>
     </code>
 
+    <%= if @endpoint_query.sandboxable do %>
+      This endpoint accepts optional sandboxed query through <code>sql</code> parameter
+    <% end%>
+
     <%= unless Enum.empty?(@parameters) do %>
       <div class="mb-4">
       <%= section_header("Parameters") %>
@@ -51,6 +55,20 @@
     <% end %>
     </pre>
     </code>
+
+    <%= if @endpoint_query.sandboxable do %>
+      <%= section_header("cURL Example for sandboxed queries") %>
+
+      <code>
+      <pre class="pt-2">
+      curl "<%= Routes.endpoint_url(@conn, :query, @endpoint_query.token)%>" \
+           -H 'Content-Type: application/json; charset=utf-8' <%= unless Enum.empty?(@parameters) do %> \
+           -G <%= for parameter <- @parameters do %>-d "<%= parameter %>=VALUE" <% end%>
+      <% end %> \
+           -d "sql=SQL"
+      </pre>
+      </code>
+    <% end%>
 
 
 </div>

--- a/priv/repo/migrations/20211123192744_sandboxable_endpoint_queries.exs
+++ b/priv/repo/migrations/20211123192744_sandboxable_endpoint_queries.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.SandboxableEndpointQueries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      add :sandboxable, :boolean, default: false
+    end
+  end
+end

--- a/sql/src/main/kotlin/app/logflare/sql/RestrictedPatternVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/RestrictedPatternVisitor.kt
@@ -1,0 +1,29 @@
+package app.logflare.sql
+
+import gudusoft.gsqlparser.nodes.TFunctionCall
+import gudusoft.gsqlparser.nodes.TIntoClause
+import gudusoft.gsqlparser.stmt.TSelectSqlStatement
+
+internal abstract class RestrictedPatternVisitor : TableVisitor() {
+    override fun postVisit(node: TSelectSqlStatement?) {
+        val hasWildcard = node!!.resultColumnList.any {
+            it.columnNameOnly == "*"
+        }
+        if (hasWildcard) {
+            throw RestrictedWildcardResultColumn()
+        }
+        super.postVisit(node)
+    }
+
+    override fun postVisit(node: TFunctionCall?) {
+        if (node!!.functionName.objectString.equals("external_query", ignoreCase = true) ||
+            node.functionName.objectString.equals("session_user", ignoreCase = true)) {
+            throw RestrictedFunctionCall(node.functionName.objectString)
+        }
+        super.postVisit(node)
+    }
+
+    override fun preVisit(node: TIntoClause?) {
+        throw RestrictedIntoClause(node!!.toString())
+    }
+}

--- a/sql/src/main/kotlin/app/logflare/sql/SandboxRestrictionViolated.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SandboxRestrictionViolated.kt
@@ -1,0 +1,8 @@
+package app.logflare.sql
+
+class SandboxRestrictionViolated(private val tableName: String) : Throwable() {
+
+    override val message: String?
+        get() = "Sandboxed query attempting access outside of sandbox (${tableName})"
+
+}

--- a/sql/src/main/kotlin/app/logflare/sql/SandboxVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SandboxVisitor.kt
@@ -1,0 +1,14 @@
+package app.logflare.sql
+
+import gudusoft.gsqlparser.nodes.*
+import gudusoft.gsqlparser.stmt.TSelectSqlStatement
+
+internal class SandboxVisitor(private val statement: TSelectSqlStatement) : RestrictedPatternVisitor() {
+    override fun visit(table: TTable?, node: TParseTreeNode) {
+        if (!(isInCTE(table!!.fullTableName()) ||
+                    (statement.cteList != null && isInCTE(listOf(statement.cteList), table.fullTableName())))) {
+            throw SandboxRestrictionViolated(table.fullTableName())
+        }
+    }
+
+}

--- a/sql/src/main/kotlin/app/logflare/sql/SelectQueryRequired.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SelectQueryRequired.kt
@@ -1,3 +1,6 @@
 package app.logflare.sql
 
-class SelectQueryRequired : Throwable()
+class SelectQueryRequired(private val query: String) : Throwable() {
+    override val message: String?
+        get() = "Only SELECT queries allowed (${query})"
+}

--- a/sql/src/main/kotlin/app/logflare/sql/SingularQueryRequired.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/SingularQueryRequired.kt
@@ -1,3 +1,6 @@
 package app.logflare.sql
 
-class SingularQueryRequired : Throwable()
+class SingularQueryRequired(private val query: String) : Throwable() {
+    override val message: String?
+        get() = "Only singular query allowed (${query})"
+}

--- a/sql/src/main/kotlin/app/logflare/sql/TableVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TableVisitor.kt
@@ -11,11 +11,7 @@ import java.util.*
 internal abstract class TableVisitor : TParseTreeVisitor() {
     private val cte: MutableList<TCTEList> = mutableListOf()
 
-    private fun isInCTE(name: String): Boolean {
-        return cte.any {
-            it.cteNames?.get(TBaseType.getTextWithoutQuoted(name).uppercase(Locale.getDefault())) != null
-        }
-    }
+    protected fun isInCTE(name: String): Boolean = isInCTE(cte, name)
 
     override fun postVisit(node: TCTE?) {
         node!!.subquery.acceptChildren(this)
@@ -66,3 +62,7 @@ internal abstract class TableVisitor : TParseTreeVisitor() {
     abstract fun visit(table: TTable?, node: TParseTreeNode)
 }
 
+fun isInCTE(cte: List<TCTEList>, name: String) =
+    cte.any {
+        it.cteNames?.get(TBaseType.getTextWithoutQuoted(name).uppercase(Locale.getDefault())) != null
+    }

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -32,9 +32,10 @@ internal class QueryProcessorTest {
         return "`${projectId}.${datasetResolver().resolve(source)}.${DefaultTableResolver.resolve(source)}`"
     }
 
-    private fun queryProcessor(query: String, dbVendor: EDbVendor = EDbVendor.dbvbigquery): QueryProcessor {
+    private fun queryProcessor(query: String, sandboxedQuery: String? = null, dbVendor: EDbVendor = EDbVendor.dbvbigquery): QueryProcessor {
         return QueryProcessor(
             query,
+            sandboxedQuery,
             sourceResolver = sourceResolver(),
             projectId = projectId,
             datasetResolver = datasetResolver(),
@@ -137,6 +138,76 @@ internal class QueryProcessorTest {
                         "SELECT a FROM something UNION SELECT a FROM something1"
             ).transformForExecution())
     }
+
+    @Test
+    fun testSandboxedQuery() {
+        assertEquals(
+            "WITH something AS (SELECT a,b,c FROM ${tableName("source")}) SELECT a FROM something",
+            queryProcessor("WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "SELECT a FROM something").transformForExecution()
+        )
+        assertEquals(
+            "WITH something AS (SELECT a,b,c FROM ${tableName("source")}), something1 AS (SELECT a,b,c FROM something where c > 1) SELECT a FROM something1",
+            queryProcessor("WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "WITH something1 AS (SELECT a,b,c FROM something where c > 1) SELECT a FROM something1").transformForExecution()
+        )
+    }
+
+    @Test
+    fun testSandboxedQuerySelectInto() {
+        assertThrows<RestrictedIntoClause> {
+            // Using a different vendor here because BigQuery does not
+            // support SELECT INTO, but if/when logflare grows to support
+            // other syntaxes, one'd wish we wouldn't have forgotten
+            // something like this
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                dbVendor = EDbVendor.dbvpostgresql,
+                sandboxedQuery = "SELECT a FROM something INTO something"
+            ).transformForExecution()
+        }
+    }
+
+    @Test
+    fun testSandboxedQueryWithWildcard() {
+        assertThrows<RestrictedWildcardResultColumn> {
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "SELECT * FROM something"
+            ).transformForExecution()
+        }
+    }
+
+    @Test
+    fun testSandboxedQueryWithRestrictedSources() {
+        assertThrows<SandboxRestrictionViolated> {
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "SELECT a FROM source"
+            ).transformForExecution()
+        }
+        assertThrows<SandboxRestrictionViolated> {
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "WITH b AS (SELECT a,b,c FROM source) SELECT a FROM b"
+            ).transformForExecution()
+        }
+    }
+
+    @Test
+    fun testSandboxRestrictedFunctions() {
+        assertThrows<RestrictedFunctionCall> {
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "SELECT SESSION_USER()").transformForExecution()
+        }
+        assertThrows<RestrictedFunctionCall> {
+            queryProcessor(
+                "WITH something AS (SELECT a,b,c FROM source) SELECT a,b,c FROM something LIMIT 10",
+                sandboxedQuery = "SELECT EXTERNAL_QUERY('','')").transformForExecution()
+        }
+    }
+
 
 
     @Test


### PR DESCRIPTION
Parametrized queries help filtering data a bit but they don't alow for a better
precision and joining of data being queried.

Solution: allow execution of sandboxed queries in endpoints

The idea here is that passing `sql` parameter in an endpoint will replace the
`SELECT` query in the pre-defined query but will *only* allow CTEs defined in
the pre-defined query to be used a source of data.

This change also makes Logflare.Endpoint.Cache instances partition by a pair of
`(Query, Params)` as opposed to just `Query`. This allows us to cache all
parameterized queries.