### PR TITLE
Timeout endpoint queries

### DIFF
--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -12,10 +12,13 @@ defmodule Logflare.BqRepo do
 
   @query_request_timeout 60_000
   @use_query_cache true
+  @type results :: %{
+          :rows => nil | [term()],
+          :num_rows => non_neg_integer(),
+          optional(atom()) => any()
+        }
   @type query_result ::
-          {:ok,
-           %{:rows => nil | [term()], :num_rows => non_neg_integer(), optional(atom()) => any()}}
-          | {:error, term()}
+          {:ok, results()} | {:error, term()}
 
   @spec query_with_sql_and_params(
           Logflare.User.t(),

--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -189,7 +189,7 @@ defmodule Logflare.Endpoint.Cache do
   end
 
   def query(cache) do
-    GenServer.call(cache, :query, :infinity)
+    GenServer.call(cache, :query, 60_000)
   end
 
   def invalidate(cache) do

--- a/lib/logflare/endpoint/cache.ex
+++ b/lib/logflare/endpoint/cache.ex
@@ -1,49 +1,34 @@
 defmodule Logflare.Endpoint.Cache do
+  @moduledoc """
+  Handles the Endpoint caching logic.
+  """
+
   require Logger
-  # Find all processes for the query
-  def resolve(%Logflare.Endpoint.Query{id: id}) do
-    Enum.filter(:global.registered_names(), fn
-      {__MODULE__, ^id, _} ->
-        true
 
-      _ ->
-        false
-    end)
-    |> Enum.map(&:global.whereis_name/1)
-  end
-
-  # Find or spawn a (query * param) process
-  def resolve(%Logflare.Endpoint.Query{id: id} = query, params) do
-    :global.set_lock({__MODULE__, {id, params}})
-
-    result =
-      case :global.whereis_name({__MODULE__, id, params}) do
-        :undefined ->
-          case DynamicSupervisor.start_child(__MODULE__, {__MODULE__, {query, params}}) do
-            {:ok, pid} ->
-              pid
-
-            {:error, {:already_started, pid}} ->
-              pid
-          end
-
-        pid ->
-          GenServer.cast(pid, :touch)
-          pid
-      end
-
-    :global.del_lock({__MODULE__, {id, params}})
-    result
-  end
-
-  use GenServer
+  use GenServer, restart: :temporary
 
   @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
-  # minutes until the Cache process is terminated
-  @inactivity_minutes 90
   @env Application.get_env(:logflare, :env)
 
   import Ecto.Query, only: [from: 2]
+
+  defstruct query: nil,
+            query_tasks: [],
+            params: %{},
+            last_query_at: nil,
+            last_update_at: nil,
+            cached_result: nil,
+            disable_cache: false
+
+  @type t :: %__MODULE__{
+          query: %Logflare.Endpoint.Query{},
+          query_tasks: list(%Task{}),
+          params: map(),
+          last_query_at: DateTime.t(),
+          last_update_at: DateTime.t(),
+          cached_result: Logflare.BqRepo.results(),
+          disable_cache: boolean()
+        }
 
   def start_link({query, params}) do
     GenServer.start_link(__MODULE__, {query, params},
@@ -51,86 +36,117 @@ defmodule Logflare.Endpoint.Cache do
     )
   end
 
-  defstruct query: nil, params: %{}, last_query_at: nil, last_update_at: nil, cached_result: nil
+  @doc """
+  Initiate a query. Times out at 90 seconds. BigQuery should timeout at 60 seconds.
+  """
+  def query(cache) when is_pid(cache) do
+    GenServer.call(cache, :query, 90_000)
+  end
+
+  @doc """
+  Invalidates the cache by stopping the cache process.
+  """
+  def invalidate(cache) when is_pid(cache) do
+    GenServer.call(cache, :invalidate)
+  end
+
+  @doc """
+  Updates the `last_query_at` key in the process state to act as if a query was recently made.
+  """
+  def touch(cache) when is_pid(cache) do
+    GenServer.cast(cache, :touch)
+  end
 
   def init({query, params}) do
-    {:ok, %__MODULE__{query: query, params: params} |> fetch_latest_query_endpoint()}
+    state =
+      %__MODULE__{
+        query: query,
+        params: params,
+        last_update_at: DateTime.utc_now(),
+        last_query_at: DateTime.utc_now()
+      }
+      |> fetch_latest_query_endpoint()
+      |> put_disable_cache()
+
+    unless state.disable_cache, do: refresh(proactive_querying_ms(state))
+
+    {:ok, state}
   end
 
-  def handle_call(:query, _from, %__MODULE__{cached_result: nil} = state) do
-    state = %{state | last_query_at: DateTime.utc_now()}
-    do_query(state)
-  end
+  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: false} = state) do
+    case do_query(state) do
+      {:ok, result} = response ->
+        state =
+          state
+          |> Map.put(:last_query_at, DateTime.utc_now())
+          |> Map.put(:cached_result, result)
 
