### PR TITLE
chore: add docs & specs to functions, remove unused code

### DIFF
--- a/lib/logflare/auth.ex
+++ b/lib/logflare/auth.ex
@@ -1,41 +1,33 @@
 defmodule Logflare.Auth do
-  @max_age_default 86_400
-
-  alias Phoenix.Token
-  alias Logflare.User
-  alias Logflare.Teams.Team
-  alias Logflare.OauthAccessTokens.OauthAccessToken
-  alias Logflare.Repo
+  @moduledoc "Authorization context"
   import Ecto.Query
+  alias Phoenix.Token
+  alias Logflare.{Repo, User, Teams.Team, OauthAccessTokens.OauthAccessToken}
+  @max_age_default 86_400
   @salt Application.get_env(:logflare, LogflareWeb.Endpoint)[:secret_key_base]
   @oauth_config Application.get_env(:logflare, ExOauth2Provider)
 
-  def gen_email_token(email) when is_binary(email) do
-    Token.sign(LogflareWeb.Endpoint, @salt, email)
+  @doc "Generates an email token, accepting either an email or id"
+  @spec gen_email_token(String.t() | number) :: String.t()
+  def gen_email_token(email_or_id) when is_binary(email_or_id) or is_integer(email_or_id) do
+    Token.sign(LogflareWeb.Endpoint, @salt, email_or_id)
   end
 
-  def gen_email_token(id) when is_integer(id) do
-    Token.sign(LogflareWeb.Endpoint, @salt, id)
-  end
-
-  def gen_email_token(map) when is_map(map) do
-    Token.sign(LogflareWeb.Endpoint, @salt, map)
-  end
-
+  @doc "Verifies the email token"
   @spec verify_email_token(nil | binary, any) ::
           {:error, :expired | :invalid | :missing} | {:ok, any}
   def verify_email_token(token, max_age \\ @max_age_default) do
     Token.verify(LogflareWeb.Endpoint, @salt, token, max_age: max_age)
   end
 
+  @doc "Generates a gravatar link based on the user's email"
+  @spec gen_gravatar_link(String.t()) :: String.t()
   def gen_gravatar_link(email) do
     hash = :crypto.hash(:md5, String.trim(email)) |> Base.encode16(case: :lower)
     "https://www.gravatar.com/avatar/" <> hash
   end
 
-  @doc """
-  Lsit Oauth access tokens by user
-  """
+  @doc "List Oauth access tokens by user"
   @spec list_valid_access_tokens(%User{}) :: [%OauthAccessToken{}]
   def list_valid_access_tokens(%User{id: user_id}) do
     Repo.all(
@@ -43,9 +35,7 @@ defmodule Logflare.Auth do
     )
   end
 
-  @doc """
-  Creates an Oauth access token with no expiry, linked to the given user or team's user.
-  """
+  @doc "Creates an Oauth access token with no expiry, linked to the given user or team's user."
   @typep create_attrs :: %{description: String.t()} | map()
   @spec create_access_token(%Team{} | %User{}, create_attrs()) ::
           {:ok, %OauthAccessToken{}} | {:error, term()}
@@ -65,9 +55,7 @@ defmodule Logflare.Auth do
     end
   end
 
-  @doc """
-  Verifies a  `%OauthAccessToken{}` or string access token. If valid, returns the token's associated user.
-  """
+  @doc "Verifies a  `%OauthAccessToken{}` or string access token. If valid, returns the token's associated user."
   @spec verify_access_token(%OauthAccessToken{} | binary()) :: {:ok, %User{}} | {:error, term()}
   def verify_access_token(%OauthAccessToken{token: str_token}) do
     verify_access_token(str_token)
@@ -84,9 +72,7 @@ defmodule Logflare.Auth do
     end
   end
 
-  @doc """
-  Revokes a given access token.
-  """
+  @doc "Revokes a given access token."
   @spec revoke_access_token(%OauthAccessToken{} | binary()) :: :ok | {:error, term()}
   def revoke_access_token(token) when is_binary(token) do
     ExOauth2Provider.AccessTokens.get_by_token(token)


### PR DESCRIPTION
Adds docs + specs to remaining auth functions, removes an unused email-related function.

Tests have been deferred to [backlog](https://www.notion.so/supabase/AuthTest-tests-for-email-tokens-move-gravatar-cfa030fe66f4415997a4861282ec9158) 