### PR TITLE
Problem: SQL parser doesn't pick up parameters in certain cases

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
@@ -1,8 +1,6 @@
 package app.logflare.sql
 
-import gudusoft.gsqlparser.nodes.TCTE
-import gudusoft.gsqlparser.nodes.TObjectName
-import gudusoft.gsqlparser.nodes.TParseTreeVisitor
+import gudusoft.gsqlparser.nodes.*
 
 class ParameterExtractor : TParseTreeVisitor() {
 
@@ -17,6 +15,12 @@ class ParameterExtractor : TParseTreeVisitor() {
 
     override fun postVisit(node: TCTE?) {
         node!!.subquery.acceptChildren(this)
+        super.postVisit(node)
+    }
+
+    override fun postVisit(node: TFunctionCall?) {
+        // GSP doesn't iterate over `args` which seem to contain parameters in our case
+        node!!.args.acceptChildren(this)
         super.postVisit(node)
     }
 

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -314,6 +314,12 @@ internal class QueryProcessorTest {
     }
 
     @Test
+    fun testParameterExtractionNestedInCall() {
+        assertEquals(queryProcessor("SELECT a, @a FROM b WHERE d > timestamp_add(@c, interval 7 day)").parameters(), setOf("c", "a"))
+        assertEquals(queryProcessor("SELECT a, @a FROM b WHERE d > timestamp_sub(@c, interval 7 day)").parameters(), setOf("c", "a"))
+    }
+
+    @Test
     fun testParameterExtractionInCTE() {
         assertEquals(queryProcessor("with q as (SELECT a, @a FROM b WHERE char_length(@c) > 4) select 1").parameters(), setOf("c", "a"))
     }


### PR DESCRIPTION
For example, here it won't pick up @c:

```
SELECT a, @a FROM b WHERE d > timestamp_sub(@c, interval 7 day)
```

Solution: ensure GSP traverses node `args`

As GSP is scarcely documented, my exploration through debugging
showed that `args` property contains parameter names we're looking for,
so we should extract them.

Currently, we'll handle this inside of function calls.