### PR TITLE
fix: BillingWriter record_to_stripe get sub item id bug

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -64,7 +64,8 @@ defmodule Logflare.Application do
       Logflare.Repo,
       # get_goth_child_spec(),
       LogflareWeb.Endpoint,
-      {Task.Supervisor, name: Logflare.TaskSupervisor}
+      {Task.Supervisor, name: Logflare.TaskSupervisor},
+      Logflare.SystemMetricsSup
     ]
   end
 

--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -138,7 +138,7 @@ defmodule Logflare.Billing do
   end
 
   @doc "retrieves the stripe plan stored on the BillingAccount"
-  @spec get_billing_account_stripe_plan(%BillingAccount{}) :: nil | term()
+  @spec get_billing_account_stripe_plan(%BillingAccount{}) :: nil | map()
   def get_billing_account_stripe_plan(%BillingAccount{
         stripe_subscriptions: %{"data" => [%{"plan" => plan} | _]}
       }),
@@ -147,7 +147,7 @@ defmodule Logflare.Billing do
   def get_billing_account_stripe_plan(_), do: nil
 
   @doc "gets the stripe subscription item data stored on the BillingAccount"
-  @spec get_billing_account_stripe_subscription_item(%BillingAccount{}) :: nil | term()
+  @spec get_billing_account_stripe_subscription_item(%BillingAccount{}) :: nil | map()
 
   def get_billing_account_stripe_subscription_item(%BillingAccount{
         stripe_subscriptions: %{

--- a/lib/logflare/billing/stripe.ex
+++ b/lib/logflare/billing/stripe.ex
@@ -116,7 +116,7 @@ defmodule Logflare.Billing.Stripe do
 
   def change_subscription(billing_account, sources, to_plan) do
     [subscription] = billing_account.stripe_subscriptions["data"]
-    {:ok, item} = Billing.get_billing_account_stripe_subscription_item(billing_account)
+    item = Billing.get_billing_account_stripe_subscription_item(billing_account)
 
     delete_item = %{id: item["id"], deleted: true}
     add_item = %{price: to_plan.stripe_id, quantity: Enum.count(sources)}
@@ -127,7 +127,7 @@ defmodule Logflare.Billing.Stripe do
 
   def change_from_metered_subscription(billing_account, _sources, to_plan) do
     [subscription] = billing_account.stripe_subscriptions["data"]
-    {:ok, item} = Billing.get_billing_account_stripe_subscription_item(billing_account)
+    item = Billing.get_billing_account_stripe_subscription_item(billing_account)
 
     delete_item = %{id: item["id"], deleted: true, clear_usage: true}
     add_item = %{price: to_plan.stripe_id}
@@ -138,7 +138,7 @@ defmodule Logflare.Billing.Stripe do
 
   def change_to_metered_subscription(billing_account, _sources, to_plan) do
     [subscription] = billing_account.stripe_subscriptions["data"]
-    {:ok, item} = Billing.get_billing_account_stripe_subscription_item(billing_account)
+    item = Billing.get_billing_account_stripe_subscription_item(billing_account)
 
     delete_item = %{id: item["id"], deleted: true}
     add_item = %{price: to_plan.stripe_id}
@@ -149,7 +149,7 @@ defmodule Logflare.Billing.Stripe do
 
   def change_metered_to_standard_subscription(billing_account, sources, to_plan) do
     [subscription] = billing_account.stripe_subscriptions["data"]
-    {:ok, item} = Billing.get_billing_account_stripe_subscription_item(billing_account)
+    item = Billing.get_billing_account_stripe_subscription_item(billing_account)
 
     delete_item = %{id: item["id"], deleted: true, clear_usage: true}
     add_item = %{price: to_plan.stripe_id, quantity: Enum.count(sources)}

--- a/lib/logflare/source/billing_writer.ex
+++ b/lib/logflare/source/billing_writer.ex
@@ -1,4 +1,5 @@
 defmodule Logflare.Source.BillingWriter do
+  @moduledoc false
   use GenServer
 
   alias Logflare.Source.RecentLogsServer, as: RLS
@@ -54,14 +55,14 @@ defmodule Logflare.Source.BillingWriter do
   defp record_to_stripe(rls, count) do
     billing_account = rls.user.billing_account
 
-    with {:ok, si} <-
+    with %{"id" => si_id} <-
            Billing.get_billing_account_stripe_subscription_item(billing_account),
          {:ok, _response} <-
-           Billing.Stripe.record_usage(si["id"], count) do
+           Billing.Stripe.record_usage(si_id, count) do
       :noop
     else
       {:error, resp} ->
-        Logger.error("Error recording usage with Stripe",
+        Logger.error("Error recording usage with Stripe. #{inspect(resp)}",
           source_id: rls.source.token,
           error_string: inspect(resp)
         )

--- a/lib/logflare_web/controllers/plugs/check_source_count.ex
+++ b/lib/logflare_web/controllers/plugs/check_source_count.ex
@@ -37,7 +37,7 @@ defmodule LogflareWeb.Plugs.CheckSourceCount do
          %{assigns: %{user: user}, method: "POST"} = conn,
          source_count
        ) do
-    {:ok, item} =
+    item =
       Billing.Cache.get_billing_account_by(user_id: user.id)
       |> Billing.get_billing_account_stripe_subscription_item()
 
@@ -52,7 +52,7 @@ defmodule LogflareWeb.Plugs.CheckSourceCount do
          %{assigns: %{user: user}, method: "DELETE"} = conn,
          source_count
        ) do
-    {:ok, item} =
+    item =
       Billing.Cache.get_billing_account_by(user_id: user.id)
       |> Billing.get_billing_account_stripe_subscription_item()
 

--- a/lib/logflare_web/live/access_tokens_live.ex
+++ b/lib/logflare_web/live/access_tokens_live.ex
@@ -131,7 +131,6 @@ defmodule LogflareWeb.AccessTokensLive do
         %{"token-id" => token_id},
         %{assigns: %{access_tokens: tokens}} = socket
       ) do
-    IO.inspect(token_id)
     token = Enum.find(tokens, &("#{&1.id}" == token_id))
     Logger.debug("Revoking access token")
     :ok = Auth.revoke_access_token(token)

--- a/test/logflare/billing_test.exs
+++ b/test/logflare/billing_test.exs
@@ -37,8 +37,8 @@ defmodule Logflare.BillingTest do
 
     test "stripe get in helpers" do
       ba = build(:billing_account)
-      assert Billing.get_billing_account_stripe_plan(ba) != nil
-      assert Billing.get_billing_account_stripe_subscription_item(ba) != nil
+      assert %{} = Billing.get_billing_account_stripe_plan(ba)
+      assert %{} = Billing.get_billing_account_stripe_subscription_item(ba)
     end
   end
 

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -22,7 +22,7 @@ defmodule Logflare.LogsTest do
   @moduletag :this
 
   setup_all do
-    Counters.start_link() |> IO.inspect()
+    Counters.start_link()
     :ok
   end
 

--- a/test/logflare/source/billing_writer_test.exs
+++ b/test/logflare/source/billing_writer_test.exs
@@ -8,9 +8,9 @@ defmodule Logflare.Source.BillingWriterTest do
 
   setup do
     user = insert(:user)
+    source = insert(:source, user: user)
     _billing_account = insert(:billing_account, user: user)
     user = user |> Logflare.Repo.preload(:billing_account)
-    source = insert(:source, user: user)
     plan = insert(:plan, type: "metered")
 
     pid =

--- a/test/logflare/source/billing_writer_test.exs
+++ b/test/logflare/source/billing_writer_test.exs
@@ -1,0 +1,44 @@
+defmodule Logflare.Source.BillingWriterTest do
+  @moduledoc false
+  use Logflare.DataCase
+  alias Logflare.Source.{BillingWriter, RecentLogsServer}
+  alias Logflare.Billing.BillingCount
+  alias Logflare.Repo
+  setup :set_mimic_global
+
+  setup do
+    user = insert(:user)
+    _billing_account = insert(:billing_account, user: user)
+    user = user |> Logflare.Repo.preload(:billing_account)
+    source = insert(:source, user: user)
+    plan = insert(:plan, type: "metered")
+
+    pid =
+      start_supervised!(
+        {BillingWriter,
+         %RecentLogsServer{source_id: source.token, source: source, user: user, plan: plan}}
+      )
+
+    # increase log count
+    start_supervised!(Logflare.Sources.Counters)
+    Logflare.Sources.Counters.incriment(source.token)
+
+    # Stripe mocks
+    Stripe.SubscriptionItem.Usage
+    |> expect(:create, fn sub_item_id, _params ->
+      if is_nil(sub_item_id) do
+        raise "subscription item id should not be nil"
+      end
+
+      {:ok, %{}}
+    end)
+
+    {:ok, pid: pid}
+  end
+
+  test ":write_count", %{pid: pid} do
+    send(pid, :write_count)
+    :timer.sleep(200)
+    assert Repo.aggregate(BillingCount, :count) == 1
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,7 @@ defmodule LogflareWeb.ConnCase do
       alias LogflareWeb.Router.Helpers, as: Routes
       import Logflare.Factory
       import Phoenix.LiveViewTest
+      use Mimic
 
       # The default endpoint for testing
       @endpoint LogflareWeb.Endpoint

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -42,7 +42,6 @@ defmodule Logflare.Factory do
       token: Faker.UUID.v4(),
       rules: [],
       favorite: false,
-      user: build(:user)
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -41,7 +41,8 @@ defmodule Logflare.Factory do
       name: Faker.Superhero.name(),
       token: Faker.UUID.v4(),
       rules: [],
-      favorite: false
+      favorite: false,
+      user: build(:user)
     }
   end
 
