### PR TITLE
fix: plug init options not passed as opts to each plug call.

### DIFF
--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -12,11 +12,10 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
   alias Logflare.Auth
   alias Logflare.{Endpoint}
 
-  def init(_), do: nil
+  def init(args), do: args |> Enum.into(%{})
 
   def call(conn, opts) do
     opts
-    |> Enum.into(%{})
     |> Map.get(:resource)
     |> do_auth(conn)
   end


### PR DESCRIPTION
Bugfix for the following error for api requests to `/endpoints/query`
```
#PID<0.10604.37> running LogflareWeb.Endpoint (connection #PID<0.32396.4>, stream id 175) terminated Server: logflare.app:80 (http) Request: GET /endpoints/query/[REDACTED]?project=[REDACTED]&sql=SELECT+count%28*%29+as+count+FROM+postgres_logs&iso_timestamp_start=2022-06-09T17%3A28%3A15.904Z&project_tier=PAYG ** 
(exit) an exception was raised: ** 
(Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): Ecto.Adapters.SQL.Stream, Postgrex.Stream, LQueue, DBConnection.PrepareStream, DBConnection.Stream, Timex.Interval, Flow, Floki.HTMLTree, Scrivener.Page, Jason.OrderedObject, Iteraptor.Array, Function, GenEvent.Stream, List, MapSet, Stream, HashSet, Date.Range, Map, HashDict, IO.Stream, Range, File.Stream 
(elixir 1.12.3) lib/enum.ex:1: Enumerable.impl_for!/1 
(elixir 1.12.3) lib/enum.ex:141: Enumerable.reduce/3 
(elixir 1.12.3) lib/enum.ex:3958: Enum.reverse/1 
(elixir 1.12.3) lib/enum.ex:3317: Enum.to_list/1 
(elixir 1.12.3) lib/enum.ex:1438: Enum.into_map/1 
(logflare 1.0.0) lib/logflare_web/controllers/plugs/verify_api_access.ex:19: LogflareWeb.Plugs.VerifyApiAccess.call/2 
(logflare 1.0.0) LogflareWeb.Router.api_auth_endpoints/2 
(logflare 1.0.0) lib/logflare_web/router.ex:1: LogflareWeb.Router.__pipe_through4__/1
```

Basically, plug init was not passing values to the opts as expected.