### PR TITLE
feat: add in /api/endpoints/query route

### DIFF
--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -3,6 +3,9 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
   Verifies if a user has access to a requested resource.
 
   Assigns the token's associated user if the token is provided
+
+  Options:
+  - `:resource`, required - an atom determining the resource accessed, as each resource has its own authorization verification flow.
   """
   import Plug.Conn
   import Phoenix.Controller
@@ -11,11 +14,11 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
 
   def init(_), do: nil
 
-  def call(%{request_path: path} = conn, _) do
-    cond do
-      path =~ "/endpoints" -> do_auth(:endpoints, conn)
-      true -> do_auth(nil, conn)
-    end
+  def call(conn, opts) do
+    opts
+    |> Enum.into(%{})
+    |> Map.get(:resource)
+    |> do_auth(conn)
   end
 
   defp do_auth(:endpoints, conn) do

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -11,12 +11,11 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
 
   def init(_), do: nil
 
-  def call(%{request_path: "/endpoints/query" <> _} = conn, _) do
-    do_auth(:endpoints, conn)
-  end
-
-  def call(%{request_path: _} = conn) do
-    do_auth(nil, conn)
+  def call(%{request_path: path} = conn, _) do
+    cond do
+      path =~ "/endpoints" -> do_auth(:endpoints, conn)
+      true -> do_auth(nil, conn)
+    end
   end
 
   defp do_auth(:endpoints, conn) do

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -95,8 +95,8 @@ defmodule LogflareWeb.Router do
     plug LogflareWeb.Plugs.CheckTeamUser
   end
 
-  pipeline :api_auth do
-    plug LogflareWeb.Plugs.VerifyApiAccess
+  pipeline :api_auth_endpoints do
+    plug LogflareWeb.Plugs.VerifyApiAccess, resource: :endpoints
   end
 
   pipeline :auth_switch do
@@ -152,7 +152,7 @@ defmodule LogflareWeb.Router do
   end
 
   scope "/endpoints/query", LogflareWeb do
-    pipe_through [:api, :api_auth]
+    pipe_through [:api, :api_auth_endpoints]
     get "/:token", EndpointController, :query
   end
 
@@ -359,7 +359,7 @@ defmodule LogflareWeb.Router do
   end
 
   scope "/api/endpoints", LogflareWeb do
-    pipe_through [:api, :api_auth]
+    pipe_through [:api, :api_auth_endpoints]
     get "/query/:token", EndpointController, :query
   end
 

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -358,6 +358,11 @@ defmodule LogflareWeb.Router do
     post "/", LogController, :create
   end
 
+  scope "/api/endpoints", LogflareWeb do
+    pipe_through [:api, :api_auth]
+    get "/query/:token", EndpointController, :query
+  end
+
   # Log ingest goes through https://api.logflare.app/logs
   scope "/logs", LogflareWeb do
     pipe_through [:api, :require_ingest_api_auth]

--- a/test/logflare_web/plugs/verify_api_access_test.exs
+++ b/test/logflare_web/plugs/verify_api_access_test.exs
@@ -27,7 +27,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
       conn =
         conn
         |> put_req_header("x-api-key", token.token)
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert conn.halted == false
       assert conn.assigns.user.id == user.id
@@ -37,7 +37,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{token.token}")
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert conn.halted == false
       assert conn.assigns.user.id == user.id
@@ -49,7 +49,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
       conn =
         conn
         |> Map.put(:params, new_params)
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert conn.halted == false
       assert conn.assigns.user.id == user.id
@@ -59,7 +59,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
       conn =
         conn
         |> put_req_header("x-api-key", "123")
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert_unauthorized(conn)
     end
@@ -71,7 +71,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
       conn =
         conn
         |> put_req_header("x-api-key", token2.token)
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert_unauthorized(conn)
     end
@@ -87,7 +87,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
     test "does not halt request", %{conn: conn} do
       conn =
         conn
-        |> VerifyApiAccess.call(%{})
+        |> VerifyApiAccess.call(%{resource: :endpoints})
 
       assert conn.halted == false
       assert Map.get(conn.assigns, :user) == nil


### PR DESCRIPTION
Adds in the `/api/endpoints/query/:token` route, with the `/endpoints/query/:token` route to be considered deprecated.


