### PR TITLE
Set default value for logflare_agent sources list.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -86,4 +86,7 @@ config :logflare, Logflare.CacheBuster,
   replication_slot: :temporary,
   publications: ["logflare_pub"]
 
+# TODO We need to add defaults to https://github.com/Logflare/logflare_agent/blob/master/lib/application.ex#L11
+config :logflare_agent, []
+
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Due to the way logflare_agent starts up the application, we need to set an empty list as a default so it doesn't fail with an attempt of iterating over a nil value.