### PR TITLE
chore: fix lql parser tests

### DIFF
--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -1934,54 +1934,20 @@ defmodule Logflare.LqlParserTest do
     end
   end
 
-  describe "LQL encoding" do
-    test "to_datetime_with_range" do
-      lv = "2020-01-01T03:14:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-01-01T03:54:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-01-01T03:{14..54}:15"
-    end
-
-    test "to_datetime_with_range 2" do
-      lv = "2020-01-01T03:40:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-01-01T03:45:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-01-01T03:{40..45}:15"
-    end
-
-    test "to_datetime_with_range 3" do
-      lv = "2020-01-01T03:05:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-01-01T03:59:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-01-01T03:{05..59}:15"
-    end
-
-    test "to_datetime_with_range 4" do
-      lv = "2020-01-01T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-01-01T23:00:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-01-01T{17..23}:00:15"
-    end
-
-    test "to_datetime_with_range 5" do
-      lv = "2020-01-01T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-01-15T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-01-{01..15}T17:00:15"
-    end
-
-    test "to_datetime_with_range 6" do
-      lv = "2020-12-01T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-12-01T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-12-01T17:00:15"
-    end
-
-    test "to_datetime_with_range 7" do
-      lv = "2020-12-01T17:00:15Z" |> NaiveDateTime.from_iso8601!()
-      rv = "2020-12-01T17:50:15Z" |> NaiveDateTime.from_iso8601!()
-
-      assert Lql.Encoder.to_datetime_with_range(lv, rv) == "2020-12-01T17:{00..50}:15"
+  test "Encoder.to_datetime_with_range/2" do
+    for {start_str, end_str, expected} <- [
+          # minutes
+          {"2020-01-01T03:05:15Z", "2020-01-01T03:59:15Z", "2020-01-01T03:{05..59}:15"},
+          # hour
+          {"2020-01-01T17:00:15Z", "2020-01-01T23:00:15Z", "2020-01-01T{17..23}:00:15"},
+          # day
+          {"2020-01-01T17:00:15Z", "2020-01-15T17:00:15Z", "2020-01-{01..15}T17:00:15"},
+          # none
+          {"2020-12-01T17:00:15Z", "2020-12-01T17:00:15Z", "2020-12-01T17:00:15"}
+        ] do
+      start_value = NaiveDateTime.from_iso8601!(start_str)
+      end_value = NaiveDateTime.from_iso8601!(end_str)
+      assert Lql.Encoder.to_datetime_with_range(start_value, end_value) == expected
     end
   end
 

--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -2,80 +2,17 @@ defmodule Logflare.LqlParserTest do
   @moduledoc false
   use Logflare.DataCase, async: true
   alias Logflare.Lql
-  alias Logflare.Lql.Parser, as: Parser
-  alias Logflare.Lql.{Utils, ChartRule, FilterRule}
+  alias Logflare.Lql.{Parser, ChartRule, FilterRule}
   alias Logflare.DateTimeUtils
   alias Logflare.Source.BigQuery.SchemaBuilder
-
   @default_schema Logflare.BigQuery.TableSchema.SchemaBuilderHelpers.schemas().initial
 
   describe "LQL parsing" do
-    test "word string regexp with special characters" do
-      schema = SchemaBuilder.build_table_schema(%{}, @default_schema)
-      str = ~S|~\d\d ~^ ~^error$ ~up|
-      {:ok, result} = Parser.parse(str, schema)
+    test "regexp" do
+      qs = ~S|~new ~"user sign up" ~^error$|
 
       lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "event_message",
