### PR TITLE
fix: add in sandboxable endpoint toggling

### DIFF
--- a/lib/logflare_web/templates/endpoints/edit.html.eex
+++ b/lib/logflare_web/templates/endpoints/edit.html.eex
@@ -41,6 +41,20 @@
       <%= submit "Save", class: "btn btn-primary form-button" %>
     <% end %>
 
+
+    <%= section_header("Endpoint Query Sandboxing") %>
+      <div class="form-group">
+        <%= form_for @changeset, Routes.endpoints_path(@conn, :update, @endpoint_query), fn a -> %>
+        <%= checkbox a, :sandboxable  %>
+        <%= label a, :sandboxable do %>
+          Sandbox the query using CTEs
+        <% end %>
+        <%= error_tag a, :sandboxable %>
+      </div>
+      <%= submit "Save", class: "btn btn-primary form-button" %>
+    <% end %>
+
+
     <%= section_header("Endpoint URL") %>
     <div class="mb-2">
       <%= Routes.endpoints_url(@conn, :query, @endpoint_query.token) %>


### PR DESCRIPTION
Adds in a form for toggling the `:sandboxable` key, closes #1040 

Have not been able to test this on dev, due to [this issue](https://supabase.slack.com/archives/C032VRDHPDE/p1664532554808509)