### PR TITLE
Problem: under memory pressure, caching endpoints can hog resources

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,9 @@ defmodule Logflare.Mixfile do
         :ssl,
         :phoenix_html,
         :phoenix,
-        :erlexec
+        :erlexec,
+        :sasl,
+        :os_mon
       ]
     ]
   end


### PR DESCRIPTION
This can lead to memory exhaustion on a given node and a subsequent restart,
which is not great.

Solution: start endpoint caches on other nodes in the cluster
when memory is higher than a set watermark (90%)

What is even more important, upon reaching this condition, the local node
will start pruning (or forcefully evicting) local endpoint caches that
haven't been used for over 5 minutes.

Note: this change also fixes a bug in endpoint caches where DynamicSupervisor
restarts a child that is normally terminated. They are now properly accounted
as transient children.