-          shorthand: nil,
-          value: "\\d\\d",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "event_message",
-          shorthand: nil,
-          value: "^",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "event_message",
-          shorthand: nil,
-          value: "^error$",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "event_message",
-          shorthand: nil,
-          value: "up",
-          values: nil
-        }
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
-    end
-
-    test "word string regexp" do
-      schema = SchemaBuilder.build_table_schema(%{}, @default_schema)
-      str = ~S|~user ~sign ~up|
-      {:ok, result} = Parser.parse(str, schema)
-
-      lql_rules = [
-        %FilterRule{operator: :"~", path: "event_message", value: "user", modifiers: %{}},
-        %FilterRule{operator: :"~", path: "event_message", value: "sign", modifiers: %{}},
-        %FilterRule{operator: :"~", path: "event_message", value: "up", modifiers: %{}}
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
-    end
-
-    test "quoted string regexp" do
-      schema = SchemaBuilder.build_table_schema(%{}, @default_schema)
-      str = ~S|~new ~"user sign up" ~server|
-      {:ok, result} = Parser.parse(str, schema)
-
-      lql_rules = [
-        %FilterRule{operator: :"~", path: "event_message", value: "new", modifiers: %{}},
+        %FilterRule{operator: :"~", path: "event_message", value: "new"},
         %FilterRule{
           operator: :"~",
           path: "event_message",
@@ -85,1689 +22,400 @@ defmodule Logflare.LqlParserTest do
         %FilterRule{
           operator: :"~",
           path: "event_message",
-          value: "server",
-          modifiers: %{}
+          value: "^error$"
         }
       ]
 
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
+      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
+      assert Lql.encode!(lql_rules) == qs
     end
 
-    test "word contains" do
-      schema = SchemaBuilder.build_table_schema(%{}, @default_schema)
-      str = ~S|user sign up|
-      {:ok, result} = Parser.parse(str, schema)
+    test "range int/float" do
+      schema = build_schema(%{"float" => 1.0, "int" => 1})
+      qs = ~S|m.float:30.1..300.1 m.int:50..200|
 
       lql_rules = [
         %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "user",
-          modifiers: %{}
-        },
-        %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "sign",
-          modifiers: %{}
-        },
-        %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "up",
-          modifiers: %{}
-        }
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
-    end
-
-    test "word contains with allowed characters" do
-      str = ~S|$user! sign.up user_sign_up%|
-      {:ok, result} = Parser.parse(str, @default_schema)
-
-      lql_rules = [
-        %FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "$user!",
-          values: nil
-        },
-        %FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "sign.up",
-          values: nil
-        },
-        %FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "user_sign_up%",
-          values: nil
-        }
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
-    end
-
-    test "quoted string contains" do
-      schema = SchemaBuilder.build_table_schema(%{}, @default_schema)
-      str = ~S|new "user sign up" server|
-      {:ok, result} = Parser.parse(str, schema)
-
-      lql_rules = [
-        %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "new",
-          modifiers: %{}
-        },
-        %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "user sign up",
-          modifiers: %{quoted_string: true}
-        },
-        %FilterRule{
-          operator: :string_contains,
-          path: "event_message",
-          value: "server",
-          modifiers: %{}
-        }
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == str
-    end
-
-    @schema SchemaBuilder.build_table_schema(
-              %{
-                user: %{
-                  type: "string",
-                  id: 1,
-                  views: 1,
-                  about: "string"
-                },
-                users: %{source_count: 100},
-                context: %{
-                  error_count3: 100.0,
-                  error_count2: 100.0,
-                  error_count4: 100.0,
-                  error_count1: 100.0,
-                  error_count: 100.0
-                }
-              }
-              |> MapKeys.to_strings(),
-              @default_schema
-            )
-
-    test "metadata quoted string value" do
-      str = ~S|
-       metadata.user.type:"string"
-       metadata.user.type:"string string"
-       metadata.user.type:~"string"
-       metadata.user.type:~"string string"
-       |
-      {:ok, result} = Parser.parse(str, @schema)
-
-      lql_rules = [
-        %FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :=,
-          path: "metadata.user.type",
-          value: "string"
-        },
-        %FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :=,
-          path: "metadata.user.type",
-          value: "string string"
-        },
-        %FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :"~",
-          path: "metadata.user.type",
-          value: "string"
-        },
-        %FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :"~",
-          path: "metadata.user.type",
-          value: "string string"
-        }
-      ]
-
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
-    end
-
-    test "range value" do
-      str = ~S|
-       metadata.context.error_count1:30.1..300.1
-       metadata.context.error_count2:40.1..400.1
-       metadata.context.error_count3:20.1..200.1
-       metadata.context.error_count4:0.1..0.9
-       metadata.users.source_count:50..200
-       |
-      {:ok, result} = Parser.parse(str, @schema)
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
           operator: :range,
-          path: "metadata.context.error_count1",
-          shorthand: nil,
-          value: nil,
+          path: "metadata.float",
           values: [30.1, 300.1]
         },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
+        %FilterRule{
           operator: :range,
-          path: "metadata.context.error_count2",
-          shorthand: nil,
-          value: nil,
-          values: [40.1, 400.1]
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "metadata.context.error_count3",
-          shorthand: nil,
-          value: nil,
-          values: [20.1, 200.1]
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "metadata.context.error_count4",
-          shorthand: nil,
-          value: nil,
-          values: [0.1, 0.9]
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "metadata.users.source_count",
-          shorthand: nil,
-          value: nil,
+          path: "metadata.int",
           values: [50, 200]
         }
       ]
 
-      assert Utils.get_filter_rules(result) == lql_rules
-      assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
+      assert {:ok, lql_rules} == Parser.parse(qs, schema)
+      assert Lql.encode!(lql_rules) == qs
     end
 
-    test "nested fields filter" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            user: %{
-              type: "string",
-              id: 1,
-              views: 1,
-              about: "string"
-            },
-            users: %{source_count: 100},
-            context: %{error_count: 100}
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
+    test "negated filter, full timestamp ranges" do
+      schema = build_schema(%{"str" => "str", "int" => 1})
 
-      str = ~S|
-        metadata.context.error_count:>=100
-        metadata.user.about:~referrall
-        metadata.user.id:<1
-        metadata.user.type:paid
-        metadata.user.views:<=1
-        metadata.users.source_count:>100
-        t:2019-01-01T00:13:37..2019-02-01T00:23:34
-      |
-
-      {:ok, result} = Parser.parse(str, schema)
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>=,
-          path: "metadata.context.error_count",
-          value: 100
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "metadata.user.about",
-          value: "referrall"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<,
-          path: "metadata.user.id",
-          value: 1
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.user.type",
-          value: "paid"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<=,
-          path: "metadata.user.views",
-          value: 1
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>,
-          path: "metadata.users.source_count",
-          value: 100
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~N[2019-01-01 00:13:37Z], ~N[2019-02-01 00:23:34Z]]
-        }
-      ]
-
-      assert lql_rules == Utils.get_filter_rules(result)
-
-      assert Lql.encode!(lql_rules) ==
-               "m.context.error_count:>=100 m.user.about:~referrall m.user.id:<1 m.user.type:paid m.user.views:<=1 m.users.source_count:>100 t:2019-{01..02}-01T00:{13..23}:{37..34}"
-
-      str = ~S|
-        t:2019-01-01..2019-02-01
-      |
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~D[2019-01-01], ~D[2019-02-01]]
-        }
-      ]
-
-      {:ok, result} = Parser.parse(str, schema)
-
-      assert Utils.get_filter_rules(result) == lql_rules
-
-      assert Lql.encode!(lql_rules) == "t:2019-{01..02}-01"
-    end
-
-    test "nested fields filter 2" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            context: %{
-              file: "string",
-              line_number: 1
-            },
-            user: %{group_id: 5, admin: false},
-            log: %{
-              label1: "string",
-              metric1: 10,
-              metric2: 10,
-              metric3: 10,
-              metric4: 10
-            }
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
-
-      str = ~S|
-         log "was generated" "by logflare pinger"
-         metadata.context.file:"some module.ex"
-         metadata.context.line_number:100
-         metadata.log.label1:~origin
-         metadata.log.metric1:<10
-         metadata.log.metric2:<=10
-         metadata.log.metric3:>10
-         metadata.log.metric4:>=10
-         metadata.user.admin:false
-         metadata.user.group_id:5
-         c:count(metadata.log.metric4)
-         c:group_by(t::minute)
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, schema)
-
-      filters = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          value: "log"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :string_contains,
-          path: "event_message",
-          value: "was generated"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :string_contains,
-          path: "event_message",
-          value: "by logflare pinger"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :=,
-          path: "metadata.context.file",
-          value: "some module.ex"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.context.line_number",
-          value: 100
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :"~",
-          path: "metadata.log.label1",
-          value: "origin"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<,
-          path: "metadata.log.metric1",
-          value: 10
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<=,
-          path: "metadata.log.metric2",
-          value: 10
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>,
-          path: "metadata.log.metric3",
-          value: 10
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>=,
-          path: "metadata.log.metric4",
-          value: 10
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.user.admin",
-          value: false
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.user.group_id",
-          value: 5
-        }
-      ]
-
-      assert Utils.get_filter_rules(lql_rules) == filters
-
-      assert Utils.get_chart_rules(lql_rules) == [
-               %ChartRule{
-                 path: "metadata.log.metric4",
-                 value_type: :integer
-               }
-             ]
-
-      assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
-    end
-
-    test "negated filter" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            user: %{
-              type: "string",
-              id: 1,
-              views: 1,
-              about: "string"
-            },
-            users: %{source_count: 100},
-            context: %{error_count: 100}
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
-
-      str = ~S|
-        -metadata.context.error_count:>=100
-        -metadata.user.about:~referrall
-        -metadata.user.type:paid
+      qs = ~S|
+        -m.int:>=100
+        -m.str:~a
         -t:2019-01-01T00:13:37..2019-02-01T00:23:34
       |
 
