### PR TITLE
chore: update timestamp comparison tests to reduce flakiness

### DIFF
--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -171,9 +171,12 @@ defmodule Logflare.LqlParserTest do
                   operator: :=,
                   path: "timestamp",
                   shorthand: "now",
-                  value: now_ndt()
+                  value: now_out
                 }
-              ]} == Parser.parse("timestamp:now", @default_schema)
+              ]} = Parser.parse("timestamp:now", @default_schema)
+
+      # use diff to reduce test flakiness
+      assert DateTime.diff(now_ndt(), now_out, :millisecond) |> abs() <= 1500
 
       for {qs, shorthand, start_value, end_value} <- [
             {"t:today", "today", today_dt(),

--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -176,7 +176,7 @@ defmodule Logflare.LqlParserTest do
               ]} = Parser.parse("timestamp:now", @default_schema)
 
       # use diff to reduce test flakiness
-      assert DateTime.diff(now_ndt(), now_out, :millisecond) |> abs() <= 1500
+      assert DateTime.diff(now_ndt(), now_out, :millisecond) |> abs() <= 150
 
       for {qs, shorthand, start_value, end_value} <- [
             {"t:today", "today", today_dt(),


### PR DESCRIPTION
update test to remove flakiness, which is causing ci tests to fail due to millisecond time diff