### PR TITLE
Move back to Google JSON file for auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,15 @@ RUN apk update && \
 COPY . /logflare
 
 WORKDIR /logflare
-RUN mix do local.rebar --force, local.hex --force
-RUN mix do deps.get, deps.compile
 
-RUN mix phx.digest
-RUN mix release
+RUN mix do local.rebar --force, local.hex --force, deps.get, phx.digest, release
 
 FROM alpine:3.16.0 as app
 WORKDIR /root/
 
 # Required for the BeamVM to run
 RUN apk update && apk add -f openssl libgcc libstdc++ ncurses-libs
+
 COPY --from=builder ./logflare/_build/prod /root/app
 COPY --from=builder ./logflare/VERSION /root/app/rel/logflare/bin/VERSION
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,4 +101,6 @@ if config_env() != :test do
   config :stripity_stripe,
     api_key: System.get_env("STRIPE_API_KEY"),
     publishable_key: System.get_env("STRIPE_PUBLISHABLE_KEY")
+
+  config :goth, json: File.read!("gcloud.json")
 end

--- a/docker/staging.app.Dockerfile
+++ b/docker/staging.app.Dockerfile
@@ -2,7 +2,9 @@ ARG TAG_VERSION=latest
 FROM supabase/logflare:${TAG_VERSION}
 
 RUN apk add tini
+
 COPY .secrets.env /tmp/.secrets.env
+COPY gcloud.json gcloud.json
 
 ENTRYPOINT ["tini", "--"]
 


### PR DESCRIPTION
For some reason storing the JSON as an env var is presenting problems, this moves back to the option of using a file.