### PR TITLE
Dev conveniences

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -92,3 +92,8 @@ config :logflare, Logflare.CacheBuster,
   publications: ["logflare_pub"]
 
 import_config "#{Mix.env()}.exs"
+
+# Any local configs a developer would like to set for themselves
+if Mix.env() == :dev do
+  import_config "local.secret.exs"
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -106,5 +106,7 @@ config :logflare, Logflare.Vercel.Client,
 config :goth,
   json: "config/secrets/logflare-dev-238720-63d50e3c9cc8.json" |> File.read!()
 
+config :logflare, Logflare.Cluster.Utils, min_cluster_size: 1
+
 import_config "dev.secret.exs"
 import_config "telemetry.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -143,6 +143,8 @@ config :logflare, Logflare.Vercel.Client,
 
 config :erlexec, root: true, user: "root"
 
+config :logflare, Logflare.Cluster.Utils, min_cluster_size: 2
+
 import_config "telemetry.exs"
 
 if File.exists?("config/prod.secret.exs") do

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -92,6 +92,8 @@ config :logflare, Logflare.Vercel.Client,
 
 config :erlexec, root: true, user: "root"
 
+config :logflare, Logflare.Cluster.Utils, min_cluster_size: 1
+
 import_config "telemetry.exs"
 
 if File.exists?("config/staging.secret.exs") do

--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -2,7 +2,7 @@ defmodule Logflare.Cluster.Utils do
   @moduledoc false
   require Logger
 
-  @min_cluster_size 2
+  @min_cluster_size Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
 
   def node_list_all() do
     [Node.self() | Node.list()]


### PR DESCRIPTION
- Imports a local config so you can override configs only locally like the log level
- Makes min_cluster_size configurable so it doesn't log so much locally