### PR TITLE
Problem: parameter extraction failing

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/ParameterExtractor.kt
@@ -20,7 +20,7 @@ class ParameterExtractor : TParseTreeVisitor() {
 
     override fun postVisit(node: TFunctionCall?) {
         // GSP doesn't iterate over `args` which seem to contain parameters in our case
-        node!!.args.acceptChildren(this)
+        node!!.args?.acceptChildren(this)
         super.postVisit(node)
     }
 


### PR DESCRIPTION
```
"
Cannot invoke \"gudusoft.gsqlparser.nodes.TExpressionList.acceptChildren(gudusoft.gsqlparser.nodes.TParseTreeVisitor)\" because the return value of \"gudusoft.gsqlparser.nodes.TFunctionCall.getArgs()\" is null
"
```

Solution: ensure we don't execute `acceptChildren` on a null expression list