### PR TITLE
Fix/top level nested lql key sql gen

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,6 +5,7 @@ config :logflare,
   env: :dev
 
 config :logflare, LogflareWeb.Endpoint,
+  server: true,
   http: [
     port: System.get_env("PORT") || 4000,
     transport_options: [

--- a/lib/logflare/logs/lql/bigquery/lql_ecto_helpers.ex
+++ b/lib/logflare/logs/lql/bigquery/lql_ecto_helpers.ex
@@ -2,7 +2,7 @@ defmodule Logflare.Lql.EctoHelpers do
   @moduledoc false
   import Ecto.Query
   alias Logflare.Lql.FilterRule
-  @top_level ~w(_PARTITIONDATE _PARTITIONTIME event_message timestamp id)
+  @special_top_level ~w(_PARTITIONDATE _PARTITIONTIME event_message timestamp id)
 
   @spec apply_filter_rules_to_query(Ecto.Query.t(), [FilterRule.t()], keyword) :: Ecto.Query.t()
   def apply_filter_rules_to_query(query, filter_rules, opts \\ [adapter: :bigquery])
@@ -12,7 +12,11 @@ defmodule Logflare.Lql.EctoHelpers do
   end
 
   def apply_filter_rules_to_query(query, rules, _opts) do
-    {top_level_filters, other_filters} = Enum.split_with(rules, &(&1.path in @top_level))
+    {top_level_filters, other_filters} =
+      Enum.split_with(
+        rules,
+        &(&1.path in @special_top_level or not String.contains?(&1.path, "."))
+      )
 
     query =
       top_level_filters

--- a/test/logflare/bigquery/ecto_query_bq_test.exs
+++ b/test/logflare/bigquery/ecto_query_bq_test.exs
@@ -84,6 +84,30 @@ defmodule Logflare.BigQuery.EctoQueryBQTest do
       end
     end
 
+    test "top level and nested" do
+      filter_rules = [
+        %FilterRule{
+          path: "metadata.nested",
+          operator: :=,
+          value: "value"
+        },
+        %FilterRule{
+          path: "top",
+          operator: :=,
+          value: "level"
+        }
+      ]
+
+      query =
+        from(@bq_table_id)
+        |> select([:timestamp, :metadata])
+        |> Lql.EctoHelpers.apply_filter_rules_to_query(filter_rules)
+
+      {sql, _params} = EctoQueryBQ.SQL.to_sql_params(query)
+      assert sql =~ "0.top = ?"
+      assert sql =~ "1.nested = ?"
+    end
+
     test "deeply nested" do
       filter_rules = [
         %FilterRule{

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -7,6 +7,10 @@ defmodule Logflare.TestUtils do
 
   def default_bq_schema, do: SchemaBuilder.initial_table_schema()
 
+  def build_bq_schema(params) do
+    SchemaBuilder.build_table_schema(params, default_bq_schema())
+  end
+
   @spec random_string(non_neg_integer()) :: String.t()
   def random_string(length \\ 6) do
     :crypto.strong_rand_bytes(length) |> Base.url_encode64() |> binary_part(0, length)


### PR DESCRIPTION
Bugfix for backend search error when top level keys are combined with nested keys for LQL, resulting in the sql generated to have all keys pointing to the inner join.

Also added a `server: true` for the phoenix endpoint config so that `iex -S mix` works as normal

ref [ticket](https://www.notion.so/supabase/Backend-Search-Error-187112eabd094dcc8042c6952f4f5fac) has full investigation.