### PR TITLE
chore: fix linting warnings, add credo check to GH action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,5 @@ jobs:
         run: mix test.format
     # - name: Code quality - typings
     #   run: mix test.typings
-    # - name: Code quality - linting
-    #   run: mix lint.diff
+    - name: Code quality - linting
+      run: mix lint --only warnings

--- a/lib/logflare/admin.ex
+++ b/lib/logflare/admin.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Admin do
 
   A delay (default is 5s) occurs just before systen stop is triggered.
   """
-  @spec shutdown(node(), integer()) :: {:ok, %Task{}}
+  @spec shutdown(node(), integer()) :: {:ok, Task.t()}
   def shutdown(node \\ Node.self(), delay \\ 5000) when is_atom(node) do
     task =
       Task.async(fn ->

--- a/lib/logflare/auth.ex
+++ b/lib/logflare/auth.ex
@@ -28,7 +28,7 @@ defmodule Logflare.Auth do
   end
 
   @doc "List Oauth access tokens by user"
-  @spec list_valid_access_tokens(%User{}) :: [%OauthAccessToken{}]
+  @spec list_valid_access_tokens(User.t()) :: [OauthAccessToken.t()]
   def list_valid_access_tokens(%User{id: user_id}) do
     Repo.all(
       from t in OauthAccessToken, where: t.resource_owner_id == ^user_id and is_nil(t.revoked_at)
@@ -37,8 +37,8 @@ defmodule Logflare.Auth do
 
   @doc "Creates an Oauth access token with no expiry, linked to the given user or team's user."
   @typep create_attrs :: %{description: String.t()} | map()
-  @spec create_access_token(%Team{} | %User{}, create_attrs()) ::
-          {:ok, %OauthAccessToken{}} | {:error, term()}
+  @spec create_access_token(Team.t() | User.t(), create_attrs()) ::
+          {:ok, OauthAccessToken.t()} | {:error, term()}
   def create_access_token(user_or_team, attrs \\ %{})
 
   def create_access_token(%Team{user_id: user_id}, attrs) do
@@ -56,7 +56,7 @@ defmodule Logflare.Auth do
   end
 
   @doc "Verifies a  `%OauthAccessToken{}` or string access token. If valid, returns the token's associated user."
-  @spec verify_access_token(%OauthAccessToken{} | binary()) :: {:ok, %User{}} | {:error, term()}
+  @spec verify_access_token(OauthAccessToken.t() | binary()) :: {:ok, User.t()} | {:error, term()}
   def verify_access_token(%OauthAccessToken{token: str_token}) do
     verify_access_token(str_token)
   end
@@ -73,7 +73,7 @@ defmodule Logflare.Auth do
   end
 
   @doc "Revokes a given access token."
-  @spec revoke_access_token(%OauthAccessToken{} | binary()) :: :ok | {:error, term()}
+  @spec revoke_access_token(OauthAccessToken.t() | binary()) :: :ok | {:error, term()}
   def revoke_access_token(token) when is_binary(token) do
     ExOauth2Provider.AccessTokens.get_by_token(token)
     |> revoke_access_token()

--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -29,20 +29,20 @@ defmodule Logflare.Billing do
   # BillingAccount
 
   @doc "Returns the list of billing_accounts"
-  @spec list_billing_accounts() :: [%BillingAccount{}]
+  @spec list_billing_accounts() :: [BillingAccount.t()]
   def list_billing_accounts, do: Repo.all(BillingAccount)
 
   @doc "Gets a single billing_account by a keyword."
-  @spec get_billing_account_by(keyword()) :: %BillingAccount{} | nil
+  @spec get_billing_account_by(keyword()) :: BillingAccount.t() | nil
   def get_billing_account_by(kv), do: Repo.get_by(BillingAccount, kv)
 
   @doc "Gets a single billing_account. Raises `Ecto.NoResultsError` if the Billing account does not exist."
-  @spec get_billing_account!(String.t() | number()) :: %BillingAccount{}
+  @spec get_billing_account!(String.t() | number()) :: BillingAccount.t()
   def get_billing_account!(id), do: Repo.get!(BillingAccount, id)
 
   @doc "Creates a billing_account."
-  @spec create_billing_account(%User{}, map()) ::
-          {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec create_billing_account(User.t(), map()) ::
+          {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def create_billing_account(%User{} = user, attrs \\ %{}) do
     user
     |> Ecto.build_assoc(:billing_account)
@@ -62,8 +62,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "Syncs stripe subscription with %BillingAccount{} with Stripe as source of truth."
-  @spec sync_subscriptions(nil | %BillingAccount{}) ::
-          :noop | {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec sync_subscriptions(nil | BillingAccount.t()) ::
+          :noop | {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def sync_subscriptions(nil), do: :noop
 
   def sync_subscriptions(%BillingAccount{stripe_customer: stripe_customer_id} = billing_account) do
@@ -74,8 +74,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "Syncs stripe invoices with %BillingAccount{} with Stripe as source of truth."
-  @spec sync_invoices(nil | %BillingAccount{}) ::
-          :noop | {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec sync_invoices(nil | BillingAccount.t()) ::
+          :noop | {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def sync_invoices(nil), do: :noop
 
   def sync_invoices(%BillingAccount{stripe_customer: stripe_customer_id} = billing_account) do
@@ -89,8 +89,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "Syncs stripe data with %BillingAccount{} with Stripe as source of truth."
-  @spec sync_billing_account(nil | %BillingAccount{}) ::
-          :noop | {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec sync_billing_account(nil | BillingAccount.t()) ::
+          :noop | {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def sync_billing_account(
         %BillingAccount{stripe_customer: customer_id} = billing_account,
         attrs \\ %{}
@@ -110,8 +110,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "Updates a billing_account"
-  @spec update_billing_account(%BillingAccount{}, map()) ::
-          {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec update_billing_account(BillingAccount.t(), map()) ::
+          {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def update_billing_account(%BillingAccount{} = billing_account, attrs) do
     billing_account
     |> BillingAccount.changeset(attrs)
@@ -119,11 +119,12 @@ defmodule Logflare.Billing do
   end
 
   @doc "Preloads the payment methods field"
-  @spec preload_payment_methods(%BillingAccount{}) :: %BillingAccount{}
+  @spec preload_payment_methods(BillingAccount.t()) :: BillingAccount.t()
   def preload_payment_methods(ba), do: Repo.preload(ba, :payment_methods)
 
   @doc "Deletes a BillingAccount for a User"
-  @spec delete_billing_account(%User{}) :: {:ok, %BillingAccount{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_billing_account(User.t()) ::
+          {:ok, BillingAccount.t()} | {:error, Ecto.Changeset.t()}
   def delete_billing_account(%User{billing_account: billing_account} = user) do
     with {:ok, _} = res <- Repo.delete(billing_account) do
       Source.Supervisor.reset_all_user_sources(user)
@@ -132,13 +133,13 @@ defmodule Logflare.Billing do
   end
 
   @doc "Returns an `%Ecto.Changeset{}` for tracking billing_account changes."
-  @spec change_billing_account(%BillingAccount{}) :: %Ecto.Changeset{}
+  @spec change_billing_account(BillingAccount.t()) :: Ecto.Changeset.t()
   def change_billing_account(%BillingAccount{} = billing_account) do
     BillingAccount.changeset(billing_account, %{})
   end
 
   @doc "retrieves the stripe plan stored on the BillingAccount"
-  @spec get_billing_account_stripe_plan(%BillingAccount{}) :: nil | map()
+  @spec get_billing_account_stripe_plan(BillingAccount.t()) :: nil | map()
   def get_billing_account_stripe_plan(%BillingAccount{
         stripe_subscriptions: %{"data" => [%{"plan" => plan} | _]}
       }),
@@ -147,8 +148,7 @@ defmodule Logflare.Billing do
   def get_billing_account_stripe_plan(_), do: nil
 
   @doc "gets the stripe subscription item data stored on the BillingAccount"
-  @spec get_billing_account_stripe_subscription_item(%BillingAccount{}) :: nil | map()
-
+  @spec get_billing_account_stripe_subscription_item(BillingAccount.t()) :: nil | map()
   def get_billing_account_stripe_subscription_item(%BillingAccount{
         stripe_subscriptions: %{
           "data" => [
@@ -172,20 +172,20 @@ defmodule Logflare.Billing do
   # PaymentMethod
 
   @doc "list PaymentMethod by keyword"
-  @spec list_payment_methods_by(keyword()) :: [%PaymentMethod{}]
+  @spec list_payment_methods_by(keyword()) :: [PaymentMethod.t()]
   def list_payment_methods_by(kv), do: Repo.all(from pm in PaymentMethod, where: ^kv)
 
   @doc "Gets a single payment_method.Raises `Ecto.NoResultsError` if the Payment method does not exist."
-  @spec get_payment_method!(number() | String.t()) :: %PaymentMethod{}
+  @spec get_payment_method!(number() | String.t()) :: PaymentMethod.t()
   def get_payment_method!(id), do: Repo.get!(PaymentMethod, id)
 
   @doc "get PaymentMethod by keyword"
-  @spec get_payment_method_by(keyword()) :: %PaymentMethod{}
+  @spec get_payment_method_by(keyword()) :: PaymentMethod.t()
   def get_payment_method_by(kv), do: Repo.get_by(PaymentMethod, kv)
 
   @doc "Creates a payment_method."
   @spec create_payment_method_with_stripe(map()) ::
-          {:ok, %PaymentMethod{}} | {:error, %Ecto.Changeset{}}
+          {:ok, PaymentMethod.t()} | {:error, Ecto.Changeset.t()}
   def create_payment_method_with_stripe(
         %{"customer_id" => cust_id, "stripe_id" => pm_id} = params
       ) do
@@ -195,7 +195,7 @@ defmodule Logflare.Billing do
   end
 
   @doc "creates a PaymentMethod"
-  @spec create_payment_method(map()) :: {:ok, %PaymentMethod{}} | {:error, %Ecto.Changeset{}}
+  @spec create_payment_method(map()) :: {:ok, PaymentMethod.t()} | {:error, Ecto.Changeset.t()}
   def create_payment_method(attrs \\ %{}) when is_map(attrs) do
     %PaymentMethod{}
     |> PaymentMethod.changeset(attrs)
@@ -203,8 +203,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "updates a PaymentMethod"
-  @spec update_payment_method(%PaymentMethod{}, map()) ::
-          {:ok, %PaymentMethod{}} | {:error, %Ecto.Changeset{}}
+  @spec update_payment_method(PaymentMethod.t(), map()) ::
+          {:ok, PaymentMethod.t()} | {:error, Ecto.Changeset.t()}
   def update_payment_method(%PaymentMethod{} = payment_method, attrs) do
     payment_method
     |> PaymentMethod.changeset(attrs)
@@ -212,8 +212,8 @@ defmodule Logflare.Billing do
   end
 
   @doc "Deletes a payment_method"
-  @spec delete_payment_method(%PaymentMethod{}) ::
-          {:ok, %PaymentMethod{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_payment_method(PaymentMethod.t()) ::
+          {:ok, PaymentMethod.t()} | {:error, Ecto.Changeset.t()}
   def delete_payment_method(%PaymentMethod{} = payment_method) do
     Repo.delete(payment_method)
   end
@@ -223,8 +223,8 @@ defmodule Logflare.Billing do
   def delete_all_payment_methods_by(kv), do: Repo.delete_all(from pm in PaymentMethod, where: ^kv)
 
   @doc "Deletes PaymentMethod both in db and stripe. User must have minimally 1 payment method"
-  @spec delete_payment_method_with_stripe(%PaymentMethod{}) ::
-          {:ok, %PaymentMethod{}} | {:error, String.t()}
+  @spec delete_payment_method_with_stripe(PaymentMethod.t()) ::
+          {:ok, PaymentMethod.t()} | {:error, String.t()}
   def delete_payment_method_with_stripe(%PaymentMethod{} = payment_method) do
     with methods <- list_payment_methods_by(customer_id: payment_method.customer_id),
          count when count > 1 <- Enum.count(methods),
@@ -243,13 +243,13 @@ defmodule Logflare.Billing do
   end
 
   @doc "Returns an `%Ecto.Changeset{}` for tracking payment_method changes."
-  @spec change_payment_method(%PaymentMethod{}) :: %Ecto.Changeset{}
+  @spec change_payment_method(PaymentMethod.t()) :: Ecto.Changeset.t()
   def change_payment_method(%PaymentMethod{} = payment_method, attrs \\ %{}) do
     PaymentMethod.changeset(payment_method, attrs)
   end
 
   @doc "Syncs db PaymentMethod with stripe as a souce of truth"
-  @spec sync_payment_methods(String.t()) :: {:ok, [%PaymentMethod{}]}
+  @spec sync_payment_methods(String.t()) :: {:ok, [PaymentMethod.t()]}
   def sync_payment_methods(cust_id) do
     with {:ok, %Stripe.List{data: stripe_payment_methods}} <-
            Billing.Stripe.list_payment_methods(cust_id),
@@ -316,7 +316,7 @@ defmodule Logflare.Billing do
   end
 
   @doc "Retrieve a user's plan. Defaults to legacy plan if billing is not enabled."
-  @spec get_plan_by_user(%User{}) :: Plan.t()
+  @spec get_plan_by_user(User.t()) :: Plan.t()
   def get_plan_by_user(%User{} = user) do
     if user.billing_enabled do
       case Billing.get_billing_account_by(user_id: user.id) do

--- a/lib/logflare/billing/billing_account.ex
+++ b/lib/logflare/billing/billing_account.ex
@@ -1,9 +1,9 @@
 defmodule Logflare.Billing.BillingAccount do
   @moduledoc false
-  use Ecto.Schema
   import Ecto.Changeset
+  use TypedEctoSchema
 
-  schema "billing_accounts" do
+  typed_schema "billing_accounts" do
     field(:latest_successful_stripe_session, :map)
     field(:stripe_customer, :string)
     field(:stripe_subscriptions, :map)

--- a/lib/logflare/billing/payment_method.ex
+++ b/lib/logflare/billing/payment_method.ex
@@ -1,9 +1,9 @@
 defmodule Logflare.Billing.PaymentMethod do
   @moduledoc false
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
-  schema "payment_methods" do
+  typed_schema "payment_methods" do
     field :price_id, :string
     field :stripe_id, :string
     field :customer_id, :string

--- a/lib/logflare/cluster/strategy/compute_client.ex
+++ b/lib/logflare/cluster/strategy/compute_client.ex
@@ -3,10 +3,8 @@ defmodule Logflare.Cluster.Strategy.GoogleComputeEngine.ComputeClient do
   Inteface to GCP for the cluster strategy.
   """
   require Logger
