### PR TITLE
fix: emit warning for no subscription item for attached billing account

### DIFF
--- a/lib/logflare/source/billing_writer.ex
+++ b/lib/logflare/source/billing_writer.ex
@@ -61,6 +61,11 @@ defmodule Logflare.Source.BillingWriter do
            Billing.Stripe.record_usage(si_id, count) do
       :noop
     else
+      nil ->
+        Logger.warning(
+          "User's billing account does not have a stripe subscription item, ignoring usage record. user_id: #{rls.user.id}"
+        )
+
       {:error, resp} ->
         Logger.error("Error recording usage with Stripe. #{inspect(resp)}",
           source_id: rls.source.token,


### PR DESCRIPTION
@chasers for billing accounts without stripe sub item attached, I'm just going to ignore recording the stripe usage.

FYI.