### PR TITLE
Acount query endpoint API

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -3,7 +3,7 @@ defmodule Logflare.Endpoints do
   import Ecto.Query
   alias Logflare.Endpoints.Query
   alias Logflare.Repo
-
+  alias Logflare.User
   @spec get_query_by_token(binary()) :: Query.t() | nil
   def get_query_by_token(token) when is_binary(token) do
     query =
@@ -16,5 +16,27 @@ defmodule Logflare.Endpoints do
   @spec get_by(Keyword.t()) :: Query.t() | nil
   def get_by(kw) do
     Repo.get_by(Query, kw)
+  end
+
+  @spec create_query(User.t(), map()) :: {:ok, Query.t()} | {:error, any()}
+  def create_query(user, params) do
+    user
+    |> Ecto.build_assoc(:endpoint_queries)
+    |> Repo.preload(:user)
+    |> Query.update_by_user_changeset(params)
+    |> Repo.insert()
+  end
+
+  @spec update_query(Query.t(), map()) :: {:ok, Query.t()} | {:error, any()}
+  def update_query(query, params) do
+    query
+    |> Repo.preload(:user)
+    |> Query.update_by_user_changeset(params)
+    |> Repo.update()
+  end
+
+  @spec delete_query(Query.t()) :: {:ok, Query.t()} | {:error, any()}
+  def delete_query(query) do
+    Repo.delete(query)
   end
 end

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -1,7 +1,7 @@
 defmodule Logflare.Endpoints do
   @moduledoc false
   import Ecto.Query
-  alias __MODULE__.Query
+  alias Logflare.Endpoints.Query
   alias Logflare.Repo
 
   @spec get_query_by_token(binary()) :: Query.t() | nil
@@ -11,5 +11,10 @@ defmodule Logflare.Endpoints do
         where: q.token == ^token
 
     Repo.one(query) |> Query.map_query()
+  end
+
+  @spec get_by(Keyword.t()) :: Query.t() | nil
+  def get_by(kw) do
+    Repo.get_by(Query, kw)
   end
 end

--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -4,6 +4,18 @@ defmodule Logflare.Endpoints.Query do
   import Ecto.Changeset
   require Logger
 
+  @derive {Jason.Encoder,
+           only: [
+             :token,
+             :name,
+             :query,
+             :source_mapping,
+             :sandboxable,
+             :cache_duration_seconds,
+             :proactive_requerying_seconds,
+             :max_limit,
+             :enable_auth
+           ]}
   schema "endpoint_queries" do
     field :token, Ecto.UUID
     field :name, :string

--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -17,7 +17,7 @@ defmodule Logflare.Endpoints.Query do
              :enable_auth
            ]}
   schema "endpoint_queries" do
-    field :token, Ecto.UUID
+    field :token, Ecto.UUID, autogenerate: true
     field :name, :string
     field :query, :string
     field :source_mapping, :map
@@ -45,7 +45,7 @@ defmodule Logflare.Endpoints.Query do
       :max_limit,
       :enable_auth
     ])
-    |> validate_required([:name, :token, :query])
+    |> validate_required([:name, :query])
   end
 
   def update_by_user_changeset(query, attrs) do
@@ -66,7 +66,7 @@ defmodule Logflare.Endpoints.Query do
 
   def default_validations(changeset) do
     changeset
-    |> validate_required([:name, :token, :query, :user])
+    |> validate_required([:name, :query, :user])
     |> validate_query(:query)
     |> unique_constraint(:name, name: :endpoint_queries_name_index)
     |> unique_constraint(:token)
@@ -85,27 +85,20 @@ defmodule Logflare.Endpoints.Query do
     end)
   end
 
-  def update_source_mapping(changeset) do
-    if Enum.empty?(changeset.errors) do
-      # Only update source mapping if there are no errors
-      query = get_field(changeset, :query)
+  # Only update source mapping if there are no errors
+  def update_source_mapping(%{errors: [], changes: %{query: query}} = changeset)
+      when is_binary(query) do
+    case Logflare.SQL.sources(query, get_field(changeset, :user)) do
+      {:ok, source_mapping} ->
+        Logger.debug("Source mapping: #{inspect(source_mapping, pretty: true)}")
+        put_change(changeset, :source_mapping, source_mapping)
 
-      if query do
-        case Logflare.SQL.sources(query, get_field(changeset, :user)) do
-          {:ok, source_mapping} ->
-            Logger.debug("Source mapping: #{inspect(source_mapping, pretty: true)}")
-            put_change(changeset, :source_mapping, source_mapping)
-
-          {:error, error} ->
-            add_error(changeset, :query, error)
-        end
-      else
-        changeset
-      end
-    else
-      changeset
+      {:error, error} ->
+        add_error(changeset, :query, error)
     end
   end
+
+  def update_source_mapping(changeset), do: changeset
 
   def map_query(%__MODULE__{query: query, source_mapping: source_mapping, user_id: user_id} = q) do
     case Logflare.SQL.source_mapping(query, user_id, source_mapping) do

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -1,11 +1,17 @@
 defmodule LogflareWeb.Api.EndpointController do
   use LogflareWeb, :controller
   alias Logflare.Users