-      {:ok, result} = Parser.parse(str, schema)
-
       lql_rules = [
-        %Logflare.Lql.FilterRule{
+        %FilterRule{
           modifiers: %{negate: true},
           operator: :>=,
-          path: "metadata.context.error_count",
+          path: "metadata.int",
           value: 100
         },
-        %Logflare.Lql.FilterRule{
+        %FilterRule{
           modifiers: %{negate: true},
           operator: :"~",
-          path: "metadata.user.about",
-          value: "referrall"
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{negate: true},
-          operator: :=,
-          path: "metadata.user.type",
-          value: "paid"
+          path: "metadata.str",
+          value: "a"
         },
         %Logflare.Lql.FilterRule{
           modifiers: %{negate: true},
           operator: :range,
           path: "timestamp",
-          shorthand: nil,
-          value: nil,
           values: [~N[2019-01-01 00:13:37Z], ~N[2019-02-01 00:23:34Z]]
         }
       ]
 
-      assert lql_rules == Utils.get_filter_rules(result)
+      assert {:ok, lql_rules} == Parser.parse(qs, schema)
 
-      assert "-m.context.error_count:>=100 -m.user.about:~referrall -m.user.type:paid -t:2019-{01..02}-01T00:{13..23}:{37..34}" ==
+      assert "-m.int:>=100 -m.str:~a -t:2019-{01..02}-01T00:{13..23}:{37..34}" ==
                Lql.encode!(lql_rules)
-
-      str = ~S|
-        t:2019-01-01..2019-02-01
-      |
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~D[2019-01-01], ~D[2019-02-01]]
-        }
-      ]
-
-      {:ok, result} = Parser.parse(str, schema)
-
-      assert Utils.get_filter_rules(result) == lql_rules
-
-      assert Lql.encode!(lql_rules) == "t:2019-{01..02}-01"
     end
 
-    @schema SchemaBuilder.build_table_schema(
-              %{
-                context: %{
-                  file: "string",
-                  address: "string",
-                  line_number: 1
-                },
-                user: %{group_id: 5, cluster_id: 100, admin: false},
-                log: %{
-                  label1: "string",
-                  metric1: 10,
-                  metric2: 10,
-                  metric3: 10,
-                  metric4: 10
-                }
-              }
-              |> MapKeys.to_strings(),
-              @default_schema
-            )
+    test "timestamp operators, value quoting" do
+      schema =
+        build_schema(%{
+          "context" => %{
+            "file" => "string",
+            "address" => "string",
+            "line_number" => 1
+          }
+        })
 
-    test "nested fields filter with timestamp 3" do
-      str = ~S|
-      log "was generated" "by logflare pinger" error
-      metadata.context.address:~"\\d\\d\\d ST"
-      metadata.context.file:"some module.ex"
-      metadata.context.line_number:100
-      metadata.log.metric1:<10
-      metadata.log.metric4:<10
-      metadata.user.cluster_id:200..300
-      metadata.user.group_id:5
+      qs = ~S|
+      unquoted "is quoted"
+      m.context.address:~"\\d\\d\\d ST"
+      m.context.file:"some module.ex"
+      m.context.line_number:100
       t:>2019-01-01
       t:<=2019-04-20
       t:<2020-01-01T03:14:15
       t:>=2019-01-01T03:14:15
-      t:<=2010-04-20|
+      t:<=2020-01-01T00:00:00.345000
+      |
 
-      {:ok, result} = Parser.parse(str, @schema)
+      {:ok, result} = Parser.parse(qs, schema)
+      rules = result |> Enum.filter(&(&1.path == "timestamp"))
+      assert Enum.map(rules, & &1.operator) == [:>, :<=, :<, :>=, :<=]
 
