### PR TITLE
Problem: parameters in CTE subqueries don't get translated

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
@@ -1,5 +1,6 @@
 package app.logflare.sql
 
+import gudusoft.gsqlparser.nodes.TCTE
 import gudusoft.gsqlparser.nodes.TObjectName
 import gudusoft.gsqlparser.nodes.TParseTreeVisitor
 
@@ -11,6 +12,11 @@ class ParameterExtractor : TParseTreeVisitor() {
         if (node.toString().startsWith('@')) {
             parameters.add(node.toString().removePrefix("@"))
         }
+        super.postVisit(node)
+    }
+
+    override fun postVisit(node: TCTE?) {
+        node!!.subquery.acceptChildren(this)
         super.postVisit(node)
     }
 

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -314,6 +314,11 @@ internal class QueryProcessorTest {
     }
 
     @Test
+    fun testParameterExtractionInCTE() {
+        assertEquals(queryProcessor("with q as (SELECT a, @a FROM b WHERE char_length(@c) > 4) select 1").parameters(), setOf("c", "a"))
+    }
+
+    @Test
     fun testSourceExtraction() {
         assertEquals(queryProcessor("SELECT a, b FROM a,b,c").sources(),
             setOf(sourceResolver().resolve("a"),


### PR DESCRIPTION
This prevents use of parameters in CTEs in general and, in particular,
impacts the usefuless of sandboxed queries as those rely on CTEs for
sandboxing.

Solution: make ParameterExtractor go deeper on CTEs

It turns out, TCTE's acceptChildren stops at TCTE and does not go into
the subquery.