-
   use Tesla
-
-  @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
+  defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
 
   plug Tesla.Middleware.Retry,
     delay: 500,
@@ -19,7 +17,7 @@ defmodule Logflare.Cluster.Strategy.GoogleComputeEngine.ComputeClient do
     end
 
   plug Tesla.Middleware.BaseUrl,
-       "https://compute.googleapis.com/compute/v1/projects/#{@project_id}"
+       "https://compute.googleapis.com/compute/v1/projects/#{env_project_id()}"
 
   plug Tesla.Middleware.JSON
 

--- a/lib/logflare/cluster/strategy/libcluster_gce_strategy.ex
+++ b/lib/logflare/cluster/strategy/libcluster_gce_strategy.ex
@@ -8,8 +8,8 @@ defmodule Logflare.Cluster.Strategy.GoogleComputeEngine do
 
   @default_polling_interval 120_000
   @default_release_name :node
-  @regions Application.get_env(:logflare, __MODULE__)[:regions]
-  @zones Application.get_env(:logflare, __MODULE__)[:zones]
+  defp env_regions, do: Application.get_env(:logflare, __MODULE__)[:regions]
+  defp env_zones, do: Application.get_env(:logflare, __MODULE__)[:zones]
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
@@ -61,13 +61,13 @@ defmodule Logflare.Cluster.Strategy.GoogleComputeEngine do
       auth_token = Map.get(metadata, "access_token")
 
       region_nodes =
