### PR TITLE
chore: add marketing announcement for supabase acquisition

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -49,23 +49,19 @@ body {
   background-color: #161616;
   color: #9a9a9a;
   font-size: 1em;
+  display: flex;
+  flex-direction: column;
+  .navbar {
+    position: sticky;
+    top:0;
+    right: 0;
+    left: 0;
+    z-index: 1030;
+  }
 }
 
 main.app {
-  margin-top: 180px;
   padding-bottom: 10px;
-  /*  & h2 {
-    color: $whitecolor;
-  }
-
-  & h3 {
-    color: $whitecolor;
-    margin-top: 1.5em;
-  }
-
-  & h4 {
-    margin-top: 1em;
-  } */
 }
 
 .pre-metadata {

--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -33,6 +33,7 @@
 }
 
 .dashboard {
+  margin-top: 16px;
   & a {
     color: white;
   }

--- a/assets/css/header.scss
+++ b/assets/css/header.scss
@@ -61,14 +61,6 @@
   }
 }
 
-.subhead-fixed {
-  position: fixed;
-  top: 65px;
-  right: 0;
-  left: 0;
-  z-index: 1020;
-}
-
 .bg-light {
   background-color: #5eeb8f !important;
 }

--- a/assets/css/header.scss
+++ b/assets/css/header.scss
@@ -69,10 +69,6 @@
   z-index: 1020;
 }
 
-.no-subhead {
-  margin-top: -125px;
-}
-
 .bg-light {
   background-color: #5eeb8f !important;
 }

--- a/assets/css/homepage.scss
+++ b/assets/css/homepage.scss
@@ -1503,26 +1503,11 @@ body {
     padding: 0;
   }
 
-  /*
-  .navbar-expand-lg .navbar-brand {
-    margin-left: 15px;
-  }
-
-  .navbar-expand-lg .navbar-toggle {
-    margin-right: 0;
-    margin-top: 17px;
-  }
-  */
   .navbar-fixed-bottom .navbar-collapse,
   .navbar-fixed-top .navbar-collapse {
     max-height: 100%;
   }
 
-  /*
-  .navbar-expand-lg .menuforphone {
-    padding-left: 20px;
-  }
-  */
   .container>.navbar-header {
     max-width: 100%;
   }
@@ -1629,15 +1614,6 @@ body {
     display: none;
   }
 
