### PR TITLE
fix: Adds handling for unrecognized oauth handling for OauthController

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ We are leaving this repo public as an example of a larger Elixir project. We hop
 
 Logflare is using a SQL parser from sqlparser.com. To set this up on your dev machine:
 
-## Dev Setup
+## Developer
+
+## Env Setup
 
 1. Install dependencies with `asdf` using `asdf install`
    1. **IMPORTANT**: [Set `JAVA_HOME`](https://github.com/halcyon/asdf-java#java_home)
@@ -71,3 +73,9 @@ Logflare is using a SQL parser from sqlparser.com. To set this up on your dev ma
 ```elixir
 iex> LogflareLogger.info("testing log message")
 ```
+
+### Logging
+
+Use the `:error_string` metadata key when logging, which is for additional information that we want to log but don't necessarily want searchable or parsed for schema updating.
+
+For example, do `Logger.error("Some error", error_string: inspect(params) )`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Logflare is using a SQL parser from sqlparser.com. To set this up on your dev ma
 
 ## Developer
 
-## Env Setup
+### Env Setup
 
 1. Install dependencies with `asdf` using `asdf install`
    1. **IMPORTANT**: [Set `JAVA_HOME`](https://github.com/halcyon/asdf-java#java_home)

--- a/lib/logflare_web/controllers/auth/oauth_controller.ex
+++ b/lib/logflare_web/controllers/auth/oauth_controller.ex
@@ -86,7 +86,11 @@ defmodule LogflareWeb.Auth.OauthController do
         %{assigns: %{ueberauth_failure: failure}} = conn,
         %{"provider" => provider} = params
       ) do
-    Logger.warn("Oauth failure for #{provider}. #{inspect(failure)}", ueberauth_failure: failure, params: params)
+    Logger.warn("Oauth failure for #{provider}. #{inspect(failure)}",
+      ueberauth_failure: failure,
+      params: params
+    )
+
     auth_error_redirect(conn)
   end
 

--- a/lib/logflare_web/controllers/auth/oauth_controller.ex
+++ b/lib/logflare_web/controllers/auth/oauth_controller.ex
@@ -2,11 +2,16 @@ defmodule LogflareWeb.Auth.OauthController do
   use LogflareWeb, :controller
 
   plug Ueberauth
-
+  require Logger
   alias Logflare.JSON
   alias Logflare.Source
   alias Logflare.Repo
   alias LogflareWeb.AuthController
+
+  def request(conn, params) do
+    Logger.warn("Received unrecognized Oauth provider request", params: params)
+    auth_error_redirect(conn)
+  end
 
   def callback(
         %{assigns: %{ueberauth_auth: _auth}} = conn,
@@ -77,7 +82,20 @@ defmodule LogflareWeb.Auth.OauthController do
     AuthController.check_invite_token_and_signin(conn, auth_params)
   end
 
-  def callback(%{assigns: %{ueberauth_failure: _auth}} = conn, _params) do
+  def callback(
+        %{assigns: %{ueberauth_failure: failure}} = conn,
+        %{"provider" => provider} = params
+      ) do
+    Logger.warn("Oauth failure for #{provider}. #{inspect(failure)}", ueberauth_failure: failure, params: params)
+    auth_error_redirect(conn)
+  end
+
+  def callback(conn, params) do
+    Logger.warn("Received unrecognized Oauth provider callback request", params: params)
+    auth_error_redirect(conn)
+  end
+
+  defp auth_error_redirect(conn) do
     conn
     |> put_flash(:error, "Authentication error! Please contact support if this continues.")
     |> redirect(to: Routes.source_path(conn, :dashboard))

--- a/lib/logflare_web/controllers/auth/oauth_controller.ex
+++ b/lib/logflare_web/controllers/auth/oauth_controller.ex
@@ -9,7 +9,7 @@ defmodule LogflareWeb.Auth.OauthController do
   alias LogflareWeb.AuthController
 
   def request(conn, params) do
-    Logger.warn("Received unrecognized Oauth provider request", params: params)
+    Logger.warn("Received unrecognized Oauth provider request", error_string: inspect(params))
     auth_error_redirect(conn)
   end
 
@@ -87,15 +87,17 @@ defmodule LogflareWeb.Auth.OauthController do
         %{"provider" => provider} = params
       ) do
     Logger.warn("Oauth failure for #{provider}. #{inspect(failure)}",
-      ueberauth_failure: failure,
-      params: params
+      error_string: inspect(params)
     )
 
     auth_error_redirect(conn)
   end
 
   def callback(conn, params) do
-    Logger.warn("Received unrecognized Oauth provider callback request", params: params)
+    Logger.warn("Received unrecognized Oauth provider callback request",
+      error_string: inspect(params)
+    )
+
     auth_error_redirect(conn)
   end
 

--- a/test/logflare_web/controllers/oauth_controller_tests.exs
+++ b/test/logflare_web/controllers/oauth_controller_tests.exs
@@ -1,0 +1,15 @@
+defmodule LogflareWeb.OAuthControllerTests do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  test "unrecognized provider handling", %{conn: conn} do
+    for path <- ["/auth/something", "/auth/something/callback"] do
+      conn =
+        conn
+        |> get(path, %{})
+
+      assert html_response(conn, 302)
+      assert get_flash(conn)["error"] =~ "Authentication error"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds handling and logging for unrecognized Oauth providers, which should let us better track these random auth errors that keep popping up.

Reference ticket: [link](https://www.notion.so/supabase/bug-OauthController-undefined-function-858073f81a1c410ea9b5123dc2014956)