### PR TITLE
fix: BillingCount schema reference

### DIFF
--- a/lib/logflare/billing/billing_counts.ex
+++ b/lib/logflare/billing/billing_counts.ex
@@ -4,11 +4,11 @@ defmodule Logflare.Billing.BillingCounts do
   """
   require Logger
   import Ecto.Query, warn: false
-  alias Logflare.{User, Repo}
+  alias Logflare.{User, Repo, BillingCounts.BillingCount}
 
   def timeseries(%User{id: user_id}, start_date, end_date) do
     q =
-      from(c in Count,
+      from(c in BillingCount,
         where: c.user_id == ^user_id,
         where: c.inserted_at >= ^start_date and c.inserted_at <= ^end_date,
         group_by: fragment("date(?)", c.inserted_at),


### PR DESCRIPTION
Fixes `Count` to `BillingCount`, the only remaining reference from billing refactor attempted module renaming.