-  /*
-  .navbar-expand-lg .navbar-nav > li > a {
-    padding: 20px;
-  }
-
-  .navbar-expand-lg .navbar-nav > li > .signin {
-    margin-top: 1px;
-  }
-  */
   .tablescalerow .col-md-6 {
     padding-left: 13px;
     padding-right: 13px;

--- a/assets/css/marketing.scss
+++ b/assets/css/marketing.scss
@@ -1,3 +1,11 @@
+.banner{
+  padding: 10px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+
 .jumbotron {
   background-color: #1d1d1d;
   margin-top: 1em;

--- a/lib/logflare_web.ex
+++ b/lib/logflare_web.ex
@@ -37,7 +37,6 @@ defmodule LogflareWeb do
       ```
       """
       def assign(conn, {key, value}), do: assign(conn, key, value)
-
     end
   end
 

--- a/lib/logflare_web.ex
+++ b/lib/logflare_web.ex
@@ -26,6 +26,18 @@ defmodule LogflareWeb do
       import Phoenix.LiveView.Controller
 
       alias LogflareWeb.Router.Helpers, as: Routes
+
+      # define global controller functions
+
+      @doc """
+      plug helper function for controller level assings setting.
+      It will set the assigns for each controller action.
+      ```
+      plug :assign {:banner, @some_value}
+      ```
+      """
+      def assign(conn, {key, value}), do: assign(conn, key, value)
+
     end
   end
 

--- a/lib/logflare_web/controllers/marketing_controller.ex
+++ b/lib/logflare_web/controllers/marketing_controller.ex
@@ -5,6 +5,14 @@ defmodule LogflareWeb.MarketingController do
   alias Number.Delimit
 
   @system_counter :total_logs_logged
+  @announcement %{
+    message: "Logflare is now part of Supabase.",
+    cta_text: "Read more →",
+    cta_link: "https://supabase.com/blog/supabase-acquires-logflare?utm_source=logflare-site&utm_medium=referral&utm_campaign=logflare-acquired"
+  }
+
+  # only set the banner assigns on marketing pages
+  plug :assign, {:banner, @announcement}
 
   def index(conn, _params) do
     {:ok, log_count} = AllLogsLogged.log_count(@system_counter)

--- a/lib/logflare_web/controllers/marketing_controller.ex
+++ b/lib/logflare_web/controllers/marketing_controller.ex
@@ -8,7 +8,8 @@ defmodule LogflareWeb.MarketingController do
   @announcement %{
     message: "Logflare is now part of Supabase.",
     cta_text: "Read more →",
-    cta_link: "https://supabase.com/blog/supabase-acquires-logflare?utm_source=logflare-site&utm_medium=referral&utm_campaign=logflare-acquired"
+    cta_link:
+      "https://supabase.com/blog/supabase-acquires-logflare?utm_source=logflare-site&utm_medium=referral&utm_campaign=logflare-acquired"
   }
 
   # only set the banner assigns on marketing pages

--- a/lib/logflare_web/live/access_tokens_live.ex
+++ b/lib/logflare_web/live/access_tokens_live.ex
@@ -5,7 +5,7 @@ defmodule LogflareWeb.AccessTokensLive do
 
   def render(assigns) do
     ~L"""
-    <div class="subhead subhead-fixed">
+    <div class="subhead">
     <div class="container mx-auto">
     <h5>~/account/access tokens</h5>
     </div>

--- a/lib/logflare_web/live/admin/cluster_live.html.leex
+++ b/lib/logflare_web/live/admin/cluster_live.html.leex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/cluster</h5>
     <%= render LogflareWeb.AdminSharedView, "nav_links_live.html", socket: @socket %>

--- a/lib/logflare_web/live/billingaccount_live/templates/edit.html.leex
+++ b/lib/logflare_web/live/billingaccount_live/templates/edit.html.leex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead">
   <div class="container mx-auto">
     <h5>~/billing/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/live/search_live/templates/logs_search.html.leex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.leex
@@ -14,7 +14,7 @@
 <% end %>
 <div id="user-preferences" data-user-local-timezone="<%= @user_local_timezone %>"
   data-use-local-time="<%= @use_local_time %>"></div>
-<div id="source-logs-search-control" class="subhead subhead-fixed" phx-hook="SourceLogsSearch">
+<div id="source-logs-search-control" class="subhead " phx-hook="SourceLogsSearch">
   <div class="container mx-auto">
     <h5>~/logs/<%= link @source.name, to: Routes.source_path(@socket, :show, @source), class: "text-primary" %>/search
     </h5>

--- a/lib/logflare_web/live/vercellogdrains_live/templates/index.html.leex
+++ b/lib/logflare_web/live/vercellogdrains_live/templates/index.html.leex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/integrations/vercel/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin/accounts.html.eex
+++ b/lib/logflare_web/templates/admin/accounts.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/accounts</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin/dashboard.html.eex
+++ b/lib/logflare_web/templates/admin/dashboard.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/dashboard</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin/search_dashboard.html.leex
+++ b/lib/logflare_web/templates/admin/search_dashboard.html.leex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/search</h5>
     <%= render LogflareWeb.AdminSharedView, "nav_links_live.html", socket: @socket %>

--- a/lib/logflare_web/templates/admin/sources.html.eex
+++ b/lib/logflare_web/templates/admin/sources.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/sources</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin_plan/edit.html.eex
+++ b/lib/logflare_web/templates/admin_plan/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/plan/<%= @plan.id %>/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin_plan/index.html.eex
+++ b/lib/logflare_web/templates/admin_plan/index.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/plans</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/admin_plan/new.html.eex
+++ b/lib/logflare_web/templates/admin_plan/new.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/admin/plans/new</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/application/edit.html.eex
+++ b/lib/logflare_web/templates/application/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/applications/<span class="text-primary overflow-scroll-nowrap"><%= @application.name %></span>/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/application/index.html.eex
+++ b/lib/logflare_web/templates/application/index.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/applications/</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/application/new.html.eex
+++ b/lib/logflare_web/templates/application/new.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/applications/new</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/application/show.html.eex
+++ b/lib/logflare_web/templates/application/show.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/applications/<span class="text-primary overflow-scroll-nowrap"><%= @application.name %></span></h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/auth/email/email_login.html.eex
+++ b/lib/logflare_web/templates/auth/email/email_login.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/<%= link "login", to: Routes.auth_path(@conn, :login), class: "text-primary" %>/email</h5>
   </div>

--- a/lib/logflare_web/templates/auth/email/verify_token.html.eex
+++ b/lib/logflare_web/templates/auth/email/verify_token.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/<%= link "login", to: Routes.auth_path(@conn, :login), class: "text-primary" %>/email/verify</h5>
   </div>

--- a/lib/logflare_web/templates/auth/login.html.eex
+++ b/lib/logflare_web/templates/auth/login.html.eex
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<div class="container">
+<div class="container mt-4">
   <div class="d-flex flex-row justify-content-center">
     <center>
       <%= if @conn.assigns[:team_user] do %>

--- a/lib/logflare_web/templates/auth/login.html.eex
+++ b/lib/logflare_web/templates/auth/login.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/login</h5>
   </div>

--- a/lib/logflare_web/templates/billing/confirm.html.eex
+++ b/lib/logflare_web/templates/billing/confirm.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <div class="log-settings float-right">
       <ul>

--- a/lib/logflare_web/templates/endpoints/edit.html.eex
+++ b/lib/logflare_web/templates/endpoints/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
     <div class="container mx-auto">
       <h5>~/endpoints/<%= link @endpoint_query.name, to: Routes.endpoints_path(@conn, :show, @endpoint_query), class: "text-primary" %>/edit</h5>
     </div>

--- a/lib/logflare_web/templates/endpoints/index.html.eex
+++ b/lib/logflare_web/templates/endpoints/index.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/endpoints</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/endpoints/new.html.eex
+++ b/lib/logflare_web/templates/endpoints/new.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/endpoints/new</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/endpoints/show.html.eex
+++ b/lib/logflare_web/templates/endpoints/show.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
 
     <h5>~/endpoints/<%= link @endpoint_query.name, to: Routes.endpoints_path(@conn, :show, @endpoint_query), class: "text-primary" %></h5>

--- a/lib/logflare_web/templates/layout/banner.html.eex
+++ b/lib/logflare_web/templates/layout/banner.html.eex
@@ -1,0 +1,9 @@
+<div class="banner">
+    <%= @message %>
+
+    <%= if @cta_text != nil and @cta_link != nil do %>
+        <a target="_blank" href="<%= @cta_link %>" %>
+            <%= @cta_text %>
+        </a>
+    <% end %>
+</div>

--- a/lib/logflare_web/templates/layout/root.html.eex
+++ b/lib/logflare_web/templates/layout/root.html.eex
@@ -39,7 +39,7 @@
     <% end %>
   </head>
   <body>
-    <nav class="app navbar fixed-top navbar-expand-lg navbar-light bg-light">
+    <nav class="app navbar  navbar-expand-lg navbar-light bg-light" >
     <%= if Plug.Conn.get_session(@conn, :vercel_setup) do %>
       <div class="navbar-brand">
         <%= render LogflareWeb.SharedView, "logo.html", assigns %>
@@ -128,6 +128,10 @@
         <% end %>
       </div>
     </nav>
+
+    <%= if assigns[:banner] do  %>
+      <%= render "banner.html", @banner %>
+    <% end %>
 
     <%= @inner_content %>
     <%= render("js_libs.html") %>

--- a/lib/logflare_web/templates/layout/root.html.eex
+++ b/lib/logflare_web/templates/layout/root.html.eex
@@ -39,7 +39,7 @@
     <% end %>
   </head>
   <body>
-    <nav class="app navbar  navbar-expand-lg navbar-light bg-light" >
+    <nav class="navbar  navbar-expand-lg navbar-light bg-light" >
     <%= if Plug.Conn.get_session(@conn, :vercel_setup) do %>
       <div class="navbar-brand">
         <%= render LogflareWeb.SharedView, "logo.html", assigns %>

--- a/lib/logflare_web/templates/log/log_event.html.leex
+++ b/lib/logflare_web/templates/log/log_event.html.leex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
     <div class="container mx-auto">
         <h5>~/logs/<%= link @source.name, to: Routes.source_path(@socket, :show, @source), class: "text-primary" %>/event
         </h5>

--- a/lib/logflare_web/templates/phoenix_oauth2_provider/authorization/new.html.eex
+++ b/lib/logflare_web/templates/phoenix_oauth2_provider/authorization/new.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/applications/authorize</h5>
   </div>

--- a/lib/logflare_web/templates/phoenix_oauth2_provider/authorized_application/index.html.eex
+++ b/lib/logflare_web/templates/phoenix_oauth2_provider/authorized_application/index.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/oauth/authorized</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/rule/source_rules.html.leex
+++ b/lib/logflare_web/templates/rule/source_rules.html.leex
@@ -7,7 +7,7 @@
   return_to: false
   %>
 <% end %>
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/logs/<%= link @source.name, to: Routes.source_path(@socket, :show, @source), class: "text-primary" %>/rules</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/source/dashboard.html.eex
+++ b/lib/logflare_web/templates/source/dashboard.html.eex
@@ -20,15 +20,6 @@
   </div>
 </div>
 
-
-<div class="container d-flex justify-content-center flex-column mb-4">
-<!--  <p class="text-center mb-0">💚 Logflare is joining Supabase! Read more on
-    <%= link "the Supabase blog", to: "http://supabase.com/blog/2021/12/02/supabase-acquires-logflare", target: "_blank" %>.</p>
-  <small class="text-center">Don't worry, we'll continue to make your logging life a little better, but now with Postgres too.</small>
--->
-</div>
-
-
 <div class="dashboard container mx-auto" hidden>
   <div class="row justify-content-md-center">
     <div id="saved-searches" class="col-lg-3">

--- a/lib/logflare_web/templates/source/dashboard.html.eex
+++ b/lib/logflare_web/templates/source/dashboard.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/logs</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/logs/<%= link @source.name, to: Routes.source_path(@conn, :show, @source), class: "text-primary" %>/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/source/new.html.eex
+++ b/lib/logflare_web/templates/source/new.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/logs/new</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -3,7 +3,7 @@
     window.publicToken = "<%= Phoenix.Token.sign(LogflareWeb.Endpoint, @conn.secret_key_base, @public_token) %>"
   </script>
 <% end %>
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
 
     <h5>~/logs/<%= link @source.name, to: Routes.source_path(@conn, :show, @source), class: "text-primary" %></h5>

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -22,7 +22,7 @@
     </div>
   </div>
 </div>
-<div id="logs-list-stream-container" class="container mx-auto console-text">
+<div id="logs-list-stream-container" class="mt-4 container mx-auto console-text">
   <ul id="logs-list" class="list-unstyled console-text-list" hidden>
     <%= @logs |> Enum.with_index |> Enum.map(fn {log, inx} -> %>
     <li>

--- a/lib/logflare_web/templates/source/show_rejected.html.eex
+++ b/lib/logflare_web/templates/source/show_rejected.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <div class="log-settings float-right">
       <ul>

--- a/lib/logflare_web/templates/team_user/edit.html.eex
+++ b/lib/logflare_web/templates/team_user/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/profile/edit</h5>
     <div class="log-settings">

--- a/lib/logflare_web/templates/user/edit.html.eex
+++ b/lib/logflare_web/templates/user/edit.html.eex
@@ -1,4 +1,4 @@
-<div class="subhead subhead-fixed">
+<div class="subhead ">
   <div class="container mx-auto">
     <h5>~/account/edit</h5>
     <div class="log-settings">

--- a/test/logflare_web/controllers/marketing_controller_test.exs
+++ b/test/logflare_web/controllers/marketing_controller_test.exs
@@ -33,6 +33,9 @@ defmodule LogflareWeb.MarketingControllerTest do
       path = Routes.marketing_path(conn, unquote(action))
       conn = conn |> get(path)
       assert conn.status == 200
+
+      # has announcement banner
+      assert html_response(conn, 200) =~ "now part of Supabase"
     end
   end
 end


### PR DESCRIPTION
Adds banner to marketing pages, as well as a configurable banner template. I've also added in an `assign` plug helper in the controller macro for setting controller-level assigns.

- [x] tests

Reference link: [link](https://www.notion.so/supabase/Banner-on-homepage-with-link-to-Supabase-Logflare-blog-post-announcement-44a202f4598f451ab1e92d96ef22ffbe)