-        Enum.map(@regions, fn {region, group_name} ->
+        Enum.map(env_regions(), fn {region, group_name} ->
           get_region_nodes(state, region, group_name, auth_token)
         end)
         |> Enum.concat()
 
       zone_nodes =
-        Enum.map(@zones, fn {zone, group_name} ->
+        Enum.map(env_zones(), fn {zone, group_name} ->
           get_zone_nodes(state, zone, group_name, auth_token)
         end)
         |> Enum.concat()

--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -2,7 +2,7 @@ defmodule Logflare.Cluster.Utils do
   @moduledoc false
   require Logger
 
-  @min_cluster_size Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
+  defp env_min_cluster_size, do: Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
 
   def node_list_all() do
     [Node.self() | Node.list()]
@@ -11,10 +11,10 @@ defmodule Logflare.Cluster.Utils do
   def cluster_size() do
     lib_cluster_size = node_list_all() |> Enum.count()
 
-    if lib_cluster_size >= @min_cluster_size do
+    if lib_cluster_size >= env_min_cluster_size() do
       lib_cluster_size
     else
-      Logger.error("Cluster size is #{lib_cluster_size} but expected #{@min_cluster_size}",
+      Logger.error("Cluster size is #{lib_cluster_size} but expected #{env_min_cluster_size()}",
         cluster_size: lib_cluster_size
       )
 

--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -18,7 +18,7 @@ defmodule Logflare.Cluster.Utils do
         cluster_size: lib_cluster_size
       )
 
-      @min_cluster_size
+      env_min_cluster_size()
     end
   end
 

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -4,7 +4,7 @@ defmodule Logflare.Endpoints do
   alias __MODULE__.Query
   alias Logflare.Repo
 
-  @spec get_query_by_token(binary()) :: %Query{} | nil
+  @spec get_query_by_token(binary()) :: Query.t() | nil
   def get_query_by_token(token) when is_binary(token) do
     query =
       from q in Query,

--- a/lib/logflare/endpoints/cache.ex
+++ b/lib/logflare/endpoints/cache.ex
@@ -7,8 +7,8 @@ defmodule Logflare.Endpoints.Cache do
 
   use GenServer, restart: :temporary
 
-  @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
-  @env Application.get_env(:logflare, :env)
+  defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
+  defp env, do: Application.get_env(:logflare, :env)
 
   import Ecto.Query, only: [from: 2]
 
@@ -228,7 +228,7 @@ defmodule Logflare.Endpoints.Cache do
             # execute the queryon bigquery
             case Logflare.BqRepo.query_with_sql_and_params(
                    state.query.user,
-                   state.query.user.bigquery_project_id || @project_id,
+                   state.query.user.bigquery_project_id || env_project_id(),
                    query,
                    params,
                    parameterMode: "NAMED",
@@ -315,7 +315,7 @@ defmodule Logflare.Endpoints.Cache do
 
   defp process_message(message, user_id) when is_binary(message) do
     regex =
-      ~r/#{@project_id}\.#{user_id}_#{@env}\.(?<uuid>[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12})/
+      ~r/#{env_project_id()}\.#{user_id}_#{env()}\.(?<uuid>[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12})/
 
     names = Regex.named_captures(regex, message)
 

--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -9,18 +9,21 @@ defmodule Logflare.Google.BigQuery.GenUtils do
   alias Logflare.{Source, User}
   alias GoogleApi.BigQuery.V2.Connection
 
-  @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
   @table_ttl 604_800_000
   @default_dataset_location "US"
-  @default_table_name_append Application.get_env(:logflare, Logflare.Google)[:dataset_id_append] ||
-                               ""
+  defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
+
+  defp env_default_table_name_append,
+    do:
+      Application.get_env(:logflare, Logflare.Google)[:dataset_id_append] ||
+        ""
 
   @spec get_project_id(atom()) :: String.t()
   def get_project_id(source_id) when is_atom(source_id) do
     %Source{user_id: user_id} = Sources.get_by(token: source_id)
     %User{bigquery_project_id: project_id} = Users.get_by(id: user_id)
 
-    project_id || @project_id
+    project_id || env_project_id()
   end
 
   @spec get_bq_user_info(atom) :: map
@@ -42,9 +45,9 @@ defmodule Logflare.Google.BigQuery.GenUtils do
         true -> ttl * 86_400_000
       end
 
-    new_project_id = project_id || @project_id
+    new_project_id = project_id || env_project_id()
     new_dataset_location = dataset_location || @default_dataset_location
-    new_dataset_id = dataset_id || "#{user_id}" <> @default_table_name_append
+    new_dataset_id = dataset_id || "#{user_id}" <> env_default_table_name_append()
 
     %{
       user_id: user_id,

--- a/lib/logflare/google/resource_manager.ex
+++ b/lib/logflare/google/resource_manager.ex
@@ -12,29 +12,50 @@ defmodule Logflare.Google.CloudResourceManager do
   alias Logflare.TeamUsers
   alias Logflare.Billing
 
-  @project_number Application.get_env(:logflare, Logflare.Google)[:project_number]
-  @service_account Application.get_env(:logflare, Logflare.Google)[:service_account]
-  @api_sa Application.get_env(:logflare, Logflare.Google)[:api_sa]
-  @compute_engine_sa Application.get_env(:logflare, Logflare.Google)[:compute_engine_sa]
-  @cloud_build_sa Application.get_env(:logflare, Logflare.Google)[:cloud_build_sa]
-  @gcp_cloud_build_sa Application.get_env(:logflare, Logflare.Google)[:gcp_cloud_build_sa]
-  @compute_system_iam_sa Application.get_env(:logflare, Logflare.Google)[:compute_system_iam_sa]
-  @container_engine_robot_sa Application.get_env(:logflare, Logflare.Google)[
-                               :container_engine_robot_sa
-                             ]
-  @dataproc_sa Application.get_env(:logflare, Logflare.Google)[:dataproc_sa]
-  @container_registry_sa Application.get_env(:logflare, Logflare.Google)[:container_registry_sa]
-  @redis_sa Application.get_env(:logflare, Logflare.Google)[:redis_sa]
-  @serverless_robot_sa Application.get_env(:logflare, Logflare.Google)[:serverless_robot_sa]
-  @service_networking_sa Application.get_env(:logflare, Logflare.Google)[:service_networking_sa]
-  @source_repo_sa Application.get_env(:logflare, Logflare.Google)[:source_repo_sa]
+  defp env_project_number, do: Application.get_env(:logflare, Logflare.Google)[:project_number]
+  defp env_service_account, do: Application.get_env(:logflare, Logflare.Google)[:service_account]
+  defp env_api_sa, do: Application.get_env(:logflare, Logflare.Google)[:api_sa]
+
+  defp env_compute_engine_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:compute_engine_sa]
+
+  defp env_cloud_build_sa, do: Application.get_env(:logflare, Logflare.Google)[:cloud_build_sa]
+
+  defp env_gcp_cloud_build_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:gcp_cloud_build_sa]
+
+  defp env_compute_system_iam_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:compute_system_iam_sa]
+
+  defp env_container_engine_robot_sa,
+    do:
+      Application.get_env(:logflare, Logflare.Google)[
+        :container_engine_robot_sa
+      ]
+
+  defp env_dataproc_sa, do: Application.get_env(:logflare, Logflare.Google)[:dataproc_sa]
+
+  defp env_container_registry_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:container_registry_sa]
+
+  defp env_redis_sa, do: Application.get_env(:logflare, Logflare.Google)[:redis_sa]
+
+  defp env_serverless_robot_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:serverless_robot_sa]
+
+  defp env_service_networking_sa,
+    do: Application.get_env(:logflare, Logflare.Google)[:service_networking_sa]
+
+  defp env_source_repo_sa, do: Application.get_env(:logflare, Logflare.Google)[:source_repo_sa]
 
   def get_iam_policy() do
     conn = GenUtils.get_conn()
 
     body = %Model.GetIamPolicyRequest{}
 
