### PR TITLE
fix: VERCEL_CLIENT_SECRET env var typo fix for vercel integration

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,7 +148,7 @@ config :logflare,
        Logflare.Vercel.Client,
        [
          client_id: System.get_env("VERCEL_CLIENT_CLIENT_ID"),
-         client_secret: System.get_env("VERCEL_CLIENT_CLIENT_SECRET"),
+         client_secret: System.get_env("VERCEL_CLIENT_SECRET"),
          redirect_uri: System.get_env("VERCEL_CLIENT_REDIRECT_URI"),
          install_vercel_uri: System.get_env("VERCEL_CLIENT_INSTALL_URI")
        ]


### PR DESCRIPTION
Fixes misnamed env var, users are unable to use the vercel integration due to misnamed secret env var


ticket [here](https://www.notion.so/supabase/Adding-in-vercel-integration-results-in-500-error-ee953a9187514ca3b85e363fd6137dfd)