### PR TITLE
fix: set the java/gradle build env with asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 elixir 1.12.3-otp-24
 erlang 24.1.6
-gradle 7.1.1
+gradle 7.3.3
 kotlin 1.5.20
 nodejs 16.4.2
+java openjdk-17

--- a/README.md
+++ b/README.md
@@ -46,26 +46,27 @@ We are leaving this repo public as an example of a larger Elixir project. We hop
 
 Logflare is using a SQL parser from sqlparser.com. To set this up on your dev machine:
 
-- Copy parser from sqlparser.com into `sql/gsp`. When extracted it's located at `lib/gudusoft.gsqlparser-2.5.2.5.jar`
-- Install Java with homebrew (MacOS) by running `brew install cask java`
-- Run `mix sql`
-
 ## Dev Setup
 
-1. Copy over secrets to two locations
+1. Install dependencies with `asdf` using `asdf install`
+   1. **IMPORTANT**: [Set `JAVA_HOME`](https://github.com/halcyon/asdf-java#java_home)
+2. Install SQL Parser
+   1. Copy parser from sqlparser.com into `sql/gsp`. When extracted it's located at `lib/gudusoft.gsqlparser-2.5.2.5.jar`
+   2. Run `mix sql`
+3. Copy over secrets to two locations
    1. Dev secrets - `configs/dev.secret.exs`
    2. Google JWT key - `config/secrets/logflare-dev-238720-63d50e3c9cc8.json`
-2. Start database `docker-compose up -d`
-3. Run `mix setup` for deps, migrations, and seed data.
-4. Restart your postgres server for replication settings to take effect `docker-compose restart`
-5. Run `(cd assets; yarn)` from project root, to install js dependencies
-6. Install `sqlparser` by following the steps in **Closed Source Usage** section.
-7. Start server`mix start`
-8. Sign in as a user
-9. Create a source
-10. Update `dev.secrets.exs`, search for the `:logflare_logger_backend` config and update the user api key and source id
-11. Set user api key can be retrieved from dashboard or from database `users` table, source id is from the source page
-12. In `iex` console, test that everything works:
+4. Start database `docker-compose up -d`
+5. Run `mix setup` for deps, migrations, and seed data.
+6. Restart your postgres server for replication settings to take effect `docker-compose restart`
+7. Run `(cd assets; yarn)` from project root, to install js dependencies
+8. Install `sqlparser` by following the steps in **Closed Source Usage** section.
+9. Start server`mix start`
+10. Sign in as a user
+11. Create a source
+12. Update `dev.secrets.exs`, search for the `:logflare_logger_backend` config and update the user api key and source id
+13. Set user api key can be retrieved from dashboard or from database `users` table, source id is from the source page
+14. In `iex` console, test that everything works:
 
 ```elixir
 iex> LogflareLogger.info("testing log message")


### PR DESCRIPTION
gradle 7.1 does not supoprt openjdk versions >=17. Since java LTS version is now 17, we should shift to it.

If developer has other jdk versions >=17 when using gradle 7.1, the following error will appear on compilation:
```
projects/logflare [staging●] » mix sql                    
> Task :compileKotlin
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :inspectClassesForKotlinIC UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :startScripts FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':startScripts'.
> BUG! exception in phase 'semantic analysis' in source unit 'SimpleTemplateScript8.groovy' Unsupported class file major version 63

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3m 38s
5 actionable tasks: 1 executed, 4 up-to-date
```
upgrade to gradle 7.3 and standardizing jdk version to 17 ensures this build error goes away.

As prod openjdk is on 16, we should upgrade prod openjdk to standardize on 17 in a subsequent PR.
