### PR TITLE
Add Teams / Teams User management API

### DIFF
--- a/lib/logflare/team_users/team_user.ex
+++ b/lib/logflare/team_users/team_user.ex
@@ -4,6 +4,7 @@ defmodule Logflare.TeamUsers.TeamUser do
   alias Logflare.Users.UserPreferences
   alias Logflare.Teams.Team
   use TypedEctoSchema
+  @derive {Jason.Encoder, only: [:email, :name]}
 
   typed_schema "team_users" do
     field :email, :string
@@ -14,7 +15,8 @@ defmodule Logflare.TeamUsers.TeamUser do
     field :phone, :string
     field :provider, :string
     field :provider_uid, :string
-    field :token, :string
+    field :token, :string, autogenerate: {Ecto.UUID, :generate, []}
+
     field :valid_google_account, :boolean
 
     embeds_one :preferences, UserPreferences
@@ -39,7 +41,7 @@ defmodule Logflare.TeamUsers.TeamUser do
       :valid_google_account,
       :provider_uid
     ])
-    |> validate_required([:email, :provider, :token, :provider_uid])
+    |> validate_required([:email, :provider, :provider_uid])
     |> downcase_emails()
     |> downcase_email_provider_uid(team_user)
   end

--- a/lib/logflare/teams.ex
+++ b/lib/logflare/teams.ex
@@ -1,13 +1,15 @@
 defmodule Logflare.Teams do
   @moduledoc false
   import Ecto.Query, warn: false
-  alias Logflare.{Repo, Teams.Team, TeamUsers.TeamUser, Users, User}
+  alias Logflare.Repo
+  alias Logflare.Teams.Team
+  alias Logflare.TeamUsers.TeamUser
+  alias Logflare.Users
+  alias Logflare.User
 
   @doc "Returns a list of teams. Unfiltered."
   @spec list_teams() :: [Team.t()]
-  def list_teams do
-    Repo.all(Team)
-  end
+  def list_teams, do: Repo.all(Team)
 
   @doc "Gets a single team. Raises `Ecto.NoResultsError` if the Team does not exist."
   @spec get_team!(String.t() | number()) :: Team.t()
@@ -21,28 +23,29 @@ defmodule Logflare.Teams do
   @spec get_home_team(TeamUser.t()) :: Team.t() | nil
   def get_home_team(%TeamUser{email: email}) do
     case Users.get_by(email: email) |> Users.preload_team() do
-      nil ->
-        nil
-
-      user ->
-        user.team
+      nil -> nil
+      %{team: team} -> team
     end
   end
 
   @doc "Preloads the `:user` assoc"
-  @spec preload_user(nil | Team.t()) :: Team.t()
+  @spec preload_user(nil | Team.t()) :: Team.t() | nil
   def preload_user(nil), do: nil
   def preload_user(team), do: Repo.preload(team, :user)
 
-  @doc "preloads the `:team_users` assoc"
-  @spec preload_team_users(nil | Team.t()) :: Team.t()
+  @doc "Preloads the `:team_users` assoc"
+  @spec preload_team_users(nil | Team.t()) :: Team.t() | nil
   def preload_team_users(nil), do: nil
   def preload_team_users(team), do: Repo.preload(team, :team_users)
 
+  @doc "Preloads given fields of a Team"
+  @spec preload_fields(nil | Team.t(), list(keyword() | atom())) :: Team.t() | nil
+  def preload_fields(nil, _fields), do: nil
+  def preload_fields(team, fields), do: Repo.preload(team, fields)
+
   @doc "Creates a team from a user."
-  @spec create_team(User.t(), %{name: String.t()}) ::
-          {:ok, Team.t()} | {:error, Ecto.Changeset.t()}
-  def create_team(user, %{name: _name} = attrs) do
+  @spec create_team(User.t(), map()) :: {:ok, Team.t()} | {:error, Ecto.Changeset.t()}
+  def create_team(user, attrs) do
     user
     |> Ecto.build_assoc(:team)
     |> Team.changeset(attrs)
