### PR TITLE
Explicit :ssl library startup during migration

### DIFF
--- a/lib/logflare/release.ex
+++ b/lib/logflare/release.ex
@@ -4,8 +4,8 @@ defmodule Logflare.Release do
 
   def migrate do
     Logger.info("Starting migration")
+    Application.ensure_all_started(:ssl)
     Application.ensure_all_started(@app)
-    Application.ensure_started(:ssl)
 
     for repo <- repos() do
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))


### PR DESCRIPTION
For some reason SSL is not starting as expected, this will try to force that startup during the migration stage