-    Api.Projects.cloudresourcemanager_projects_get_iam_policy(conn, @project_number, body: body)
+    Api.Projects.cloudresourcemanager_projects_get_iam_policy(conn, env_project_number(),
+      body: body
+    )
   end
 
   def set_iam_policy() do
@@ -62,7 +83,7 @@ defmodule Logflare.Google.CloudResourceManager do
       {f, a} = __ENV__.function
       fun = "#{f}" <> "_" <> "#{a}"
 
-      case Api.Projects.cloudresourcemanager_projects_set_iam_policy(conn, @project_number,
+      case Api.Projects.cloudresourcemanager_projects_set_iam_policy(conn, env_project_number(),
              body: body
            ) do
         {:ok, _response} ->
@@ -102,101 +123,101 @@ defmodule Logflare.Google.CloudResourceManager do
   defp get_service_accounts() do
     [
       %Model.Binding{
-        members: ["serviceAccount:#{@service_account}"],
+        members: ["serviceAccount:#{env_service_account()}"],
         role: "roles/bigquery.admin"
       },
       %Model.Binding{
-        members: ["serviceAccount:#{@compute_engine_sa}"],
+        members: ["serviceAccount:#{env_compute_engine_sa()}"],
         role: "roles/editor"
       },
       %Model.Binding{
-        members: ["serviceAccount:#{@api_sa}"],
+        members: ["serviceAccount:#{env_api_sa()}"],
         role: "roles/editor"
       },
       %Model.Binding{
-        members: ["serviceAccount:#{@service_account}"],
+        members: ["serviceAccount:#{env_service_account()}"],
         role: "roles/resourcemanager.projectIamAdmin"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@cloud_build_sa}"],
+        members: ["serviceAccount:#{env_cloud_build_sa()}"],
         role: "roles/cloudbuild.builds.builder"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@gcp_cloud_build_sa}"],
+        members: ["serviceAccount:#{env_gcp_cloud_build_sa()}"],
         role: "roles/cloudbuild.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@cloud_build_sa}"],
+        members: ["serviceAccount:#{env_cloud_build_sa()}"],
         role: "roles/compute.admin"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@compute_system_iam_sa}"],
+        members: ["serviceAccount:#{env_compute_system_iam_sa()}"],
         role: "roles/compute.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@cloud_build_sa}"],