@@ -64,4 +67,44 @@ defmodule Logflare.Teams do
   @doc "Returns an `%Ecto.Changeset{}` for tracking team changes"
   @spec change_team(Team.t()) :: Ecto.Changeset.t()
   def change_team(%Team{} = team), do: Team.changeset(team, %{})
+
+  @doc """
+  Lists all the teams a given user is part of.
+
+  ## Examples
+  ### User is owner of a team and belongs another user team
+  iex(1) > Logflare.Teams.list_teams_by_user_access(user, "token")
+  [%Logflare.Team{}, %Logflare.Team{}]
+  """
+  @spec list_teams_by_user_access(User.t()) :: [Team.t()]
+  def list_teams_by_user_access(user) do
+    user
+    |> query_teams_by_user_access()
+    |> Repo.all()
+  end
+
+  @doc """
+  Fetchesa single team with the given token from the list of teams he's part of
+
+  ## Examples
+  ### User is owner of a team and belongs another user team
+  iex(1) > Logflare.Teams.get_team_by_user_access(user, "token")
+  %Logflare.Team{}
+  """
+  @spec get_team_by_user_access(User.t(), binary()) :: Team.t() | nil
+  def get_team_by_user_access(user, token) do
+    user
+    |> query_teams_by_user_access()
+    |> where([t, tu], t.token == ^token or tu.token == ^token)
+    |> Repo.one()
+  end
+
+  defp query_teams_by_user_access(%User{email: email, id: id}) do
+    from t in Team,
+      join: tu in TeamUser,
+      on: tu.email == ^email,
+      where: t.user_id == ^id or tu.email == ^email,
+      distinct: true,
+      preload: [:user, :team_users]
+  end
 end

--- a/lib/logflare/teams/team.ex
+++ b/lib/logflare/teams/team.ex
@@ -3,8 +3,10 @@ defmodule Logflare.Teams.Team do
   import Ecto.Changeset
   use TypedEctoSchema
 
+  @derive {Jason.Encoder, only: [:name, :user, :team_users, :token]}
   typed_schema "teams" do
     field :name, :string
+    field :token, :string, autogenerate: {Ecto.UUID, :generate, []}
     belongs_to :user, Logflare.User
     has_many :team_users, Logflare.TeamUsers.TeamUser
 
@@ -16,5 +18,6 @@ defmodule Logflare.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required([:name])
+    |> unique_constraint(:token)
   end
 end

--- a/lib/logflare/user.ex
+++ b/lib/logflare/user.ex
@@ -27,7 +27,8 @@ defmodule Logflare.User do
              :bigquery_dataset_location,
              :bigquery_dataset_id,
              :api_quota,
-             :company
+             :company,
+             :token
            ]}
 
   @default_user_api_quota 150

--- a/lib/logflare_web/controllers/api/team_controller.ex
+++ b/lib/logflare_web/controllers/api/team_controller.ex
@@ -1,0 +1,45 @@
+defmodule LogflareWeb.Api.TeamController do
+  use LogflareWeb, :controller
+  alias Logflare.Teams
+  action_fallback LogflareWeb.Api.FallbackController
+
+  def index(%{assigns: %{user: user}} = conn, _) do
+    teams = Teams.list_teams_by_user_access(user)
+    json(conn, teams)
+  end
+
+  def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with team when not is_nil(team) <- Teams.get_team_by_user_access(user, token),
+         team <- Teams.preload_fields(team, [:user, :team_users]) do
+      json(conn, team)
+    end
+  end
+
+  def create(%{assigns: %{user: user}} = conn, params) do
+    with {:ok, team} <- Teams.create_team(user, params),
+         team <- Teams.preload_fields(team, [:user, :team_users]) do
+      conn
+      |> put_status(201)
+      |> json(team)
+    end
+  end
+
+  def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
+    with team when not is_nil(team) <- Teams.get_team_by(token: token, user_id: user.id),
+         {:ok, team} <- Teams.update_team(team, params),
+         team <- Teams.preload_fields(team, [:user, :team_users]) do
+      conn
+      |> put_status(204)
+      |> json(team)
+    end
+  end
+
+  def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with team when not is_nil(team) <- Teams.get_team_by(token: token, user_id: user.id),
+         {:ok, _} <- Teams.delete_team(team) do
+      conn
+      |> Plug.Conn.send_resp(204, [])
+      |> Plug.Conn.halt()
+    end
+  end
+end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -359,6 +359,10 @@ defmodule LogflareWeb.Router do
     resources "/endpoints", Api.EndpointController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]
