### PR TITLE
chore: fix flaky ci tests relating to SystemMetrics

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -64,8 +64,7 @@ defmodule Logflare.Application do
       Logflare.Repo,
       # get_goth_child_spec(),
       LogflareWeb.Endpoint,
-      {Task.Supervisor, name: Logflare.TaskSupervisor},
-      Logflare.SystemMetricsSup
+      {Task.Supervisor, name: Logflare.TaskSupervisor}
     ]
   end
 

--- a/test/logflare_web/controllers/marketing_controller_test.exs
+++ b/test/logflare_web/controllers/marketing_controller_test.exs
@@ -2,6 +2,10 @@ defmodule LogflareWeb.MarketingControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  setup do
+    start_supervised!(Logflare.SystemMetricsSup)
+    :ok
+  end
   for action <- [
         :index,
         :contact,

--- a/test/logflare_web/controllers/marketing_controller_test.exs
+++ b/test/logflare_web/controllers/marketing_controller_test.exs
@@ -6,6 +6,7 @@ defmodule LogflareWeb.MarketingControllerTest do
     start_supervised!(Logflare.SystemMetricsSup)
     :ok
   end
+
   for action <- [
         :index,
         :contact,


### PR DESCRIPTION
Fixes flaky tests where SystemMetricsSup dies somehow and brings everything down with it.

This fix starts the supervisor on demand in test