-      expected = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "log",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "was generated",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "by logflare pinger",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :string_contains,
-          path: "event_message",
-          shorthand: nil,
-          value: "error",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :"~",
-          path: "metadata.context.address",
-          shorthand: nil,
-          value: "\\\\d\\\\d\\\\d ST",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :=,
-          path: "metadata.context.file",
-          shorthand: nil,
-          value: "some module.ex",
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.context.line_number",
-          shorthand: nil,
-          value: 100,
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<,
-          path: "metadata.log.metric1",
-          shorthand: nil,
-          value: 10,
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<,
-          path: "metadata.log.metric4",
-          shorthand: nil,
-          value: 10,
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "metadata.user.cluster_id",
-          shorthand: nil,
-          value: nil,
-          values: [200, 300]
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :=,
-          path: "metadata.user.group_id",
-          shorthand: nil,
-          value: 5,
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>,
-          path: "timestamp",
-          shorthand: nil,
-          value: ~D[2019-01-01],
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<=,
-          path: "timestamp",
-          shorthand: nil,
-          value: ~D[2019-04-20],
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<,
-          path: "timestamp",
-          shorthand: nil,
-          value: ~N[2020-01-01 03:14:15Z],
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :>=,
-          path: "timestamp",
-          shorthand: nil,
-          value: ~N[2019-01-01 03:14:15Z],
-          values: nil
-        },
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :<=,
-          path: "timestamp",
-          shorthand: nil,
-          value: ~D[2010-04-20],
-          values: nil
-        }
-      ]
+      assert Enum.map(rules, & &1.value) == [
+               ~D[2019-01-01],
+               ~D[2019-04-20],
+               ~N[2020-01-01 03:14:15Z],
+               ~N[2019-01-01 03:14:15Z],
+               ~N[2020-01-01 00:00:00.345000Z]
+             ]
 
-      assert Utils.get_filter_rules(result) == expected
+      rules = result |> Enum.filter(&(&1.path == "event_message"))
+      assert Enum.map(rules, & &1.modifiers) == [%{}, %{quoted_string: true}]
+      assert Enum.map(rules, & &1.value) == ["unquoted", "is quoted"]
+      assert Enum.map(rules, & &1.operator) |> Enum.all?(&(&1 == :string_contains))
 
-      assert length(Utils.get_filter_rules(result)) == length(expected)
+      rules = result |> Enum.filter(&(&1.path =~ "metadata.context"))
+      assert Enum.map(rules, & &1.operator) == [:"~", :=, :=]
+
+      assert Enum.map(rules, & &1.modifiers) == [
+               %{quoted_string: true},
+               %{quoted_string: true},
+               %{}
+             ]
+
+      assert Enum.map(rules, & &1.value) == [~S(\\d\\d\\d ST), "some module.ex", 100]
 
       assert Lql.encode!(result) ==
-               clean_and_trim_lql_string(str) |> String.replace(" metadata.", " m.")
-    end
-
-    test "timestamp with microseconds" do
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :>=,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: ~N[2020-01-01 00:00:00.345000Z]
-                }
-              ]} == Parser.parse("timestamp:>=2020-01-01T00:00:00.345000", @schema)
+               String.split(qs, "\n")
+               |> Enum.map(&String.trim/1)
+               |> Enum.join(" ")
+               |> String.trim()
     end
 
     test "timestamp shorthands" do
       assert {:ok,
               [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
+                %FilterRule{
                   operator: :=,
                   path: "timestamp",
                   shorthand: "now",
                   value: now_ndt()
                 }
-              ]} == Parser.parse("timestamp:now", @schema)
+              ]} == Parser.parse("timestamp:now", @default_schema)
 
-      lvalue = Timex.today() |> Timex.to_datetime()
+      for {qs, shorthand, start_value, end_value} <- [
+            {"t:today", "today", today_dt(),
+             today_dt()
+             |> Timex.shift(days: 1)
+             |> Timex.shift(seconds: -1)},
+            {"t:yesterday", "yesterday", today_dt() |> Timex.shift(days: -1),
+             today_dt() |> Timex.shift(seconds: -1)},
+            {
+              "t:this@minute",
+              "this@minute",
+              now_udt_zero_sec(),
+              DateTimeUtils.truncate(Timex.now(), :second)
+            },
+            {
+              "t:this@hour",
+              "this@hour",
+              %{now_udt_zero_sec() | minute: 0},
+              DateTimeUtils.truncate(Timex.now(), :second)
+            },
+            {
+              "t:this@day",
+              "this@day",
+              %{now_udt_zero_sec() | minute: 0, hour: 0},
+              DateTimeUtils.truncate(Timex.now(), :second)
+            },
+            {"t:this@week", "this@week",
+             Timex.beginning_of_week(%{now_udt_zero_sec() | minute: 0, hour: 0}),
+             DateTimeUtils.truncate(Timex.now(), :second)},
+            {"t:this@month", "this@month",
+             Timex.beginning_of_month(%{now_udt_zero_sec() | minute: 0, hour: 0}),
+             DateTimeUtils.truncate(Timex.now(), :second)},
+            {"t:this@year", "this@year",
+             Timex.beginning_of_year(%{now_udt_zero_sec() | minute: 0, hour: 0}),
+             DateTimeUtils.truncate(Timex.now(), :second)},
+            {
+              "t:last@50s",
+              "last@50second",
+              Timex.shift(now_ndt(), seconds: -50),
+              now_ndt()
+            },
+            {
+              "t:last@43m",
+              "last@43minute",
+              Timex.shift(now_udt_zero_sec(), minutes: -43),
+              now_ndt()
+            },
+            {"t:last@100h", "last@100hour",
+             Timex.shift(%{now_udt_zero_sec() | minute: 0}, hours: -100), now_ndt()},
+            {"t:last@7d", "last@7day",
+             Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, days: -7), now_ndt()},
+            {"t:last@2w", "last@2week",
+             Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, weeks: -2), now_ndt()},
+            {"t:last@1mm", "last@1month",
+             Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, months: -1), now_ndt()},
+            {"t:last@1y", "last@1year",
+             Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, years: -1), now_ndt()}
+          ] do
+        lql_rules = [
+          %Logflare.Lql.FilterRule{
+            operator: :range,
+            path: "timestamp",
+            shorthand: shorthand,
+            values: [start_value, end_value]
+          }
+        ]
 
