### PR TITLE
chore: partial refactoring for sobelow recommendations

### DIFF
--- a/config/staging.exs
+++ b/config/staging.exs
@@ -77,12 +77,6 @@ config :logflare, Logflare.Cluster.Strategy.GoogleComputeEngine,
 
 config :logflare, Logflare.Tracker, pool_size: 1
 
-config :logflare, Logflare.Vercel.Client,
-  client_id: "oac_9AFs6dPQPFhy5xS1IOvc2xrf",
-  client_secret: "mmDrqcJYuJeIxNX9AXbNqrhm",
-  redirect_uri: "https://logflarestaging.com/install/vercel-v2",
-  install_vercel_uri: "https://vercel.com/integrations/logflare-dev/new"
-
 config :logflare, Logflare.Cluster.Utils, min_cluster_size: 1
 
 import_config "telemetry.exs"

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -8,6 +8,21 @@ defmodule LogflareWeb.AdminController do
   require Logger
 
   @page_size 50
+  @accounts_sort_options [
+    :inserted_at,
+    :updated_at
+  ]
+  @sources_sort_options [
+    :fields,
+    :latest,
+    :rejected,
+    :rate,
+    :avg,
+    :max,
+    :buffer,
+    :inserts,
+    :recent
+  ]
   defp env_node_shutdown_code, do: Application.get_env(:logflare, :node_shutdown_code)
 
   def dashboard(conn, _params) do
@@ -16,16 +31,11 @@ defmodule LogflareWeb.AdminController do
   end
 
   def accounts(conn, params) do
-    sort_options = [
-      :inserted_at,
-      :updated_at
-    ]
-
     accounts = paginate_accounts(params)
 
     conn
     |> assign(:accounts, accounts)
-    |> assign(:sort_options, sort_options)
+    |> assign(:sort_options, @accounts_sort_options)
     |> render("accounts.html")
   end
 
@@ -78,11 +88,16 @@ defmodule LogflareWeb.AdminController do
   end
 
   defp do_authorized_code_shutdown(conn, %{"node" => node}) do
-    node = String.to_atom(node)
-    nodes = Node.list()
+    node_names = [Node.self() | Node.list()]
+    nodes = node_names |> Enum.map(Atom.to_string() / 1)
 
-    if Enum.member?([Node.self() | nodes], node) do
-      Admin.shutdown(node)
+    if Enum.member?(nodes, node) do
+      node_name =
+        Enum.find(node_names, fn nn ->
+          Atom.to_string(nn) == node
+        end)
+
+      Admin.shutdown(node_name)
 
       conn
       |> put_status(:ok)
@@ -117,21 +132,8 @@ defmodule LogflareWeb.AdminController do
   end
 
   def sources(conn, params) do
-    sort_options = [
-      :fields,
-      :latest,
-      :rejected,
-      :rate,
-      :avg,
-      :max,
-      :buffer,
-      :inserts,
-      :recent
-    ]
-
     sorted_sources = sorted_sources(params)
-
-    render(conn, "sources.html", sources: sorted_sources, sort_options: sort_options)
+    render(conn, "sources.html", sources: sorted_sources, sort_options: @sources_sort_options)
   end
 
   defp paginate_accounts(%{"page" => page, "sort_by" => ""}) do
@@ -175,7 +177,7 @@ defmodule LogflareWeb.AdminController do
     |> Repo.all()
     |> Stream.map(&Sources.refresh_source_metrics/1)
     |> Stream.map(&Sources.put_schema_field_count/1)
-    |> Enum.sort_by(&Map.fetch(&1.metrics, String.to_atom(sort_by)), &>=/2)
+    |> Enum.sort_by(&Map.fetch(&1.metrics, sort_option_to_atom(sort_by)), &>=/2)
     |> Repo.paginate(%{page_size: @page_size, page: page})
   end
 
@@ -184,7 +186,7 @@ defmodule LogflareWeb.AdminController do
     |> Repo.all()
     |> Stream.map(&Sources.refresh_source_metrics/1)
     |> Stream.map(&Sources.put_schema_field_count/1)
-    |> Enum.sort_by(&Map.fetch(&1.metrics, String.to_atom(sort_by)), &>=/2)
+    |> Enum.sort_by(&Map.fetch(&1.metrics, sort_option_to_atom(sort_by)), &>=/2)
     |> Repo.paginate(%{page_size: @page_size, page: 1})
   end
 
@@ -212,7 +214,7 @@ defmodule LogflareWeb.AdminController do
 
   defp query_accounts(sort_by) when is_binary(sort_by) do
     from u in User,
-      order_by: [desc: ^String.to_atom(sort_by)],
+      order_by: [desc: ^sort_option_to_atom(sort_by)],
       select: u,
       preload: :billing_account
   end
@@ -221,9 +223,14 @@ defmodule LogflareWeb.AdminController do
     e = "%#{email}%"
 
     from u in User,
