### PR TITLE
chore: remove top-level option from build_table_schema

### DIFF
--- a/lib/logflare/source/bigquery/schema_builder.ex
+++ b/lib/logflare/source/bigquery/schema_builder.ex
@@ -178,15 +178,6 @@ defmodule Logflare.Source.BigQuery.SchemaBuilder do
     }
   end
 
-  @spec build_metadata_fields_schemas(map, TFS.t()) :: TFS.t()
-  defp build_metadata_fields_schemas(metadata, old_metadata_schema) do
-    new_metadata_schema = build_fields_schemas({"metadata", metadata})
-
-    old_metadata_schema
-    # DeepMerge resolver is implemented for Model.TableFieldSchema structs
-    |> DeepMerge.deep_merge(new_metadata_schema)
-  end
-
   defp build_fields_schemas({params_key, params_val}) when is_map(params_val) do
     %TFS{
       description: nil,

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -55,9 +55,7 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
                TestUtils.get_bq_field_schema(schema, "a")
 
       schema =
-        SchemaBuilder.build_table_schema(%{"a" => %{"b" => "something"}}, @default_schema,
-          top_level: true
-        )
+        SchemaBuilder.build_table_schema(%{"a" => %{"b" => "something"}}, @default_schema)
 
       assert %TFS{name: "b", type: "STRING", mode: "NULLABLE"} =
                TestUtils.get_bq_field_schema(schema, "a.b")

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -54,8 +54,7 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
       assert %TFS{name: "a", type: "STRING", mode: "NULLABLE"} =
                TestUtils.get_bq_field_schema(schema, "a")
 
-      schema =
-        SchemaBuilder.build_table_schema(%{"a" => %{"b" => "something"}}, @default_schema)
+      schema = SchemaBuilder.build_table_schema(%{"a" => %{"b" => "something"}}, @default_schema)
 
       assert %TFS{name: "b", type: "STRING", mode: "NULLABLE"} =
                TestUtils.get_bq_field_schema(schema, "a.b")

--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -536,7 +536,7 @@ defmodule Logflare.LqlParserTest do
     |> String.replace("(metadata.", "(m.")
   end
 
-  defp build_schema(input, opts \\ []) do
-    SchemaBuilder.build_table_schema(input, @default_schema, opts)
+  defp build_schema(input) do
+    SchemaBuilder.build_table_schema(input, @default_schema)
   end
 end


### PR DESCRIPTION
Removes the `top_level` option from the `SchemaBuilder.build_table_schema/3` and converts it to two arity, which as top-level keys are now the default behaviour for ingestion and schema comparisons