### PR TITLE
Fix Static serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,16 @@ FROM alpine:3.16.0 as app
 # Required for the BeamVM to run
 RUN apk update && apk add -f openssl libgcc libstdc++ ncurses-libs
 
+# Copy required files from builder step
 COPY --from=builder logflare/_build/prod /opt/app
-COPY --from=builder logflare/VERSION /opt/app/rel/logflare/bin/VERSION
-COPY --from=builder logflare/priv /opt/app/rel/logflare/bin/priv
+COPY --from=builder logflare/VERSION /opt/app/VERSION
+COPY --from=builder logflare/priv/static /opt/app/rel/logflare/bin/priv/static
+
+# Move files to the correct folder taking into consideration the VERSION
+RUN cp -r /opt/app/rel/logflare/bin/priv/static /opt/app/rel/logflare/lib/logflare-$(cat /opt/app/VERSION)/priv/static
+
+# Cleanup static assets not in use
+RUN rm -r /opt/app/rel/logflare/bin/priv
 
 WORKDIR /opt/app/rel/logflare/bin
 COPY run.sh ./run.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         read_only: true
       - type: bind
         source: ${PWD}/gcloud.json
-        target: /root/app/rel/logflare/bin/gcloud.json
+        target: /opt/app/rel/logflare/bin/gcloud.json
         read_only: true
     depends_on:
       - db

--- a/lib/logflare_web/endpoint.ex
+++ b/lib/logflare_web/endpoint.ex
@@ -16,7 +16,7 @@ defmodule LogflareWeb.Endpoint do
   plug Plug.Static,
     at: "/",
     from: :logflare,
-    gzip: false,
+    gzip: !code_reloading?,
     only: ~w(css fonts images js favicon.ico robots.txt worker.js manifest.json),
     only_matching: ~w(manifest)
 


### PR DESCRIPTION
Changed the location where generated static files will be moved into.

The issue until now was the location of the static files. The application has the starting script at `/opt/app/rel/logflare/bin/` but the `Application.app_dir(:logflare)` it's actually `/opt/app/rel/logflare/lib/` and this was the folder that Plug.Static is expected to have the static content to be served.

Also enabled gzip to enable compressed assets to be served in a more performant way.