### PR TITLE
chore: add log event testing

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -46,7 +46,68 @@ defmodule Logflare.LogEvent do
     field :make_from, :string
   end
 
-  def mapper(params, source) do
+  @doc """
+  Used to generate log events from bigquery rows.
+  """
+  @spec make_from_db(map(), %{source: Source.t()}) :: LE.t()
+  def make_from_db(params, %{source: %Source{} = source}) do
+    params =
+      params
+      |> Map.update(:metadata, %{}, fn
+        [] -> %{}
+        [metadata] -> metadata
+      end)
+      |> Map.put(:make_from, "db")
+      |> mapper(source)
+
+    changes =
+      %__MODULE__{}
+      |> cast(params, [:valid, :validation_error, :id, :make_from])
+      |> cast_embed(:body, with: &make_body/2)
+      |> cast_embed(:source, with: &Source.no_casting_changeset/1)
+      |> Map.get(:changes)
+
+    body = struct!(Body, changes.body.changes)
+
+    __MODULE__
+    |> struct!(changes)
+    |> Map.put(:body, body)
+    |> Map.replace!(:source, source)
+  end
+
+  @doc """
+  Used to make log event from user-provided parameters, for ingestion.
+  """
+  @spec make(%{optional(String.t()) => term}, %{source: Source.t()}) :: LE.t()
+  def make(params, %{source: source}) do
+    changeset =
+      %__MODULE__{}
+      |> cast(mapper(params, source), [:valid, :validation_error, :ephemeral, :make_from])
+      |> cast_embed(:source, with: &Source.no_casting_changeset/1)
+      |> cast_embed(:body, with: &make_body/2)
+      |> validate_required([:body])
+
+    body = struct!(Body, changeset.changes.body.changes)
+
+    le_map =
+      changeset.changes
+      |> Map.put(:body, body)
+      |> Map.put(:validation_error, changeset_error_to_string(changeset))
+      |> Map.put(:source, source)
+      |> Map.put(:origin_source_id, source.token)
+      |> Map.put(:valid, changeset.valid?)
+      |> Map.put(:params, params)
+      |> Map.put(:ingested_at, NaiveDateTime.utc_now())
+      |> Map.put(:id, body.id)
+      |> Map.put(:sys_uint, System.unique_integer([:monotonic]))
+
+    Logflare.LogEvent
+    |> struct!(le_map)
+    |> validate()
+  end
+
+  # Parses input parameters and performs casting.
+  defp mapper(params, source) do
     message =
       params["log_entry"] || params["message"] ||
         params["event_message"] ||
@@ -103,61 +164,8 @@ defmodule Logflare.LogEvent do
     |> MetadataCleaner.deep_reject_nil_and_empty()
   end
 
-  @spec make_from_db(map(), %{source: Source.t()}) :: LE.t()
-  def make_from_db(params, %{source: %Source{} = source}) do
-    params =
-      params
-      |> Map.update(:metadata, %{}, fn
-        [] -> %{}
-        [metadata] -> metadata
-      end)
-      |> Map.put(:make_from, "db")
-      |> mapper(source)
 
