### PR TITLE
fix: linking to contact page, add test coverage for marketing pages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -79,7 +79,7 @@ config :number,
 # of this file so it overrides the configuration defined above.
 config :logflare, LogflareWeb.Endpoint,
   live_view: [
-    signing_salt: System.get_env("PHOENIX_LIVE_VIEW_SECRET_SALT", "Fvo_-oQi4bjPfQLh" )
+    signing_salt: System.get_env("PHOENIX_LIVE_VIEW_SECRET_SALT", "Fvo_-oQi4bjPfQLh")
   ]
 
 config :scrivener_html,

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,7 +79,7 @@ config :number,
 # of this file so it overrides the configuration defined above.
 config :logflare, LogflareWeb.Endpoint,
   live_view: [
-    signing_salt: System.get_env("PHOENIX_LIVE_VIEW_SECRET_SALT")
+    signing_salt: System.get_env("PHOENIX_LIVE_VIEW_SECRET_SALT", "Fvo_-oQi4bjPfQLh" )
   ]
 
 config :scrivener_html,

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -64,7 +64,8 @@ defmodule Logflare.Application do
       Logflare.Repo,
       # get_goth_child_spec(),
       LogflareWeb.Endpoint,
-      {Task.Supervisor, name: Logflare.TaskSupervisor}
+      {Task.Supervisor, name: Logflare.TaskSupervisor},
+      Logflare.SystemMetricsSup
     ]
   end
 

--- a/lib/logflare_web/controllers/marketing_controller.ex
+++ b/lib/logflare_web/controllers/marketing_controller.ex
@@ -62,8 +62,4 @@ defmodule LogflareWeb.MarketingController do
   def log_search(conn, _params) do
     render(conn, "log_search.html")
   end
-
-  def getting_started(conn, _params) do
-    render(conn, "getting_started.html")
-  end
 end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -130,21 +130,19 @@ defmodule LogflareWeb.Router do
     get "/privacy", MarketingController, :privacy
     get "/cookies", MarketingController, :cookies
     get "/contact", MarketingController, :contact
-    get "/guides", MarketingController, :guides
   end
 
   scope "/guides", LogflareWeb do
     pipe_through :browser
+    get "/", MarketingController, :guides
     get "/overview", MarketingController, :overview
     get "/bigquery-setup", MarketingController, :big_query_setup
     get "/data-studio-setup", MarketingController, :data_studio_setup
     get "/event-analytics", MarketingController, :event_analytics_demo
     get "/log-search", MarketingController, :log_search
-    get "/getting-started", MarketingController, :getting_started
     get "/slack-app-setup", MarketingController, :slack_app_setup
     get "/vercel-setup", MarketingController, :vercel_setup
   end
-
   scope "/", LogflareWeb do
     pipe_through [:browser, :require_auth]
     get "/dashboard", SourceController, :dashboard

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -143,6 +143,7 @@ defmodule LogflareWeb.Router do
     get "/slack-app-setup", MarketingController, :slack_app_setup
     get "/vercel-setup", MarketingController, :vercel_setup
   end
+
   scope "/", LogflareWeb do
     pipe_through [:browser, :require_auth]
     get "/dashboard", SourceController, :dashboard

--- a/lib/logflare_web/templates/marketing/pricing.html.eex
+++ b/lib/logflare_web/templates/marketing/pricing.html.eex
@@ -10,15 +10,8 @@
                 </div>
             </div>
         </div>
-        <!--
-        <div class="my-5">
-        <%= live_render(@conn, LogflareWeb.LifetimeLive) %>
-        </div>
-        -->
         <div id="plans">
-
             <%= live_render(@conn, LogflareWeb.MeteredPlansLive) %>
-
         </div>
     </div>
 
@@ -86,7 +79,7 @@
         <div class="col-md-12">
             <div class="trialwork">
                 <h1>How do I sign up for an Enterprise plan?</h1>
-                <p><%= link "Contact us", to: Routes.marketing_path(@conn, :new) %> to learn more about our Enterprise
+                <p><%= link "Contact us", to: Routes.marketing_path(@conn, :contact) %> to learn more about our Enterprise
                     plans and support options. We can handle any event volume required. Need to ingest directly to the
                     EU? Curious about our AWS support? Need us to impliment a custom storage pipeline? We can help you
                     do just about anything you need with your data pipeline so please reach out.</p>
