### PR TITLE
Move nil check for Source into GenServer

### DIFF
--- a/lib/logflare/source/supervisor.ex
+++ b/lib/logflare/source/supervisor.ex
@@ -149,11 +149,10 @@ defmodule Logflare.Source.Supervisor do
 
     # Double check source is in the database before starting
     # Can be removed when manager fns move into their own genserver
-    if Sources.get_by(token: source_id) do
-      GenServer.abcast(__MODULE__, {:create, source_id})
-    else
-      Logger.warn("Attempted to start a source not found in the database.", source_id: source_id)
-    end
+
+    GenServer.abcast(__MODULE__, {:create, source_id})
+
+    {:ok, source_id}
   end
 
   def delete_source(source_id) do
@@ -181,15 +180,20 @@ defmodule Logflare.Source.Supervisor do
 
   defp create_source(source_id) do
     source = Sources.get_by(token: source_id)
-    rls = %RLS{source_id: source_id, source: source}
 
-    children = [
-      Supervisor.child_spec({RLS, rls}, id: source_id, restart: :transient)
-    ]
+    if source do
+      rls = %RLS{source_id: source_id, source: source}
 
-    init_table(source_id)
+      children = [
+        Supervisor.child_spec({RLS, rls}, id: source_id, restart: :transient)
+      ]
 
-    Supervisor.start_link(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)
+      init_table(source_id)
+
+      Supervisor.start_link(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)
+    else
+      {:error, :not_found_in_db}
+    end
   end
 
   defp reset_persisted_schema(source_id) do


### PR DESCRIPTION
- Makes sure the source exists before trying to start it.
- Moves this check into the Supervisor handle_info so that it should never try to start a source which is not found in the database.