### PR TITLE
fix: allow non-map values for metadata key ingestion transformers

### DIFF
--- a/lib/logflare/logs/ingest_transformers.ex
+++ b/lib/logflare/logs/ingest_transformers.ex
@@ -14,9 +14,7 @@ defmodule Logflare.Logs.IngestTransformers do
   end
 
   def transform(log_params, rules) when is_map(log_params) and is_list(rules) do
-    Map.update(log_params, "metadata", %{}, fn m ->
-      Enum.reduce(rules, m, &do_transform(&2, &1))
-    end)
+    Enum.reduce(rules, log_params, &do_transform(&2, &1))
   end
 
   @spec do_transform(map, atom) :: map

--- a/test/logflare/logs/ingest/ingest_transformer_test.exs
+++ b/test/logflare/logs/ingest/ingest_transformer_test.exs
@@ -244,9 +244,9 @@ defmodule Logflare.Logs.IngestTransformerTest do
 
     test "max length" do
       assert Enum.map(@batch, &transform(&1, [{:field_length, max: 5}])) == [
-               %{"metadata" => %{"_12345" => %{"_12345" => %{"12345" => "value"}}}},
-               %{"metadata" => %{"_12345" => %{"_12345" => %{"12345" => "value"}}}},
-               %{"metadata" => %{"_12345" => [%{"_12345" => %{"12345" => "value"}}]}}
+               %{"_metad" => %{"_12345" => %{"_12345" => %{"12345" => "value"}}}},
+               %{"_metad" => %{"_12345" => %{"_12345" => %{"12345" => "value"}}}},
+               %{"_metad" => %{"_12345" => [%{"_12345" => %{"12345" => "value"}}]}}
              ]
     end
   end

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -14,8 +14,10 @@ defmodule Logflare.LogsTest do
   end
 
   describe "ingest input" do
-    test "empty list" do
-      source = insert(:source, user: build(:user))
+    setup do
+      [source: insert(:source, user: build(:user))]
+    end
+    test "empty list", %{source: source} do
 
       Logs
       |> Mimic.reject(:broadcast, 1)
@@ -23,9 +25,7 @@ defmodule Logflare.LogsTest do
       assert :ok = Logs.ingest_logs([], source)
     end
 
-    test "top level keys" do
-      source = insert(:source, user: build(:user))
-
+    test "top level keys" , %{source: source} do
       Logs
       |> expect(:broadcast, 1, fn le ->
         # TODO: should be event_message
@@ -40,6 +40,20 @@ defmodule Logflare.LogsTest do
       ]
 
       assert :ok = Logs.ingest_logs(batch, source)
+    end
+    test "non-map value for metadata key" , %{source: source} do
+        Logs
+        |> expect(:broadcast, 1, fn le ->
+          assert %{"metadata" => "some_value"} = le.body
+          le
+        end)
+
+        batch = [
+          %{"event_message" => "any", "metadata"=> "some_value"}
+        ]
+
+        assert :ok = Logs.ingest_logs(batch, source)
+
     end
   end
 

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -17,15 +17,15 @@ defmodule Logflare.LogsTest do
     setup do
       [source: insert(:source, user: build(:user))]
     end
-    test "empty list", %{source: source} do
 
+    test "empty list", %{source: source} do
       Logs
       |> Mimic.reject(:broadcast, 1)
 
       assert :ok = Logs.ingest_logs([], source)
     end
 
-    test "top level keys" , %{source: source} do
+    test "top level keys", %{source: source} do
       Logs
       |> expect(:broadcast, 1, fn le ->
         # TODO: should be event_message
@@ -41,19 +41,19 @@ defmodule Logflare.LogsTest do
 
       assert :ok = Logs.ingest_logs(batch, source)
     end
-    test "non-map value for metadata key" , %{source: source} do
-        Logs
-        |> expect(:broadcast, 1, fn le ->
-          assert %{"metadata" => "some_value"} = le.body
-          le
-        end)
 
-        batch = [
-          %{"event_message" => "any", "metadata"=> "some_value"}
-        ]
+    test "non-map value for metadata key", %{source: source} do
+      Logs
+      |> expect(:broadcast, 1, fn le ->
+        assert %{"metadata" => "some_value"} = le.body
+        le
+      end)
 
-        assert :ok = Logs.ingest_logs(batch, source)
+      batch = [
+        %{"event_message" => "any", "metadata" => "some_value"}
+      ]
 
+      assert :ok = Logs.ingest_logs(batch, source)
     end
   end
 


### PR DESCRIPTION
Bugfix with ingestion transformers only applying to the `metadata` key and assuming that it is always a map.

This PR adjusts this behaviour and applies the transformers on all parameters, which is the desired behaviour for top-level keys ingestion.

Reference [ticket](https://www.notion.so/supabase/bug-log-ingestion-do_transform-no-matching-function-clause-error-953faff4efda40e2940ff3ad9059d294)