### PR TITLE
chore: indentation fix for github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,8 @@ jobs:
     #   run: mix test.compile
     # - name: Test - security
     #   run: mix test.security
-    - name: Code quality - formatting
-      run: mix test.format
+      - name: Code quality - formatting
+        run: mix test.format
     # - name: Code quality - typings
     #   run: mix test.typings
     # - name: Code quality - linting


### PR DESCRIPTION
yaml indentation when I previously uncommented a new step was causing the whole action to fail.