+
+    resources "/teams", Api.TeamController,
+      param: "token",
+      only: [:index, :show, :create, :update, :delete]
   end
 
   # Old log ingest endpoint. Deprecate.

--- a/priv/repo/migrations/20221210010955_add_token_to_team.exs
+++ b/priv/repo/migrations/20221210010955_add_token_to_team.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddTokenToTeam do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :token, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20221210011115_set_token_default_values.exs
+++ b/priv/repo/migrations/20221210011115_set_token_default_values.exs
@@ -1,0 +1,14 @@
+defmodule Logflare.Repo.Migrations.SetTokenDefaultValues do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    alter table(:teams) do
+      modify :token, :string, default: fragment("gen_random_uuid()")
+    end
+
+    execute "UPDATE teams SET token=gen_random_uuid() WHERE token is null"
+  end
+end

--- a/priv/repo/migrations/20230206155428_add_team_token_index.exs
+++ b/priv/repo/migrations/20230206155428_add_team_token_index.exs
@@ -1,0 +1,7 @@
+defmodule Logflare.Repo.Migrations.AddTeamTokenIndex do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:teams, [:token])
+  end
+end

--- a/test/logflare/teams_test.exs
+++ b/test/logflare/teams_test.exs
@@ -1,44 +1,91 @@
 defmodule Logflare.TeamsTest do
   @moduledoc false
   use Logflare.DataCase
-  alias Logflare.{Teams, User}
+  alias Logflare.Teams
+  alias Logflare.Teams.Team
+  alias Logflare.User
 
-  describe "teams" do
-    alias Logflare.Teams.Team
-    @valid_attrs %{name: "some name"}
-    @update_attrs %{name: "diff name"}
-    test "list_teams/0, get_team/1, get_team_by/1 fetches data correctly" do
-      team = insert(:team)
-      id = team.id
-      assert [%Team{}] = Teams.list_teams()
-      assert %Team{id: ^id} = Teams.get_team!(team.id)
-      assert %Team{id: ^id} = Teams.get_team_by(name: team.name)
+  test "list_teams/0 fetches data correctly" do
+    teams = insert_list(2, :team)
+    expected = teams |> Enum.map(& &1.id) |> Enum.sort()
+    result = Teams.list_teams() |> Enum.map(& &1.id) |> Enum.sort()
 