-
+  alias Logflare.Endpoints
   action_fallback LogflareWeb.Api.FallbackController
 
   def index(%{assigns: %{user: user}} = conn, _) do
     user = Users.preload_endpoints(user)
     json(conn, user.endpoint_queries)
+  end
+
+  def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with source when not is_nil(source) <- Endpoints.get_by(token: token, user_id: user.id) do
+      json(conn, source)
+    end
   end
 end

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -10,8 +10,34 @@ defmodule LogflareWeb.Api.EndpointController do
   end
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
-    with source when not is_nil(source) <- Endpoints.get_by(token: token, user_id: user.id) do
-      json(conn, source)
+    with query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id) do
+      json(conn, query)
+    end
+  end
+
+  def create(%{assigns: %{user: user}} = conn, params) do
+    with {:ok, query} <- Endpoints.create_query(user, params) do
+      conn
+      |> put_status(201)
+      |> json(query)
+    end
+  end
+
+  def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
+    with query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id),
+         {:ok, query} <- Endpoints.update_query(query, params) do
+      conn
+      |> put_status(204)
+      |> json(query)
+    end
+  end
+
+  def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id),
+         {:ok, _} <- Endpoints.delete_query(query) do
+      conn
+      |> Plug.Conn.send_resp(204, [])
+      |> Plug.Conn.halt()
     end
   end
 end

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -1,0 +1,11 @@
+defmodule LogflareWeb.Api.EndpointController do
+  use LogflareWeb, :controller
+  alias Logflare.Users
+
+  action_fallback LogflareWeb.Api.FallbackController
+
+  def index(%{assigns: %{user: user}} = conn, _) do
+    user = Users.preload_endpoints(user)
+    json(conn, user.endpoint_queries)
+  end
+end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -351,6 +351,10 @@ defmodule LogflareWeb.Router do
     resources "/sources", Api.SourceController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]
+
+    resources "/endpoints", Api.EndpointController,
+      param: "token",
+      only: [:index, :show, :create, :update, :delete]
   end
 
   # Old log ingest endpoint. Deprecate.

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -354,7 +354,7 @@ defmodule LogflareWeb.Router do
 
     resources "/endpoints", Api.EndpointController,
       param: "token",
-      only: [:index, :show, :create, :update, :delete]
+      only: [:index, :show]
   end
 
   # Old log ingest endpoint. Deprecate.

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -354,7 +354,7 @@ defmodule LogflareWeb.Router do
 
     resources "/endpoints", Api.EndpointController,
       param: "token",
-      only: [:index, :show]
+      only: [:index, :show, :create, :update, :delete]
   end
 
   # Old log ingest endpoint. Deprecate.

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -6,11 +6,15 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     endpoints = insert_list(2, :endpoint)
     user = insert(:user, endpoint_queries: endpoints)
 
+    Logflare.SQL
+    |> stub(:transform, fn _, _ -> {:ok, nil} end)
+    |> stub(:sources, fn _, _ -> {:ok, nil} end)
+
     {:ok, user: user, endpoints: endpoints}
   end
 
   describe "index/2" do
