### PR TITLE
chore: remove ephemeral logevent key

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -128,7 +128,7 @@ defmodule Logflare.LogEvent do
 
     %{
       "body" => body,
-      "id" => id,
+      "id" => id
     }
     |> MetadataCleaner.deep_reject_nil_and_empty()
   end

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -25,7 +25,6 @@ defmodule Logflare.LogEvent do
     field :params, :map
     field :origin_source_id, Ecto.UUID.Atom
     field :via_rule, :map
-    field :ephemeral, :boolean
   end
 
   @doc """
@@ -55,7 +54,7 @@ defmodule Logflare.LogEvent do
   def make(params, %{source: source}) do
     changeset =
       %__MODULE__{}
-      |> cast(mapper(params, source), [:body, :valid, :validation_error, :ephemeral])
+      |> cast(mapper(params, source), [:body, :valid, :validation_error])
       |> cast_embed(:source, with: &Source.no_casting_changeset/1)
       |> validate_required([:body])
 
@@ -130,7 +129,6 @@ defmodule Logflare.LogEvent do
     %{
       "body" => body,
       "id" => id,
-      "ephemeral" => params["ephemeral"]
     }
     |> MetadataCleaner.deep_reject_nil_and_empty()
   end

--- a/lib/logflare_web/live/search_live/templates/logs_list.html.leex
+++ b/lib/logflare_web/live/search_live/templates/logs_list.html.leex
@@ -14,10 +14,8 @@
               <mark class="log-datestamp" data-timestamp="<%= timestamp %>"> <%= format_timestamp(timestamp) <> " UTC"%></mark>
             <% end %>
             <%= message %>
-            <%= unless log.ephemeral do %>
-              <%= live_modal_show_link(component: LogflareWeb.Search.LogEventViewerComponent, modal_id: :log_event_viewer, title: "Log Event", phx_value_log_event_id: log.id, phx_value_log_event_timestamp: log.body["timestamp"]) do %>
-                <span>event data</span>
-              <% end %>
+            <%= live_modal_show_link(component: LogflareWeb.Search.LogEventViewerComponent, modal_id: :log_event_viewer, title: "Log Event", phx_value_log_event_id: log.id, phx_value_log_event_timestamp: log.body["timestamp"]) do %>
+              <span>event data</span>
             <% end %>
           </li>
         <% end %>

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -16,7 +16,6 @@ defmodule Logflare.LogEventTest do
     assert %LogEvent{
              body: body,
              drop: false,
-             ephemeral: nil,
              id: id,
              ingested_at: _,
              is_from_stale_query: nil,
@@ -41,7 +40,6 @@ defmodule Logflare.LogEventTest do
 
     assert %LogEvent{
              drop: false,
-             ephemeral: nil,
              # validity gets overwritten
              valid: true,
              validation_error: "",


### PR DESCRIPTION
Removes the `:ephemeral` key from the `LogEvent` struct, as it is unused.

Depends on #1184 
