### PR TITLE
Fix config issue

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,7 +1,7 @@
 import Config
 
 logger_config =
-  case System.get_env("LOGGER_CONFIG", Mix.env() |> Atom.to_string()) do
+  case System.get_env("LOGGER_CONFIG", config_env() |> Atom.to_string()) do
     "prod" ->
       [
         level: :info,


### PR DESCRIPTION
We were using Mix.env() which is not available on runtime.