### PR TITLE
chore: remove _includes lql operator

### DIFF
--- a/lib/logflare/logs/lql/lql_parser_helpers.ex
+++ b/lib/logflare/logs/lql/lql_parser_helpers.ex
@@ -160,7 +160,7 @@ defmodule Logflare.Lql.Parser.Helpers do
       string(":>") |> replace(:>),
       string(":<") |> replace(:<),
       string(":~") |> replace(:"~"),
-      choice([string(":@>"), string(":_includes")]) |> replace(@list_includes_op),
+      string(":@>") |> replace(@list_includes_op),
       # string(":") should always be the last choice
       string(":") |> replace(:=)
     ])


### PR DESCRIPTION
removes the undocumented and unused `_includes` lql operator. Tests containing it has already been refactored and removed in a previous PR.