-      assert %{user: %User{}, team_users: []} =
-               team |> Teams.preload_user() |> Teams.preload_team_users()
+    assert expected == result
+  end
+
+  test "get_team/1 fetches data correctly" do
+    %{id: team_id} = insert(:team)
+
+    assert %Team{id: ^team_id} = Teams.get_team!(team_id)
+  end
+
+  test "get_team_by/1 fetches data correctly" do
+    %{id: team_id, name: name} = insert(:team)
+
+    assert %Team{id: ^team_id} = Teams.get_team_by(name: name)
+  end
+
+  test "preload_user/1 preloads user" do
+    %{id: user_id} = user = insert(:user)
+    team = insert(:team, user: user)
+
+    assert %{user: %User{id: ^user_id}} = Teams.preload_user(team)
+  end
+
+  test "preload_user/1 preloads preload_team_users" do
+    team = insert(:team, user: insert(:user))
+    %{email: user_email} = user = insert(:user)
+    insert(:team_user, team: team, email: user.email)
+
+    assert %{team_users: [%{email: ^user_email}]} = Teams.preload_team_users(team)
+  end
+
+  test "get_home_team/1 returns a paying user's home team" do
+    # owned by different user
+    home_team = insert(:team)
+    user = insert(:user, team: home_team)
+    team_user = insert(:team_user, email: user.email)
+
+    assert Teams.get_home_team(team_user).id == home_team.id
+  end
+
+  test "create_team/2 creates a new team in the database" do
+    name = TestUtils.random_string()
+    user = insert(:user)
+    assert {:ok, %Team{name: ^name}} = Teams.create_team(user, %{name: name})
+  end
+
+  test "update_team/2 updates an existing team" do
+    name = TestUtils.random_string()
+    %{id: id} = team = insert(:team)
+    assert {:ok, %{id: ^id, name: ^name}} = Teams.update_team(team, %{name: name})
+  end
+
+  test "delete_team/1 deletes an existing teams" do
+    %{id: id} = team = insert(:team)
+    assert {:ok, %{id: ^id}} = Teams.delete_team(team)
+
+    assert_raise Ecto.StaleEntryError, fn ->
+      Teams.delete_team(team)
     end
+  end
 
-    test "get_home_team/1 returns a paying user's home team" do
-      # owned by different user
-      home_team = insert(:team)
-      user = insert(:user, team: home_team)
-      team_user = insert(:team_user, email: user.email)
-      assert Teams.get_home_team(team_user).id == home_team.id
-    end
+  test "list_teams_by_user_access/1 lists all teams of a given user" do
+    user = insert(:user)
+    teams = insert_list(2, :team_user, email: user.email)
 
-    test "create_team/2, update_team/2, delete_team/1" do
-      user = insert(:user)
-      assert {:ok, %Team{} = team} = Teams.create_team(user, @valid_attrs)
-      assert team.name == @valid_attrs.name
+    expected = Enum.map(teams, & &1.team.id) |> Enum.sort()
+    result = Enum.map(Teams.list_teams_by_user_access(user), & &1.id) |> Enum.sort()
 
-      assert {:ok, %Team{} = team} = Teams.update_team(team, @update_attrs)
-      assert team.name == @update_attrs.name
+    assert expected == result
+  end
 
-      assert {:ok, %Team{} = team} = Teams.delete_team(team)
+  test "get_team_by_user_access/2 gets a team for a given user and token" do
+    user = insert(:user)
+    team = insert(:team)
+    _team_user = insert(:team_user, email: user.email, team: team)
+    insert_list(2, :team_user)
 
-      assert_raise Ecto.StaleEntryError, fn ->
-        Teams.delete_team(team)
-      end
-    end
+    assert team.id == Teams.get_team_by_user_access(user, team.token).id
   end
 end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -1,0 +1,182 @@
