### PR TITLE
fix: add docs and handle special case for project key temporarily

### DIFF
--- a/lib/logflare/logs/vector.ex
+++ b/lib/logflare/logs/vector.ex
@@ -1,11 +1,37 @@
 defmodule Logflare.Logs.Vector do
-  @moduledoc false
+  @moduledoc """
+  Takes payloadds from Vector and puts the whole payload in the `metadata` key.
+  """
+
   require Logger
 
   def handle_batch(batch) when is_list(batch) do
     Enum.map(batch, fn x -> handle_event(x) end)
   end
 
+  @doc """
+  Handles the top level `project` field if it exists. For Supabase only. Need this field on the top level
+  because we cluster by it in BigQuery.
+
+  TODDO: The Supabase infra Vector config should should match what we expect to insert into BigQuery.
+  And we should have a v2 Vector ingest endpoint which doesn't do any payload manipulation.
+  """
+  def handle_event(
+        %{"project" => project, "timestamp" => timestamp, "message" => message} = params
+      ) do
+    metadata = Map.drop(params, ["message", "timestamp"])
+
+    %{
+      "message" => message,
+      "metadata" => metadata,
+      "timestamp" => timestamp,
+      "project" => project
+    }
+  end
+
+  @doc """
+  If a log event from vector contains a `message` let's use it.
+  """
   def handle_event(%{"timestamp" => timestamp, "message" => message} = params) do
     metadata = Map.drop(params, ["message", "timestamp"])
 
@@ -16,6 +42,9 @@ defmodule Logflare.Logs.Vector do
     }
   end
 
+  @doc """
+  If no `message` is present on the payload Jason encode the params and use that as the message in the log event feed.
+  """
   def handle_event(%{"timestamp" => timestamp} = params) do
     metadata = Map.drop(params, ["timestamp"])
     message = Jason.encode!(metadata)


### PR DESCRIPTION
The top level `project` key is missing from the Postgres logs. We pulled out some special handling of that now that Logflare fully supports top level fields.

But the Vector ingest endpoint currently takes the whole payload and puts it in the `metadata` key before doing anything else. 

So we need to add a new v2 Vector endpoint which doesn't do this, and then update the infra vector config to point to this new Vector ingest Endpoint. 

This PR contains a temp fix until the above happens. 

Infra Vector config is here: https://github.com/supabase/infrastructure/blob/f02e65790b89050c2b97953aa8fd233237825b95/init-scripts/project/vector.yaml