### PR TITLE
Problem: endpoint query cache invalidation is broken

### DIFF
--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -1,4 +1,15 @@
 defmodule Logflare.Endpoint.Cache do
+
+  # Find all processes for the query
+  def resolve(%Logflare.Endpoint.Query{id: id} = query) do
+    Enum.filter(:global.registered_names(), fn {__MODULE__, ^id, _} ->
+      true
+    _ ->
+      false
+    end) |> Enum.map(&:global.whereis_name/1)
+  end
+
+  # Find or spawn a (query * param) process
   def resolve(%Logflare.Endpoint.Query{id: id} = query, params) do
     :global.set_lock({__MODULE__, {id, params}})
 

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -117,7 +117,7 @@ defmodule LogflareWeb.EndpointController do
       |> Logflare.Repo.one()
       |> Logflare.Repo.preload(:user)
 
-    Logflare.Endpoint.Cache.resolve(endpoint_query, %{}) |> Logflare.Endpoint.Cache.invalidate()
+    for q <- Logflare.Endpoint.Cache.resolve(endpoint_query), do: Logflare.Endpoint.Cache.invalidate(q)
 
     Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, params)
     |> Logflare.Repo.update()


### PR DESCRIPTION
It's trying to lookup a specific endpoint query cache with no given parameters,
so it'll only invalidate the no-parameters cache. But it will not invalidate
parameterized instances.

Solution: iterate over all matching registered cache instances

The implementation is not highly efficient as we're iterating over all
`global`ly-registered names, but it works for the time being and current load (at least
it should). Switching to a registry where a more efficient pattern lookup is possible
will fix this problem.