-    changes =
-      %__MODULE__{}
-      |> cast(params, [:valid, :validation_error, :id, :make_from])
-      |> cast_embed(:body, with: &make_body/2)
-      |> cast_embed(:source, with: &Source.no_casting_changeset/1)
-      |> Map.get(:changes)
-
-    body = struct!(Body, changes.body.changes)
-
-    __MODULE__
-    |> struct!(changes)
-    |> Map.put(:body, body)
-    |> Map.replace!(:source, source)
-  end
-
-  @spec make(%{optional(String.t()) => term}, %{source: Source.t()}) :: LE.t()
-  def make(params, %{source: source}) do
-    changeset =
-      %__MODULE__{}
-      |> cast(mapper(params, source), [:valid, :validation_error, :ephemeral, :make_from])
-      |> cast_embed(:source, with: &Source.no_casting_changeset/1)
-      |> cast_embed(:body, with: &make_body/2)
-      |> validate_required([:body])
-
-    body = struct!(Body, changeset.changes.body.changes)
-
-    le_map =
-      changeset.changes
-      |> Map.put(:body, body)
-      |> Map.put(:validation_error, changeset_error_to_string(changeset))
-      |> Map.put(:source, source)
-      |> Map.put(:origin_source_id, source.token)
-      |> Map.put(:valid, changeset.valid?)
-      |> Map.put(:params, params)
-      |> Map.put(:ingested_at, NaiveDateTime.utc_now())
-      |> Map.put(:id, body.id)
-      |> Map.put(:sys_uint, System.unique_integer([:monotonic]))
-
-    Logflare.LogEvent
-    |> struct!(le_map)
-    |> validate()
-  end
-
-  def make_body(_struct, params) do
+  defp make_body(_struct, params) do
     %__MODULE__.Body{}
     |> cast(params, [
       :id,
@@ -172,9 +180,9 @@ defmodule Logflare.LogEvent do
   end
 
   @spec validate(LE.t()) :: LE.t()
-  def validate(%LE{valid: false} = le), do: le
+  defp validate(%LE{valid: false} = le), do: le
 
-  def validate(%LE{valid: true} = le) do
+  defp validate(%LE{valid: true} = le) do
     @validators
     |> Enum.reduce_while(true, fn validator, _acc ->
       case validator.validate(le) do
@@ -187,7 +195,9 @@ defmodule Logflare.LogEvent do
     end)
   end
 
-  def changeset_error_to_string(changeset) do
+  # used to stringify changeset errors
+  # TODO: move to utils
+  defp changeset_error_to_string(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
       Enum.reduce(opts, msg, fn {key, value}, acc ->
         String.replace(acc, "%{#{key}}", to_string(value))
@@ -199,7 +209,8 @@ defmodule Logflare.LogEvent do
     end)
   end
 
-  def put_clustering_keys(params, source) do
+  # hack for adding top level keys to payload
+  defp put_clustering_keys(params, source) do
     case source.token do
       # dev
       :"83e59828-b6ee-408c-92a8-c17bc523e6e0" ->
@@ -235,6 +246,13 @@ defmodule Logflare.LogEvent do
     end
   end
 
+  @doc """
+  Generates a custom event message from source settings.any()
+
+  The `:custom_event_message_keys` key on the source determines what values are extracted from the log event body and set into the `message` key.
+
+  Configuration should be comma separated, and it accepts json query syntax.
+  """
   def apply_custom_event_message(%LE{source: %Source{} = source} = le) do
     message = make_message(le, source)
 

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -164,7 +164,6 @@ defmodule Logflare.LogEvent do
     |> MetadataCleaner.deep_reject_nil_and_empty()
   end
 
-
   defp make_body(_struct, params) do
     %__MODULE__.Body{}
     |> cast(params, [

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -51,4 +51,16 @@ defmodule Logflare.LogEventTest do
     params = %{metadata: [%{"some"=> "value"}]}
     assert %{body: %{metadata: %{"some"=> "value"}}} = LogEvent.make_from_db(params, %{source: source})
   end
+
+  test "apply_custom_event_message/1 generates custom event message from source setting", %{source: source} do
+    params = %{
+      "message"=> "some message",
+      "metadata"=> %{"a"=> "value"}
+    }
+    le =  LogEvent.make(params, %{source: %{source | custom_event_message_keys: "id, message, m.a"}})
+    le = LogEvent.apply_custom_event_message(le)
+    assert le.body.message =~ le.id
+    assert le.body.message =~ "value"
+    assert le.body.message =~ "some message"
+  end
 end

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -1,0 +1,54 @@
+defmodule Logflare.LogEventTest do
+  @moduledoc false
+  use Logflare.DataCase
+  alias Logflare.{LogEvent}
+
+  setup do
+    user = insert(:user)
+    source = insert(:source, user_id: user.id)
+    [source: source, user: user]
+  end
+
+  @valid_params %{"message" => "something", "metadata"=> %{"my"=> "key"}}
+  test "make/2 from valid params", %{source: source} do
+    params = @valid_params
+
+    assert %LogEvent{
+             body: body,
+             drop: false,
+             ephemeral: nil,
+             id: id,
+             ingested_at: _,
+             is_from_stale_query: nil,
+             make_from: nil,
+             params: ^params,
+             source: %_{},
+             sys_uint: _,
+             valid: true,
+             validation_error: "",
+             via_rule: nil
+           } = LogEvent.make(@valid_params, %{source: source})
+
+    assert id == body.id
+    assert body.metadata["my"] == "key"
+  end
+
+  test "make/2 cast custom param values", %{source: source} do
+    params = Map.merge(@valid_params, %{ "make_from"=> "custom", "valid"=> false, "validation_error"=> "some error"})
+    assert %LogEvent{
+      drop: false,
+      ephemeral: nil,
+      # validity gets overwritten
+      valid: true,
+      validation_error: "",
+    } = LogEvent.make(params, %{source: source})
+  end
+
+  test "make_from_db/2", %{source: source} do
+    params = %{metadata: []}
+    assert %{body: %{metadata: %{}}, make_from: "db"} = LogEvent.make_from_db(params, %{source: source})
+
+    params = %{metadata: [%{"some"=> "value"}]}
+    assert %{body: %{metadata: %{"some"=> "value"}}} = LogEvent.make_from_db(params, %{source: source})
+  end
+end

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -9,7 +9,7 @@ defmodule Logflare.LogEventTest do
     [source: source, user: user]
   end
 
-  @valid_params %{"message" => "something", "metadata"=> %{"my"=> "key"}}
+  @valid_params %{"message" => "something", "metadata" => %{"my" => "key"}}
   test "make/2 from valid params", %{source: source} do
     params = @valid_params
 
@@ -34,30 +34,45 @@ defmodule Logflare.LogEventTest do
   end
 
   test "make/2 cast custom param values", %{source: source} do
-    params = Map.merge(@valid_params, %{ "make_from"=> "custom", "valid"=> false, "validation_error"=> "some error"})
+    params =
+      Map.merge(@valid_params, %{
+        "make_from" => "custom",
+        "valid" => false,
+        "validation_error" => "some error"
+      })
+
     assert %LogEvent{
-      drop: false,
-      ephemeral: nil,
-      # validity gets overwritten
-      valid: true,
-      validation_error: "",
-    } = LogEvent.make(params, %{source: source})
+             drop: false,
+             ephemeral: nil,
+             # validity gets overwritten
+             valid: true,
+             validation_error: ""
+           } = LogEvent.make(params, %{source: source})
   end
 
   test "make_from_db/2", %{source: source} do
     params = %{metadata: []}
-    assert %{body: %{metadata: %{}}, make_from: "db"} = LogEvent.make_from_db(params, %{source: source})
 
-    params = %{metadata: [%{"some"=> "value"}]}
-    assert %{body: %{metadata: %{"some"=> "value"}}} = LogEvent.make_from_db(params, %{source: source})
+    assert %{body: %{metadata: %{}}, make_from: "db"} =
+             LogEvent.make_from_db(params, %{source: source})
+
+    params = %{metadata: [%{"some" => "value"}]}
+
+    assert %{body: %{metadata: %{"some" => "value"}}} =
+             LogEvent.make_from_db(params, %{source: source})
   end
 
-  test "apply_custom_event_message/1 generates custom event message from source setting", %{source: source} do
+  test "apply_custom_event_message/1 generates custom event message from source setting", %{
+    source: source
+  } do
     params = %{
-      "message"=> "some message",
-      "metadata"=> %{"a"=> "value"}
+      "message" => "some message",
+      "metadata" => %{"a" => "value"}
     }
-    le =  LogEvent.make(params, %{source: %{source | custom_event_message_keys: "id, message, m.a"}})
+
+    le =
+      LogEvent.make(params, %{source: %{source | custom_event_message_keys: "id, message, m.a"}})
+
     le = LogEvent.apply_custom_event_message(le)
     assert le.body.message =~ le.id
     assert le.body.message =~ "value"


### PR DESCRIPTION
Adds some testing for LogEvent functions, as #1178 requires removal of the LogEvent.Body for more payload flexibility.