### PR TITLE
Aliases for easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Logflare is using a SQL parser from sqlparser.com. To set this up on your dev ma
    1. Dev secrets - `.dev.env`
    2. Google JWT key - `.gcloud.json`
 1. Start database `docker-compose up -d db`
-1  Run `source .dev.env` to load up environment variables into you session
 1. Run `mix setup` for deps, migrations, and seed data.
 1. Run `(cd assets; yarn)` from project root, to install js dependencies
 1. Install `sqlparser` by following the steps in **Closed Source Usage** section.

--- a/mix.exs
+++ b/mix.exs
@@ -199,10 +199,18 @@ defmodule Logflare.Mixfile do
   defp aliases do
     [
       setup: ["deps.get", "cmd elixir --sname orange --cookie monster -S mix ecto.setup"],
-      start: "cmd PORT=4000 iex --sname orange --cookie monster -S mix phx.server",
-      "start.orange":
-        "cmd PORT=4000 iex --name orange@127.0.0.1 --cookie monster -S mix phx.server",
-      "start.pink": "cmd PORT=4001 iex --name pink@127.0.0.1 --cookie monster -S mix phx.server",
+      start: [
+        "cmd source .dev.env",
+        "cmd PORT=4000 iex --sname orange --cookie monster -S mix phx.server"
+      ],
+      "start.orange": [
+        "cmd source .dev.env",
+        "cmd PORT=4000 iex --name orange@127.0.0.1 --cookie monster -S mix phx.server"
+      ],
+      "start.pink": [
+        "cmd source .dev.env",
+        "cmd PORT=4001 iex --name pink@127.0.0.1 --cookie monster -S mix phx.server"
+      ],
       # coveralls will trigger unit tests as well
       test: ["cmd epmd -daemon", "ecto.create --quiet", "ecto.migrate", "test --no-start"],
       "test.watch": ["cmd epmd -daemon", "test.watch --no-start"],
@@ -215,7 +223,19 @@ defmodule Logflare.Mixfile do
       "lint.diff": ["credo diff master"],
       "lint.all": ["credo --strict"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
-      "ecto.reset": ["ecto.drop", "ecto.setup"]
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      "decrypt.dev":
+        "cmd gcloud kms decrypt --ciphertext-file='./.dev.env.enc' --plaintext-file=./.dev.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
+      "encrypt.dev":
+        "cmd gcloud kms encrypt --ciphertext-file='./.dev.env.enc' --plaintext-file=./.dev.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
+      "decrypt.staging": [
+        "cmd gcloud kms decrypt --ciphertext-file='./.staging.env.enc' --plaintext-file=./.staging.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
+        "cmd gcloud kms decrypt --ciphertext-file='./gcloud_staging.json.enc' --plaintext-file=./gcloud_staging.json --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging"
+      ],
+      "encrypt.staging": [
+        "cmd gcloud kms encrypt --ciphertext-file='./.staging.env.enc' --plaintext-file=./.staging.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
+        "cmd gcloud kms encrypt --ciphertext-file='./gcloud_staging.json.enc' --plaintext-file=./gcloud_staging.json --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging"
+      ]
     ]
   end
 


### PR DESCRIPTION
Added multiple alias to facilitate startup and setup of deployment:
* start commands now source the .dev.env file
* added command to decrypt and encrypt dev .env file
* addec command to encrypt and decrypt staging .env and gcloud.json files