### PR TITLE
Fix/clustering key fix

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -167,6 +167,7 @@ defmodule Logflare.LogEvent do
   # hack for adding top level keys to payload
   defp put_clustering_keys(params, source) do
     top_level_project = Map.get(params, "project")
+
     case source.token do
       # dev
       :"83e59828-b6ee-408c-92a8-c17bc523e6e0" ->
@@ -175,7 +176,7 @@ defmodule Logflare.LogEvent do
         params |> Map.put("level", key)
 
       # prod Postgres logs
-      :"74c7911a-4671-46b7-9c7f-440a18bc6bad" when is_nil(top_level_project)->
+      :"74c7911a-4671-46b7-9c7f-440a18bc6bad" when is_nil(top_level_project) ->
         key = Kernel.get_in(params, ["metadata", "project"])
 
         if is_nil(key),

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -166,6 +166,7 @@ defmodule Logflare.LogEvent do
 
   # hack for adding top level keys to payload
   defp put_clustering_keys(params, source) do
+    top_level_project = Map.get(params, "project")
     case source.token do
       # dev
       :"83e59828-b6ee-408c-92a8-c17bc523e6e0" ->
@@ -174,7 +175,7 @@ defmodule Logflare.LogEvent do
         params |> Map.put("level", key)
 
       # prod Postgres logs
-      :"74c7911a-4671-46b7-9c7f-440a18bc6bad" ->
+      :"74c7911a-4671-46b7-9c7f-440a18bc6bad" when is_nil(top_level_project)->
         key = Kernel.get_in(params, ["metadata", "project"])
 
         if is_nil(key),
@@ -183,7 +184,7 @@ defmodule Logflare.LogEvent do
         params |> Map.put("project", key)
 
       # prod Cloudflare
-      :"7b5df630-a551-4c79-ae17-042650b37a3e" ->
+      :"7b5df630-a551-4c79-ae17-042650b37a3e" when is_nil(top_level_project) ->
         host = Kernel.get_in(params, ["metadata", "request", "host"])
 
         unless is_nil(host) do


### PR DESCRIPTION
This PR adds in a guard for the top level `project` field for specific sources, as a fix for phasing the workaround for the top level project key rewrite.

Full removal of the clustering key logic can only be done once CF and pg log pipelines are updated, hence the addition of the guard ensure that we only do the rewrite when the key is not provided (should not be the case anymore once the api gateway fix is rolled to prod).