@@ -63,13 +64,22 @@ defmodule Logflare.Factory do
 
   def plan_factory() do
     %Plan{
-      stripe_id: "31415"
+      stripe_id: "31415",
+      price: 123,
+      period: "month"
     }
   end
 
   def billing_account_factory(attrs) do
     stripe_plan_id = Map.get(attrs, :stripe_plan_id, "some plan id #{random_string()}")
-    attrs = Map.delete(attrs, :stripe_plan_id)
+
+    stripe_sub_item_id =
+      Map.get(attrs, :stripe_subscription_item_id, "some sub id #{random_string()}")
+
+    attrs =
+      attrs
+      |> Map.delete(:stripe_plan_id)
+      |> Map.delete(:stripe_subscription_item_id)
 
     %BillingAccount{
       user: build(:user),
@@ -80,7 +90,7 @@ defmodule Logflare.Factory do
             "plan" => %{"id" => stripe_plan_id},
             "items" => [
               %{
-                "data" => [%{}]
+                "data" => [%{"id" => stripe_sub_item_id}]
               }
             ]
           }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -41,7 +41,7 @@ defmodule Logflare.Factory do
       name: Faker.Superhero.name(),
       token: Faker.UUID.v4(),
       rules: [],
-      favorite: false,
+      favorite: false
     }
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,7 +11,7 @@ Mimic.copy(Sources.Counters)
 Mimic.copy(Sources.Cache)
 Mimic.copy(Stripe.PaymentMethod)
 Mimic.copy(Logflare.SQL)
-
+Mimic.copy(Stripe.SubscriptionItem.Usage)
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 {:ok, _} = Application.ensure_all_started(:mimic)
 


### PR DESCRIPTION
Fixes for the following bug, currently blocking prod release. This bugfix also adds test coverage for BillingWriter module
```
GenServer :"2ab8cead-8956-4f37-b3f7-b9163e4891c3-bw" terminating
** (WithClauseError) no with clause matching: nil 
(logflare 1.0.0) lib/logflare/source/billing_writer.ex:57: Logflare.Source.BillingWriter.record_to_stripe/2 
(logflare 1.0.0) lib/logflare/source/billing_writer.ex:31: Logflare.Source.BillingWriter.handle_info/2 
(stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4 
(stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6 
(stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: :write_count
```