-      rvalue =
-        Timex.today()
-        |> Timex.shift(days: 1)
-        |> Timex.to_datetime()
-        |> Timex.shift(seconds: -1)
+        assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
+      end
+    end
 
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "today",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:today", @schema)
-
-      lvalue = Timex.today() |> Timex.shift(days: -1) |> Timex.to_datetime()
-      rvalue = Timex.today() |> Timex.to_datetime() |> Timex.shift(seconds: -1)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "yesterday",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:yesterday", @schema)
-
-      lvalue = now_udt_zero_sec()
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@minute",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@minute", @schema)
-
-      lvalue = %{now_udt_zero_sec() | minute: 0}
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@hour",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@hour", @schema)
-
-      lvalue = %{now_udt_zero_sec() | minute: 0, hour: 0}
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@day",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@day", @schema)
-
-      lvalue = Timex.beginning_of_week(%{now_udt_zero_sec() | minute: 0, hour: 0})
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@week",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@week", @schema)
-
-      lvalue = Timex.beginning_of_month(%{now_udt_zero_sec() | minute: 0, hour: 0})
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@month",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@month", @schema)
-
-      lvalue = Timex.beginning_of_year(%{now_udt_zero_sec() | minute: 0, hour: 0})
-      rvalue = DateTimeUtils.truncate(Timex.now(), :second)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "this@year",
-                   value: nil,
-                   values: [lvalue, rvalue]
-                 }
-               ]
-             } == Parser.parse("timestamp:this@year", @schema)
-
-      lvalue = Timex.shift(now_ndt(), seconds: -50)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@50second",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@50s", @schema)
-
-      lvalue = Timex.shift(now_udt_zero_sec(), minutes: -43)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@43minute",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@43m", @schema)
-
-      lvalue = Timex.shift(%{now_udt_zero_sec() | minute: 0}, hours: -100)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@100hour",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@100h", @schema)
-
-      lvalue = Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, days: -7)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@7day",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@7d", @schema)
-
-      lvalue = Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, weeks: -2)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@2week",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@2w", @schema)
-
-      lvalue = Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, months: -1)
+    test "NULL" do
+      schema = build_schema(%{"nullable" => "val"})
+      qs = "metadata.nullable:NULL"
 
       lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: "last@1month",
-          value: nil,
-          values: [lvalue, now_ndt()]
+        %FilterRule{
+          operator: :=,
+          path: "metadata.nullable",
+          value: :NULL
         }
       ]
 
-      str = "timestamp:last@1mm"
-
-      assert {:ok, lql_rules} == Parser.parse(str, @schema)
-
-      lvalue = Timex.shift(%{now_udt_zero_sec() | minute: 0, hour: 0}, years: -1)
-
-      assert {
-               :ok,
-               [
-                 %Logflare.Lql.FilterRule{
-                   modifiers: %{},
-                   operator: :range,
-                   path: "timestamp",
-                   shorthand: "last@1year",
-                   value: nil,
-                   values: [lvalue, now_ndt()]
-                 }
-               ]
-             } == Parser.parse("timestamp:last@1y", @schema)
+      assert {:ok, lql_rules} == Parser.parse(qs, schema)
     end
 
-    test "timestamp range shorthand" do
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [~N[2020-01-01 00:00:00Z], ~N[2020-01-01 00:50:00Z]]
-                }
-              ]} == Parser.parse("timestamp:2020-01-01T00:{00..50}:00Z", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-01-01 00:00:35Z],
-                    ~N[2020-01-01 00:00:55Z]
-                  ]
-                }
-              ]} == Parser.parse("timestamp:2020-01-01T00:00:{35..55}", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-05-01 12:44:24Z],
-                    ~N[2020-06-01 12:44:24Z]
-                  ]
-                }
-              ]} == Parser.parse("timestamp:2020-{05..06}-01T12:44:24", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-05-01 12:00:05Z],
-                    ~N[2020-05-01 14:00:05Z]
-                  ]
-                }
-              ]} == Parser.parse("timestamp:2020-05-01T{12..14}:00:05Z", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-05-01 14:00:05.000001Z],
-                    ~N[2020-05-01 14:00:05.460560Z]
-                  ]
-                }
-              ]} == Parser.parse("timestamp:2020-05-01T14:00:05.{000001..460560}Z", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-12-24 00:00:00],
-                    ~N[2021-01-24 23:59:00]
-                  ]
-                }
-              ]} == Parser.parse("t:{2020..2021}-{12..01}-24T{00..23}:{00..59}:00", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [~D[2020-12-24], ~D[2021-01-24]]
-                }
-              ]} == Parser.parse("t:{2020..2021}-{12..01}-24", @schema)
-    end
-
-    test "m,t shorthands" do
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :=,
-                  path: "metadata.user.cluster_id",
-                  value: 1
-                }
-              ]} == Parser.parse("m.user.cluster_id:1", @schema)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :=,
-                  path: "timestamp",
-                  shorthand: "now",
-                  value: now_ndt()
-                }
-              ]} == Parser.parse("t:now", @schema)
-    end
-
-    @schema SchemaBuilder.build_table_schema(
-              %{
-                "nullable" => "string"
-              },
-              @default_schema
-            )
-    test "NULL" do
-      str = ~S|
-         metadata.nullable:NULL
-       |
-
-      {:ok, result} = Parser.parse(str, @schema)
-
-      assert result == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.nullable",
-                 value: :NULL
-               }
-             ]
-    end
-
-    @schema SchemaBuilder.build_table_schema(
-              %{
-                "level" => "info"
-              },
-              @default_schema
-            )
     test "level ranges" do