-  def handle_call(:query, _from, %__MODULE__{last_update_at: last_update_at} = state) do
-    state = %{state | last_query_at: DateTime.utc_now()}
+        {:reply, response, state}
 
-    if DateTime.diff(DateTime.utc_now(), last_update_at, :second) >
-         state.query.cache_duration_seconds do
-      do_query(state)
-    else
-      {:reply, {:ok, state.cached_result}, state, timeout_until_fetching(state)}
+      {:error, _err} = response ->
+        {:reply, response, state}
     end
   end
 
-  def handle_call(:invalidate, _from, state) do
-    {:reply, :ok, %{state | cached_result: nil}}
+  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: true} = state) do
+    case do_query(state) do
+      {:ok, _result} = response ->
+        {:stop, :normal, response, state}
+
+      {:error, _err} = response ->
+        {:stop, :normal, response, state}
+    end
   end
 
-  def handle_cast(:touch, %__MODULE__{} = state) do
+  def handle_call(:query, _from, %__MODULE__{cached_result: cached_result} = state) do
+    state =
+      state
+      |> Map.put(:last_query_at, DateTime.utc_now())
+
+    {:reply, {:ok, cached_result}, state}
+  end
+
+  def handle_call(:invalidate, _from, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_cast(:touch, state) do
     state = %{state | last_query_at: DateTime.utc_now()}
     {:noreply, state}
   end
 
-  def handle_info(:timeout, state) do
-    now = DateTime.utc_now()
+  def handle_info(:refresh, state) do
+    task = Task.async(__MODULE__, :do_query, [state])
+    tasks = [task | state.query_tasks]
 
-    if DateTime.diff(now, state.last_query_at || now, :second) >= @inactivity_minutes * 60 do
-      {:stop, :normal, state}
-    else
-      if state.query.proactive_requerying_seconds > 0 &&
-           state.query.proactive_requerying_seconds -
-             DateTime.diff(DateTime.utc_now(), state.last_update_at, :second) >= 0 do
-        case do_query(state) do
-          {:reply, _, state, timeout} ->
-            {:noreply, state, timeout}
+    {:noreply, %{state | query_tasks: tasks}}
+  end
 
-          unknown ->
-            Logger.warn("Unhandled Endpoint query response", error_string: inspect(unknown))
+  def handle_info({_from_task, {:ok, results}}, state) do
+    {:noreply, %{state | cached_result: results}}
+  end
 
-            {:stop, :normal, state}
-        end
-      else
-        {:noreply, state, timeout_until_fetching(state)}
-      end
+  def handle_info({_from_task, {:error, _response}}, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    tasks = Enum.reject(state.query_tasks, &(&1.pid == pid))
+
+    cond do
+      since_last_query(state) < state.query.cache_duration_seconds ->
+        refresh(proactive_querying_ms(state))
+        {:noreply, %{state | query_tasks: tasks}}
+
+      tasks == [] ->
+        {:stop, :normal, state}
+
+      true ->
+        {:stop, :normal, state}
     end
   end
 
-  defp timeout_until_fetching(state) do
-    min(
-      @inactivity_minutes * 60,
-      max(
-        0,
-        state.query.proactive_requerying_seconds -
-          DateTime.diff(DateTime.utc_now(), state.last_update_at, :second)
-      )
-    ) * 1000
-  end
-
-  defp fetch_latest_query_endpoint(state) do
-    %{
-      state
-      | query:
-          Logflare.Repo.reload(state.query)
-          |> Logflare.Repo.preload(:user)
-          |> Logflare.Endpoint.Query.map_query(),
-        last_update_at: DateTime.utc_now()
-    }
-  end
-
-  defp do_query(state) do
-    # Ensure latest version of the query is used
-    state = fetch_latest_query_endpoint(state)
+  def do_query(state) do
     params = state.params
 
     case Logflare.SQL.parameters(state.query.query) do
@@ -167,33 +183,51 @@ defmodule Logflare.Endpoint.Cache do
                    location: state.query.user.bigquery_dataset_location
                  ) do
               {:ok, result} ->
-                # Cache the result (no parameters)
-                state = %{state | cached_result: result}
-                {:reply, {:ok, result}, state, timeout_until_fetching(state)}
+                {:ok, result}
 
               {:error, %{body: body}} ->
                 error = Jason.decode!(body)["error"] |> process_error(state.query.user_id)
-                {:reply, {:error, error}, state}
+                {:error, error}
 
               {:error, err} when is_atom(err) ->
-                {:reply, {:error, process_error(err, state.query.user_id)}, state}
+                {:error, process_error(err, state.query.user_id)}
             end
 
           {:error, err} ->
-            {:reply, {:error, err}, state}
+            {:error, err}
         end
 
       {:error, err} ->
-        {:reply, {:error, err}, state}
+        {:error, err}
     end
   end
 
-  def query(cache) do
-    GenServer.call(cache, :query, 60_000)
+  defp refresh(every) do
+    Process.send_after(self(), :refresh, every)
   end
 
-  def invalidate(cache) do
-    GenServer.call(cache, :invalidate)
+  defp since_last_query(state) do
+    DateTime.diff(DateTime.utc_now(), state.last_query_at, :second)
+  end
+
+  defp proactive_querying_ms(state) do
+    state.query.proactive_requerying_seconds * 1_000
+  end
+
+  defp fetch_latest_query_endpoint(state) do
+    %{
+      state
+      | query:
+          Logflare.Repo.reload(state.query)
+          |> Logflare.Repo.preload(:user)
+          |> Logflare.Endpoint.Query.map_query()
+    }
+  end
+
+  defp put_disable_cache(state) do
+    if state.query.cache_duration_seconds == 0,
+      do: %{state | disable_cache: true},
+      else: %{state | disable_cache: false}
   end
 
   defp process_error(error, user_id) when is_atom(error) do

--- a/lib/logflare/endpoint/resolver.ex
+++ b/lib/logflare/endpoint/resolver.ex
@@ -1,0 +1,43 @@
+defmodule Logflare.Endpoint.Resolver do
+  @moduledoc """
+  Finds or spawns Endpoint.Cache processes across the cluster. Unique process for query plus query params.
+  """
+  alias Logflare.Endpoint.Cache2
+
+  def resolve(%Logflare.Endpoint.Query{id: id}) do
+    Enum.filter(:global.registered_names(), fn
+      {Cache, ^id, _} ->
+        true
+
+      _ ->
+        false
+    end)
+    |> Enum.map(&:global.whereis_name/1)
+  end
+
+  def resolve(%Logflare.Endpoint.Query{id: id} = query, params) do
+    :global.set_lock({Cache2, {id, params}})
+
+    result =
+      case :global.whereis_name({Cache2, id, params}) do
+        :undefined ->
+          spec = {Cache2, {query, params}}
+
+          case DynamicSupervisor.start_child(Cache2, spec) do
+            {:ok, pid} ->
+              pid
+
+            {:error, {:already_started, pid}} ->
+              pid
+          end
+
+        pid ->
+          Cache2.touch(pid)
+          pid
+      end
+
+    :global.del_lock({Cache2, {id, params}})
+
+    result
+  end
+end

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -19,7 +19,7 @@ defmodule LogflareWeb.EndpointController do
     methods: ["GET", "POST", "OPTIONS"],
     send_preflight_response?: true
 
-  def query(%{params: %{"token" => token}} = conn, _) do
+  def query(conn, %{"token" => token}) do
     endpoint_query = Endpoint.get_query_by_token(token)
 
     case Endpoint.Resolver.resolve(endpoint_query, conn.query_params)

--- a/lib/logflare_web/controllers/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/endpoint_controller.ex
@@ -3,6 +3,8 @@ defmodule LogflareWeb.EndpointController do
   import Ecto.Query, only: [from: 2]
   require Logger
   alias Logflare.Endpoint
+  alias Logflare.Repo
+  alias Logflare.SQL
 
   plug CORSPlug,
     origin: "*",
@@ -20,8 +22,8 @@ defmodule LogflareWeb.EndpointController do
   def query(%{params: %{"token" => token}} = conn, _) do
     endpoint_query = Endpoint.get_query_by_token(token)
 
-    case Logflare.Endpoint.Cache.resolve(endpoint_query, conn.query_params)
-         |> Logflare.Endpoint.Cache.query() do
+    case Endpoint.Resolver.resolve(endpoint_query, conn.query_params)
+         |> Endpoint.Cache.query() do
       {:ok, result} ->
         render(conn, "query.json", result: result.rows)
 
@@ -32,21 +34,21 @@ defmodule LogflareWeb.EndpointController do
 
   def index(%{assigns: %{user: user}} = conn, _) do
     render(conn, "index.html",
-      endpoint_queries: Logflare.Repo.preload(user, :endpoint_queries).endpoint_queries,
+      endpoint_queries: Repo.preload(user, :endpoint_queries).endpoint_queries,
       current_node: Node.self()
     )
   end
 
   def show(%{assigns: %{user: user}, params: %{"id" => id}} = conn, _) do
     endpoint_query =
-      from(q in Logflare.Endpoint.Query,
+      from(q in Endpoint.Query,
         where: q.user_id == ^user.id and q.id == ^id
       )
-      |> Logflare.Repo.one()
-      |> Logflare.Endpoint.Query.map_query()
+      |> Repo.one()
+      |> Endpoint.Query.map_query()
 
     parameters =
-      case Logflare.SQL.parameters(endpoint_query.query) do
+      case SQL.parameters(endpoint_query.query) do
         {:ok, params} -> params
         _ -> []
       end
@@ -60,14 +62,14 @@ defmodule LogflareWeb.EndpointController do
 
   def edit(%{assigns: %{user: user}, params: %{"id" => id}} = conn, _) do
     endpoint_query =
-      from(q in Logflare.Endpoint.Query,
+      from(q in Endpoint.Query,
         where: q.user_id == ^user.id and q.id == ^id
       )
-      |> Logflare.Repo.one()
-      |> Logflare.Repo.preload(:user)
-      |> Logflare.Endpoint.Query.map_query()
+      |> Repo.one()
+      |> Repo.preload(:user)
+      |> Endpoint.Query.map_query()
 
-    changeset = Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, %{})
+    changeset = Endpoint.Query.update_by_user_changeset(endpoint_query, %{})
 
     render(conn, "edit.html",
       endpoint_query: endpoint_query,
@@ -77,7 +79,7 @@ defmodule LogflareWeb.EndpointController do
   end
 
   def new(conn, _) do
-    changeset = Logflare.Endpoint.Query.update_by_user_changeset(%Logflare.Endpoint.Query{}, %{})
+    changeset = Endpoint.Query.update_by_user_changeset(%Endpoint.Query{}, %{})
     render(conn, "new.html", changeset: changeset)
   end
 
@@ -86,8 +88,8 @@ defmodule LogflareWeb.EndpointController do
       params
       |> Map.put("token", Ecto.UUID.generate())
 
-    Logflare.Endpoint.Query.update_by_user_changeset(%Logflare.Endpoint.Query{user: user}, params)
-    |> Logflare.Repo.insert()
+    Endpoint.Query.update_by_user_changeset(%Endpoint.Query{user: user}, params)
+    |> Repo.insert()
     |> case do
       {:ok, endpoint_query} ->
         conn
@@ -104,17 +106,17 @@ defmodule LogflareWeb.EndpointController do
 
   def update(%{assigns: %{user: user}} = conn, %{"id" => id, "query" => params}) do
     endpoint_query =
-      from(q in Logflare.Endpoint.Query,
+      from(q in Endpoint.Query,
         where: q.user_id == ^user.id and q.id == ^id
       )
-      |> Logflare.Repo.one()
-      |> Logflare.Repo.preload(:user)
+      |> Repo.one()
+      |> Repo.preload(:user)
 
-    for q <- Logflare.Endpoint.Cache.resolve(endpoint_query),
-        do: Logflare.Endpoint.Cache.invalidate(q)
+    for q <- Endpoint.Resolver.resolve(endpoint_query),
+        do: Endpoint.Cache.invalidate(q)
 
-    Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, params)
-    |> Logflare.Repo.update()
+    Endpoint.Query.update_by_user_changeset(endpoint_query, params)
+    |> Repo.update()
     |> case do
       {:ok, endpoint_query} ->
         conn
@@ -134,16 +136,16 @@ defmodule LogflareWeb.EndpointController do
 
   def reset_url(%{assigns: %{user: user}} = conn, %{"id" => id}) do
     endpoint_query =
-      from(q in Logflare.Endpoint.Query,
+      from(q in Endpoint.Query,
         where: q.user_id == ^user.id and q.id == ^id
       )
-      |> Logflare.Repo.one()
-      |> Logflare.Repo.preload(:user)
+      |> Repo.one()
+      |> Repo.preload(:user)
 
-    Logflare.Endpoint.Query.update_by_user_changeset(endpoint_query, %{
+    Endpoint.Query.update_by_user_changeset(endpoint_query, %{
       token: Ecto.UUID.generate()
     })
-    |> Logflare.Repo.update()
+    |> Repo.update()
     |> case do
       {:ok, endpoint_query} ->
         conn
@@ -163,12 +165,12 @@ defmodule LogflareWeb.EndpointController do
 
   def delete(%{assigns: %{user: user}} = conn, %{"id" => id}) do
     _endpoint_query =
-      from(q in Logflare.Endpoint.Query,
+      from(q in Endpoint.Query,
         where: q.user_id == ^user.id and q.id == ^id
       )
-      |> Logflare.Repo.one()
-      |> Logflare.Repo.preload(:user)
-      |> Logflare.Repo.delete()
+      |> Repo.one()
+      |> Repo.preload(:user)
+      |> Repo.delete()
       |> case do
         {:ok, _endpoint_query} ->
           conn

--- a/test/logflare_web/controllers/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/endpoint_controller_test.exs
@@ -1,0 +1,79 @@
+defmodule LogflareWeb.EndpointControllerTest do
+  @moduledoc false
+  import Logflare.Factory
+  use LogflareWeb.ConnCase
+
+  @session Plug.Session.init(
+             store: :cookie,
+             key: "_app",
+             encryption_salt: "yadayada",
+             signing_salt: "yadayada"
+           )
+
+  describe "create" do
+    @tag :failing
+    test "Endpoint for User", %{conn: conn} do
+      _plan = insert(:plan, name: "Free", type: "standard")
+      user = insert(:user)
+      _source = insert(:source, user: user)
+      _billing_account = insert(:billing_account, user: user)
+      user = user |> Logflare.Repo.preload(:billing_account)
+
+      params = %{
+        "name" => "current date",
+        "query" => "select current_date() as date"
+      }
+
+      conn =
+        conn |> assign(:user, user) |> post(Routes.endpoint_path(conn, :create), query: params)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.endpoint_path(conn, :show, id)
+
+      conn = get(conn, Routes.endpoint_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "/endpoints/"
+    end
+  end
+
+  describe "query" do
+    @tag :failing
+    test "Query Endpoint", %{conn: conn} do
+      # This fails to start because :erlexec fails to start
+      # Adding Application.ensure_all_started(:erlexec) to test_helper.exs and it stall there instead
+      Logflare.SQL.start_link([])
+
+      _plan = insert(:plan, name: "Free", type: "standard")
+      user = insert(:user)
+      _source = insert(:source, user: user)
+      _billing_account = insert(:billing_account, user: user)
+      _user = user |> Logflare.Repo.preload(:billing_account)
+      endpoint = insert(:endpoint, name: "current date", query: "select current_date() as date")
+
+      conn = get(conn, Routes.endpoint_path(conn, :query, endpoint.token))
+
+      assert [%{"date" => "2022-06-21"}] = json_response(conn, 200)["result"]
+    end
+  end
+
+  describe "index" do
+    test "Endpoints index", %{conn: conn} do
+      _plan = insert(:plan, name: "Free", type: "standard")
+      user = insert(:user)
+      _source = insert(:source, user: user)
+      _billing_account = insert(:billing_account, user: user)
+      user = user |> Logflare.Repo.preload(:billing_account)
+
+      conn =
+        conn
+        |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
+        |> Plug.Session.call(@session)
+        |> fetch_session()
+
+      conn = conn |> put_session(:user_id, user.id) |> assign(:user, user)
+
+      conn = get(conn, Routes.endpoint_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "/endpoints"
+    end
+  end
+end


### PR DESCRIPTION
Previously Endpoints would block when queries were running even when they were cached. 

Now It doesn't block except for the first response, and if queries are not cached at all.

Need some feedback with the tests I created here too, but I got one to work!