### PR TITLE
Problem: gsp 2.5.0.8 fails tests

### DIFF
--- a/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
+++ b/sql/src/main/kotlin/app/logflare/sql/TransformerVisitor.kt
@@ -11,8 +11,14 @@ internal class TransformerVisitor(
     private val datasetResolver: DatasetResolver<Source>
 ) : RestrictedPatternVisitor() {
 
+    private val visited = mutableSetOf<TTable>()
+
     override fun visit(table: TTable?, node: TParseTreeNode) {
-        val name = table!!.fullTableName()
+        if (visited.contains(table!!)) {
+            return;
+        }
+        visited.add(table)
+        val name = table.fullTableName()
         val source = sourceResolver.resolve(name)
         val newName = "`${projectId}.${datasetResolver.resolve(source)}.${tableResolver.resolve(source)}`"
         table.tableName.setString(newName)


### PR DESCRIPTION
It seems as if table names are mapped twice.

Solution: ensure visitor visits tables only once

This might not be a perfect fix, but it might serve
as a temporary mitigation for the problem. Time will show.