+        members: ["serviceAccount:#{env_cloud_build_sa()}"],
         role: "roles/container.admin"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@cloud_build_sa}"],
+        members: ["serviceAccount:#{env_cloud_build_sa()}"],
         role: "roles/cloudkms.cryptoKeyDecrypter"
       },
       %Model.Binding{
         condition: nil,
         members: [
-          "serviceAccount:#{@container_engine_robot_sa}"
+          "serviceAccount:#{env_container_engine_robot_sa()}"
         ],
         role: "roles/container.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@dataproc_sa}"],
+        members: ["serviceAccount:#{env_dataproc_sa()}"],
         role: "roles/dataproc.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
         members: [
-          "serviceAccount:#{@compute_engine_sa}",
-          "serviceAccount:#{@api_sa}",
-          "serviceAccount:#{@container_registry_sa}"
+          "serviceAccount:#{env_compute_engine_sa()}",
+          "serviceAccount:#{env_api_sa()}",
+          "serviceAccount:#{env_container_registry_sa()}"
         ],
         role: "roles/editor"
       },
       %Model.Binding{
         condition: nil,
         members: [
-          "serviceAccount:#{@compute_engine_sa}",
-          "serviceAccount:#{@cloud_build_sa}"
+          "serviceAccount:#{env_compute_engine_sa()}",
+          "serviceAccount:#{env_cloud_build_sa()}"
         ],
         role: "roles/iam.serviceAccountUser"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@redis_sa}"],
+        members: ["serviceAccount:#{env_redis_sa()}"],
         role: "roles/redis.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
         members: [
-          "serviceAccount:#{@serverless_robot_sa}"
+          "serviceAccount:#{env_serverless_robot_sa()}"
         ],
         role: "roles/run.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
-        members: ["serviceAccount:#{@service_networking_sa}"],
+        members: ["serviceAccount:#{env_service_networking_sa()}"],
         role: "roles/servicenetworking.serviceAgent"
       },
       %Model.Binding{
         condition: nil,
         members: [
-          "serviceAccount:#{@source_repo_sa}"
+          "serviceAccount:#{env_source_repo_sa()}"
         ],
         role: "roles/sourcerepo.serviceAgent"
       }

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -26,7 +26,8 @@ defmodule Logflare.Source do
              :notifications,
              :custom_event_message_keys
            ]}
-  @dataset_id_append Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
+  defp env_dataset_id_append,
+    do: Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
 
   defmodule Metrics do
     @moduledoc false
@@ -234,7 +235,7 @@ defmodule Logflare.Source do
 
     table = format_table_name(source.token)
 
-    dataset_id = source.user.bigquery_dataset_id || "#{source.user.id}" <> @dataset_id_append
+    dataset_id = source.user.bigquery_dataset_id || "#{source.user.id}" <> env_dataset_id_append()
 
     "`#{bq_project_id}`.#{dataset_id}.#{table}"
   end

--- a/lib/logflare/team_users/team_user.ex
+++ b/lib/logflare/team_users/team_user.ex
@@ -1,11 +1,11 @@
 defmodule Logflare.TeamUsers.TeamUser do
   @moduledoc false
-  use Ecto.Schema
   import Ecto.Changeset
   alias Logflare.Users.UserPreferences
   alias Logflare.Teams.Team
+  use TypedEctoSchema
 
-  schema "team_users" do
+  typed_schema "team_users" do
     field :email, :string
     field :email_me_product, :boolean, default: true
     field :email_preferred, :string

--- a/lib/logflare/teams.ex
+++ b/lib/logflare/teams.ex
@@ -4,21 +4,21 @@ defmodule Logflare.Teams do
   alias Logflare.{Repo, Teams.Team, TeamUsers.TeamUser, Users, User}
 
   @doc "Returns a list of teams. Unfiltered."
-  @spec list_teams() :: [%Team{}]
+  @spec list_teams() :: [Team.t()]
   def list_teams do
     Repo.all(Team)
   end
 
   @doc "Gets a single team. Raises `Ecto.NoResultsError` if the Team does not exist."
-  @spec get_team!(String.t() | number()) :: %Team{}
+  @spec get_team!(String.t() | number()) :: Team.t()
   def get_team!(id), do: Repo.get!(Team, id)
 
   @doc "Gets a single team by attribute. Returns nil if not found"
-  @spec get_team_by(keyword()) :: %Team{} | nil
+  @spec get_team_by(keyword()) :: Team.t() | nil
   def get_team_by(keyword), do: Repo.get_by(Team, keyword)
 
   @doc "Gets a user's home team. A home team is set on the `User`'s `:team` key. Uses email as an identifier."
-  @spec get_home_team(%TeamUser{}) :: %Team{} | nil
+  @spec get_home_team(TeamUser.t()) :: Team.t() | nil
   def get_home_team(%TeamUser{email: email}) do
     case Users.get_by(email: email) |> Users.preload_team() do
       nil ->
@@ -30,17 +30,18 @@ defmodule Logflare.Teams do
   end
 
   @doc "Preloads the `:user` assoc"
-  @spec preload_user(nil | %Team{}) :: %Team{}
+  @spec preload_user(nil | Team.t()) :: Team.t()
   def preload_user(nil), do: nil
   def preload_user(team), do: Repo.preload(team, :user)
 
   @doc "preloads the `:team_users` assoc"
-  @spec preload_team_users(nil | %Team{}) :: %Team{}
+  @spec preload_team_users(nil | Team.t()) :: Team.t()
   def preload_team_users(nil), do: nil
   def preload_team_users(team), do: Repo.preload(team, :team_users)
 
   @doc "Creates a team from a user."
-  @spec create_team(%User{}, %{name: String.t()}) :: {:ok, %Team{}} | {:error, %Ecto.Changeset{}}
+  @spec create_team(User.t(), %{name: String.t()}) ::
+          {:ok, Team.t()} | {:error, Ecto.Changeset.t()}
   def create_team(user, %{name: _name} = attrs) do
     user
     |> Ecto.build_assoc(:team)
@@ -49,7 +50,7 @@ defmodule Logflare.Teams do
   end
 
   @doc "Updates a team"
-  @spec update_team(%Team{}, map()) :: {:ok, %Team{}} | {:error, %Ecto.Changeset{}}
+  @spec update_team(Team.t(), map()) :: {:ok, Team.t()} | {:error, Ecto.Changeset.t()}
   def update_team(%Team{} = team, attrs) do
     team
     |> Team.changeset(attrs)
@@ -57,10 +58,10 @@ defmodule Logflare.Teams do
   end
 
   @doc "Deletes a Team"
