### PR TITLE
Ensure that a mask is added to secrets; make curl fail on bad response

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -131,13 +131,6 @@ jobs:
     steps:
       - name: Call Webhook
         run: |
-              curl -X POST https://cloudbuild.googleapis.com/v1/projects/logflare-staging/triggers/logflare-app-staging-trigger:webhook \
-              -d key=${{ secrets.STAGING_CLOUD_BUILD_KEY }} \
-              -d secret=${{ secrets.STAGING_CLOUD_BUILD_SECRET}}
-
-        env:
-          webhook_url: ${{ secrets.STAGING_CLOUD_BUILD_TRIGGER_KEY }}
-          webhook_secret: ${{ secrets.STAGING_CLOUD_BUILD_TRIGGER_SECRET }}
-
-
-
+              curl --fail-with-body -s -X POST https://cloudbuild.googleapis.com/v1/projects/logflare-staging/triggers/logflare-app-staging-trigger:webhook \
+              -d key=::add-mask::${{ secrets.STAGING_CLOUD_BUILD_KEY }} \
+              -d secret=::add-mask::${{ secrets.STAGING_CLOUD_BUILD_SECRET}}


### PR DESCRIPTION
* Getting secrets should be enough but to have extra insurance we're adding a mask to avoid leaking secrets
* Currently a bad response is returning no error code, adding --fail-with-body so we can fail the build step and have some feedback