-      str = ~S|
-         metadata.level:info..error
-       |
+      schema = build_schema(%{"level" => "info"})
 
-      {:ok, result} = Parser.parse(str, @schema)
+      for {qs, levels} <- [
+            {"metadata.level:debug..critical",
+             ["debug", "info", "notice", "warning", "error", "critical"]},
+            {"metadata.level:notice..warning", ["notice", "warning"]},
+            {"metadata.level:debug..error", ["debug", "info", "notice", "warning", "error"]}
+          ] do
+        lql_rules =
+          for level <- levels do
+            %FilterRule{
+              operator: :=,
+              path: "metadata.level",
+              value: level
+            }
+          end
 
-      assert result == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "info",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "notice",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "warning",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "error",
-                 values: nil
-               }
-             ]
-
-      str = ~S|
-         metadata.level:debug..warning
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, @schema)
-
-      assert lql_rules == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "debug",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "info",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "notice",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "warning",
-                 values: nil
-               }
-             ]
-
-      # assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
-
-      str = ~S|
-         metadata.level:debug..error
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, @schema)
-
-      assert lql_rules == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "debug",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "info",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "notice",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "warning",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "error",
-                 values: nil
-               }
-             ]
-
-      str = ~S|
-         metadata.level:debug..critical
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, @schema)
-
-      assert lql_rules == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "debug",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "info",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "notice",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "warning",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "error",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "critical",
-                 values: nil
-               }
-             ]
-
-      str = ~S|
-         metadata.level:notice..warning
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, @schema)
-
-      assert lql_rules == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "notice",
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.level",
-                 shorthand: nil,
-                 value: "warning",
-                 values: nil
-               }
-             ]
-
-      # assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
+        assert {:ok, lql_rules} == Parser.parse(qs, schema)
+      end
     end
-
-    @schema SchemaBuilder.build_table_schema(
-              %{
-                "string_array" => ["string1", "string2"],
-                "integer_array" => [1, 2],
-                "float_array" => [1.0, 2.0]
-              },
-              @default_schema
-            )
 
     test "list contains operator: string" do
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :list_includes,
-          path: "metadata.string_array",
-          value: "string"
-        }
-      ]
+      schema = build_schema(%{"arr" => ["a"]})
 
-      str = "metadata.string_array:@>string"
-      assert {:ok, lql_rules} == Parser.parse(str, @schema)
-      assert clean_and_trim_lql_string(str) == Lql.encode!(lql_rules)
+      for {qs, modifier} <- [
+            {~S(m.arr:@>a), %{}},
+            {~S(m.arr:@>"a"), %{quoted_string: true}}
+          ] do
+        lql_rules = [
+          %FilterRule{
+            modifiers: modifier,
+            operator: :list_includes,
+            path: "metadata.arr",
+            value: "a"
+          }
+        ]
 
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :list_includes,
-          path: "metadata.string_array",
-          value: "string"
-        }
-      ]
-
-      str = "m.string_array:_includes(string)"
-      assert {:ok, lql_rules} == Parser.parse(str, @schema)
+        assert {:ok, lql_rules} == Parser.parse(qs, schema)
+        assert Lql.encode!(lql_rules) == qs
+      end
     end
 
     test "list contains operator: integer" do
-      filter = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :list_includes,
-          path: "metadata.integer_array",
-          value: 1
-        }
-      ]
+      schema = build_schema(%{"arr" => [1]})
 
-      assert {:ok, filter} == Parser.parse("m.integer_array:@>1", @schema)
+      for {qs, modifier} <- [
+            {~S(m.arr:@>1), %{}},
+            {~S(m.arr:@>"1"), %{quoted_string: true}}
+          ] do
+        lql_rules = [
+          %FilterRule{
+            modifiers: modifier,
+            operator: :list_includes,
+            path: "metadata.arr",
+            value: 1
+          }
+        ]
 
-      filter = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :list_includes,
-          path: "metadata.integer_array",
-          value: 1
-        }
-      ]
-
-      assert {:ok, filter} == Parser.parse("m.integer_array:_includes(1)", @schema)
+        assert {:ok, lql_rules} == Parser.parse(qs, schema)
+        assert Lql.encode!(lql_rules) == qs
+      end
     end
 
     test "list contains operator: float" do
-      filter = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :list_includes,
-          path: "metadata.float_array",
-          value: 1.0
-        }
-      ]
+      schema = build_schema(%{"arr" => [1.0]})
 
-      assert {:ok, filter} == Parser.parse("m.float_array:@>1.0", @schema)
+      for {qs, modifier} <- [
+            {~S(m.arr:@>1.0), %{}},
+            {~S(m.arr:@>"1.0"), %{quoted_string: true}}
+          ] do
+        lql_rules = [
+          %FilterRule{
+            modifiers: modifier,
+            operator: :list_includes,
+            path: "metadata.arr",
+            value: 1.0
+          }
+        ]
 
-      filter = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{quoted_string: true},
-          operator: :list_includes,
-          path: "metadata.float_array",
-          value: 1.0
-        }
-      ]
-
-      assert {:ok, filter} == Parser.parse("m.float_array:_includes(1.0)", @schema)
+        assert {:ok, lql_rules} == Parser.parse(qs, schema)
+        assert Lql.encode!(lql_rules) == qs
+      end
     end
 
-    test "lt, lte, gte, gt for float values" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            log: %{
-              metric5: 10.0
-            },
-            user: %{
-              cluster_group: 1.0
-            }
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
+    test "lt, range for float values" do
+      schema = build_schema(%{"metric" => 10.0, "user" => 1.0})
+      qs = "m.metric:<10.0 m.user:0.1..100.111"
 
-      str = ~S|
-         metadata.log.metric5:<10.0
-         metadata.user.cluster_group:200.042..300.1337
-       |
+      lql_rules = [
+        %FilterRule{
+          operator: :<,
+          path: "metadata.metric",
+          value: 10.0
+        },
+        %FilterRule{
+          operator: :range,
+          path: "metadata.user",
+          values: [0.1, 100.111]
+        }
+      ]
 