-  @spec delete_team(%Team{}) :: {:ok, %Team{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_team(Team.t()) :: {:ok, Team.t()} | {:error, Ecto.Changeset.t()}
   def delete_team(%Team{} = team), do: Repo.delete(team)
 
   @doc "Returns an `%Ecto.Changeset{}` for tracking team changes"
-  @spec change_team(%Team{}) :: %Ecto.Changeset{}
+  @spec change_team(Team.t()) :: Ecto.Changeset.t()
   def change_team(%Team{} = team), do: Team.changeset(team, %{})
 end

--- a/lib/logflare/teams/team.ex
+++ b/lib/logflare/teams/team.ex
@@ -1,9 +1,9 @@
 defmodule Logflare.Teams.Team do
   @moduledoc false
-  use Ecto.Schema
   import Ecto.Changeset
+  use TypedEctoSchema
 
-  schema "teams" do
+  typed_schema "teams" do
     field :name, :string
     belongs_to :user, Logflare.User
     has_many :team_users, Logflare.TeamUsers.TeamUser

--- a/lib/logflare/telemetry/telemetry_ingest.ex
+++ b/lib/logflare/telemetry/telemetry_ingest.ex
@@ -3,10 +3,10 @@ defmodule Logflare.TelemetryBackend.BQ do
   require Logger
   alias Logflare.Logs
   alias Logflare.Sources
-  @default_source_id Application.get_env(:logflare_telemetry, :source_id)
+  defp env_default_source_id, do: Application.get_env(:logflare_telemetry, :source_id)
 
   def ingest(payload) do
-    source = Sources.Cache.get_by_id(@default_source_id)
+    source = Sources.Cache.get_by_id(env_default_source_id())
 
     payload = prepare_for_bq(payload)
     Logs.ingest_logs(payload, source)

--- a/lib/logflare/user.ex
+++ b/lib/logflare/user.ex
@@ -31,8 +31,7 @@ defmodule Logflare.User do
            ]}
 
   @default_user_api_quota 150
-  @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
-  @dataset_id_append Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
+
   @default_dataset_location "US"
   @valid_bq_dataset_locations [
     "US",
@@ -52,6 +51,10 @@ defmodule Logflare.User do
     "asia-southeast1",
     "australia-southeast1"
   ]
+  defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
+
+  defp env_dataset_id_append,
+    do: Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
 
   typed_schema "users" do
     field :email, :string
@@ -156,18 +159,16 @@ defmodule Logflare.User do
   end
 
   def hide_bigquery_defaults(user) do
-    case user do
-      %{bigquery_project_id: @project_id} = u ->
-        %{
-          u
-          | bigquery_project_id: nil,
-            bigquery_dataset_id: nil,
-            bigquery_dataset_location: nil,
-            bigquery_processed_bytes_limit: nil
-        }
-
-      u ->
-        u
+    if user.bigquery_project_id == env_project_id() do
+      %{
+        user
+        | bigquery_project_id: nil,
+          bigquery_dataset_id: nil,
+          bigquery_dataset_location: nil,
+          bigquery_processed_bytes_limit: nil
+      }
+    else
+      user
     end
   end
 
@@ -185,11 +186,12 @@ defmodule Logflare.User do
       user_id = Integer.to_string(options[:user_id])
 
       dataset_id =
-        changeset.changes[:bigquery_dataset_id] || "#{options[:user_id]}" <> @dataset_id_append
+        changeset.changes[:bigquery_dataset_id] ||
+          "#{options[:user_id]}" <> env_dataset_id_append()
 
       location = changeset.changes[:bigquery_dataset_location] || @default_dataset_location
 