+defmodule LogflareWeb.Api.TeamControllerTest do
+  use LogflareWeb.ConnCase
+
+  import Logflare.Factory
+
+  alias Logflare.Sources.Counters
+
+  setup do
+    insert(:plan, name: "Free")
+    user = insert(:user)
+    main_team = insert(:team, user: user)
+
+    another_user_team_with_main_user = insert(:team, user: insert(:user))
+    insert(:team_user, team: another_user_team_with_main_user, email: user.email)
+
+    _non_relevant_to_main_user = insert(:team_user, team: main_team, email: insert(:user).email)
+
+    Counters.start_link()
+
+    {:ok, user: user, main_team: main_team, non_owner_team: another_user_team_with_main_user}
+  end
+
+  describe "index/2" do
+    test "returns list of teams for given user", %{
+      conn: conn,
+      user: user,
+      main_team: %{token: main_team_token},
+      non_owner_team: %{token: non_owner_team_token}
+    } do
+      response =
+        conn
+        |> login_user(user)
+        |> get("/api/teams")
+        |> json_response(200)
+
+      assert Enum.any?(response, fn %{"token" => token} -> main_team_token == token end)
+      assert Enum.any?(response, fn %{"token" => token} -> non_owner_team_token == token end)
+    end
+  end
+
+  describe "show/2" do
+    test "returns a single team given user and team token", %{
+      conn: conn,
+      user: user,
+      main_team: %{token: token}
+    } do
+      response =
+        conn
+        |> login_user(user)
+        |> get("/api/teams/#{token}")
+        |> json_response(200)
+
+      assert response["token"] == token
+    end
+
+    test "returns a single team given user and team token where his not an owner but a member", %{
+      conn: conn,
+      user: user,
+      non_owner_team: non_owner_team
+    } do
+      response =
+        conn
+        |> login_user(user)
+        |> get("/api/teams/#{non_owner_team.token}")
+        |> json_response(200)
+
+      assert response["name"] == non_owner_team.name
+    end
+
+    test "returns not found if doesn't own the team or isn't part of it", %{
+      conn: conn,
+      main_team: main_team,
+      non_owner_team: non_owner_team
+    } do
+      invalid_user = insert(:user)
+
+      conn
+      |> login_user(invalid_user)
+      |> get("/api/teams/#{main_team.token}")
+      |> response(404)
+
+      conn
+      |> login_user(invalid_user)
+      |> get("/api/teams/#{non_owner_team.token}")
+      |> response(404)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a new team for an authenticated user", %{conn: conn} do
+      user = insert(:user)
+      name = TestUtils.random_string()
+
+      response =
+        conn
+        |> login_user(user)
+        |> post("/api/teams", %{name: name})
+        |> json_response(201)
+
+      assert response["name"] == name
+    end
+
+    test "returns 422 on bad arguments", %{conn: conn, user: user} do
+      resp =
+        conn
+        |> login_user(user)
+        |> post("/api/teams", %{name: 123})
+        |> json_response(422)
+
+      assert resp == %{"errors" => %{"name" => ["is invalid"]}}
+    end
+
+    test "returns 422 on missing arguments", %{conn: conn, user: user} do
+      resp =
+        conn
+        |> login_user(user)
+        |> post("/api/teams")
+        |> json_response(422)
+
+      assert resp == %{"errors" => %{"name" => ["can't be blank"]}}
+    end
+  end
+
+  describe "update/2" do
+    test "updates an existing team from a user", %{
+      conn: conn,
+      user: user,
+      main_team: main_team
+    } do
+      name = TestUtils.random_string()
+
+      response =
+        conn
+        |> login_user(user)
+        |> patch("/api/teams/#{main_team.token}", %{name: name})
+        |> json_response(204)
+
+      assert response["name"] == name
+    end
+
+    test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
+      invalid_user = insert(:user)
+
+      conn
+      |> login_user(invalid_user)
+      |> patch("/api/teams/#{main_team.token}", %{name: TestUtils.random_string()})
+      |> response(404)
+    end
+
+    test "returns 422 on bad arguments", %{conn: conn, user: user, main_team: main_team} do
+      resp =
+        conn
+        |> login_user(user)
+        |> patch("/api/teams/#{main_team.token}", %{name: 123})
+        |> json_response(422)
+
+      assert resp == %{"errors" => %{"name" => ["is invalid"]}}
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an existing team from a user", %{
+      conn: conn,
+      user: user,
+      main_team: main_team
+    } do
+      assert conn
+             |> login_user(user)
+             |> delete("/api/teams/#{main_team.token}")
+             |> response(204)
+    end
+
+    test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
+      invalid_user = insert(:user)
+
+      assert conn
+             |> login_user(invalid_user)
+             |> delete("/api/teams/#{main_team.token}")
+             |> response(404)
+    end
+  end
+end


### PR DESCRIPTION
* Add token field to Team
* Add List Teams endpoint
* Add Show Team endpoint
* Add Create team endpoint
* Add Update team endpoint
* Add Delete endpoint
* Fix assertions on other endpoint tests

When listing or showing teams, we will consider the team the user is owner of and the ones he is part of via Team User.

Create, Update and Delete can only be done to the team they are owner of.