### PR TITLE
Problem: endpoint termination during query

### DIFF
--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -22,6 +22,7 @@ defmodule Logflare.Endpoint.Cache do
           pid
 
         pid ->
+          GenServer.call(pid, :touch)
           pid
       end
 
@@ -49,6 +50,11 @@ defmodule Logflare.Endpoint.Cache do
 
   def init({query, params}) do
     {:ok, %__MODULE__{query: query, params: params} |> fetch_latest_query_endpoint() }
+  end
+
+  def handle_call(:touch, _from, %__MODULE__{} = state) do
+    state = %{state | last_query_at: DateTime.utc_now()}
+    {:reply, :ok, state}
   end
 
   def handle_call(:query, _from, %__MODULE__{cached_result: nil} = state) do


### PR DESCRIPTION
Logs indicate that there was on occurrence of endpoint query execution
being terminated with `crash_reason` of `shutdown` which indicates that
the endpoint cache process terminated while `query` call was being processed.

Solution: reset expiration timer upon endpoint process resolution

My working theory of what could have happened there:

1. We have a running endpoint E.
2. E approaches cache expiration time.
3. We resolve query to the endpoint E.
4. We start making a query call to E.
5. Just before gen_server sends a message for the call, its internal timeout is processed and the process is stopped.
6. gen_server doesn't get a response but gets a termination notice.

Essentially, a race condition.

In an attempt to resolve it, if endpoint resolution points us to an existing
process, we make a call to it (`touch`) to update `last_query_at` to prevent
a potential timeout handler from terminating the process too early.