### PR TITLE
Fix static file digest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,5 @@ npm-debug.log
 # Docker
 /docker
 docker*
+
+/priv/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,17 @@ FROM elixir:1.12-alpine as builder
 ENV MIX_ENV prod
 
 RUN apk update && \
-    apk add -f curl git build-base nodejs yarn rust cargo
+    apk add -f curl git build-base nodejs yarn rust cargo python3
 
 COPY . /logflare
 
-WORKDIR /logflare
 
-RUN mix do local.rebar --force, local.hex --force, deps.get, phx.digest, release
+WORKDIR /logflare
+RUN mix do local.rebar --force, local.hex --force, deps.get, release
+
+WORKDIR /logflare/assets
+RUN yarn install
+RUN yarn run deploy
 
 FROM alpine:3.16.0 as app
 


### PR DESCRIPTION
Due to the fact that we're using an older version of phoenix we still require to run the assets pipeline via webpack