-      {:ok, lql_rules} = Parser.parse(str, schema)
-
-      assert Utils.get_filter_rules(lql_rules) == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :<,
-                 path: "metadata.log.metric5",
-                 shorthand: nil,
-                 value: 10.0,
-                 values: nil
-               },
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :range,
-                 path: "metadata.user.cluster_group",
-                 shorthand: nil,
-                 value: nil,
-                 values: [200.042, 300.1337]
-               }
-             ]
-
-      assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
+      assert {:ok, lql_rules} == Parser.parse(qs, schema)
+      assert Lql.encode!(lql_rules) == qs
     end
 
     test "boolean" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            isAllowed: true
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
+      schema = build_schema(%{"isAllowed" => true})
+      qs = "m.isAllowed:true m.isAllowed:false"
 
-      str = ~S|
-         metadata.isAllowed:true
-       |
+      lql_rules = [
+        %FilterRule{
+          operator: :=,
+          path: "metadata.isAllowed",
+          value: true
+        },
+        %FilterRule{
+          operator: :=,
+          path: "metadata.isAllowed",
+          value: false
+        }
+      ]
 
-      {:ok, lql_rules} = Parser.parse(str, schema)
-
-      assert Utils.get_filter_rules(lql_rules) == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.isAllowed",
-                 shorthand: nil,
-                 value: true,
-                 values: nil
-               }
-             ]
-
-      str = ~S|
-         metadata.isAllowed:false
-       |
-
-      {:ok, lql_rules} = Parser.parse(str, schema)
-
-      assert Utils.get_filter_rules(lql_rules) == [
-               %Logflare.Lql.FilterRule{
-                 modifiers: %{},
-                 operator: :=,
-                 path: "metadata.isAllowed",
-                 shorthand: nil,
-                 value: false,
-                 values: nil
-               }
-             ]
-
-      assert Lql.encode!(lql_rules) == clean_and_trim_lql_string(str)
+      assert {:ok, lql_rules} == Parser.parse(qs, schema)
+      assert Lql.encode!(lql_rules) == qs
     end
 
     test "chart period, chart aggregate" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{
-            log: %{
-              metric5: 10.0
-            },
-            user: %{
-              cluster_group: 1.0
-            }
-          }
-          |> MapKeys.to_strings(),
-          @default_schema
-        )
-
-      str = ~S|
-         c:sum(metadata.log.metric5)
-         c:group_by(t::minute)
-       |
-
-      {:ok, result} = Parser.parse(str, schema)
+      schema = build_schema(%{"metric" => 10.0})
+      qs = "c:sum(m.metric) c:group_by(t::minute)"
+      assert {:ok, result} = Parser.parse(qs, schema)
 
       assert result == [
-               %Logflare.Lql.ChartRule{
-                 path: "metadata.log.metric5",
+               %ChartRule{
+                 path: "metadata.metric",
                  aggregate: :sum,
                  period: :minute,
                  value_type: :float
                }
              ]
 
-      str = ~S|
-         c:sum(m.log.metric5)
-         c:group_by(t::minute)
-       |
-
-      {:ok, result} = Parser.parse(str, schema)
-
-      assert result == [
-               %Logflare.Lql.ChartRule{
-                 path: "metadata.log.metric5",
-                 aggregate: :sum,
-                 period: :minute,
-                 value_type: :float
-               }
-             ]
-
-      assert Lql.encode!(result)
-             |> String.replace("metadata", "m")
-             |> String.replace("timestamp", "t") ==
-               clean_and_trim_lql_string(str)
+      assert Lql.encode!(result) == qs
     end
 
     test "returns error on malformed timestamp filter" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{},
-          @default_schema
-        )
-
-      str = ~S|
-         log "was generated" "by logflare pinger"
-         timestamp:>20
-       |
-
-      assert {:error,
-              "Error while parsing timestamp filter value: expected ISO8601 string or range or shorthand, got '20'"} ==
-               Parser.parse(str, schema)
-    end
-
-    @tag :failing
-    test "suggests did you mean this when path is not present in schema" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{"user" => %{"user_id" => 1}},
-          @default_schema
-        )
-
-      str = ~S|
-        metadata.user.id:1
-       |
-
-      assert {
-               :error,
-               :field_not_found,
-               "\n        metadata.user.user_id:1\n       ",
-               [
-                 "LQL Parser error: path 'metadata.user.id' not present in source schema. Did you mean '",
-                 "metadata.user.user_id",
-                 "'?"
-               ]
-             } = Parser.parse(str, schema)
+      assert {:error, "Error while parsing timestamp" <> _err} =
+               Parser.parse("timestamp:>20", @default_schema)
     end
 
     test "returns human readable error for invalid query" do
-      schema =
-        SchemaBuilder.build_table_schema(
-          %{},
-          @default_schema
-        )
+      assert {:error, "Error while parsing" <> err} =
+               Parser.parse("metadata.user.emailAddress:", @default_schema)
 
-      str = ~S|
-         metadata.user.emailAddress:
-         metadata.user.clusterId:200..300
-       |
-
-      assert {:error,
-              "Error while parsing `metadata.user.emailAddress` field metadata filter value: \"\""} =
-               Parser.parse(str, schema)
+      assert err =~ "emailAddress"
+      assert err =~ "metadata filter value"
     end
   end
 
   describe "LQL parser for timestamp range shorthand" do
