### PR TITLE
Only startup logflare_agent if URL is present by moving sources to runtime.exs

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -37,30 +37,6 @@ config :logflare, Logflare.Repo,
   queue_target: 5_000,
   port: 5432
 
-config :logflare_agent,
-  sources: [
-    %{
-      path: "/home/logflare/app_release/logflare/var/log/erlang.log.1",
-      source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
-    },
-    %{
-      path: "/home/logflare/app_release/logflare/var/log/erlang.log.2",
-      source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
-    },
-    %{
-      path: "/home/logflare/app_release/logflare/var/log/erlang.log.3",
-      source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
-    },
-    %{
-      path: "/home/logflare/app_release/logflare/var/log/erlang.log.4",
-      source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
-    },
-    %{
-      path: "/home/logflare/app_release/logflare/var/log/erlang.log.5",
-      source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
-    }
-  ]
-
 config :logger,
   sync_threshold: 10_001,
   discard_threshold: 10_000,
@@ -76,9 +52,7 @@ config :libcluster,
   topologies: [
     gce: [
       strategy: Logflare.Cluster.Strategy.GoogleComputeEngine,
-      config: [
-        release_name: :logflare
-      ]
+      config: [release_name: :logflare]
     ]
   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,7 +8,29 @@ if System.get_env("LOGFLARE_AGENT_URL") != nil do
   config :logflare_agent,
          [
            api_key: System.get_env("LOGFLARE_AGENT_API_KEY"),
-           url: System.get_env("LOGFLARE_AGENT_URL")
+           url: System.get_env("LOGFLARE_AGENT_URL"),
+           sources: [
+             %{
+               path: "/home/logflare/app_release/logflare/var/log/erlang.log.1",
+               source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
+             },
+             %{
+               path: "/home/logflare/app_release/logflare/var/log/erlang.log.2",
+               source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
+             },
+             %{
+               path: "/home/logflare/app_release/logflare/var/log/erlang.log.3",
+               source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
+             },
+             %{
+               path: "/home/logflare/app_release/logflare/var/log/erlang.log.4",
+               source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
+             },
+             %{
+               path: "/home/logflare/app_release/logflare/var/log/erlang.log.5",
+               source: "4ec9216e-a8e9-46eb-92cb-1576092c9e4b"
+             }
+           ]
          ]
          |> filter_nil_kv_pairs.()
 end


### PR DESCRIPTION
Since logflare_agent only starts children based on the sources provided, we're moving the sources to the runtime.exs to be loaded when LOGFLARE_AGENT_URL is set.