### PR TITLE
Problem: no way to control caching intervals for endpoint queries

### DIFF
--- a/lib/logflare/endpoint/query.ex
+++ b/lib/logflare/endpoint/query.ex
@@ -8,6 +8,8 @@ defmodule Logflare.Endpoint.Query do
     field :query, :string
     field :source_mapping, :map
     field :sandboxable, :boolean
+    field :cache_duration_seconds, :integer
+    field :proactive_requerying_seconds, :integer
 
     belongs_to :user, Logflare.User
 
@@ -17,7 +19,7 @@ defmodule Logflare.Endpoint.Query do
   @doc false
   def changeset(query, attrs) do
     query
-    |> cast(attrs, [:name, :token, :query, :sandboxable])
+    |> cast(attrs, [:name, :token, :query, :sandboxable, :cache_duration_seconds, :proactive_requerying_seconds])
     |> validate_required([:name, :token, :query])
   end
 
@@ -27,7 +29,8 @@ defmodule Logflare.Endpoint.Query do
       :name,
       :token,
       :query,
-      :sandboxable
+      :sandboxable,
+      :cache_duration_seconds, :proactive_requerying_seconds
     ])
     |> default_validations()
     |> update_source_mapping()

--- a/lib/logflare_web/templates/endpoint/edit.html.eex
+++ b/lib/logflare_web/templates/endpoint/edit.html.eex
@@ -29,5 +29,23 @@
     <%= submit "Reset", class: "btn btn-primary form-button" %>
     <% end %>
 
+    <%= section_header("Cache settings") %>
+    <div class="form-group">
+      <%= form_for @changeset, Routes.endpoint_path(@conn, :update, @endpoint_query), fn a -> %>
+      <%= text_input a, :cache_duration_seconds, placeholder: "Caching interval", class: "form-control form-control-margin" %>
+      <%= error_tag a, :query %>
+      <small class="form-text text-muted">
+      Caching interval, in seconds. Zero disables caching.
+      </small>
+
+      <%= text_input a, :proactive_requerying_seconds, placeholder: "Cache warming interval", class: "form-control form-control-margin" %>
+      <%= error_tag a, :query %>
+      <small class="form-text text-muted">
+      Cache warming interval, in seconds. It will proactively re-query the endpoint at these intervals.
+    </small>
+    </div>
+    <%= submit "Update cache settings", class: "btn btn-primary form-button" %>
+    <% end %>
+
   </div>
 </div>

--- a/priv/repo/migrations/20211130201505_configurable_endpoint_caching.exs
+++ b/priv/repo/migrations/20211130201505_configurable_endpoint_caching.exs
@@ -1,0 +1,10 @@
+defmodule Logflare.Repo.Migrations.ConfigurableEndpointCaching do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      add :cache_duration_seconds, :integer, default: 1800
+      add :proactive_requerying_seconds, :integer, default: 1800
+    end
+  end
+end


### PR DESCRIPTION
Solution: make endpoint query caching intervals configurable

`cache_duration_seconds` -- how long to cache the value for (default: 1800 secs, 0 turns caching off)
`proactive_requerying_seconds` -- how often to refresh proactively (default: 1800 secs, 0 turns requerying off)