### PR TITLE
fix: Stripe payload unnesting for stripe subscription item bug

### DIFF
--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -151,7 +151,18 @@ defmodule Logflare.Billing do
 
   def get_billing_account_stripe_subscription_item(%BillingAccount{
         stripe_subscriptions: %{
-          "data" => [%{"items" => [%{"data" => [item | _]} | _]} | _]
+          "data" => [
+            # get first sub
+            %{
+              "items" => %{
+                "data" => [
+                  # get first sub item
+                  item | _
+                ]
+              }
+            }
+            | _
+          ]
         }
       }),
       do: item

--- a/lib/logflare/source/billing_writer.ex
+++ b/lib/logflare/source/billing_writer.ex
@@ -59,11 +59,18 @@ defmodule Logflare.Source.BillingWriter do
            Billing.get_billing_account_stripe_subscription_item(billing_account),
          {:ok, _response} <-
            Billing.Stripe.record_usage(si_id, count) do
+      Logger.info("Successfully recorded usage counts (#{inspect(count)}) to Stripe",
+        user_id: rls.user.id,
+        count: count
+      )
+
       :noop
     else
       nil ->
         Logger.warning(
-          "User's billing account does not have a stripe subscription item, ignoring usage record. user_id: #{rls.user.id}"
+          "User's billing account does not have a stripe subscription item, ignoring usage record",
+          user_id: rls.user.id,
+          count: count
         )
 
       {:error, resp} ->

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -87,11 +87,9 @@ defmodule Logflare.Factory do
         "data" => [
           %{
             "plan" => %{"id" => stripe_plan_id},
-            "items" => [
-              %{
-                "data" => [%{"id" => stripe_sub_item_id}]
-              }
-            ]
+            "items" => %{
+              "data" => [%{"id" => stripe_sub_item_id}]
+            }
           }
         ]
       }


### PR DESCRIPTION
Closer investigation when comparing unnesting code used prior to refactor showed that the post-refactor code attempted to do an additional list unnest. I've updated the code to match the stripe api response payload

Reference code prior to refactor

https://github.com/Logflare/logflare/blob/57062df2f1b9133c88117907671b1a7f1b5af0e8/lib/logflare/billing_accounts.ex

Tests have been updated.