-      order_by: [desc: ^String.to_atom(sort_by)],
+      order_by: [desc: ^sort_option_to_atom(sort_by)],
       where: ilike(u.email, ^e),
       select: u,
       preload: :billing_account
+  end
+
+  defp sort_option_to_atom(option) when is_binary(option) do
+    options = @accounts_sort_options ++ @sources_sort_options
+    Enum.find(options, &(Atom.to_string(&1) == option))
   end
 end

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -89,7 +89,7 @@ defmodule LogflareWeb.AdminController do
 
   defp do_authorized_code_shutdown(conn, %{"node" => node}) do
     node_names = [Node.self() | Node.list()]
-    nodes = node_names |> Enum.map(Atom.to_string() / 1)
+    nodes = node_names |> Enum.map(&Atom.to_string/1)
 
     if Enum.member?(nodes, node) do
       node_name =

--- a/lib/logflare_web/controllers/auth/email_controller.ex
+++ b/lib/logflare_web/controllers/auth/email_controller.ex
@@ -31,7 +31,7 @@ defmodule LogflareWeb.Auth.EmailController do
     |> redirect(to: Routes.email_path(conn, :verify_token))
   end
 
-  def verify_token_form(conn, %{"token"=> _token} = params) do
+  def verify_token_form(conn, %{"token" => _token} = params) do
     callback(conn, params)
   end
 

--- a/lib/logflare_web/controllers/auth/email_controller.ex
+++ b/lib/logflare_web/controllers/auth/email_controller.ex
@@ -31,6 +31,10 @@ defmodule LogflareWeb.Auth.EmailController do
     |> redirect(to: Routes.email_path(conn, :verify_token))
   end
 
+  def verify_token_form(conn, %{"token"=> _token} = params) do
+    callback(conn, params)
+  end
+
   def callback(conn, %{"token" => token}) do
     token = String.trim(token)
 

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -15,6 +15,7 @@ defmodule LogflareWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, {LogflareWeb.LayoutView, :root}
     plug :protect_from_forgery
+
     plug :put_secure_browser_headers, %{
       "content-security-policy" =>
         (fn ->

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -330,7 +330,7 @@ defmodule LogflareWeb.Router do
     get "/login/email/verify", Auth.EmailController, :verify_token
     get "/logout", AuthController, :logout
     get "/:provider", Auth.OauthController, :request
-    post "/login/email/verify", Auth.EmailController, :callback
+    post "/login/email/verify", Auth.EmailController, :verify_token_form
     get "/email/callback/:token", Auth.EmailController, :callback
     get "/:provider/callback", Auth.OauthController, :callback
   end

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -15,7 +15,6 @@ defmodule LogflareWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, {LogflareWeb.LayoutView, :root}
     plug :protect_from_forgery
-
     plug :put_secure_browser_headers, %{
       "content-security-policy" =>
         (fn ->
@@ -85,7 +84,7 @@ defmodule LogflareWeb.Router do
 
   pipeline :oauth_public do
     plug :accepts, ["json"]
-    plug :put_secure_browser_headers
+    plug :put_secure_browser_headers, %{"content-security-policy" => "default-src 'self'"}
   end
 
   pipeline :check_admin do
@@ -328,9 +327,9 @@ defmodule LogflareWeb.Router do
     get "/login/email", Auth.EmailController, :login
     post "/login/email", Auth.EmailController, :send_link
     get "/login/email/verify", Auth.EmailController, :verify_token
-    post "/login/email/verify", Auth.EmailController, :callback
     get "/logout", AuthController, :logout
     get "/:provider", Auth.OauthController, :request
+    post "/login/email/verify", Auth.EmailController, :callback
     get "/email/callback/:token", Auth.EmailController, :callback
     get "/:provider/callback", Auth.OauthController, :callback
   end

--- a/mix.exs
+++ b/mix.exs
@@ -209,7 +209,7 @@ defmodule Logflare.Mixfile do
       "test.watch": ["cmd epmd -daemon", "test.watch --no-start"],
       "test.compile": ["compile --warnings-as-errors"],
       "test.format": ["format --check-formatted"],
-      "test.security": ["sobelow --threshold high"],
+      "test.security": ["sobelow --threshold high --ignore Config.HTTPS"],
       "test.typings": ["dialyzer --format short"],
       "test.coverage": ["coveralls"],
       lint: ["credo"],


### PR DESCRIPTION
Adds some refactoring based on sobelow recommendations:
- Removes String.to_atom/1 usage  in admin_controller
- ignore https check (done outside of release)
- add CSP for oauth public routes.
- get rid of CSRF warning by having separate controller action, even though logic is the same.


Ref [ticket](https://www.notion.so/supabase/WIP-Add-in-Logflare-to-Quality-Gate-2ba0d013846f413f97a17ba22e52f06a)