### PR TITLE
Problem: it's hard to understand the schema of sandboxed endpoints

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -75,6 +75,12 @@ defmodule Logflare.SQL do
     {:noreply, put_in(state.requests[ref], from)}
   end
 
+  def handle_call({:cte_schema, query}, from, state) do
+    ref = make_ref()
+    send(state.pid, {:cteSchema, self(), ref, query})
+    {:noreply, put_in(state.requests[ref], from)}
+  end
+
   def handle_call({:sources, query, user_id}, from, state) do
     ref = make_ref()
     send(state.pid, {:sources, self(), ref, query, user_id})
@@ -136,6 +142,13 @@ defmodule Logflare.SQL do
   """
   def parameters(query, timeout \\ 60_000) do
     GenServer.call(__MODULE__, {:parameters, query}, timeout)
+  end
+
+  @doc """
+  Gets CTE schema from the query
+  """
+  def cte_schema(query, timeout \\ 60_000) do
+    GenServer.call(__MODULE__, {:cte_schema, query}, timeout)
   end
 
   @doc """

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -37,6 +37,22 @@ defmodule LogflareWeb.EndpointController do
     end
   end
 
+  def sandbox_schema(%{params: %{"token" => token}} = conn, _) do
+    query =
+      from q in Logflare.Endpoint.Query,
+        where: q.token == ^token
+
+    endpoint_query = Logflare.Repo.one(query) |> Logflare.Endpoint.Query.map_query()
+
+    case Logflare.SQL.cte_schema(endpoint_query.query) do
+      {:ok, result} ->
+        render(conn, "sandbox_schema.json", schema: result)
+
+      {:error, err} ->
+        render(conn, "sandbox_schema.json", error: err)
+    end
+  end
+
   def index(%{assigns: %{user: user}} = conn, _) do
     render(conn, "index.html",
       endpoint_queries: Logflare.Repo.preload(user, :endpoint_queries).endpoint_queries,

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -150,6 +150,7 @@ defmodule LogflareWeb.Router do
   scope "/endpoints/query", LogflareWeb do
     pipe_through [:api]
     get "/:token", EndpointController, :query
+    get "/:token/sandbox_schema", EndpointController, :sandbox_schema
   end
 
   scope "/endpoints", LogflareWeb do

--- a/lib/logflare_web/views/endpoint_view.ex
+++ b/lib/logflare_web/views/endpoint_view.ex
@@ -10,4 +10,12 @@ defmodule LogflareWeb.EndpointView do
         %{error: error}
     end
 
+    def render("sandbox_schema.json", %{schema: data}) do
+        %{schema: data}
+    end
+
+    def render("sandbox_schema.json", %{error: error}) do
+        %{error: error}
+    end
+
   end

--- a/sql/src/main/kotlin/app/logflare/sql/CTESchemaExtractor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/CTESchemaExtractor.kt
@@ -1,0 +1,47 @@
+package app.logflare.sql
+
+import gudusoft.gsqlparser.EExpressionType
+import gudusoft.gsqlparser.EFunctionType
+import gudusoft.gsqlparser.nodes.TAliasClause
+import gudusoft.gsqlparser.nodes.TCTE
+import gudusoft.gsqlparser.nodes.TExpression
+import gudusoft.gsqlparser.nodes.TParseTreeVisitor
+import gudusoft.gsqlparser.stmt.TSelectSqlStatement
+
+class CTESchemaExtractor(): TParseTreeVisitor() {
+
+    val schema: MutableMap<String, MutableMap<String, String>> = mutableMapOf()
+
+    private var currentCte: String? = null
+
+    override fun preVisit(node: TCTE?) {
+        currentCte = node!!.tableName.objectString
+        super.postVisit(node)
+    }
+
+    override fun postVisit(node: TCTE?) {
+        node!!.subquery.acceptChildren(this)
+        currentCte = null
+        super.postVisit(node)
+    }
+
+    override fun postVisit(node: TSelectSqlStatement?) {
+        if (currentCte != null) {
+            val cteSchema = schema.getOrPut(currentCte!!) { mutableMapOf() }
+            val columns = node!!.resultColumnList
+            columns.forEach { col ->
+                val name = col.columnNameOnly.ifEmpty { col.columnAlias }
+                if (name.isNotEmpty()) {
+                    if (col.expr is TExpression && col.expr.expressionType == EExpressionType.function_t &&
+                            col.expr.functionCall.functionType == EFunctionType.cast_t) {
+                        cteSchema[name] = col.expr.functionCall.typename.dataTypeName
+                    } else {
+                        cteSchema[name] = "any"
+                    }
+                }
+            }
+        }
+        super.postVisit(node)
+    }
+
+}

--- a/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/QueryProcessor.kt
@@ -122,4 +122,12 @@ class QueryProcessor(
         statement.acceptChildren(SourceMappingVisitor(mapping, sourceResolver))
         return statement.toString()
     }
+
+    fun cteSchema(): Map<String, Map<String, String>> {
+        parse()
+        val statement = parser.sqlstatements[0]
+        val cteSchemaExtractor = CTESchemaExtractor()
+        statement.cteList.acceptChildren(cteSchemaExtractor)
+        return cteSchemaExtractor.schema
+    }
 }

--- a/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
+++ b/sql/src/test/kotlin/app/logflare/sql/QueryProcessorTest.kt
@@ -429,6 +429,25 @@ internal class QueryProcessorTest {
         }
     }
 
+    @Test
+    fun testCTESchema() {
+        assertEquals(
+            mapOf("tab1" to mapOf("a" to "any", "a1" to "int"), "tab2" to mapOf("b" to "any")),
+            queryProcessor("""
+                WITH tab1 AS (
+                SELECT a,
+                       a + 1,
+                       CAST(a AS INTEGER) AS a1
+                       FROM src
+                   ),
+                   tab2 AS (
+                       SELECT b from src1
+                   )
+                   SELECT 1;
+                """.trimIndent()).cteSchema()
+        )
+    }
+
 
 
 }


### PR DESCRIPTION
Solution: expose an API call for extracting sandboxed endpoint query schema

The columns defined in CTEs have to be explicitly named and if the type information
is important, it has to be casted using `CAST(value AS type) AS column_name` in
order to derive type information.