-      project_id = bigquery_project_id || @project_id
+      project_id = bigquery_project_id || env_project_id()
 
       case BigQuery.create_dataset(
              user_id,
@@ -227,6 +229,6 @@ defmodule Logflare.User do
   end
 
   def generate_bq_dataset_id(%__MODULE__{id: id} = _user) do
-    "#{id}" <> @dataset_id_append
+    "#{id}" <> env_dataset_id_append()
   end
 end

--- a/lib/logflare/vercel/client.ex
+++ b/lib/logflare/vercel/client.ex
@@ -4,9 +4,9 @@ defmodule Logflare.Vercel.Client do
 
   alias Logflare.Vercel
 
-  @client_id Application.get_env(:logflare, __MODULE__)[:client_id]
-  @client_secret Application.get_env(:logflare, __MODULE__)[:client_secret]
-  @redirect_uri Application.get_env(:logflare, __MODULE__)[:redirect_uri]
+  defp env_client_id, do: Application.get_env(:logflare, __MODULE__)[:client_id]
+  defp env_client_secret, do: Application.get_env(:logflare, __MODULE__)[:client_secret]
+  defp env_redirect_uri, do: Application.get_env(:logflare, __MODULE__)[:redirect_uri]
 
   def new() do
     new(%Vercel.Auth{})
@@ -27,10 +27,10 @@ defmodule Logflare.Vercel.Client do
 
   def get_access_token(client, code) do
     body = %{
-      client_id: @client_id,
-      client_secret: @client_secret,
+      client_id: env_client_id(),
+      client_secret: env_client_secret(),
       code: code,
-      redirect_uri: @redirect_uri
+      redirect_uri: env_redirect_uri()
     }
 
     make_form_encoded(client)

--- a/lib/logflare_web/channels/user_socket.ex
+++ b/lib/logflare_web/channels/user_socket.ex
@@ -4,7 +4,7 @@ defmodule LogflareWeb.UserSocket do
   alias Logflare.User
   alias Logflare.Repo
 
-  @salt Application.get_env(:logflare, LogflareWeb.Endpoint)[:secret_key_base]
+  defp env_salt, do: Application.get_env(:logflare, LogflareWeb.Endpoint)[:secret_key_base]
   @max_age 86_400
 
   channel "source:*", LogflareWeb.SourceChannel
@@ -50,5 +50,5 @@ defmodule LogflareWeb.UserSocket do
   end
 
   defp verify_token(token),
-    do: Phoenix.Token.verify(LogflareWeb.Endpoint, @salt, token, max_age: @max_age)
+    do: Phoenix.Token.verify(LogflareWeb.Endpoint, env_salt(), token, max_age: @max_age)
 end

--- a/lib/logflare_web/controllers/auth/oauth_provider_controller.ex
+++ b/lib/logflare_web/controllers/auth/oauth_provider_controller.ex
@@ -3,10 +3,10 @@ defmodule LogflareWeb.Auth.OauthProviderController do
 
   alias ExOauth2Provider.Token
 
-  @config Application.get_env(:logflare, ExOauth2Provider)
+  defp env_config, do: Application.get_env(:logflare, ExOauth2Provider)
 
   def vercel_grant(conn, params) do
-    case Token.grant(params, @config) do
+    case Token.grant(params, env_config()) do
       {:ok, access_token} ->
         conn
         |> json(access_token)
@@ -19,7 +19,7 @@ defmodule LogflareWeb.Auth.OauthProviderController do
   end
 
   def cloudflare_grant(conn, params) do
-    case Token.grant(params, @config) do
+    case Token.grant(params, env_config()) do
       {:ok, access_token} ->
         conn
         |> json(Map.drop(access_token, [:expires_in, :refresh_token]))

--- a/lib/logflare_web/controllers/auth/vercel_auth.ex
+++ b/lib/logflare_web/controllers/auth/vercel_auth.ex
@@ -6,13 +6,13 @@ defmodule LogflareWeb.Auth.VercelAuth do
   alias Logflare.Vercel
   alias LogflareWeb.Router.Helpers, as: Routes
 
-  @config Application.get_env(:logflare, __MODULE__)
+  defp env_config, do: Application.get_env(:logflare, __MODULE__)
 
   def set_oauth_params(%{query_string: query_string} = conn, _params) do
-    redirect_uri = "#{@config[:vercel_app_host]}/api/callback?#{query_string}"
+    redirect_uri = "#{env_config()[:vercel_app_host]}/api/callback?#{query_string}"
 
     params = %{
-      "client_id" => "#{@config[:client_id]}",
+      "client_id" => "#{env_config()[:client_id]}",
       "redirect_uri" => redirect_uri,
       "scope" => "read write",
       "response_type" => "code"

--- a/lib/logflare_web/controllers/billing_controller.ex
+++ b/lib/logflare_web/controllers/billing_controller.ex
@@ -8,8 +8,8 @@ defmodule LogflareWeb.BillingController do
   alias Logflare.{User, Users}
   alias Logflare.Billing.Stripe
 
-  @stripe_publishable_key Application.get_env(:stripity_stripe, :publishable_key)
   @default_error_message "Something went wrong. Try that again! If this continues please contact support."
+  defp env_stripe_publishable_key, do: Application.get_env(:stripity_stripe, :publishable_key)
 
   def create(%{assigns: %{user: %User{} = user}} = conn, _params) do
     with {:ok, customer} <- Stripe.create_customer(user),
@@ -101,7 +101,7 @@ defmodule LogflareWeb.BillingController do
          {:ok, session} <- Stripe.create_payment_session(user, plan) do
       conn
       |> put_session(:stripe_session, session)
-      |> render("confirm.html", stripe_key: @stripe_publishable_key, stripe_session: session)
+      |> render("confirm.html", stripe_key: env_stripe_publishable_key(), stripe_session: session)
     else
       true ->
         error_and_redirect(conn, "Please delete your current subscription first!")
@@ -123,7 +123,7 @@ defmodule LogflareWeb.BillingController do
          {:ok, session} <- Stripe.create_metered_customer_session(user, plan) do
       conn
       |> put_session(:stripe_session, session)
-      |> render("confirm.html", stripe_key: @stripe_publishable_key, stripe_session: session)
+      |> render("confirm.html", stripe_key: env_stripe_publishable_key(), stripe_session: session)
     else
       true ->
         error_and_redirect(conn, "Please delete your current subscription first!")
@@ -144,7 +144,7 @@ defmodule LogflareWeb.BillingController do
          {:ok, session} <- Stripe.create_customer_session(user, plan) do
       conn
       |> put_session(:stripe_session, session)
-      |> render("confirm.html", stripe_key: @stripe_publishable_key, stripe_session: session)
+      |> render("confirm.html", stripe_key: env_stripe_publishable_key(), stripe_session: session)
     else
       true ->
         error_and_redirect(conn, "Please delete your current subscription first!")
@@ -277,7 +277,7 @@ defmodule LogflareWeb.BillingController do
          {:ok, session} <- Stripe.create_add_credit_card_session(billing_account) do
       conn
       |> put_session(:stripe_session, session)
-      |> render("confirm.html", stripe_key: @stripe_publishable_key, stripe_session: session)
+      |> render("confirm.html", stripe_key: env_stripe_publishable_key(), stripe_session: session)
     else
       false ->
         error_and_redirect(conn, "Please subscribe first!")

--- a/lib/logflare_web/controllers/plugs/set_verify_user.ex
+++ b/lib/logflare_web/controllers/plugs/set_verify_user.ex
@@ -7,7 +7,7 @@ defmodule LogflareWeb.Plugs.SetVerifyUser do
   alias Logflare.{Users, User}
   alias ExOauth2Provider.AccessTokens
 
-  @oauth_config Application.get_env(:logflare, ExOauth2Provider)
+  defp env_oauth_config, do: Application.get_env(:logflare, ExOauth2Provider)
 
   def init(_), do: nil
 
@@ -69,7 +69,7 @@ defmodule LogflareWeb.Plugs.SetVerifyUser do
         put_401(conn, message)
 
       true ->
-        oauth_access_token = AccessTokens.get_by_token(bearer, @oauth_config)
+        oauth_access_token = AccessTokens.get_by_token(bearer, env_oauth_config())
         user = Users.Cache.get_by_and_preload(id: oauth_access_token.resource_owner_id)
 
         assign(conn, :user, user)
@@ -113,7 +113,7 @@ defmodule LogflareWeb.Plugs.SetVerifyUser do
   end
 
   defp is_expired?(bearer) do
-    AccessTokens.get_by_token(bearer, @oauth_config)
+    AccessTokens.get_by_token(bearer, env_oauth_config())
     |> AccessTokens.is_expired?()
   end
 end

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -23,8 +23,8 @@ defmodule LogflareWeb.SourceController do
   alias Logflare.Logs.{RejectedLogEvents, Search}
   alias LogflareWeb.AuthController
 
-  @project_id Application.get_env(:logflare, Logflare.Google)[:project_id]
-  @dataset_id_append Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
+  defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
+  defp env_dataset_id_append, do: Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
   @lql_dialect :routing
 
   def api_index(%{assigns: %{user: user}} = conn, _params) do
@@ -186,8 +186,8 @@ defmodule LogflareWeb.SourceController do
           conn,
         _params
       ) do
-    bigquery_project_id = user.bigquery_project_id || @project_id
-    dataset_id = user.bigquery_dataset_id || Integer.to_string(user.id) <> @dataset_id_append
+    bigquery_project_id = user.bigquery_project_id || env_project_id()
+    dataset_id = user.bigquery_dataset_id || Integer.to_string(user.id) <> env_dataset_id_append()
 
     explore_link =
       generate_explore_link(team_user.email, source.token, bigquery_project_id, dataset_id)
@@ -211,8 +211,8 @@ defmodule LogflareWeb.SourceController do
   end
 
   def explore(%{assigns: %{user: %{provider: "google"} = user, source: source}} = conn, _params) do
-    bigquery_project_id = user.bigquery_project_id || @project_id
-    dataset_id = user.bigquery_dataset_id || Integer.to_string(user.id) <> @dataset_id_append
+    bigquery_project_id = user.bigquery_project_id || env_project_id()
+    dataset_id = user.bigquery_dataset_id || Integer.to_string(user.id) <> env_dataset_id_append()
 
     explore_link =
       generate_explore_link(user.email, source.token, bigquery_project_id, dataset_id)

--- a/lib/logflare_web/controllers/user_controller.ex
+++ b/lib/logflare_web/controllers/user_controller.ex
@@ -6,7 +6,7 @@ defmodule LogflareWeb.UserController do
 
   alias Logflare.{User, Repo, Users, TeamUsers, Source.Supervisor, Billing.Stripe}
 
-  @service_account Application.get_env(:logflare, Logflare.Google)[:service_account] || ""
+  defp env_service_account, do: Application.get_env(:logflare, Logflare.Google)[:service_account] || ""
 
   def api_show(%{assigns: %{user: user}} = conn, _params) do
     conn
@@ -19,7 +19,7 @@ defmodule LogflareWeb.UserController do
     render(conn, "edit.html",
       changeset: changeset,
       user: user,
-      service_account: @service_account
+      service_account: env_service_account()
     )
   end
 
@@ -59,7 +59,7 @@ defmodule LogflareWeb.UserController do
         |> render("edit.html",
           changeset: changeset,
           user: conn.assigns.user,
-          service_account: @service_account
+          service_account: env_service_account()
         )
     end
   end

--- a/lib/logflare_web/live/billingaccount_live/payment_method_component.ex
+++ b/lib/logflare_web/live/billingaccount_live/payment_method_component.ex
@@ -10,14 +10,14 @@ defmodule LogflareWeb.BillingAccountLive.PaymentMethodComponent do
 
   require Logger
 
-  @stripe_publishable_key Application.get_env(:stripity_stripe, :publishable_key)
+  defp env_stripe_publishable_key, do: Application.get_env(:stripity_stripe, :publishable_key)
 
   def preload(assigns) when is_list(assigns) do
     assigns
   end
 
   def mount(socket) do
-    socket = assign(socket, :stripe_key, @stripe_publishable_key)
+    socket = assign(socket, :stripe_key, env_stripe_publishable_key())
 
     {:ok, socket}
   end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -7,17 +7,6 @@ defmodule LogflareWeb.Router do
 
   # TODO: move plug calls in SourceController and RuleController into here
 
-  @csp """
-  \
-  default-src 'self';\
-  connect-src 'self' #{if Application.get_env(:logflare, :env) == :prod, do: "wss://logflare.app", else: "ws://localhost:4000"} https://api.github.com;\
-  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://buttons.github.io https://platform.twitter.com https://cdnjs.cloudflare.com https://js.stripe.com;\
-  style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com;\
-  img-src 'self' data: https://*.googleusercontent.com https://www.gravatar.com https://avatars.githubusercontent.com https://platform.slack-edge.com;\
-  font-src 'self' https://use.fontawesome.com;\
-  frame-src 'self' https://platform.twitter.com https://install.cloudflareapps.com https://datastudio.google.com https://js.stripe.com https://www.youtube.com;\
-  """
-
   pipeline :browser do
     plug Plug.RequestId
     plug :accepts, ["html"]
@@ -28,7 +17,19 @@ defmodule LogflareWeb.Router do
     plug :protect_from_forgery
 
     plug :put_secure_browser_headers, %{
-      "content-security-policy" => @csp,
+      "content-security-policy" =>
+        (fn ->
+           """
+           \
+           default-src 'self';\
+           connect-src 'self' #{if Application.get_env(:logflare, :env) == :prod, do: "wss://logflare.app", else: "ws://localhost:4000"} https://api.github.com;\
+           script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://buttons.github.io https://platform.twitter.com https://cdnjs.cloudflare.com https://js.stripe.com;\
+           style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com;\
+           img-src 'self' data: https://*.googleusercontent.com https://www.gravatar.com https://avatars.githubusercontent.com https://platform.slack-edge.com;\
+           font-src 'self' https://use.fontawesome.com;\
+           frame-src 'self' https://platform.twitter.com https://install.cloudflareapps.com https://datastudio.google.com https://js.stripe.com https://www.youtube.com;\
+           """
+         end).(),
       "referrer-policy" => "same-origin"
     }
 

--- a/lib/sig_term_handler.ex
+++ b/lib/sig_term_handler.ex
@@ -3,7 +3,7 @@ defmodule Logflare.SigtermHandler do
   @behaviour :gen_event
   require Logger
 
-  @grace_period Application.get_env(:logflare, :sigterm_shutdown_grace_period_ms) ||
+  defp env_grace_period, do: Application.get_env(:logflare, :sigterm_shutdown_grace_period_ms) ||
                   throw("Not configured")
 
   @impl true
@@ -21,22 +21,22 @@ defmodule Logflare.SigtermHandler do
 
   @impl true
   def handle_event(:sigterm, state) do
-    Logger.warn("#{__MODULE__}: SIGTERM received: waiting for #{@grace_period / 1_000} seconds")
+    Logger.warn("#{__MODULE__}: SIGTERM received: waiting for #{env_grace_period() / 1_000} seconds")
 
     # Not sure something is causing the cluster to have issues when an instance gets shutdown
     :rpc.eval_everywhere(Node.list(), :erlang, :disconnect_node, [Node.self()])
 
     System.stop()
 
-    Process.send_after(self(), :proceed_with_sigterm, @grace_period)
+    Process.send_after(self(), :proceed_with_sigterm, env_grace_period())
 
     {:ok, state}
   end
 
   def handle_event(:sigquit, state) do
-    Logger.warn("#{__MODULE__}: SIGQUIT received: waiting for #{@grace_period / 1_000} seconds")
+    Logger.warn("#{__MODULE__}: SIGQUIT received: waiting for #{env_grace_period() / 1_000} seconds")
 
-    Process.send_after(self(), :proceed_with_sigterm, @grace_period)
+    Process.send_after(self(), :proceed_with_sigterm, env_grace_period())
 
     {:ok, state}
   end


### PR DESCRIPTION
Adds two main credo warning fixes:
- remove all `Application.get_env/3` calls
- remove all struct usage in `@spec` tags.

This PR also enables credo linting for warnings on GH actions