### PR TITLE
Move from curl to gcloud

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -122,14 +122,29 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
   trigger_cloud_build:
-    name: Trigger Cloud Build
+    name: Trigger Cloud Build in Staging
     if: github.ref == 'refs/heads/staging'
     needs:
       - publish_latest
       - publish_version
     runs-on: ubuntu-latest
     steps:
-      - name: Call Webhook
-        run: |
-              curl 'https://cloudbuild.googleapis.com/v1/projects/logflare-staging/triggers/${{ secrets.CLOUDBUILD_TRIGGER_ID }}:run?fields=name' -s --fail-with-body -X POST -H 'Authorization: Bearer ${{ secrets.CLOUDBUILD_BEARER_TOKEN }}'
-
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_STAGING_CREDENTIALS }}'
+          create_credentials_file: true
+          export_environment_variables: true
+          cleanup_credentials: false
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '413.0.0'
+          install_components: 'beta'
+          project_id: 'logflare-staging'
+      - name: 'Trigger Cloud Build'
+        run: 'gcloud beta builds triggers run logflare-app-staging-trigger --branch=staging --format "value(name)"'


### PR DESCRIPTION
Due to the fact that curl was using oauth2 credentials we were not able to make this step repeatable without messing around with oauth2 authentication due to temporary tokens.

This will move the job to use gcloud beta features