-    test "month/day range" do
-      qs = "t:2020-{05..07}-01"
+    test "year/month/day range" do
+      for {qs, start_date, end_date} <- [
+            {"t:2020-{05..07}-01", ~D[2020-05-01], ~D[2020-07-01]},
+            {"t:2020-05-{01..02}", ~D[2020-05-01], ~D[2020-05-02]},
+            {"t:{2010..2020}-05-{01..02}", ~D[2010-05-01], ~D[2020-05-02]}
+          ] do
+        lql_rules = [
+          %FilterRule{
+            operator: :range,
+            path: "timestamp",
+            values: [start_date, end_date]
+          }
+        ]
 
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~D[2020-05-01], ~D[2020-07-01]]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
-
-      qs = "t:2020-05-{01..02}"
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~D[2020-05-01], ~D[2020-05-02]]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
+        assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
+        assert qs == Lql.encode!(lql_rules)
+      end
     end
 
     test "timestamp filter with leading zero microseconds" do
@@ -1775,12 +423,9 @@ defmodule Logflare.LqlParserTest do
 
       lql_rules = [
         %Logflare.Lql.FilterRule{
-          modifiers: %{},
           operator: :>,
           path: "timestamp",
-          shorthand: nil,
-          value: ~N[2020-01-01 13:14:15.000500],
-          values: nil
+          value: ~N[2020-01-01 13:14:15.000500]
         }
       ]
 
@@ -1790,147 +435,46 @@ defmodule Logflare.LqlParserTest do
     end
 
     test "timestamp microsecond ranges" do
-      qs = "t:2020-01-01T13:14:15.{0..515}"
+      for {range, start_micro, end_micro} <- [
+            {"0..515", "000000", "515000"},
+            {"0101..3555", "010100", "355500"},
+            {"1..7", "100000", "700000"},
+            {"005001..1", "005001", "100000"}
+          ] do
+        qs = "t:2020-01-01T13:14:15.{#{range}}"
 
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [
-            ~N[2020-01-01 13:14:15.000000],
-            ~N[2020-01-01 13:14:15.515000]
-          ]
-        }
-      ]
+        lql_rules = [
+          %Logflare.Lql.FilterRule{
+            operator: :range,
+            path: "timestamp",
+            values: [
+              NaiveDateTime.from_iso8601!("2020-01-01T13:14:15.#{start_micro}"),
+              NaiveDateTime.from_iso8601!("2020-01-01T13:14:15.#{end_micro}")
+            ]
+          }
+        ]
 
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
-
-      qs = "t:2020-01-01T13:14:15.{0101..3555}"
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [
-            ~N[2020-01-01 13:14:15.010100],
-            ~N[2020-01-01 13:14:15.355500]
-          ]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
-
-      qs = "t:2020-01-01T13:14:15.{1..7}"
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [
-            ~N[2020-01-01 13:14:15.100000],
-            ~N[2020-01-01 13:14:15.700000]
-          ]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
-
-      qs = "t:2020-01-01T13:14:15.{005001..100000}"
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [
-            ~N[2020-01-01 13:14:15.005001],
-            ~N[2020-01-01 13:14:15.100000]
-          ]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert "t:2020-01-01T13:14:15.{005001..1}" == Lql.encode!(lql_rules)
+        assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
+        assert qs == Lql.encode!(lql_rules)
+      end
     end
 
-    test "simple case" do
-      qs = "t:2020-{01..02}-01T00:{00..50}:00"
+    test "combined ranges" do
+      qs = "t:2020-{01..12}-{01..30}T{00..23}:{15..20}:{35..55}.{000001..585444}"
 
       lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
+        %FilterRule{
           operator: :range,
           path: "timestamp",
-          shorthand: nil,
-          value: nil,
-          values: [~N[2020-01-01 00:00:00Z], ~N[2020-02-01 00:50:00Z]]
-        }
-      ]
-
-      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
-
-      assert qs == Lql.encode!(lql_rules)
-
-      lql_rules = [
-        %Logflare.Lql.FilterRule{
-          modifiers: %{},
-          operator: :range,
-          path: "timestamp",
-          shorthand: nil,
-          value: nil,
           values: [
-            ~N[2020-01-05 00:15:35],
-            ~N[2020-12-30 23:20:55]
+            ~N[2020-01-01 00:15:35.000001],
+            ~N[2020-12-30 23:20:55.585444]
           ]
         }
       ]
 
-      qs = "t:2020-{01..12}-{05..30}T{00..23}:{15..20}:{35..55}"
-
-      assert {:ok, lql_rules} ==
-               Parser.parse(
-                 qs,
-                 @schema
-               )
-
+      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
       assert qs == Lql.encode!(lql_rules)
-
-      assert {:ok,
-              [
-                %Logflare.Lql.FilterRule{
-                  modifiers: %{},
-                  operator: :range,
-                  path: "timestamp",
-                  shorthand: nil,
-                  value: nil,
-                  values: [
-                    ~N[2020-01-01 00:15:35.000001],
-                    ~N[2020-12-30 23:20:55.585444]
-                  ]
-                }
-              ]} ==
-               Parser.parse(
-                 "timestamp:2020-{01..12}-{01..30}T{00..23}:{15..20}:{35..55}.{000001..585444}",
-                 @schema
-               )
     end
   end
 
@@ -1951,6 +495,10 @@ defmodule Logflare.LqlParserTest do
     end
   end
 
+  def today_dt() do
+    Timex.today() |> Timex.to_datetime()
+  end
+
   def now_ndt() do
     %{Timex.now() | microsecond: {0, 0}}
   end
@@ -1966,5 +514,9 @@ defmodule Logflare.LqlParserTest do
     |> String.replace_prefix("metadata.", "m.")
     |> String.replace(" metadata.", " m.")
     |> String.replace("(metadata.", "(m.")
+  end
+
+  defp build_schema(input) do
+    SchemaBuilder.build_table_schema(input, @default_schema)
   end
 end


### PR DESCRIPTION
This PR fixes the LQL parser tests, and removes lots of redundant and irregular tests. 
Key improvement involves cutting down LOC from >1.5k to ~500, which makes tests drastically easier to grok

part of #1178 