-    test "returns list of sources for given user", %{
+    test "returns list of endpoint queries for given user", %{
       conn: conn,
       user: user,
       endpoints: endpoints
@@ -29,7 +33,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
   end
 
   describe "show/2" do
-    test "returns single sources for given user", %{
+    test "returns single endpoint query for given user", %{
       conn: conn,
       user: user,
       endpoints: [endpoint | _]
@@ -43,7 +47,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       assert response["token"] == endpoint.token
     end
 
-    test "returns not found if doesn't own the source", %{
+    test "returns not found if doesn't own the endpoint query", %{
       conn: conn,
       endpoints: [endpoint | _]
     } do
@@ -54,5 +58,106 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> get("/api/endpoints/#{endpoint.token}")
       |> response(404)
     end
+  end
+
+  describe "create/2" do
+    test "creates a new endpoint query for an authenticated user", %{
+      conn: conn,
+      user: user
+    } do
+      name = TestUtils.random_string()
+
+      response =
+        conn
+        |> login_user(user)
+        |> post("/api/endpoints", %{name: name, query: "select * from logs"})
+        |> json_response(201)
+
+      assert response["name"] == name
+    end
+  end
+
+  describe "update/2" do
+    test "updates an existing enpoint query from a user", %{
+      conn: conn,
+      user: user,
+      endpoints: [endpoint | _]
+    } do
+      name = TestUtils.random_string()
+
+      response =
+        conn
+        |> login_user(user)
+        |> patch("/api/endpoints/#{endpoint.token}", %{name: name})
+        |> json_response(204)
+
+      assert response["name"] == name
+    end
+
+    test "returns not found if doesn't own the enpoint query", %{
+      conn: conn,
+      endpoints: [endpoint | _]
+    } do
+      invalid_user = insert(:user)
+
+      conn
+      |> login_user(invalid_user)
+      |> patch("/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
+      |> response(404)
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an existing enpoint query from a user", %{
+      conn: conn,
+      user: user,
+      endpoints: [endpoint | _]
+    } do
+      name = TestUtils.random_string()
+
+      conn
+      |> login_user(user)
+      |> delete("/api/endpoints/#{endpoint.token}", %{name: name})
+      |> response(204)
+
+      conn
+      |> login_user(user)
+      |> get("/api/endpoints/#{endpoint.token}")
+      |> response(404)
+    end
+
+    test "returns not found if doesn't own the enpoint query", %{
+      conn: conn,
+      endpoints: [endpoint | _]
+    } do
+      invalid_user = insert(:user)
+
+      conn
+      |> login_user(invalid_user)
+      |> delete("/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
+      |> response(404)
+    end
+  end
+
+  test "changeset errors handled gracefully", %{
+    conn: conn,
+    user: user,
+    endpoints: [endpoint | _]
+  } do
+    resp =
+      conn
+      |> login_user(user)
+      |> post("/api/endpoints")
+      |> json_response(422)
+
+    assert resp == %{"errors" => %{"name" => ["can't be blank"], "query" => ["can't be blank"]}}
+
+    resp =
+      conn
+      |> login_user(user)
+      |> patch("/api/endpoints/#{endpoint.token}", %{name: 123})
+      |> json_response(422)
+
+    assert resp == %{"errors" => %{"name" => ["is invalid"]}}
   end
 end

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule LogflareWeb.Api.EndpointControllerTest do
+  use LogflareWeb.ConnCase
+  import Logflare.Factory
+
+  setup do
+    endpoints = insert_list(2, :endpoint)
+    user = insert(:user, endpoint_queries: endpoints)
+
+    {:ok, user: user, endpoints: endpoints}
+  end
+
+  describe "index/2" do
+    test "returns list of sources for given user", %{
+      conn: conn,
+      user: user,
+      endpoints: endpoints
+    } do
+      response =
+        conn
+        |> login_user(user)
+        |> get("/api/endpoints")
+        |> json_response(200)
+
+      response = response |> Enum.map(& &1["token"]) |> Enum.sort()
+      expected = endpoints |> Enum.map(& &1.token) |> Enum.sort()
+
+      assert response == expected
+    end
+  end
+end

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -27,4 +27,32 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       assert response == expected
     end
   end
+
+  describe "show/2" do
+    test "returns single sources for given user", %{
+      conn: conn,
+      user: user,
+      endpoints: [endpoint | _]
+    } do
+      response =
+        conn
+        |> login_user(user)
+        |> get("/api/endpoints/#{endpoint.token}")
+        |> json_response(200)
+
+      assert response["token"] == endpoint.token
+    end
+
+    test "returns not found if doesn't own the source", %{
+      conn: conn,
+      endpoints: [endpoint | _]
+    } do
+      invalid_user = insert(:user)
+
+      conn
+      |> login_user(invalid_user)
+      |> get("/api/endpoints/#{endpoint.token}")
+      |> response(404)
+    end
+  end
 end

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -1,5 +1,4 @@
 defmodule LogflareWeb.Api.SourceControllerTest do
-  use ExUnit.Case
   use LogflareWeb.ConnCase
 
   import Logflare.Factory

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -12,6 +12,7 @@ defmodule Logflare.Factory do
   alias Logflare.Billing.Plan
   alias Logflare.Endpoints.Query
   alias Logflare.LogEvent
+  alias Logflare.Lql
   alias Logflare.OauthAccessTokens.OauthAccessToken
   alias Logflare.Rule
   alias Logflare.Source

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,21 +4,21 @@ defmodule Logflare.Factory do
   """
   use ExMachina.Ecto, repo: Logflare.Repo
 
-  alias Logflare.{
-    Lql,
-    User,
-    Source,
-    Rule,
-    LogEvent,
-    Billing.BillingAccount,
-    Billing.PaymentMethod
-  }
-
-  alias Logflare.Users.UserPreferences
-  alias Logflare.Endpoints.Query
-  alias Logflare.OauthAccessTokens.OauthAccessToken
-  alias Logflare.{Billing.Plan, Teams.Team, TeamUsers.TeamUser, Backends.SourceBackend}
   import Logflare.TestUtils
+
+  alias Logflare.Backends.SourceBackend
+  alias Logflare.Billing.BillingAccount
+  alias Logflare.Billing.PaymentMethod
+  alias Logflare.Billing.Plan
+  alias Logflare.Endpoints.Query
+  alias Logflare.LogEvent
+  alias Logflare.OauthAccessTokens.OauthAccessToken
+  alias Logflare.Rule
+  alias Logflare.Source
+  alias Logflare.Teams.Team
+  alias Logflare.TeamUsers.TeamUser
+  alias Logflare.User
+  alias Logflare.Users.UserPreferences
 
   def user_factory do
     %User{


### PR DESCRIPTION
Adds multiple operations to an accounts query endpoint API

* GET /api/endpoints - Lists all queries for a given user
* GET /api/endpoints/:token - Show single query for a given user
* POST /api/endpoints - Create a new query entry
* PUT /api/endpoints/:token - Updates an existing query
* DELETE /api/endpoints/:token - Deletes an existing query