### PR TITLE
Problem: some quoted table names are not translated to sources

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/TableVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TableVisitor.kt
@@ -27,7 +27,7 @@ internal abstract class TableVisitor : TParseTreeVisitor() {
 
     override fun postVisit(node: TSelectSqlStatement?) {
         node!!.tables.forEach { table ->
-            val name = table.tableName.tableString
+            val name = table.fullTableName()
             // if table is not coming from CTE
             if (!isInCTE(name)) {
                 if (table.tableType == ETableSource.unnest) {

--- a/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
@@ -1,5 +1,6 @@
 package app.logflare.sql
 
+import gudusoft.gsqlparser.TBaseType
 import gudusoft.gsqlparser.nodes.*
 import gudusoft.gsqlparser.stmt.TSelectSqlStatement
 
@@ -17,7 +18,7 @@ internal class TransformerVisitor(
         table.tableName.setString(newName)
         val tableRenamer = object : TParseTreeVisitor() {
             override fun postVisit(node: TObjectName?) {
-                if (node?.objectToken != null && node.tableString == name) {
+                if (node?.objectToken != null && TBaseType.getTextWithoutQuoted(node.tableString) == name) {
                     node.objectToken.setString(newName)
                 }
             }

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -51,6 +51,36 @@ internal class QueryProcessorTest {
     }
 
     @Test
+    fun testTableNameSubstitutionBackquoted() {
+        assertEquals(
+            "SELECT a,b,c FROM ${tableName("source")} WHERE ${tableName("source")}.d > 4",
+            queryProcessor("SELECT a,b,c FROM `source` WHERE `source`.d > 4").transformForExecution())
+    }
+
+    @Test
+    fun testTableNameSubstitutionBackquotedMatchingCTEName() {
+        assertEquals(
+            """
+                WITH src as (
+                  SELECT
+                  name
+                  FROM ${tableName("first.src")}
+                )
+                SELECT value FROM src
+                """.trimIndent(),
+            queryProcessor(
+                """
+                WITH src as (
+                  SELECT
+                  name
+                  FROM `first.src`
+                )
+                SELECT value FROM src
+                """.trimIndent()
+               ).transformForExecution())
+    }
+
+    @Test
     fun testTableNameSubstitutionSelectClause() {
         assertEquals(
             "SELECT ${tableName("source")}.a,b,c FROM ${tableName("source")}",


### PR DESCRIPTION
SQL component omits translating some names from table names to source names
when they are backquoted.

Solution: ensure full table name is used for comparison and quotes aren't

There's a particularly important aspect of doing the former. A case like this:

```sql
 WITH src as (
                  SELECT
                  name
                  FROM `first.src`
                )
                SELECT value FROM src
```

resulted in `first.src` treated as `src` and effectively not processed because
it matches CTE's name.