@@ -121,18 +114,6 @@
                 <h1 class="scroll-margin" id="rate-limit">What happens when I'm rate limited?</h1>
                 <p>The free plan is rate limited at 5 log events per second on average for the last 60 seconds. When you hit
                     that average we will stop ingesting log events. You will be warned via an email and an alert in the interface.</p>
-                <!--
-                <h1 class="scroll-margin" id="fair-use">What is considered fair use?</h1>
-                <p>We provide unlimited log event data for all standard plans up to 25 events per second on average over
-                    the last 60 seconds. Our rate limiting actually allows bursting above this limit up to a maximum of
-                    1,500 log events ingested in a single second. As an example, if you're doing 5 requests a second
-                    you'd be able to burst up to 1200 requests in a second (1500 - (5 * 60) = 1200).</p>
-                <p>If you require more throughput please <%= link "contact us", to: Routes.marketing_path(@conn, :new) %>
-                    about our Enterprise plans & support.</p>
-                <p>If we notice abuse of our fair use policy we'll typically reach out to discuss your continued use of
-                    Logflare that is feasible for both parties long term. However, we reserve the right to delete your
-                    account without notice.</p>
-                -->
             </div>
         </div>
     </div>

--- a/test/logflare_web/controllers/marketing_controller_test.exs
+++ b/test/logflare_web/controllers/marketing_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule LogflareWeb.MarketingControllerTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  for action <- [
+    :index,
+    :contact,
+    :pricing,
+    :overview,
+    :vercel_setup,
+    :big_query_setup,
+    :slack_app_setup,
+    :data_studio_setup,
+    :event_analytics_demo,
+    :terms,
+    :privacy,
+    :cookies,
+    :guides,
+    :log_search,
+  ] do
+    test "public marketing path #{action} ", %{
+      conn: conn,
+    } do
+      if unquote(action) == :pricing do
+        insert(:plan, price: 123, period: "month", name: "Metered")
+        insert(:plan, price: 123, period: "month", name: "Metered BYOB")
+      end
+      path = Routes.marketing_path(conn, unquote(action))
+      conn = conn |> get(path)
+      assert conn.status == 200
+    end
+  end
+end

--- a/test/logflare_web/controllers/marketing_controller_test.exs
+++ b/test/logflare_web/controllers/marketing_controller_test.exs
@@ -3,28 +3,29 @@ defmodule LogflareWeb.MarketingControllerTest do
   use LogflareWeb.ConnCase
 
   for action <- [
-    :index,
-    :contact,
-    :pricing,
-    :overview,
-    :vercel_setup,
-    :big_query_setup,
-    :slack_app_setup,
-    :data_studio_setup,
-    :event_analytics_demo,
-    :terms,
-    :privacy,
-    :cookies,
-    :guides,
-    :log_search,
-  ] do
+        :index,
+        :contact,
+        :pricing,
+        :overview,
+        :vercel_setup,
+        :big_query_setup,
+        :slack_app_setup,
+        :data_studio_setup,
+        :event_analytics_demo,
+        :terms,
+        :privacy,
+        :cookies,
+        :guides,
+        :log_search
+      ] do
     test "public marketing path #{action} ", %{
-      conn: conn,
+      conn: conn
     } do
       if unquote(action) == :pricing do
         insert(:plan, price: 123, period: "month", name: "Metered")
         insert(:plan, price: 123, period: "month", name: "Metered BYOB")
       end
+
       path = Routes.marketing_path(conn, unquote(action))
       conn = conn |> get(path)
       assert conn.status == 200

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -63,7 +63,9 @@ defmodule Logflare.Factory do
 
   def plan_factory() do
     %Plan{
-      stripe_id: "31415"
+      stripe_id: "31415",
+      price: 123,
+      period: "month"
     }
   end
 


### PR DESCRIPTION
Fixes a bug where marketing page references in templates were stale, leading to pricing page erroring out. Removes a few unused routes/actions.

Also adds controller test coverage for templates, to prevent such regressions.

Cleanup of code in separate PR.