### PR TITLE
Fix/logflare cloudflare links, refactor of homepage styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,47 +4,31 @@
 
 Stream logs to a central service and tail them in your browser. Logflare is different because you can **bring your own backend**. Simply provide your BigQuery credentials and we stream logs into your BigQuery table while automatically managing the schema.
 
+Logflare is now a part of [Supabase](https://github.com/supabase/supabase).
+
 Sign up at https://logflare.app.
 
 ![Logflare Example Gif](https://logflare.app/images/logflare-example.gif)
 
-## For Cloudflare
+## Integrations
 
-Automatically log structured request/response data in a few clicks with the Cloudflare app.
-
-<a href="https://www.cloudflare.com/apps/logflare/install?source=button">
-  <img
-    src="https://install.cloudflareapps.com/install-button.png"
-    alt="Install Logflare with Cloudflare"
-    border="0"
-    width="150">
-</a>
-
-## For Vercel
-
-Setup the [Logflare Vercel integration](https://vercel.com/integrations/logflare) and we'll automatically structure your Vercel logs.
-
-## For Javascript
-
-Use [our Pino transport](https://github.com/Logflare/pino-logflare) to log structured data and exceptions straight from your Javascript project.
-
-## For Elixir
-
-Use [our Logger backend](https://github.com/Logflare/logflare_logger_backend) to send your Elixir exceptions and structured logs to Logflare.
+| Provider/Runtime | Link                                                                                                                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cloudflare       | <a href="https://www.cloudflare.com/apps/logflare/install"><img src="https://install.cloudflareapps.com/install-button.png" alt="Install Logflare with Cloudflare" border="0" width="110"></a> |
+| Vercel           | [Logflare Vercel integration](https://vercel.com/integrations/logflare)                                                                                                                        |
+| Fly              | [Logflare/fly-log-shipper](https://github.com/Logflare/fly-log-shipper)                                                                                                                        |
+| Github Action    | [Logflare/action](https://github.com/Logflare/action)                                                                                                                                          |
+| Javascript       | [Logflare/pino-transport](https://github.com/Logflare/pino-logflare)                                                                                                                           |
+| Javascript       | [Logflare/winston-logflare](https://github.com/Logflare/winston-logflare)                                                                                                                      |
+| Elixir           | [Logflare/logflare_logger_backend](https://github.com/Logflare/logflare_logger_backend)                                                                                                        |
+| Elixir           | [Logflare/logflare_agent](https://github.com/Logflare/logflare_agent)                                                                                                                          |
+| Erlang           | [Logflare/logflare_erl](https://github.com/Logflare/logflare_erl)                                                                                                                              |
 
 ## Learn more
 
-- Official website: https://logflare.app
-- All our guides: https://logflare.app/guides
-- Support: https://twitter.com/logflare_logs or support@logflare.app
-
-## Source available
-
-We are leaving this repo public as an example of a larger Elixir project. We hope to have an open source edition of Logflare at some point in the future.
-
-## Closed Source Usage
-
-Logflare is using a SQL parser from sqlparser.com. To set this up on your dev machine:
+- [Official website](https://logflare.app)
+- [Guides](https://logflare.app/guides) and [documentation](https://docs.logflare.app)
+- <support@logflare.app> or <support@supabase.com>
 
 ## Developer
 
@@ -65,14 +49,15 @@ Logflare is using a SQL parser from sqlparser.com. To set this up on your dev ma
 1. Set user api key can be retrieved from dashboard or from database `users` table, source id is from the source page
 1. In `iex` console, test that everything works:
 
-
 ```elixir
 iex> LogflareLogger.info("testing log message")
 ```
 
 ### Using Docker
+
 1. Build images with `docker compose build`
 2. Run with `docker compose up -d`
+
 ### Logging
 
 Use the `:error_string` metadata key when logging, which is for additional information that we want to log but don't necessarily want searchable or parsed for schema updating.

--- a/assets/css/homepage.scss
+++ b/assets/css/homepage.scss
@@ -1,33 +1,234 @@
-a:hover {
-  text-decoration: none;
+@import "mixins";
+
+@mixin cta-btns-links {
+  .cta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    max-width: 500px;
+    margin: 0 auto;
+
+    .btns {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
+      @include tablet() {
+        justify-content: flex-start;
+      }
+      gap: 4px;
+      a {
+        display: inline-block;
+      }
+      button {
+        height: 40px;
+        img {
+          width: 120px;
+          height: 30px;
+        }
+        img.vercel {
+          height: 18px;
+        }
+      }
+    }
+
+    // common CTA buttons/links layout
+    .cta-links {
+      margin-top: 4px;
+    }
+  }
+}
+
+.homepage {
+  .hero-banner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 50px;
+    @include tablet {
+      padding: 0;
+    }
+    @include cta-btns-links();
+  }
+  .banner-footer {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 26px;
+    h1 {
+      color: #fff;
+      font-size: 26px;
+      text-align: center
+    }
+    @include cta-btns-links();
+  }
+  .hero {
+    background: url("/images/marketing/homepage/bgDesktopTop-4x.png") no-repeat
+      center;
+    background-size: cover;
+    padding-bottom: 20px;
+    padding-top: 100px;
+    @include tablet {
+      padding-top: 230px;
+    }
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 7em;
+    .ifreamfordiagram {
+      width: 269px;
+      height: 600px;
+      position: absolute;
+      z-index: 1;
+      right: 0;
+      top: 0;
+      overflow-y: hidden;
+    }
+
+    .forifream {
+      display: none;
+      @include tablet() {
+        display: block;
+        width: 269px;
+        height: 472px;
+        position: absolute;
+        z-index: 1;
+        right: 86px;
+        top: 200px;
+        overflow: hidden;
+        -webkit-transform: rotate3d(5, -5, 5, 5deg);
+        transform: rotate3d(5, -5, 5, 5deg);
+      }
+    }
+    .report-embedding .lego-reporting-view .mainBlock {
+      overflow: hidden;
+    }
+
+    .cta {
+      position: relative;
+      z-index: 1;
+    }
+    h1 {
+      padding: 0;
+      margin: 0;
+      color: #fff;
+      font-weight: 600;
+      line-height: 52px;
+      font-size: 44px;
+      max-width: 580px;
+    }
+    h2 {
+      padding: 0;
+      margin: 25px 0 0;
+      color: #969696;
+      font-weight: 600;
+      line-height: 26px;
+      font-size: 21px;
+      max-width: 580px;
+    }
+    h3 {
+      padding: 0;
+      margin: 0;
+      color: #fff;
+      font-weight: 600;
+      line-height: 39px;
+      font-size: 26px;
+    }
+    h3 span {
+      color: #e35b8d;
+      font-family: monospace;
+      font-weight: normal;
+    }
+    p {
+      padding: 0;
+      margin: 0;
+      color: #969696;
+      font-weight: 400;
+      line-height: 26px;
+      font-size: 14px;
+    }
+
+    .imghero {
+      display: none;
+      @include tablet {
+        margin: auto;
+        display: block;
+        margin-top: 220px;
+        width: 100%;
+        position: relative;
+        z-index: 0;
+        box-shadow: 0 0 50px #2a2a2a;
+        max-width: 100vw;
+      }
+    }
+
+    .phonimg {
+      display: none;
+      @include tablet {
+        display: block;
+        position: absolute;
+        right: -70px;
+        top: 10px;
+        -webkit-transform: rotate3d(5, -5, 5, 5deg);
+        transform: rotate3d(5, -5, 5, 5deg);
+        max-width: 300px;
+      }
+      @include desktop {
+        max-width: 450px;
+      }
+    }
+    .h3div {
+      margin-top: 40px;
+      margin-bottom: 100px;
+    }
+    .paragraph img {
+      max-width: 100%;
+    }
+    .paragraph h4 {
+      padding: 0;
+      margin: 20px 0;
+      color: #fff;
+      font-weight: 600;
+      line-height: 39px;
+      font-size: 26px;
+    }
+    .paragraph p {
+      max-width: 493px;
+      padding: 0;
+      margin: 40px 0 0;
+      color: #969696;
+      font-weight: 400;
+      line-height: 26px;
+      font-size: 16px;
+      margin-top: 80px;
+    }
+  }
+  .dashboard-cta {
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .twitter-reviews {
+    background: #161616;
+    padding-top: 50px;
+  }
 }
 
 .navbar-toggler:focus {
   outline: none !important;
 }
 
-/*
-CSS
-*/
 body {
   background: #b7b7b7;
   overflow-x: hidden;
 }
 
-@media (min-width: 1320px) {
+@include desktop {
   .container {
     max-width: 1180px;
   }
-}
-
-@media (min-width: 1400px) {
-  .container {
-    max-width: 1300px;
-  }
-}
-
-.forphone2 {
-  display: none;
 }
 
 .inner-shadow-box {
@@ -35,15 +236,7 @@ body {
   border-radius: 3px;
 }
 
-@media screen and (max-width: 1200px) {
-
-  /*
-  .navbar-expand-lg .container {
-    max-width: 100%;
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-*/
+@include desktop(max) {
   .container {
     max-width: 100%;
     padding-left: 15px;
@@ -51,11 +244,7 @@ body {
   }
 }
 
-.xicon {
-  display: none;
-}
-
-@media screen and (max-width: 992px) {
+@include desktop(max) {
   .navbar-toggler {
     z-index: 99;
     margin-top: 0;
@@ -113,69 +302,6 @@ body {
     opacity: 0;
     visibility: hidden;
   }
-
-  .forphone2 {
-    display: block;
-    background: #161616 !important;
-    margin: 0 !important;
-    padding-left: 20px;
-  }
-
-  .forphone2 .install {
-    padding: 0;
-    margin: 0;
-    color: #969696;
-    font-weight: 400;
-    line-height: 26px;
-    font-size: 14px;
-    padding-top: 10px;
-  }
-
-  .forphone2 .btns p {
-    display: inline-block;
-    margin-top: 13px;
-    margin-bottom: 23px;
-  }
-
-  .forphone2 .btns p iframe {
-    display: inline-block;
-    margin-bottom: -25px;
-    height: 32px;
-    width: 130px;
-  }
-
-  .forphone2 .btns a {
-    width: 130px;
-    display: block;
-    float: left;
-  }
-
-  .forphone2 .btns .signup {
-    font-weight: 700;
-    letter-spacing: 1.5px;
-    font-size: 13px;
-    text-transform: uppercase;
-    background: #474747;
-    border-radius: 3px;
-    padding: 8px 15px;
-    margin-top: 7px;
-    margin-left: 15px;
-    color: #fff;
-    width: 150px;
-    width: 130px;
-    display: block;
-    float: left;
-  }
-
-  .forphone2 .btns .signup:focus,
-  .forphone2 .btns .signup:hover {
-    background: rgba(71, 71, 71, 0.75);
-  }
-
-  .forphone2 .btns .install:focus img,
-  .forphone2 .btns .install:hover img {
-    opacity: 0.9;
-  }
 }
 
 .navbar-toggle {
@@ -225,403 +351,35 @@ body {
   transform: rotate(0);
 }
 
-@media (max-width: 768px) {}
-
-.hero {
-  
-  background: url("/images/marketing/homepage/bgDesktopTop-4x.png") no-repeat center;
-  background-size: cover;
-  padding-bottom: 20px;
-  padding-top: 230px;
-  position: relative;
-  overflow: hidden;
-  margin-bottom: 7em;
-}
-
-.hero .ifreamfordiagram {
-  width: 269px;
-  height: 600px;
-  position: absolute;
-  z-index: 1;
-  right: 0;
-  top: 0;
-  overflow-y: hidden;
-}
-
-.hero .forifream {
-  width: 269px;
-  height: 472px;
-  position: absolute;
-  z-index: 1;
-  right: 86px;
-  top: 200px;
-  overflow: hidden;
-  -webkit-transform: rotate3d(5, -5, 5, 5deg);
-  transform: rotate3d(5, -5, 5, 5deg);
-}
-
-.hero .report-embedding .lego-reporting-view .mainBlock {
-  overflow: hidden;
-}
-
-.hero .cta {
-  position: relative;
-  z-index: 1;
-}
-
-.hero h1 {
-  padding: 0;
-  margin: 0;
-  color: #fff;
-  font-weight: 600;
-  line-height: 52px;
-  font-size: 44px;
-  max-width: 580px;
-}
-
-.hero h2 {
-  padding: 0;
-  margin: 25px 0 0;
-  color: #969696;
-  font-weight: 600;
-  line-height: 26px;
-  font-size: 21px;
-  max-width: 580px;
-}
-
-.hero p {
-  padding: 0;
-  margin: 0;
-  color: #969696;
-  font-weight: 400;
-  line-height: 26px;
-  font-size: 14px;
-}
-
-.hero .btns p {
-  display: inline-block;
-  margin-top: 23px;
-  margin-bottom: 23px;
-}
-
-.hero .btns p iframe {
-  display: inline-block;
-  margin-bottom: -15px;
-  height: 38px;
-  width: 160px;
-}
-
-.hero .btns a {}
-
-.hero .btns .signup {
-  font-weight: 700;
-  letter-spacing: 1.5px;
-  font-size: 13px;
-  text-transform: uppercase;
-  background: #474747;
-  border-radius: 3px;
-  padding: 12px 15px;
-  margin-top: 13px;
-  margin-left: 15px;
-  color: #fff;
-}
-
-.hero .btns .signup:focus,
-.hero .btns .signup:hover {
-  background: rgba(71, 71, 71, 0.75);
-}
-
-.hero .btns .install:focus img,
-.hero .btns .install:hover img {
-  opacity: 0.9;
-}
-
-.hero .btn {
-  margin-top: 30px;
-}
-
-.tablescalerow .btn {
-  margin-top: 30px;
-}
-
-.hero .imghero {
-  margin: auto;
-  display: block;
-  margin-top: 220px;
-  width: 100%;
-  position: relative;
-  z-index: 0;
-  box-shadow: 0 0 50px #2a2a2a;
-  max-width: 1300px;
-}
-
-.hero .phonimg {
-  position: absolute;
-  right: -70px;
-  top: -70px;
-  -webkit-transform: rotate3d(5, -5, 5, 5deg);
-  transform: rotate3d(5, -5, 5, 5deg);
-}
-
-.hero .h3div {
-  margin-top: 40px;
-  margin-bottom: 100px;
-}
-
-.hero h3 {
-  padding: 0;
-  margin: 0;
-  color: #fff;
-  font-weight: 600;
-  line-height: 39px;
-  font-size: 26px;
-}
-
-.hero h3 span {
-  color: #e35b8d;
-  font-family: monospace;
-  font-weight: normal;
-}
-
-.hero .paragraph img {
-  max-width: 100%;
-}
-
-.hero .paragraph h4 {
-  padding: 0;
-  margin: 20px 0 0;
-  color: #fff;
-  font-weight: 600;
-  line-height: 39px;
-  font-size: 26px;
-  margin-bottom: -50px;
-}
-
-.hero .paragraph p {
-  max-width: 493px;
-  padding: 0;
-  margin: 40px 0 0;
-  color: #969696;
-  font-weight: 400;
-  line-height: 26px;
-  font-size: 16px;
-  margin-top: 80px;
-}
-
-.catchimgbtn img,
-.catchimgtop img {
-  width: 100%;
-  display: block;
-  position: relative;
-  z-index: 1;
-}
-
 .catch {
   position: relative;
   z-index: 1;
   background: #161616;
   padding-top: 20px;
   padding-bottom: 20px;
-}
-
-.catch img {
-  max-width: 100%;
-}
-
-.catch h4 {
-  padding: 0;
-  margin: 20px 0 0;
-  color: #fff;
-  font-weight: 600;
-  line-height: 39px;
-  font-size: 26px;
-  max-width: 314px;
-  margin-bottom: -100px;
-}
-
-.catch p {
-  max-width: 493px;
-  padding: 0;
-  margin: 40px 0 0;
-  color: #969696;
-  font-weight: 400;
-  line-height: 26px;
-  font-size: 16px;
-  margin-top: 120px;
-}
-
-.scale {
-  position: relative;
-  z-index: 0;
-  background: #121212;
-  padding-top: 200px;
-  padding-bottom: 200px;
-  margin-top: -200px;
-}
-
-.scale h4 {
-  padding: 0;
-  margin: 20px 0 0;
-  color: #fff;
-  font-weight: 600;
-  line-height: 39px;
-  font-size: 26px;
-  max-width: 314px;
-  margin-bottom: -50px;
-}
-
-.scale p {
-  max-width: 493px;
-  padding: 0;
-  margin: 40px 0 0;
-  color: #969696;
-  font-weight: 400;
-  line-height: 26px;
-  font-size: 16px;
-  margin-top: 80px;
-}
-
-.scale .spanp {
-  color: #474747;
-  font-size: 14px;
-  margin-top: 40px;
-}
-
-.scale .container {
-  position: relative;
-}
-
-.scale .bgoftable {
-  position: absolute;
-  top: -200px;
-  left: -200px;
-  z-index: 0;
-}
-
-.scale .tablescale {
-  width: 100%;
-  position: relative;
-  z-index: 1;
-}
-
-.scale .tablescale .col1,
-.scale .tablescale .col2,
-.scale .tablescale .col3 {
-  display: inline-block;
-  background: yellow;
-  background: rgba(22, 22, 22, 0.5);
-  padding-top: 30px;
-  padding-bottom: 30px;
-}
-
-.scale .tablescale .col1 h2,
-.scale .tablescale .col2 h2,
-.scale .tablescale .col3 h2 {
-  padding: 0;
-  margin: 0;
-  color: #b7b7b7;
-  font-weight: 600;
-  line-height: 26px;
-  font-size: 16px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  padding-right: 30px;
-}
-
-.scale .tablescale .col1 h3,
-.scale .tablescale .col2 h3,
-.scale .tablescale .col3 h3 {
-  padding: 0;
-  margin: 0;
-  color: #b7b7b7;
-  font-weight: 500;
-  line-height: 26px;
-  font-size: 14px;
-  padding-left: 30px;
-  padding-right: 30px;
-  margin-bottom: 15px;
-}
-
-.scale .tablescale .col1 h3 i,
-.scale .tablescale .col2 h3 i,
-.scale .tablescale .col3 h3 i {
-  font-size: 21px;
-  color: #474747;
-}
-
-.scale .tablescale .col1 .lastone,
-.scale .tablescale .col2 .lastone,
-.scale .tablescale .col3 .lastone {
-  border-bottom: 1px solid #202020;
-  padding-bottom: 15px;
-  margin-bottom: 15px;
-}
-
-.scale .tablescale .col1 .nothing,
-.scale .tablescale .col2 .nothing,
-.scale .tablescale .col3 .nothing {
-  font-size: 0;
-}
-
-.scale .tablescale .col1 .money,
-.scale .tablescale .col2 .money,
-.scale .tablescale .col3 .money {
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.scale .tablescale .col1 {
-  width: 39%;
-  overflow: hidden;
-}
-
-.scale .tablescale .col2 {}
-
-.scale .tablescale .col2 h2,
-.scale .tablescale .col2 h3 {
-  text-align: center;
-}
-
-.scale .tablescale .col3 {
-  width: 29%;
-  overflow: hidden;
-  margin-left: -5px;
-}
-
-.scale .tablescale .col3 h2,
-.scale .tablescale .col3 h3 {
-  text-align: center;
-}
-
-.scale .tablescale .col2:hover,
-.scale .tablescale .col3:hover {
-  background: #1f1c24;
-}
-
-.scale .tablescale .col2:hover h3,
-.scale .tablescale .col3:hover h3 {
-  color: #fff;
-}
-
-.scale .tablescale .col2:hover h3 i,
-.scale .tablescale .col3:hover h3 i {
-  color: #64debf;
-}
-
-.scale .tablescale .col2:hover .money,
-.scale .tablescale .col3:hover .money {
-  color: #64debf;
-}
-
-.stepsimgtop img {
-  width: 100%;
-  display: block;
-  position: relative;
-  z-index: 1;
-}
-
-.stepsimgtop {
-  margin-top: -180px;
+  img {
+    max-width: 100%;
+  }
+  h4 {
+    padding: 0;
+    margin: 20px 0 0;
+    color: #fff;
+    font-weight: 600;
+    line-height: 39px;
+    font-size: 26px;
+    max-width: 314px;
+    margin-bottom: -100px;
+  }
+  p {
+    max-width: 493px;
+    padding: 0;
+    margin: 40px 0 0;
+    color: #969696;
+    font-weight: 400;
+    line-height: 26px;
+    font-size: 16px;
+    margin-top: 120px;
+  }
 }
 
 .steps {
@@ -763,20 +521,6 @@ body {
   margin-bottom: 10px;
 }
 
-.ctav2 {
-  background: #161616;
-  padding-top: 50px;
-}
-
-.ctav2 img {
-  max-width: 100%;
-}
-
-.ctav2 .fordesk {
-  z-index: 1;
-  position: relative;
-}
-
 .ctav2 h1 {
   padding: 0;
   margin: 0 0 15px;
@@ -795,67 +539,6 @@ body {
   line-height: 26px;
   font-size: 14px;
   list-style-type: none;
-}
-
-.ctav2 .btns p {
-  display: inline-block;
-  margin-top: 23px;
-  margin-bottom: 23px;
-}
-
-.ctav2 .btns p iframe {
-  display: inline-block;
-  margin-bottom: -15px;
-  height: 38px;
-  width: 160px;
-}
-
-
-.ctav2 .btns .signup {
-  font-weight: 700;
-  letter-spacing: 1.5px;
-  font-size: 13px;
-  text-transform: uppercase;
-  background: #474747;
-  border-radius: 3px;
-  padding: 12px 15px;
-  margin-top: 13px;
-  margin-left: 15px;
-  color: #fff;
-}
-
-.ctav2 .btns .signup:focus,
-.ctav2 .btns .signup:hover {
-  background: rgba(71, 71, 71, 0.75);
-}
-
-.ctav2 .btns .install:focus img,
-.ctav2 .btns .install:hover img {
-  opacity: 0.9;
-}
-
-.ctav2 .forphone3 {
-  display: none;
-}
-
-.ctav2 .forphone3 .text {
-  background: #202020;
-  padding: 15px;
-  margin-top: -10px;
-}
-
-.ctav2 .forphone3 .text p {
-  padding: 0;
-  margin: 15px 0 0;
-  color: #b7b7b7;
-  font-weight: 400;
-  line-height: 26px;
-  font-size: 16px;
-  list-style-type: none;
-}
-
-.ctav2 .forphone3 .text p span {
-  font-weight: 600;
 }
 
 .footer {
@@ -945,94 +628,13 @@ body {
   font-weight: 500;
 }
 
-@media (max-width: 1400px) {
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col3 h2 {
-    font-size: 13px;
-  }
-
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h3 {
-    font-size: 13px;
-  }
-}
-
-@media (max-width: 1350px) {
-  .hero .imghero {
-    width: 100%;
-  }
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h2,
-  .scale .tablescale .col3 h3 {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
-}
-
-@media (max-width: 1200px) {
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h2,
-  .scale .tablescale .col3 h3 {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-  .hero .forifream {
-    width: 209px;
-    height: 367px;
-    position: absolute;
-    z-index: 1;
-    right: 52px;
-    top: 221px;
-    overflow: hidden;
-    -webkit-transform: rotate3d(5, -5, 5, 5deg);
-    transform: rotate3d(5, -5, 5, 5deg);
-  }
-
-  .hero .ifreamfordiagram {
-    width: 209px;
-    height: 400px;
-  }
-
-  /*
-  .navbar-expand-lg .navbar-nav > li > a {
-    margin-left: 0;
-  }
-*/
+@include desktop(max) {
   .hero {
     padding-top: 160px;
   }
 
-  .hero .h3div {
-    margin-top: 40px;
-  }
-
-  .hero .phonimg {
-    position: absolute;
-    right: -70px;
-    top: 10px;
-    max-width: 450px;
-  }
-
   .hero h1 {
     margin: auto;
-  }
-
-  .hero .btns .signup,
-  .hero .btns p img {
-    margin-left: 10px;
-    margin-right: 10px;
   }
 
   .hero h2,
@@ -1040,70 +642,9 @@ body {
     margin-left: auto;
     margin-right: auto;
   }
-
-  .ctav2 h1,
-  .ctav2 p {}
 }
 
-@media (max-width: 992px) {
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h2,
-  .scale .tablescale .col3 h3 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-
-  .hero .forifream {
-    width: 140px;
-    height: 247px;
-    position: absolute;
-    z-index: 1;
-    right: 62px;
-    top: 44px;
-    overflow: hidden;
-    -webkit-transform: rotate3d(5, -5, 5, 5deg);
-    transform: rotate3d(5, -5, 5, 5deg);
-  }
-
-  .hero .ifreamfordiagram {
-    width: 140px;
-    height: 270px;
-  }
-
-  .hero .phonimg {
-    position: absolute;
-    right: -20px;
-    top: -104px;
-    max-width: 300px;
-  }
-
-  .hero .imghero {
-    margin-top: 30px;
-  }
-
-  .ctav2 .btns p iframe {
-    display: inline-block;
-    margin-bottom: 0;
-    height: 30px;
-    width: 130px;
-    margin-top: -1px;
-  }
-
-  .hero .btns .signup,
-  .hero .btns p img {
-    width: 150px;
-  }
-
-  .hero .btns .signup {
-    display: block;
-    width: 150px;
-    padding: 6px 15px;
-  }
-
+@include tablet(max) {
   .navbar-expand-lg {
     min-height: auto;
   }
@@ -1114,10 +655,6 @@ body {
 
   .hero {
     text-align: left !important;
-  }
-
-  .hero .h3div {
-    margin-top: 0;
   }
 
   .hero h3 {
@@ -1134,8 +671,6 @@ body {
   .hero .paragraph h4,
   .hero .paragraph p,
   .hero h3,
-  .scale h4,
-  .scale p,
   .steps h2,
   .steps p {
     text-align: left;
@@ -1146,10 +681,6 @@ body {
 
   .hero {
     min-height: auto;
-  }
-
-  .catchimgtop {
-    display: none;
   }
 
   .footer .rightside {
@@ -1166,8 +697,7 @@ body {
   }
 
   .catch h4,
-  .hero .paragraph h4,
-  .scale h4 {
+  .hero .paragraph h4 {
     margin-top: 20px;
     margin-bottom: 20px;
   }
@@ -1183,33 +713,7 @@ body {
     margin-left: 0;
   }
 
-  .btns {
-    text-align: left;
-  }
-
-  .hero .btns .signup {
-    text-align: center;
-  }
-
-  .hero .btns {
-    display: block;
-  }
-
-  .hero .btns {
-    height: 90px;
-  }
-
-  .hero .btns p {
-    float: left;
-  }
-
-  .hero .btns .signup {
-    text-align: center;
-    margin-top: -3px;
-  }
-
-  .catch p,
-  .hero .paragraph p .scale p {
+  .catch p {
     margin-top: 30px;
   }
 
@@ -1218,51 +722,7 @@ body {
     text-align: left;
   }
 
-  .btns .signup {
-    text-align: center;
-  }
-
-  .btns {
-    display: block;
-  }
-
-  .btns {
-    height: 90px;
-  }
-
-  .btns p {
-    float: left;
-  }
-
-  .ctav2 .btns .signup {
-    display: block;
-    margin-top: -2px;
-    padding: 7px 20px;
-    width: 130px;
-    padding: 2px 15px;
-    margin-top: -2px;
-    color: #fff;
-  }
-
-  .ctav2 .btns p img {
-    width: 130px;
-  }
-
   .hero h2 {
-    margin-bottom: 40px;
-  }
-
-  .scale .bgoftable {
-    display: none;
-  }
-
-  .hero .btns p img {
-    margin-left: 5px;
-    margin-right: 5px;
-  }
-
-  .hero .h3div {
-    margin-top: 50px;
     margin-bottom: 40px;
   }
 }
@@ -1304,7 +764,7 @@ body {
   border: 0;
 }
 
-.forphone .nav-tabs>li {
+.forphone .nav-tabs > li {
   width: 50%;
   text-align: center;
   padding: 0;
@@ -1315,7 +775,7 @@ body {
   font-size: 13px;
 }
 
-.forphone .nav-tabs>li>a {
+.forphone .nav-tabs > li > a {
   width: 100%;
   text-align: center;
   padding: 0;
@@ -1329,7 +789,7 @@ body {
   padding-bottom: 10px;
 }
 
-.forphone .nav-tabs>li>a {
+.forphone .nav-tabs > li > a {
   color: #969696;
 }
 
@@ -1338,9 +798,9 @@ body {
   border-top: 1px solid #969696;
 }
 
-.forphone .nav-tabs>li.active>a,
-.forphone .nav-tabs>li.active>a:focus,
-.forphone .nav-tabs>li.active>a:hover {
+.forphone .nav-tabs > li.active > a,
+.forphone .nav-tabs > li.active > a:focus,
+.forphone .nav-tabs > li.active > a:hover {
   background: transparent;
   border: 0;
   border-bottom: 2px solid #cf407b;
@@ -1349,9 +809,9 @@ body {
   margin-bottom: -2px;
 }
 
-.forphone .nav-tabs>li>.active,
-.forphone .nav-tabs>li>.active:focus,
-.forphone .nav-tabs>li>.active:hover {
+.forphone .nav-tabs > li > .active,
+.forphone .nav-tabs > li > .active:focus,
+.forphone .nav-tabs > li > .active:hover {
   background: transparent;
   border: 0;
   border-bottom: 2px solid #cf407b;
@@ -1388,54 +848,11 @@ body {
   background-color: #515151;
 }
 
-.forifream2 {
-  display: none;
-}
-
-@media (max-width: 772px) {
-  .hero .forifream {
-    display: none;
-  }
-
-  .ifreamfordiagram2 {
-    display: block;
-    width: 100%;
-    height: 1500px;
-    max-width: 350px;
-    position: relative;
-    margin: auto;
-  }
-
-  .forifream2 {
-    height: 600px;
-    overflow: hidden;
-    display: block;
-  }
-
-  .hero .phonimg {
-    display: none;
-  }
-
-  .hero .btns p iframe {
-    display: inline-block;
-    margin-bottom: -14px;
-    height: 38px;
-    width: 160px;
-    margin-top: -3px;
-  }
-
-  .hero .btns {
-    margin-bottom: 10px;
-  }
-
+@include tablet(max) {
   .forphone {
     display: block;
     background: rgba(22, 22, 22, 0.5);
     margin-top: 40px;
-  }
-
-  .hero .imghero {
-    display: none;
   }
 
   .container-fluid {
@@ -1449,10 +866,6 @@ body {
 
   .footer {
     margin-top: 40px;
-  }
-
-  .ctav2 .btns p img {
-    width: 120px;
   }
 
   .hero h3 {
@@ -1481,10 +894,6 @@ body {
     padding-bottom: 30px;
   }
 
-  .scale .spanp {
-    margin-top: 30px;
-  }
-
   .steps {
     padding-top: 10px;
     padding-bottom: 10px;
@@ -1508,7 +917,7 @@ body {
     max-height: 100%;
   }
 
-  .container>.navbar-header {
+  .container > .navbar-header {
     max-width: 100%;
   }
 
@@ -1520,14 +929,6 @@ body {
     margin-top: 25px;
     margin-bottom: 40px;
     font-size: 21px;
-  }
-
-  .hero .btns {
-    height: 80px;
-  }
-
-  .hero .h3div {
-    margin-bottom: 50px;
   }
 
   .hero h3 {
@@ -1546,56 +947,6 @@ body {
     margin-bottom: 40px;
   }
 
-  .scale h4 {
-    font-size: 21px;
-    line-height: 26px;
-    margin-bottom: 40px;
-    margin-top: 40px;
-  }
-
-  .catchimgbtn {
-    display: none;
-  }
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col3 h2 {
-    font-size: 16px;
-    padding-bottom: 10px;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h3 {
-    font-size: 14px;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .scale .tablescale .col1,
-  .scale .tablescale .col2,
-  .scale .tablescale .col3 {
-    min-height: 370px;
-  }
-
-  .scale p {
-    margin-top: 0;
-  }
-
-  .scale .spanp {
-    padding: 0;
-  }
-
-  .stepsimgtop {
-    display: none;
-  }
-
-  .scale {
-    padding-bottom: 40px;
-  }
-
   .steps {
     padding-top: 40px;
   }
@@ -1603,9 +954,11 @@ body {
   .footer {
     padding-top: 40px;
     margin: 0;
-    background: url("/images/marketing/homepage/footerbg.png") no-repeat top left,
+    background: url("/images/marketing/homepage/footerbg.png") no-repeat top
+        left,
       -webkit-gradient(linear, left top, left bottom, color-stop(100%, #161616), to(#161616));
-    background: url("/images/marketing/homepage/footerbg.png") no-repeat top left,
+    background: url("/images/marketing/homepage/footerbg.png") no-repeat top
+        left,
       linear-gradient(#161616 100%, #161616 100%);
     background-size: cover;
   }
@@ -1613,126 +966,4 @@ body {
   .footer .footerbg {
     display: none;
   }
-
-  .tablescalerow .col-md-6 {
-    padding-left: 13px;
-    padding-right: 13px;
-  }
 }
-
-@media (max-width: 500px) {
-  .ctav2 .fordesk {
-    display: none;
-  }
-
-  .ctav2 .forphone3 {
-    display: block;
-  }
-
-  .ctav2 .forphone3 img {
-    width: 100%;
-  }
-}
-
-@media (max-width: 480px) {
-  .hero .btns p iframe {
-    display: inline-block;
-    /* margin-bottom: -4px; */
-    height: 38px;
-    width: 160px;
-    margin-top: -3px;
-  }
-
-  .hero .btns {
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width: 430px) {
-
-  .scale .tablescale .col1 h3 i,
-  .scale .tablescale .col2 h3 i,
-  .scale .tablescale .col3 h3 i {
-    font-size: 19px;
-  }
-
-  .ctav2 .btns .signup {
-    width: 130px;
-    padding: 2px 14px;
-  }
-
-  .forphone .firstline p {
-    font-size: 12px;
-  }
-
-  .hero .btns p {
-    width: 130px;
-    padding: 0;
-  }
-
-  .hero .btns p img {
-    width: 130px;
-  }
-
-  .hero .btns .signup {
-    display: block;
-    width: 130px;
-    padding: 3px 15px;
-  }
-
-  .forphone2 .btns .signup {
-    font-weight: 700;
-    letter-spacing: 1.5px;
-    font-size: 13px;
-    text-transform: uppercase;
-    background: #474747;
-    border-radius: 3px;
-    padding: 7px 15px;
-    margin-top: 7.5px;
-    margin-left: 5px;
-    color: #fff;
-    width: 150px;
-    width: 130px;
-    display: block;
-    float: left;
-  }
-
-  .hero .btns p iframe {
-    display: inline-block;
-    margin-bottom: -4px;
-    height: 31px;
-    width: 130px;
-    margin-top: -2px;
-  }
-}
-
-@media (max-width: 385px) {
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col3 h2 {
-    font-size: 15px;
-  }
-}
-
-@media (max-width: 357px) {
-
-  .scale .tablescale .col1 h2,
-  .scale .tablescale .col2 h2,
-  .scale .tablescale .col3 h2 {
-    font-size: 12px;
-    padding-bottom: 10px;
-    padding-left: 2px;
-    padding-right: 2px;
-  }
-
-  .scale .tablescale .col1 h3,
-  .scale .tablescale .col2 h3,
-  .scale .tablescale .col3 h3 {
-    font-size: 11px;
-    padding-left: 2px;
-    padding-right: 2px;
-  }
-}
-
-/*# sourceMappingURL=style.css.map */

--- a/assets/css/marketing.scss
+++ b/assets/css/marketing.scss
@@ -1,4 +1,6 @@
-.banner{
+@import "mixins";
+
+.banner {
   padding: 10px;
   display: flex;
   flex-direction: row;
@@ -65,7 +67,7 @@
   margin-left: 0.75em;
   color: #f58220;
 }
-@media screen and (max-width: 992px) {
+@include tablet(max) {
   #pwa {
     flex-direction: column;
   }

--- a/assets/css/marketing_pricing.scss
+++ b/assets/css/marketing_pricing.scss
@@ -1,1015 +1,955 @@
+@import "mixins";
+
 .heropricing {
-    min-height: 1697px;
-    background: url("/images/marketing/pricing/pricingDesktopBackground.png") no-repeat top center;
-    -webkit-background-size: cover;
-    -moz-background-size: cover;
-    -o-background-size: cover;
-    background-size: cover;
-    padding-bottom: 20px;
-    margin-top: -155px;
+  min-height: 1697px;
+  background: url("/images/marketing/pricing/pricingDesktopBackground.png")
+    no-repeat top center;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+  padding-bottom: 20px;
+  margin-top: -155px;
 
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 
-    .heropr {
-        h1 {
-            min-height: 80px;
-            margin-top: 206px;
-            color: #FFFFFF;
-            font-family: 'Rubik', sans-serif;
-            font-size: 44px;
-            font-weight: bold;
-            line-height: 52px;
-            text-align: center;
-        }
-
-        .paragraph {
-            min-height: 72px;
-            max-width: 600px;
-            color: #969696;
-            font-family: 'Rubik', sans-serif;
-            font-size: 18px;
-            line-height: 26px;
-            text-align: center;
-            margin: auto;
-            margin-bottom: 13px;
-        }
-
-        .sign-up {
-            text-align: center;
-            margin-bottom: 8px;
-
-            a {
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 13px;
-                font-weight: bold;
-                letter-spacing: 1.5px;
-                line-height: 26px;
-                text-align: center;
-                background: #E35B8D;
-                display: inline-block;
-                min-width: 171px;
-                border-radius: 5px;
-                padding: 7px 15px;
-            }
-
-            a:hover {
-                opacity: 0.8;
-            }
-        }
-
-        p {
-            text-align: center;
-
-            span {
-
-                color: #E35B8D;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                text-align: center;
-            }
-        }
+  .heropr {
+    h1 {
+      min-height: 80px;
+      margin-top: 206px;
+      color: #ffffff;
+      font-family: "Rubik", sans-serif;
+      font-size: 44px;
+      font-weight: bold;
+      line-height: 52px;
+      text-align: center;
     }
 
-    .pricingtable {
-        margin-top: 83px;
-
-        .tablecol1 {
-            min-height: 702px;
-            padding-top: 40px;
-            padding-bottom: 25px;
-
-            h2 {
-                height: 26px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 26px;
-                text-align: center;
-                margin-bottom: 35px;
-            }
-
-            p {
-                margin: 0;
-                margin-top: 0px;
-                margin-bottom: 0px;
-                height: 37px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-size: 16px;
-                line-height: 39px;
-
-                i {
-                    color: #474747;
-                    font-size: 15px;
-                    position: absolute;
-                    right: 15px;
-                    margin-top: 12px;
-                }
-            }
-
-            .line {
-                height: 1px;
-                width: 100%;
-                background-color: rgba(255, 255, 255, 0.07);
-                margin-top: 5px;
-                margin-bottom: 5px;
-            }
-        }
-
-        .tablecol {
-            min-height: 675px;
-            border-radius: 12px;
-            background-color: #1D1D1D;
-            padding-top: 40px;
-            padding-bottom: 0px;
-
-            h2 {
-                height: 26px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 26px;
-                text-align: center;
-                margin-bottom: 35px;
-            }
-
-            p {
-                margin: 0;
-                margin-top: 0px;
-                margin-bottom: 0px;
-                height: 37px;
-                color: #B7B7B7;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 16px;
-                line-height: 39px;
-                text-align: center;
-
-                g i {
-                    color: #474747;
-                    font-size: 21px;
-                    line-height: 39px;
-                }
-            }
-
-            .line {
-                height: 1px;
-                width: 100%;
-                background-color: rgba(255, 255, 255, 0.07);
-                margin-top: 5px;
-                margin-bottom: 5px;
-            }
-
-            .custom {
-                height: 39px;
-                color: #B7B7B7;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 39px;
-                text-align: center;
-                margin-top: 37px;
-                margin-bottom: 0;
-            }
-
-            .price {
-                height: 39px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 26px;
-                font-weight: bold;
-                line-height: 39px;
-                text-align: center;
-                margin-top: 37px;
-                margin-bottom: 0;
-            }
-
-            .pm {
-                height: 26px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                text-align: center;
-                margin: 0;
-            }
-
-            .free30 {
-                height: 26px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                text-align: center;
-                margin-top: 20px;
-                padding-bottom: 40px;
-            }
-
-            .btn {
-                text-align: center;
-                width: 100%;
-                margin-top: 30px;
-
-                a {
-                    color: #FFFFFF;
-                    font-family: 'Rubik', sans-serif;
-                    font-size: 13px;
-                    font-weight: bold;
-                    letter-spacing: 1.5px;
-                    line-height: 26px;
-                    text-align: center;
-                    background: #474747;
-                    display: inline-block;
-                    min-width: 171px;
-                    border-radius: 5px;
-                    padding: 7px 15px;
-                    text-transform: uppercase;
-                }
-            }
-        }
-
-        .oneactive {
-            background: linear-gradient(0deg, #2A1057 0%, #9c59ff 100%);
-
-            .btn {
-                a {
-                    background-color: #9667E6;
-                }
-            }
-
-            p {
-                color: #fff;
-            }
-
-            .pm {
-                color: #9667E6;
-            }
-
-            .free30 {
-                color: #9667E6;
-            }
-
-            .btn a:hover {
-                opacity: 0.5;
-            }
-        }
-
-        .tablecol {
-
-            .btn a {}
-
-            p {}
-        }
-
-        .tablecol:hover {
-            background: linear-gradient(0deg, #2A1057 0%, #9c59ff 100%);
-
-            .btn {
-                a {
-                    background-color: #9667E6;
-
-                }
-            }
-
-            p {
-                color: #fff;
-
-                i {
-                    color: #fff;
-                }
-            }
-
-            .pm {
-                color: #9667E6;
-            }
-
-            .free30 {
-                color: #9667E6;
-            }
-
-            .btn a:hover {
-                opacity: 0.5;
-            }
-        }
-
-
+    .paragraph {
+      min-height: 72px;
+      max-width: 600px;
+      color: #969696;
+      font-family: "Rubik", sans-serif;
+      font-size: 18px;
+      line-height: 26px;
+      text-align: center;
+      margin: auto;
+      margin-bottom: 13px;
     }
 
-    .tablescalerowpricing {
-        h1 {
-            height: 39px;
-            color: #FFFFFF;
-            font-family: 'Rubik', sans-serif;
-            font-size: 32px;
-            font-weight: bold;
-            line-height: 39px;
-            text-align: center;
-            margin-top: 105px;
-        }
+    .sign-up {
+      text-align: center;
+      margin-bottom: 8px;
 
-        h2 {
-            height: 26px;
-            color: #969696;
-            font-family: 'Rubik', sans-serif;
-            font-size: 21px;
-            font-weight: bold;
-            line-height: 26px;
-            text-align: center;
-            margin-top: 35px;
-            position: relative;
-            z-index: 1;
+      a {
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        letter-spacing: 1.5px;
+        line-height: 26px;
+        text-align: center;
+        background: #e35b8d;
+        display: inline-block;
+        min-width: 171px;
+        border-radius: 5px;
+        padding: 7px 15px;
+      }
 
-            span {
-                color: #fff;
-            }
-
-            .openpopup {
-                cursor: pointer;
-                color: #fff;
-                padding-right: 39px;
-                position: relative;
-
-                span {
-                    border-bottom-style: dashed;
-                }
-
-                i {
-                    color: #969696;
-                    position: absolute;
-                    top: 3px;
-                    font-size: 25px;
-                    right: 5px;
-                }
-            }
-        }
-
-        .custompopup {
-            display: none;
-            opacity: 0;
-            visibility: hidden;
-
-
-            z-index: 99;
-            max-width: 350px;
-            position: absolute;
-            left: 0;
-            right: 0;
-            margin: auto;
-            border-radius: 12px;
-            background-color: #1C1C1C;
-            box-shadow: 0 3px 39px 0 rgba(0, 0, 0, 0.15);
-
-            h3 {
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 16px;
-                line-height: 26px;
-                padding: 15px;
-                position: relative;
-                margin: 0;
-
-                .xpopup {
-                    position: absolute;
-                    right: 15px;
-                    top: 15px;
-                    cursor: pointer;
-
-                    i {
-                        color: #474747;
-                        font-size: 21px;
-                        line-height: 25px;
-                    }
-                }
-            }
-
-            .line {
-                height: 1px;
-                width: 100%;
-                background-color: rgba(255, 255, 255, 0.07);
-            }
-
-            p {
-                margin: auto;
-                color: #474747;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                padding: 7px 15px;
-            }
-
-            a {
-                padding: 7px 15px;
-                width: 100%;
-                display: block;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 13px;
-                font-weight: bold;
-                letter-spacing: 1.5px;
-                line-height: 26px;
-                text-transform: uppercase;
-
-            }
-
-            a:hover {
-                opacity: 0.7;
-            }
-        }
-
-
-        .bgoftable {
-            position: absolute;
-            top: -140px;
-            left: -150px;
-            z-index: 0;
-            opacity: 0.4;
-        }
-
-        .tablescale {
-            margin-top: 50px;
-            width: 100%;
-            position: relative;
-            z-index: 1;
-
-            .col1,
-            .col2,
-            .col3 {
-                display: inline-block;
-                background: yellow;
-                background: rgba(22, 22, 22, 0.5);
-                padding-top: 30px;
-                padding-bottom: 30px;
-
-                h2 {
-                    padding: 0;
-                    margin: 0;
-                    font-family: 'Rubik', sans-serif;
-                    color: #B7B7B7;
-                    font-weight: 600;
-                    line-height: 26px;
-                    font-size: 16px;
-                    padding-bottom: 30px;
-                    padding-left: 30px;
-                    padding-right: 30px;
-                    margin-bottom: 20px;
-                }
-
-                h3 {
-                    padding: 0;
-                    margin: 0;
-                    font-family: 'Rubik', sans-serif;
-                    color: #B7B7B7;
-                    font-weight: 500;
-                    line-height: 26px;
-                    font-size: 14px;
-                    padding-left: 30px;
-                    padding-right: 30px;
-                    margin-bottom: 15px;
-
-                    i {
-                        font-size: 21px;
-                        color: #474747;
-                    }
-                }
-
-                .lastone {
-                    border-bottom: 1px solid #202020;
-                    padding-bottom: 15px;
-                    margin-bottom: 15px;
-                }
-
-                .nothing {
-                    font-size: 0;
-                }
-
-                .money {
-                    font-size: 16px;
-                    font-weight: 600;
-                }
-            }
-
-            .col1 {
-                width: 39%;
-                overflow: hidden;
-
-                h2 {
-                    text-align: left;
-                    margin-bottom: 20px;
-                }
-            }
-
-            .col2 {
-                width: 29%;
-                overflow: hidden;
-                margin-left: -5px;
-
-                h2,
-                h3 {
-                    text-align: center;
-                }
-            }
-
-            .col3 {
-                width: 29%;
-                overflow: hidden;
-                margin-left: -5px;
-
-                h2,
-                h3 {
-                    text-align: center;
-                }
-
-            }
-
-            .col2:hover,
-            .col3:hover {
-                background: #1F1C24;
-
-                h3 {
-                    color: #fff;
-
-                    i {
-                        color: #64DEBF;
-                    }
-                }
-
-                .money {
-                    color: #64DEBF;
-                }
-            }
-        }
+      a:hover {
+        opacity: 0.8;
+      }
     }
 
-    .nam-consectetur-an {
-        max-width: 627px;
-        margin: auto;
-        margin-top: 40px;
-        color: #474747;
-        font-family: 'Rubik', sans-serif;
+    p {
+      text-align: center;
+
+      span {
+        color: #e35b8d;
+        font-family: "Rubik", sans-serif;
         font-weight: 500;
         font-size: 14px;
         line-height: 26px;
         text-align: center;
+      }
+    }
+  }
+
+  .pricingtable {
+    margin-top: 83px;
+
+    .tablecol1 {
+      min-height: 702px;
+      padding-top: 40px;
+      padding-bottom: 25px;
+
+      h2 {
+        height: 26px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 26px;
+        text-align: center;
+        margin-bottom: 35px;
+      }
+
+      p {
+        margin: 0;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        height: 37px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-size: 16px;
+        line-height: 39px;
+
+        i {
+          color: #474747;
+          font-size: 15px;
+          position: absolute;
+          right: 15px;
+          margin-top: 12px;
+        }
+      }
+
+      .line {
+        height: 1px;
+        width: 100%;
+        background-color: rgba(255, 255, 255, 0.07);
+        margin-top: 5px;
+        margin-bottom: 5px;
+      }
     }
 
-    .trialwork {
-        h1 {
-            color: #FFFFFF;
-            font-family: 'Rubik', sans-serif;
-            font-size: 32px;
-            font-weight: bold;
-            line-height: 39px;
-            text-align: center;
-            margin-top: 106px;
-            margin-bottom: 40px;
+    .tablecol {
+      min-height: 675px;
+      border-radius: 12px;
+      background-color: #1d1d1d;
+      padding-top: 40px;
+      padding-bottom: 0px;
+
+      h2 {
+        height: 26px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 26px;
+        text-align: center;
+        margin-bottom: 35px;
+      }
+
+      p {
+        margin: 0;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        height: 37px;
+        color: #b7b7b7;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 16px;
+        line-height: 39px;
+        text-align: center;
+
+        g i {
+          color: #474747;
+          font-size: 21px;
+          line-height: 39px;
+        }
+      }
+
+      .line {
+        height: 1px;
+        width: 100%;
+        background-color: rgba(255, 255, 255, 0.07);
+        margin-top: 5px;
+        margin-bottom: 5px;
+      }
+
+      .custom {
+        height: 39px;
+        color: #b7b7b7;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 39px;
+        text-align: center;
+        margin-top: 37px;
+        margin-bottom: 0;
+      }
+
+      .price {
+        height: 39px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 26px;
+        font-weight: bold;
+        line-height: 39px;
+        text-align: center;
+        margin-top: 37px;
+        margin-bottom: 0;
+      }
+
+      .pm {
+        height: 26px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 26px;
+        text-align: center;
+        margin: 0;
+      }
+
+      .free30 {
+        height: 26px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 26px;
+        text-align: center;
+        margin-top: 20px;
+        padding-bottom: 40px;
+      }
+
+      .btn {
+        text-align: center;
+        width: 100%;
+        margin-top: 30px;
+
+        a {
+          color: #ffffff;
+          font-family: "Rubik", sans-serif;
+          font-size: 13px;
+          font-weight: bold;
+          letter-spacing: 1.5px;
+          line-height: 26px;
+          text-align: center;
+          background: #474747;
+          display: inline-block;
+          min-width: 171px;
+          border-radius: 5px;
+          padding: 7px 15px;
+          text-transform: uppercase;
+        }
+      }
+    }
+
+    .oneactive {
+      background: linear-gradient(0deg, #2a1057 0%, #9c59ff 100%);
+
+      .btn {
+        a {
+          background-color: #9667e6;
+        }
+      }
+
+      p {
+        color: #fff;
+      }
+
+      .pm {
+        color: #9667e6;
+      }
+
+      .free30 {
+        color: #9667e6;
+      }
+
+      .btn a:hover {
+        opacity: 0.5;
+      }
+    }
+
+    .tablecol {
+      .btn a {
+      }
+
+      p {
+      }
+    }
+
+    .tablecol:hover {
+      background: linear-gradient(0deg, #2a1057 0%, #9c59ff 100%);
+
+      .btn {
+        a {
+          background-color: #9667e6;
+        }
+      }
+
+      p {
+        color: #fff;
+
+        i {
+          color: #fff;
+        }
+      }
+
+      .pm {
+        color: #9667e6;
+      }
+
+      .free30 {
+        color: #9667e6;
+      }
+
+      .btn a:hover {
+        opacity: 0.5;
+      }
+    }
+  }
+
+  .tablescalerowpricing {
+    h1 {
+      height: 39px;
+      color: #ffffff;
+      font-family: "Rubik", sans-serif;
+      font-size: 32px;
+      font-weight: bold;
+      line-height: 39px;
+      text-align: center;
+      margin-top: 105px;
+    }
+
+    h2 {
+      height: 26px;
+      color: #969696;
+      font-family: "Rubik", sans-serif;
+      font-size: 21px;
+      font-weight: bold;
+      line-height: 26px;
+      text-align: center;
+      margin-top: 35px;
+      position: relative;
+      z-index: 1;
+
+      span {
+        color: #fff;
+      }
+
+      .openpopup {
+        cursor: pointer;
+        color: #fff;
+        padding-right: 39px;
+        position: relative;
+
+        span {
+          border-bottom-style: dashed;
         }
 
-        p {
-            max-width: 627px;
-            margin: auto;
-            color: #969696;
-            font-family: 'Rubik', sans-serif;
-            font-size: 18px;
-            line-height: 26px;
-            text-align: center;
-            margin-bottom: 50px;
+        i {
+          color: #969696;
+          position: absolute;
+          top: 3px;
+          font-size: 25px;
+          right: 5px;
         }
+      }
     }
+
+    .custompopup {
+      display: none;
+      opacity: 0;
+      visibility: hidden;
+
+      z-index: 99;
+      max-width: 350px;
+      position: absolute;
+      left: 0;
+      right: 0;
+      margin: auto;
+      border-radius: 12px;
+      background-color: #1c1c1c;
+      box-shadow: 0 3px 39px 0 rgba(0, 0, 0, 0.15);
+
+      h3 {
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 16px;
+        line-height: 26px;
+        padding: 15px;
+        position: relative;
+        margin: 0;
+
+        .xpopup {
+          position: absolute;
+          right: 15px;
+          top: 15px;
+          cursor: pointer;
+
+          i {
+            color: #474747;
+            font-size: 21px;
+            line-height: 25px;
+          }
+        }
+      }
+
+      .line {
+        height: 1px;
+        width: 100%;
+        background-color: rgba(255, 255, 255, 0.07);
+      }
+
+      p {
+        margin: auto;
+        color: #474747;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 26px;
+        padding: 7px 15px;
+      }
+
+      a {
+        padding: 7px 15px;
+        width: 100%;
+        display: block;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        letter-spacing: 1.5px;
+        line-height: 26px;
+        text-transform: uppercase;
+      }
+
+      a:hover {
+        opacity: 0.7;
+      }
+    }
+
+    .bgoftable {
+      position: absolute;
+      top: -140px;
+      left: -150px;
+      z-index: 0;
+      opacity: 0.4;
+    }
+
+    .tablescale {
+      margin-top: 50px;
+      width: 100%;
+      position: relative;
+      z-index: 1;
+
+      .col1,
+      .col2,
+      .col3 {
+        display: inline-block;
+        background: yellow;
+        background: rgba(22, 22, 22, 0.5);
+        padding-top: 30px;
+        padding-bottom: 30px;
+
+        h2 {
+          padding: 0;
+          margin: 0;
+          font-family: "Rubik", sans-serif;
+          color: #b7b7b7;
+          font-weight: 600;
+          line-height: 26px;
+          font-size: 16px;
+          padding-bottom: 30px;
+          padding-left: 30px;
+          padding-right: 30px;
+          margin-bottom: 20px;
+        }
+
+        h3 {
+          padding: 0;
+          margin: 0;
+          font-family: "Rubik", sans-serif;
+          color: #b7b7b7;
+          font-weight: 500;
+          line-height: 26px;
+          font-size: 14px;
+          padding-left: 30px;
+          padding-right: 30px;
+          margin-bottom: 15px;
+
+          i {
+            font-size: 21px;
+            color: #474747;
+          }
+        }
+
+        .lastone {
+          border-bottom: 1px solid #202020;
+          padding-bottom: 15px;
+          margin-bottom: 15px;
+        }
+
+        .nothing {
+          font-size: 0;
+        }
+
+        .money {
+          font-size: 16px;
+          font-weight: 600;
+        }
+      }
+
+      .col1 {
+        width: 39%;
+        overflow: hidden;
+
+        h2 {
+          text-align: left;
+          margin-bottom: 20px;
+        }
+      }
+
+      .col2 {
+        width: 29%;
+        overflow: hidden;
+        margin-left: -5px;
+
+        h2,
+        h3 {
+          text-align: center;
+        }
+      }
+
+      .col3 {
+        width: 29%;
+        overflow: hidden;
+        margin-left: -5px;
+
+        h2,
+        h3 {
+          text-align: center;
+        }
+      }
+
+      .col2:hover,
+      .col3:hover {
+        background: #1f1c24;
+
+        h3 {
+          color: #fff;
+
+          i {
+            color: #64debf;
+          }
+        }
+
+        .money {
+          color: #64debf;
+        }
+      }
+    }
+  }
+
+  .nam-consectetur-an {
+    max-width: 627px;
+    margin: auto;
+    margin-top: 40px;
+    color: #474747;
+    font-family: "Rubik", sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 26px;
+    text-align: center;
+  }
+
+  .trialwork {
+    h1 {
+      color: #ffffff;
+      font-family: "Rubik", sans-serif;
+      font-size: 32px;
+      font-weight: bold;
+      line-height: 39px;
+      text-align: center;
+      margin-top: 106px;
+      margin-bottom: 40px;
+    }
+
+    p {
+      max-width: 627px;
+      margin: auto;
+      color: #969696;
+      font-family: "Rubik", sans-serif;
+      font-size: 18px;
+      line-height: 26px;
+      text-align: center;
+      margin-bottom: 50px;
+    }
+  }
 }
 
 .footerpricing {
-    background: #111010;
+  background: #111010;
 }
 
 .footerguide {
-    background: #0f0f0f;
+  background: #0f0f0f;
 }
 
 .footerguidepage {
-    background: #181818;
+  background: #181818;
 }
 
 .footercon {
-    background: rgba(24, 24, 24, 1);
+  background: rgba(24, 24, 24, 1);
 }
 
-
-@media (min-width: 768px) {
-    .col-md-2-5 {
-        -ms-flex: 0 0 20%;
-        flex: 0 0 20%;
-        max-width: 20%;
-        position: relative;
-        width: 100%;
-        padding-right: 15px;
-        padding-left: 15px;
-    }
+@include tablet {
+  .col-md-2-5 {
+    -ms-flex: 0 0 20%;
+    flex: 0 0 20%;
+    max-width: 20%;
+    position: relative;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+  }
 }
 
+@include desktop {
+  .scale .tablescale .col1 h2,
+  .scale .tablescale .col2 h2,
+  .scale .tablescale .col3 h2 {
+    font-size: 13px;
+  }
 
-
-
-
-@media(max-width: 1400px) {
-
-    .scale .tablescale .col1 h2,
-    .scale .tablescale .col2 h2,
-    .scale .tablescale .col3 h2 {
-        font-size: 13px;
-    }
-
-    .scale .tablescale .col1 h3,
-    .scale .tablescale .col2 h3,
-    .scale .tablescale .col3 h3 {
-        font-size: 13px;
-    }
+  .scale .tablescale .col1 h3,
+  .scale .tablescale .col2 h3,
+  .scale .tablescale .col3 h3 {
+    font-size: 13px;
+  }
 }
 
-@media(max-width: 1350px) {
-    .hero .imghero {
-        width: 100%;
-    }
+@include desktop {
 
-    .scale .tablescale .col1 h3,
-    .scale .tablescale .col2 h3,
-    .scale .tablescale .col3 h3,
-    .scale .tablescale .col1 h2,
-    .scale .tablescale .col2 h2,
-    .scale .tablescale .col3 h2 {
-        padding-left: 20px;
-        padding-right: 20px;
-    }
+  .scale .tablescale .col1 h3,
+  .scale .tablescale .col2 h3,
+  .scale .tablescale .col3 h3,
+  .scale .tablescale .col1 h2,
+  .scale .tablescale .col2 h2,
+  .scale .tablescale .col3 h2 {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
 }
 
-@media(max-width: 1200px) {
-    .heropricing .pricingtable .tablecol .btn a {
-        min-width: 100%;
-    }
+@include desktop {
+  .heropricing .pricingtable .tablecol .btn a {
+    min-width: 100%;
+  }
 
-    .getstartguide .bigbox p {
-        padding-right: 180px;
-    }
+  .getstartguide .bigbox p {
+    padding-right: 180px;
+  }
 
-    .getstartguide .miniboxguid h2 {
-        padding-top: 10px;
-        font-size: 17px;
-    }
+  .getstartguide .miniboxguid h2 {
+    padding-top: 10px;
+    font-size: 17px;
+  }
 
-    .getstartguide .miniboxguid p {
-        padding-top: 20px;
-        font-size: 15px;
-    }
+  .getstartguide .miniboxguid p {
+    padding-top: 20px;
+    font-size: 15px;
+  }
 
-    .heropricing .tablescalerowpricing .bgoftable {
-        display: none;
-    }
+  .heropricing .tablescalerowpricing .bgoftable {
+    display: none;
+  }
 
-    .heropricing .tablescalerowpricing .tablescale .col1 h3,
-    .heropricing .tablescalerowpricing .tablescale .col2 h3,
-    .heropricing .tablescalerowpricing .tablescale .col3 h3,
-    .scale .tablescale .col1 h3,
-    .scale .tablescale .col2 h3,
-    .scale .tablescale .col3 h3,
-    .scale .tablescale .col1 h2,
-    .scale .tablescale .col2 h2,
-    .scale .tablescale .col3 h2 {
-        padding-left: 15px;
-        padding-right: 15px;
-    }
+  .heropricing .tablescalerowpricing .tablescale .col1 h3,
+  .heropricing .tablescalerowpricing .tablescale .col2 h3,
+  .heropricing .tablescalerowpricing .tablescale .col3 h3,
+  .scale .tablescale .col1 h3,
+  .scale .tablescale .col2 h3,
+  .scale .tablescale .col3 h3,
+  .scale .tablescale .col1 h2,
+  .scale .tablescale .col2 h2,
+  .scale .tablescale .col3 h2 {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
 
-    .heropricing .tablescalerowpricing .tablescale .col1 h2,
-    .heropricing .tablescalerowpricing .tablescale .col2 h2,
-    .heropricing .tablescalerowpricing .tablescale .col3 h2 {
-        padding: 0;
-        margin: 0;
-        font-family: 'Rubik', sans-serif;
-        color: #B7B7B7;
-        font-weight: 600;
-        line-height: 24px;
-        font-size: 15px;
-        padding-bottom: 30px;
-        padding-left: 15px;
-        padding-right: 10px;
-    }
+  .heropricing .tablescalerowpricing .tablescale .col1 h2,
+  .heropricing .tablescalerowpricing .tablescale .col2 h2,
+  .heropricing .tablescalerowpricing .tablescale .col3 h2 {
+    padding: 0;
+    margin: 0;
+    font-family: "Rubik", sans-serif;
+    color: #b7b7b7;
+    font-weight: 600;
+    line-height: 24px;
+    font-size: 15px;
+    padding-bottom: 30px;
+    padding-left: 15px;
+    padding-right: 10px;
+  }
 
-    .heropricing .tablescalerowpricing .tablescale .col1 h2 {
-        text-align: left;
-    }
+  .heropricing .tablescalerowpricing .tablescale .col1 h2 {
+    text-align: left;
+  }
 
-    .hero .forifream {
-        width: 209px;
-        height: 367px;
-        position: absolute;
-        z-index: 1;
-        right: 52px;
-        top: 221px;
-        overflow: hidden;
-        transform: rotate3d(5, -5, 5, 5deg);
-    }
 
-    .hero .ifreamfordiagram {
-        width: 209px;
-        height: 400px;
-    }
+  .navbar-expand-lg .navbar-nav > li > a {
+    margin-left: 0;
+  }
 
-    .navbar-expand-lg .navbar-nav>li>a {
-        margin-left: 0;
-    }
+  .hero {
+    padding-top: 160px;
+  }
 
-    .hero {
-        padding-top: 160px;
-    }
+  .hero h1 {
+    text-align: center;
+    margin: auto;
+  }
 
-    .hero .h3div {
-        margin-top: 40px;
-    }
-
-    .hero .phonimg {
-        position: absolute;
-        right: -70px;
-        top: 10px;
-        max-width: 450px;
-    }
-
-    .hero h1 {
-        text-align: center;
-        margin: auto;
-    }
-
-    .btns {
-        text-align: center;
-    }
-
-    .hero .btns .signup,
-    .hero .btns p img {
-        margin-left: 10px;
-        margin-right: 10px;
-    }
-
-    .hero p,
-    .hero h2 {
-        text-align: center;
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    .catchimgtop {
-        margin-top: -580px;
-    }
-
-    .ctav2 h1,
-    .ctav2 p {
-        text-align: center;
-    }
+  .hero p,
+  .hero h2 {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .formobilepricingplan {
-    display: none;
+  display: none;
 
-    .plansforslider {
-        position: absolute;
-        right: 0px;
-        top: -45px;
-        width: 47%;
+  .plansforslider {
+    position: absolute;
+    right: 0px;
+    top: -45px;
+    width: 47%;
+  }
+
+  margin-top: 50px;
+
+  .maxwidthplan {
+    position: relative;
+    max-width: 550px;
+    width: 100%;
+    margin: auto;
+
+    .carousel-indicators li {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: transparent;
+      border: 2px solid #474747;
     }
 
-    margin-top: 50px;
+    .carousel-indicators .active {
+      background: #474747;
+      border: 2px solid #474747;
+    }
 
-    .maxwidthplan {
-        position: relative;
-        max-width: 550px;
+    .carousel-indicators {
+      bottom: 60px;
+    }
+
+    .nom {
+      width: 100%;
+      text-align: center;
+      margin-top: 40px;
+      color: #474747;
+      font-family: "Rubik", sans-serif;
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 26px;
+    }
+
+    .tablecol1 {
+      min-height: 702px;
+      padding-top: 40px;
+      padding-bottom: 25px;
+
+      h2 {
+        height: 26px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 26px;
+        text-align: center;
+        margin-bottom: 41px;
+      }
+
+      p {
+        margin: 0;
+        margin-top: 9px;
+        margin-bottom: 9px;
+        height: 39px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-size: 16px;
+        line-height: 39px;
+
+        i {
+          color: #474747;
+          font-size: 15px;
+          position: absolute;
+          right: 15px;
+          margin-top: 5px;
+        }
+      }
+
+      .line {
+        height: 1px;
         width: 100%;
-        margin: auto;
-
-        .carousel-indicators li {
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            background: transparent;
-            border: 2px solid #474747;
-        }
-
-        .carousel-indicators .active {
-            background: #474747;
-            border: 2px solid #474747;
-        }
-
-        .carousel-indicators {
-            bottom: 60px;
-        }
-
-        .nom {
-            width: 100%;
-            text-align: center;
-            margin-top: 40px;
-            color: #474747;
-            font-family: 'Rubik', sans-serif;
-            font-weight: 500;
-            font-size: 14px;
-            line-height: 26px;
-        }
-
-
-
-        .tablecol1 {
-            min-height: 702px;
-            padding-top: 40px;
-            padding-bottom: 25px;
-
-            h2 {
-                height: 26px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 26px;
-                text-align: center;
-                margin-bottom: 41px;
-            }
-
-            p {
-                margin: 0;
-                margin-top: 9px;
-                margin-bottom: 9px;
-                height: 39px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-size: 16px;
-                line-height: 39px;
-
-                i {
-                    color: #474747;
-                    font-size: 15px;
-                    position: absolute;
-                    right: 15px;
-                    margin-top: 5px;
-                }
-            }
-
-            .line {
-                height: 1px;
-                width: 100%;
-                background-color: rgba(255, 255, 255, 0.07);
-            }
-        }
-
-        .tablecol {
-            min-height: 702px;
-            border-radius: 12px;
-            background-color: #1D1D1D;
-            padding-top: 40px;
-            padding-bottom: 25px;
-
-            h2 {
-                height: 26px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 26px;
-                text-align: center;
-                margin-bottom: 41px;
-            }
-
-            p {
-                margin: 0;
-                margin-top: 9px;
-                margin-bottom: 9px;
-                height: 39px;
-                color: #B7B7B7;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 16px;
-                line-height: 39px;
-                text-align: center;
-
-                i {
-                    color: #474747;
-                    font-size: 21px;
-                    line-height: 39px;
-                }
-            }
-
-            .line {
-                height: 1px;
-                width: 100%;
-                background-color: rgba(255, 255, 255, 0.07);
-            }
-
-            .custom {
-                height: 39px;
-                color: #B7B7B7;
-                font-family: 'Rubik', sans-serif;
-                font-size: 21px;
-                font-weight: bold;
-                line-height: 39px;
-                text-align: center;
-                margin-top: 37px;
-                margin-bottom: 0;
-            }
-
-            .price {
-                height: 39px;
-                color: #FFFFFF;
-                font-family: 'Rubik', sans-serif;
-                font-size: 26px;
-                font-weight: bold;
-                line-height: 39px;
-                text-align: center;
-                margin-top: 37px;
-                margin-bottom: 0;
-            }
-
-            .pm {
-                height: 26px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                text-align: center;
-                margin: 0;
-            }
-
-            .free30 {
-                height: 26px;
-                color: #969696;
-                font-family: 'Rubik', sans-serif;
-                font-weight: 500;
-                font-size: 14px;
-                line-height: 26px;
-                text-align: center;
-            }
-
-            .btn {
-                text-align: center;
-                width: 100%;
-                margin-top: 30px;
-
-                a {
-                    color: #FFFFFF;
-                    font-family: 'Rubik', sans-serif;
-                    font-size: 13px;
-                    font-weight: bold;
-                    letter-spacing: 1.5px;
-                    line-height: 26px;
-                    text-align: center;
-                    background: #474747;
-                    display: inline-block;
-                    min-width: 171px;
-                    border-radius: 5px;
-                    padding: 7px 15px;
-                    text-transform: uppercase;
-                }
-            }
-        }
-
-        .oneactive {
-            background: linear-gradient(0deg, #2A1057 0%, #9c59ff 100%);
-
-            .btn {
-                a {
-                    background-color: #9667E6;
-                }
-
-                p {
-                    color: #fff;
-
-                    i {
-                        color: #fff;
-                    }
-                }
-
-                .pm {
-                    color: #9667E6;
-                }
-
-                .free30 {
-                    color: #9667E6;
-                }
-
-                .btn a:hover {
-                    opacity: 0.5;
-                }
-            }
-
-            .tablecol {
-
-                .btn a {}
-
-                p {}
-            }
-        }
+        background-color: rgba(255, 255, 255, 0.07);
+      }
     }
 
+    .tablecol {
+      min-height: 702px;
+      border-radius: 12px;
+      background-color: #1d1d1d;
+      padding-top: 40px;
+      padding-bottom: 25px;
+
+      h2 {
+        height: 26px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 26px;
+        text-align: center;
+        margin-bottom: 41px;
+      }
+
+      p {
+        margin: 0;
+        margin-top: 9px;
+        margin-bottom: 9px;
+        height: 39px;
+        color: #b7b7b7;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 16px;
+        line-height: 39px;
+        text-align: center;
+
+        i {
+          color: #474747;
+          font-size: 21px;
+          line-height: 39px;
+        }
+      }
+
+      .line {
+        height: 1px;
+        width: 100%;
+        background-color: rgba(255, 255, 255, 0.07);
+      }
+
+      .custom {
+        height: 39px;
+        color: #b7b7b7;
+        font-family: "Rubik", sans-serif;
+        font-size: 21px;
+        font-weight: bold;
+        line-height: 39px;
+        text-align: center;
+        margin-top: 37px;
+        margin-bottom: 0;
+      }
+
+      .price {
+        height: 39px;
+        color: #ffffff;
+        font-family: "Rubik", sans-serif;
+        font-size: 26px;
+        font-weight: bold;
+        line-height: 39px;
+        text-align: center;
+        margin-top: 37px;
+        margin-bottom: 0;
+      }
+
+      .pm {
+        height: 26px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 26px;
+        text-align: center;
+        margin: 0;
+      }
+
+      .free30 {
+        height: 26px;
+        color: #969696;
+        font-family: "Rubik", sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 26px;
+        text-align: center;
+      }
+
+      .btn {
+        text-align: center;
+        width: 100%;
+        margin-top: 30px;
+
+        a {
+          color: #ffffff;
+          font-family: "Rubik", sans-serif;
+          font-size: 13px;
+          font-weight: bold;
+          letter-spacing: 1.5px;
+          line-height: 26px;
+          text-align: center;
+          background: #474747;
+          display: inline-block;
+          min-width: 171px;
+          border-radius: 5px;
+          padding: 7px 15px;
+          text-transform: uppercase;
+        }
+      }
+    }
+
+    .oneactive {
+      background: linear-gradient(0deg, #2a1057 0%, #9c59ff 100%);
+
+      .btn {
+        a {
+          background-color: #9667e6;
+        }
+
+        p {
+          color: #fff;
+
+          i {
+            color: #fff;
+          }
+        }
+
+        .pm {
+          color: #9667e6;
+        }
+
+        .free30 {
+          color: #9667e6;
+        }
+
+        .btn a:hover {
+          opacity: 0.5;
+        }
+      }
+
+      .tablecol {
+        .btn a {
+        }
+
+        p {
+        }
+      }
+    }
+  }
 }

--- a/assets/css/marketing_responsive.scss
+++ b/assets/css/marketing_responsive.scss
@@ -1,4 +1,6 @@
-@media(max-width: 1135px) {
+@import "mixins";
+
+@include desktop {
   .fordesktopmap {
     display: none !important;
   }
@@ -46,7 +48,7 @@
     }
   }
 }
-@media(max-width: 992px) {
+@include tablet(max) {
   .contactcon .gidepr h1 {
     height: 87px;
     color: #FFFFFF;
@@ -62,15 +64,6 @@
 
   .contactcon .gidepr h2 {
     font-size: 21px;
-  }
-
-  .concontenet .maxwidth .btns {
-    margin-bottom: 0 !important;
-    height: auto !important;
-  }
-
-  .concontenet .leftside {
-    padding-top: 0;
   }
 
   .readmorecon .heropr .sign-up {
@@ -255,52 +248,6 @@
     padding-right: 6px;
   }
 
-  .hero .forifream {
-    width: 140px;
-    height: 247px;
-    position: absolute;
-    z-index: 1;
-    right: 62px;
-    top: 44px;
-    overflow: hidden;
-    transform: rotate3d(5, -5, 5, 5deg);
-  }
-
-  .hero .ifreamfordiagram {
-    width: 140px;
-    height: 270px;
-  }
-
-  .hero .phonimg {
-    position: absolute;
-    right: -20px;
-    top: -104px;
-    max-width: 300px;
-  }
-
-  .hero .imghero {
-    margin-top: 30px;
-  }
-
-  .ctav2 .btns p iframe {
-    display: inline-block;
-    margin-bottom: 0;
-    height: 30px;
-    width: 130px;
-    margin-top: -1px;
-  }
-
-  .hero .btns .signup,
-  .hero .btns p img {
-    width: 150px;
-  }
-
-  .hero .btns .signup {
-    display: block;
-    width: 150px;
-    padding: 6px 15px;
-  }
-
   .navbar-expand-lg {
     min-height: auto;
   }
@@ -311,10 +258,6 @@
 
   .hero {
     text-align: left !important;
-  }
-
-  .hero .h3div {
-    margin-top: 0;
   }
 
   .hero h3 {
@@ -342,10 +285,6 @@
 
   .hero {
     min-height: auto;
-  }
-
-  .catchimgtop {
-    display: none;
   }
 
   .footer .rightside {
@@ -379,71 +318,12 @@
     margin-left: 0;
   }
 
-  .btns {
-    text-align: left;
-  }
-
-  .hero .btns .signup {
-    text-align: center;
-  }
-
-  .hero .btns {
-    display: block;
-  }
-
-  .hero .btns {
-    height: 90px;
-  }
-
-  .hero .btns p {
-    float: left;
-  }
-
-  .hero .btns .signup {
-    text-align: center;
-    margin-top: -3px;
-  }
-
   .catch p,
   .hero .paragraph p,
   .scale p {
     margin-top: 30px;
   }
 
-  .ctav2 h1,
-  .ctav2 p {
-    text-align: left;
-  }
-
-  .btns .signup {
-    text-align: center;
-  }
-
-  .btns {
-    display: block;
-  }
-
-  .btns {
-    height: 90px;
-  }
-
-  .btns p {
-    float: left;
-  }
-
-  .ctav2 .btns .signup {
-    display: block;
-    margin-top: -2px;
-    padding: 7px 20px;
-    width: 130px;
-    padding: 2px 15px;
-    margin-top: -2px;
-    color: #fff;
-  }
-
-  .ctav2 .btns p img {
-    width: 130px;
-  }
 
   .hero h2 {
     margin-bottom: 40px;
@@ -451,16 +331,6 @@
 
   .scale .bgoftable {
     display: none;
-  }
-
-  .hero .btns p img {
-    margin-left: 5px;
-    margin-right: 5px;
-  }
-
-  .hero .h3div {
-    margin-top: 50px;
-    margin-bottom: 40px;
   }
 }
 
@@ -592,10 +462,7 @@
   }
 }
 
-.forifream2 {
-  display: none;
-}
-@media(max-width: 772px) {
+@include tablet(max) {
   .heropricing .heropr h1 {
     color: #FFFFFF;
     // font-family: 'Rubik', sans-serif;
@@ -677,40 +544,6 @@
     text-align: center;
   }
 
-  .hero .forifream {
-    display: none;
-  }
-
-  .ifreamfordiagram2 {
-    display: block;
-    width: 100%;
-    height: 1500px;
-    max-width: 350px;
-    position: relative;
-    margin: auto;
-  }
-
-  .forifream2 {
-    height: 600px;
-    overflow: hidden;
-    display: block;
-  }
-
-  .hero .phonimg {
-    display: none;
-  }
-
-  .hero .btns p iframe {
-    display: inline-block;
-    margin-bottom: -14px;
-    height: 38px;
-    width: 160px;
-    margin-top: -3px;
-  }
-
-  .hero .btns {
-    margin-bottom: 10px;
-  }
 
   .forphone {
     display: block;
@@ -718,9 +551,6 @@
     margin-top: 40px;
   }
 
-  .hero .imghero {
-    display: none;
-  }
 
   .container-fluid {
     padding-left: 0;
@@ -733,10 +563,6 @@
 
   .footer {
     margin-top: 40px;
-  }
-
-  .ctav2 .btns p img {
-    width: 120px;
   }
 
   .hero h3 {
@@ -822,14 +648,6 @@
     font-size: 21px;
   }
 
-  .hero .btns {
-    height: 80px;
-  }
-
-  .hero .h3div {
-    margin-bottom: 50px;
-  }
-
   .hero h3 {
     line-height: 39px;
     font-size: 26px;
@@ -851,10 +669,6 @@
     line-height: 26px;
     margin-bottom: 40px;
     margin-top: 40px;
-  }
-
-  .catchimgbtn {
-    display: none;
   }
 
   .scale .tablescale .col1 h2,
@@ -886,10 +700,6 @@
 
   .scale .spanp {
     padding: 0;
-  }
-
-  .stepsimgtop {
-    display: none;
   }
 
   .scale {
@@ -939,21 +749,7 @@
     }
   }
 }
-@media(max-width: 500px) {
-  .ctav2 {
-    .fordesk {
-      display: none;
-    }
-
-    .forphone3 {
-      display: block;
-
-      img {
-        width: 100%;
-      }
-    }
-  }
-
+@include mobile(max) {
   .formobilepricingplan .maxwidthplan .tablecol .btn a {
     min-width: 100%;
     max-width: 171px;
@@ -975,32 +771,7 @@
     margin-top: -70px;
   }
 }
-@media(max-width: 480px) {
-  // .scale .tablescale .col1 h2, .scale .tablescale .col2 h2, .scale .tablescale .col3 h2{
-  // 	font-size: 12px;
-  // 	padding-bottom: 10px;
-  // 	padding-left: 10px;
-  // 	padding-right: 10px;
-  // }
-  // .scale .tablescale .col1 h3, .scale .tablescale .col2 h3, .scale .tablescale .col3 h3{
-  // 	font-size: 12px;
-  // 	padding-left: 10px;
-  // 	padding-right: 10px;
-  // 	margin-bottom: 7px;
-  // }
-  .hero .btns p iframe {
-    display: inline-block;
-    /* margin-bottom: -4px; */
-    height: 38px;
-    width: 160px;
-    margin-top: -3px;
-  }
-
-  .hero .btns {
-    margin-bottom: 10px;
-  }
-}
-@media(max-width: 430px) {
+@include mobile(max) {
   .scale .tablescale .col1 h3 i,
   .scale .tablescale .col2 h3 i,
   .scale .tablescale .col3 h3 i {
@@ -1013,54 +784,8 @@
     height: 29px;
   }
 
-  .ctav2 .btns .signup {
-    width: 130px;
-    padding: 2px 14px;
-  }
-
   .forphone .firstline p {
     font-size: 12px;
-  }
-
-  .hero .btns p {
-    width: 130px;
-    padding: 0;
-
-    img {
-      width: 130px;
-    }
-  }
-
-  .hero .btns .signup {
-    display: block;
-    width: 130px;
-    padding: 3px 15px;
-  }
-
-  .forphone2 .btns .signup {
-    // font-family: 'Rubik', sans-serif;
-    font-weight: 700;
-    letter-spacing: 1.5px;
-    font-size: 13px;
-    text-transform: uppercase;
-    background: #474747;
-    border-radius: 3px;
-    padding: 7px 15px;
-    margin-top: 7.5px;
-    margin-left: 5px;
-    color: #fff;
-    width: 150px;
-    width: 130px;
-    display: block;
-    float: left;
-  }
-
-  .hero .btns p iframe {
-    display: inline-block;
-    margin-bottom: -4px;
-    height: 31px;
-    width: 130px;
-    margin-top: -2px;
   }
 
   .heropricing .tablescalerowpricing .tablescale .col1 h2,
@@ -1085,7 +810,7 @@
     font-size: 12px;
   }
 }
-@media(max-width: 400px) {
+@include mobile(max) {
   .contactcon .mapdown .maxboxd .leftside {
     top: 235px;
   }
@@ -1094,7 +819,7 @@
     height: auto;
   }
 }
-@media(max-width: 385px) {
+@include mobile(max) {
   .scale .tablescale .col1 h2,
   .scale .tablescale .col2 h2,
   .scale .tablescale .col3 h2 {
@@ -1105,7 +830,7 @@
     height: 190px;
   }
 }
-@media(max-width: 357px) {
+@include mobile(max) {
   .scale .tablescale .col1 h2,
   .scale .tablescale .col2 h2,
   .scale .tablescale .col3 h2 {

--- a/assets/css/media_queries.scss
+++ b/assets/css/media_queries.scss
@@ -1,10 +1,9 @@
-@media (min-width: 993px) {
+@import "mixins";
+
+@include tablet {
   .value {
     margin-right: 15%;
     margin-left: 15%;
-  }
-
-  #source-list {
   }
 
   .live-pause {
@@ -12,7 +11,7 @@
   }
 }
 
-@media screen and (max-width: 992px) {
+@include tablet(max) {
   .hide-on-mobile {
     display: none !important;
   }

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -1,0 +1,33 @@
+// include only if below/above specified size
+// minmax - min or max
+// min -> include if above width (default)
+// max -> include if below width
+//
+// Example usage
+// .my-style {
+//   display: block; // for mobile and up
+//   @include tablet {
+//     display: inline-block; // for tablet and up
+//   }
+//   @include desktop {
+//     display: flex; // for desktop and up
+//   }
+// }
+
+@mixin mobile($minmax: min) {
+  @media screen and (#{$minmax}-width: 640px) {
+    @content;
+  }
+}
+
+@mixin tablet($minmax: min) {
+  @media screen and (#{$minmax}-width: 768px) {
+    @content;
+  }
+}
+
+@mixin desktop($minmax: min) {
+  @media screen and (#{$minmax}-width: 1024px) {
+    @content;
+  }
+}

--- a/lib/logflare_web/templates/marketing/homepage_cta.html.eex
+++ b/lib/logflare_web/templates/marketing/homepage_cta.html.eex
@@ -1,0 +1,34 @@
+<div class="cta">
+    <p>Use one of our integrations</p>
+    <div class="btns">
+    <%= link to: "https://www.cloudflare.com/apps/logflare/install" do %>
+        <button class="btn btn-primary" title="Install the Cloudflare integration">
+        <img src="<%= Routes.static_path(@conn, "/images/logos/cloudflare-white.svg")%>" class="cloudflare" />
+        </button>
+    <% end %>
+
+    <%= link to: "https://vercel.co/integrations/logflare" do %>
+        <button class="btn btn-primary" title="Install the Vercel integration">
+        <img src="<%= Routes.static_path(@conn, "/images/logos/vercel-white.svg")%>" class="vercel" />
+        </button>
+    <% end  %>
+
+        <%= link to: Routes.auth_path(@conn, :login), role: "button"  do %>
+        <button class="btn btn-secondary">Sign Up</button>
+        <% end %>
+    </div>
+
+    <div class="cta-links">
+        <p>Install the
+        <%= link "Cloudflare app", to: "https://www.cloudflare.com/apps/logflare/install", target: "_blank" %></p>
+        <p>Setup our
+        <%= link "Elixir Logger backend", to: "https://github.com/Logflare/logflare_logger_backend", target: "_blank" %>
+        </p>
+        <p>Check out the
+        <%= link "Logflare Vercel app", to: "https://vercel.co/integrations/logflare", target: "_blank" %></p>
+        <p>Javascript? Use our
+        <%= link "Pino transport", to: "https://github.com/Logflare/pino-logflare", target: "_blank" %></p>
+    </div>
+
+    </div>
+</div>

--- a/lib/logflare_web/templates/marketing/index.html.eex
+++ b/lib/logflare_web/templates/marketing/index.html.eex
@@ -1,43 +1,20 @@
-<div class="container-fluid hero no-subhead">
-  <div class="container">
-    <div class="row cta">
-      <div class="col-lg-10 order-lg-1">
-        <div class="row">
-          <div class="col-lg-7">
-            <h1>Never get surprised by a logging bill again</h1>
-            <!--
-						<h1>Affordable log management & event analytics</h1>
-						-->
-            <h2>Collect for years, query in seconds</h2>
-          </div>
-          <div class="col-lg-5">
-            <p>For Cloudflare, Vercel & Elixir apps</p>
-            <div class="btns">
-              <p>
-                <iframe src="https://install.cloudflareapps.com?appId=K4MXdgCp7956" allowTransparency="true" scroll="no"
-                  frameBorder="0" loading="lazy">
-                </iframe>
-              </p>
-              <p><%= link "Sign up", to: Routes.auth_path(@conn, :login), class: "signup", role: "button" %></p>
-            </div>
-            <p>Install the
-              <%= link "Cloudflare app", to: "https://www.cloudflare.com/apps/logflare", target: "_blank" %></p>
-            <p>Setup our
-              <%= link "Elixir Logger backend", to: "https://github.com/Logflare/logflare_logger_backend", target: "_blank" %>
-            </p>
-            <p>Check out the
-              <%= link "Logflare Vercel app", to: "https://vercel.co/integrations/logflare", target: "_blank" %></p>
-            <p>Javascript? Use our
-              <%= link "Pino transport", to: "https://github.com/Logflare/pino-logflare", target: "_blank" %></p>
-          </div>
-        </div>
+<div class="homepage">
+
+  <%# hero %>
+  <div class="container-fluid hero">
+    <div class="row hero-banner">
+      <div class="col-lg-6 col-12 taglines">
+        <h1>Never get surprised by a logging bill again</h1>
+        <h2>Collect for years, query in seconds</h2>
       </div>
-      <div class="col-lg-1">
+      <div class="col-lg-6 ">
+        <%= render("homepage_cta.html", assigns) %>
       </div>
-    </div>
+
+    <%# example source %>
     <div class="row">
       <div class="col-md-12">
-        <img src="images/marketing/homepage/heroimg11.png" class=" imghero" alt="">
+        <img src="images/marketing/homepage/heroimg11.png" class="imghero" alt="">
         <img src="images/marketing/homepage/iphoneDesktop.png" class="phonimg" alt="">
         <div class="forifream">
           <iframe class="ifreamfordiagram"
@@ -46,6 +23,8 @@
         </div>
       </div>
     </div>
+
+    <%# metrics %>
     <div class="row">
       <div class="col-lg-10 order-lg-1">
         <div class="row">
@@ -58,6 +37,8 @@
       </div>
       <div class="col-lg-1"></div>
     </div>
+
+    <%# dashboard example %>
     <div class="row paragraph">
       <div class="col-lg-10 order-lg-1">
         <div class="row">
@@ -74,234 +55,232 @@
               events and maintain pipelines to power our dashboards. Check out our status dashboard which is a good
               example of what you can do with
               the Elixir library.</p>
-            <center>
-              <%= link "Backend status (Elixir) »", to: "https://datastudio.google.com/s/gIAFsUMbDS4", class: "btn btn-secondary", role: "button", target: "_blank" %>
-              <%= link "CDN status (Cloudflare) »", to: "https://datastudio.google.com/s/pKMWyqEWiTA", class: "btn btn-secondary", role: "button", target: "_blank" %>
-            </center>
+          <div class="dashboard-cta">
+            <%= link "Backend status (Elixir) »", to: "https://datastudio.google.com/s/gIAFsUMbDS4", class: "btn btn-secondary", role: "button", target: "_blank" %>
+            <%= link "CDN status (Cloudflare) »", to: "https://datastudio.google.com/s/pKMWyqEWiTA", class: "btn btn-secondary", role: "button", target: "_blank" %>
+          </div>
           </div>
         </div>
       </div>
-      <div class="col-lg-1">
-      </div>
     </div>
   </div>
-</div>
 
-<div class="container">
-  <div class="my-5">
-    <h2 class="text-white text-center mb-4">Ingest</h2>
-    <div class="d-flex justify-content-around align-items-center flex-wrap">
-      <div class="m-4"><img src="images/logos/cloudflare-white.svg" height="50" alt="Cloudflare"></div>
-      <div class="m-4"><img src="images/logos/vercel-white.svg" height="50" alt="Vercel"></div>
-      <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/elixir-dark.png" height="50" alt="Elixir">
-      </div>
-      <div class="m-4"><img src="images/logos/javascript-logo.png" height="50" alt="Javascript"></div>
-      <div class="m-4"><img src="images/logos/heroku-logotype-horizontal-white.svg" height="50" alt="Heroku"></div>
-      <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/gigalixir_logo.svg" height="50"
-          alt="Gigalixir"></div>
-      <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/fluent-bit-logo.png" height="50"
-          alt="FluentBit"></div>
-      <div class="m-4"><img src="images/logos/webhook-logo-white.svg" height="50" alt="Webhook"></div>
-    </div>
-  </div>
-  <div class="my-5">
-    <h2 class="text-white text-center mb-4">Stream, Query & Dashboard</h2>
-    <div class="d-flex justify-content-around">
-      <div class="text-white m-4" style="font-size: 1.25em;"><%= render LogflareWeb.SharedView, "logo.html", assigns %>
-      </div>
-      <div class="m-4"><img src="images/logos/google-bigquery-logo.svg" height="50" alt="Google BigQuery"></div>
-      <div class="m-4"><img src="images/logos/google-data-studio.svg" height="50" alt="Google BigQuery"></div>
-    </div>
-  </div>
-  <div class="my-5">
-    <h2 class="text-white text-center mb-4">Alert</h2>
-    <div class="d-flex justify-content-around flex-wrap">
-      <div class="m-4"><img src="images/logos/slack-new-logo.svg" height="50" alt="Slack"></div>
-      <div class="m-4"><img src="images/logos/discord-logo-1.svg" height="50" alt="Discord"></div>
-      <div class="m-4"><img src="images/logos/sms-solid.svg" height="50" alt="SMS"></div>
-      <div class="m-4"><img src="images/logos/gmail-icon.svg" height="50" alt="Email"></div>
-      <div class="m-4"><img src="images/logos/webhook-logo-white.svg" height="50" alt="Webhook"></div>
-    </div>
-  </div>
-</div>
-</div>
 
-<div class="container-fluid pt-5">
-<div class="container-fluid">
-  <div class="container d-flex flex-wrap">
-      <div class="d-flex" style="background-image: url(images/marketing/homepage/bgoftable.png)">
-        <div class="m-1">
-          <h5>Compare</h5>
-          <p>Plan</p>
-          <hr>
-          <p>Exceptions</p>
-          <p>Transactions (events)</p>
-          <p>Data retention</p>
-          <p>Dashboards</p>
-          <p>Simple Query Lang</p>
-          <p>Team members</p>
-          <hr>
-          <p><strong>Price</strong></p>
+
+  <%# ingest logos %>
+  <div class="container ingest-logs">
+    <div class="my-5">
+      <h2 class="text-white text-center mb-4">Ingest</h2>
+      <div class="d-flex justify-content-around align-items-center flex-wrap">
+        <div class="m-4"><img src="images/logos/cloudflare-white.svg" height="50" alt="Cloudflare"></div>
+        <div class="m-4"><img src="images/logos/vercel-white.svg" height="50" alt="Vercel"></div>
+        <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/elixir-dark.png" height="50" alt="Elixir">
         </div>
-        <div class="m-1">
-          <h5>Logflare</h5>
-          <p>Metered</p>
-          <hr>
-          <p>Unlimited<sup>1</sup></p>
-          <p>Unlimited<sup>1</sup></p>
-          <p>30 days or BYOB</p>
-          <p>Google Data Studio</p>
-          <p>Logflare QL</p>
-          <p>4 additional</p>
-          <hr>
-          <p>
-            <strong>$15 </strong><small>per million</small>
+        <div class="m-4"><img src="images/logos/javascript-logo.png" height="50" alt="Javascript"></div>
+        <div class="m-4"><img src="images/logos/heroku-logotype-horizontal-white.svg" height="50" alt="Heroku"></div>
+        <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/gigalixir_logo.svg" height="50"
+            alt="Gigalixir"></div>
+        <div class="bg-white p-3 m-4 inner-shadow-box"><img src="images/logos/fluent-bit-logo.png" height="50"
+            alt="FluentBit"></div>
+        <div class="m-4"><img src="images/logos/webhook-logo-white.svg" height="50" alt="Webhook"></div>
+      </div>
+    </div>
+    <div class="my-5">
+      <h2 class="text-white text-center mb-4">Stream, Query & Dashboard</h2>
+      <div class="d-flex justify-content-around">
+        <div class="text-white m-4" style="font-size: 1.25em;"><%= render LogflareWeb.SharedView, "logo.html", assigns %>
+        </div>
+        <div class="m-4"><img src="images/logos/google-bigquery-logo.svg" height="50" alt="Google BigQuery"></div>
+        <div class="m-4"><img src="images/logos/google-data-studio.svg" height="50" alt="Google BigQuery"></div>
+      </div>
+    </div>
+    <div class="my-5">
+      <h2 class="text-white text-center mb-4">Alert</h2>
+      <div class="d-flex justify-content-around flex-wrap">
+        <div class="m-4"><img src="images/logos/slack-new-logo.svg" height="50" alt="Slack"></div>
+        <div class="m-4"><img src="images/logos/discord-logo-1.svg" height="50" alt="Discord"></div>
+        <div class="m-4"><img src="images/logos/sms-solid.svg" height="50" alt="SMS"></div>
+        <div class="m-4"><img src="images/logos/gmail-icon.svg" height="50" alt="Email"></div>
+        <div class="m-4"><img src="images/logos/webhook-logo-white.svg" height="50" alt="Webhook"></div>
+      </div>
+    </div>
+  </div>
+
+  <%# pricing comparison %>
+  <div class="container-fluid pricing">
+    <div class="container d-flex flex-wrap">
+        <div class="d-flex" style="background-image: url(images/marketing/homepage/bgoftable.png)">
+          <div class="m-1">
+            <h5>Compare</h5>
+            <p>Plan</p>
+            <hr>
+            <p>Exceptions</p>
+            <p>Transactions (events)</p>
+            <p>Data retention</p>
+            <p>Dashboards</p>
+            <p>Simple Query Lang</p>
+            <p>Team members</p>
+            <hr>
+            <p><strong>Price</strong></p>
+          </div>
+          <div class="m-1">
+            <h5>Logflare</h5>
+            <p>Metered</p>
+            <hr>
+            <p>Unlimited<sup>1</sup></p>
+            <p>Unlimited<sup>1</sup></p>
+            <p>30 days or BYOB</p>
+            <p>Google Data Studio</p>
+            <p>Logflare QL</p>
+            <p>4 additional</p>
+            <hr>
+            <p>
+              <strong>$15 </strong><small>per million</small>
+              <br />
+              <strong>$10 </strong><small>per million for BYOB</small>
+            </p>
+          </div>
+          <div class="m-1">
+            <h5>Sentry</h5>
+            <p>Team</p>
+            <hr>
+            <p>50,000</p>
+            <p>10,000,000</p>
+            <p>90 days</p>
+            <p>None</p>
+            <p>None</p>
+            <p>Unlimited</p>
+            <hr>
+            <p><strong>$520 </strong><small>per month</small>
             <br />
-            <strong>$10 </strong><small>per million for BYOB</small>
-          </p>
-        </div>
-        <div class="m-1">
-          <h5>Sentry</h5>
-          <p>Team</p>
-          <hr>
-          <p>50,000</p>
-          <p>10,000,000</p>
-          <p>90 days</p>
-          <p>None</p>
-          <p>None</p>
-          <p>Unlimited</p>
-          <hr>
-          <p><strong>$520 </strong><small>per month</small>
-          <br />
-            <strong>≈$52</strong> <small>per million</small>
-          </p>
+              <strong>≈$52</strong> <small>per million</small>
+            </p>
 
-        </div>
+          </div>
 
-    </div>
-    <div class="col-lg m-4">
-      <h3 class="text-white mb-4">Typically Expensive</h3>
-      <p>Costs escalates quickly with typical log management solutions. To setup long term analytics on
-        events you need to archive to a CSV and setup another data pipeline to ingest events into a custom tailored
-        data warehouse.</p>
-      <p>With Logflare and BigQuery there is no setup for long term analytics. You can ingest immediately, query in
-        seconds and store data for years.</p>
-      <%= link "See plans & pricing", to: Routes.marketing_path(@conn, :pricing), class: "btn btn-pink mt-4", role: "button" %>
-      <p class="mt-3"><small><sup>1</sup> Unlimited is subject to our fair use policy.</small></p>
+      </div>
+      <div class="col-lg m-4">
+        <h3 class="text-white mb-4">Typically Expensive</h3>
+        <p>Costs escalates quickly with typical log management solutions. To setup long term analytics on
+          events you need to archive to a CSV and setup another data pipeline to ingest events into a custom tailored
+          data warehouse.</p>
+        <p>With Logflare and BigQuery there is no setup for long term analytics. You can ingest immediately, query in
+          seconds and store data for years.</p>
+        <%= link "See plans & pricing", to: Routes.marketing_path(@conn, :pricing), class: "btn btn-pink mt-4", role: "button" %>
+        <p class="mt-3"><small><sup>1</sup> Unlimited is subject to our fair use policy.</small></p>
+      </div>
     </div>
   </div>
-  </div>
-</div>
-</div>
 
-<div class="catchimgtop"><img src="images/marketing/homepage/bgtop.png" alt=""></div>
-<div class="container-fluid catch">
-  <div class="container-fluid">
+  <%# catch %>
+  <div class="container-fluid catch">
+    <div class="container-fluid">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-10 order-lg-1">
+            <div class="row">
+              <div class="col-md-6">
+                <h4>Structured logging without limits (no added latency)</h4>
+              </div>
+              <div class="col-md-6">
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6 order-md-6">
+                <img src="images/marketing/homepage/catchImgDesktop-4x.png" class="img-responsive" alt="">
+              </div>
+              <div class="col-md-6 pull-md-6">
+                <p>Use our Cloudflare app and catch every request to your web service no matter what. Our Cloudflare App
+                  worker doesn't modify your request, it simply pulls the request/response data and logs to Logflare
+                  asynchronously after passing
+                  your request through. </br> </br> Want to monitor your Elixir app? Our library adds minimal overhead.
+                  We
+                  batch logs and use
+                  <%= link "BERT binary serialization", to: "http://bert-rpc.org/", target: "_blank" %>
+                  to keep payload size and
+                  serialization load low.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-lg-1"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%# steps %>
+  <div class="container-fluid steps">
     <div class="container">
       <div class="row">
-        <div class="col-lg-10 order-lg-1">
-          <div class="row">
-            <div class="col-md-6">
-              <h4>Structured logging without limits (no added latency)</h4>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="fas fa-history"></i>
             </div>
-            <div class="col-md-6">
+            <h2>Unlimited event history</h2>
+            <p>Logflare is backed by Google BigQuery. We immediately insert your logs into BigQuery and store those
+              there
+              for 7 days. Need more than 7 days? Bring your own BigQuery table and keep as much as you like!</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="fab fa-google"></i>
             </div>
+            <h2>BigQuery & DataStudio</h2>
+            <p>When you sign in with your Google account, we give you access to your underlying BigQuery table. Make
+              dashboards with Google Data Studio using your new BigQuery table.</p>
+            <%= link "Show me more »", to: Routes.marketing_path(@conn, :overview), class: "btn btn-secondary", role: "button" %>
           </div>
-          <div class="row">
-            <div class="col-md-6 order-md-6">
-              <img src="images/marketing/homepage/catchImgDesktop-4x.png" class="img-responsive" alt="">
+        </div>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="fas fa-code-branch"></i>
             </div>
-            <div class="col-md-6 pull-md-6">
-              <p>Use our Cloudflare app and catch every request to your web service no matter what. Our Cloudflare App
-                worker doesn't modify your request, it simply pulls the request/response data and logs to Logflare
-                asynchronously after passing
-                your request through. </br> </br> Want to monitor your Elixir app? Our library adds minimal overhead.
-                We
-                batch logs and use
-                <%= link "BERT binary serialization", to: "http://bert-rpc.org/", target: "_blank" %>
-                to keep payload size and
-                serialization load low.</p>
+            <h2>Log routing</h2>
+            <p>Route logs to difference sources with Regex. Consolidate important events with log routing.</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="far fa-bell"></i>
             </div>
+            <h2>Email & SMS alerts</h2>
+            <p>Never miss an important event with realtime alerts via email or text message. Add multiple email
+              addresses
+              to alert everyone.</p>
           </div>
         </div>
-        <div class="col-lg-1"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="container-fluid steps">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="fas fa-history"></i>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="fas fa-users"></i>
+            </div>
+            <h2>Sharing via public URL</h2>
+            <p>Easily generate a public URL for a source. Useful for sharing realtime events with anyone without a
+              login.
+              Here we've routed all Googlebot traffic to this source and created a public path for it.</p>
           </div>
-          <h2>Unlimited event history</h2>
-          <p>Logflare is backed by Google BigQuery. We immediately insert your logs into BigQuery and store those
-            there
-            for 7 days. Need more than 7 days? Bring your own BigQuery table and keep as much as you like!</p>
         </div>
-      </div>
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="fab fa-google"></i>
+        <div class="col-md-4">
+          <div class="stepscont">
+            <div class="circle">
+              <i class="fas fa-code"></i>
+            </div>
+            <h2>Add metadata and query it</h2>
+            <p>Include metadata with your event for logging structured data. Query this structured data with standard
+              SQL
+              in BigQuery. Schema is managed for you, adapting to new metadata on the fly.</p>
           </div>
-          <h2>BigQuery & DataStudio</h2>
-          <p>When you sign in with your Google account, we give you access to your underlying BigQuery table. Make
-            dashboards with Google Data Studio using your new BigQuery table.</p>
-          <%= link "Show me more »", to: Routes.marketing_path(@conn, :overview), class: "btn btn-secondary", role: "button" %>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="fas fa-code-branch"></i>
-          </div>
-          <h2>Log routing</h2>
-          <p>Route logs to difference sources with Regex. Consolidate important events with log routing.</p>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="far fa-bell"></i>
-          </div>
-          <h2>Email & SMS alerts</h2>
-          <p>Never miss an important event with realtime alerts via email or text message. Add multiple email
-            addresses
-            to alert everyone.</p>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="fas fa-users"></i>
-          </div>
-          <h2>Sharing via public URL</h2>
-          <p>Easily generate a public URL for a source. Useful for sharing realtime events with anyone without a
-            login.
-            Here we've routed all Googlebot traffic to this source and created a public path for it.</p>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="stepscont">
-          <div class="circle">
-            <i class="fas fa-code"></i>
-          </div>
-          <h2>Add metadata and query it</h2>
-          <p>Include metadata with your event for logging structured data. Query this structured data with standard
-            SQL
-            in BigQuery. Schema is managed for you, adapting to new metadata on the fly.</p>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="features container-fluid">
-  <div class="container">
+  <%# features %>
+  <div class="container features">
     <div class="row">
       <div class="col-md-4">
         <h3>Other features</h3>
@@ -342,180 +321,139 @@
       </div>
     </div>
   </div>
-</div>
-<div class="container-fluid ctav2">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet" data-lang="en">
-          <p lang="en" dir="ltr">Big shoutout and 🙏 to <a
-              href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> for his super cool <a
-              href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a> workers app <a
-              href="https://t.co/Nr0VzXskc9">https://t.co/Nr0VzXskc9</a> I was able to quickly identify a painful bug
-            in
-            our latest app release that my team couldn&#39;t figure out. They introduced a small change that created
-            recursive (infinite) API
-            calls</p>
-          &mdash; Hamlet 🇩🇴 (@hamletbatista) <a
-            href="https://twitter.com/hamletbatista/status/1121766630244143104?ref_src=twsrc%5Etfw">April 26, 2019</a>
-        </blockquote>
+
+  <div class="container-fluid twitter-reviews">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet" data-lang="en">
+            <p lang="en" dir="ltr">Big shoutout and 🙏 to <a
+                href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> for his super cool <a
+                href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a> workers app <a
+                href="https://t.co/Nr0VzXskc9">https://t.co/Nr0VzXskc9</a> I was able to quickly identify a painful bug
+              in
+              our latest app release that my team couldn&#39;t figure out. They introduced a small change that created
+              recursive (infinite) API
+              calls</p>
+            &mdash; Hamlet 🇩🇴 (@hamletbatista) <a
+              href="https://twitter.com/hamletbatista/status/1121766630244143104?ref_src=twsrc%5Etfw">April 26, 2019</a>
+          </blockquote>
+        </div>
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet" data-cards="hidden" data-lang="en">
+            <p lang="en" dir="ltr">If you can&#39;t get enough log files, someone posted a cool hack that uses
+              CloudFlare
+              to collect Googlebot requests. <a href="https://t.co/LlAr5ir6M3">https://t.co/LlAr5ir6M3</a> <a
+                href="https://t.co/q2pWdzKv0i">pic.twitter.com/q2pWdzKv0i</a></p>
+            &mdash; 🍌 John 🍌 (@JohnMu) <a
+              href="https://twitter.com/JohnMu/status/1092712358319927297?ref_src=twsrc%5Etfw">February 5, 2019</a>
+          </blockquote>
+        </div>
       </div>
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet" data-cards="hidden" data-lang="en">
-          <p lang="en" dir="ltr">If you can&#39;t get enough log files, someone posted a cool hack that uses
-            CloudFlare
-            to collect Googlebot requests. <a href="https://t.co/LlAr5ir6M3">https://t.co/LlAr5ir6M3</a> <a
-              href="https://t.co/q2pWdzKv0i">pic.twitter.com/q2pWdzKv0i</a></p>
-          &mdash; 🍌 John 🍌 (@JohnMu) <a
-            href="https://twitter.com/JohnMu/status/1092712358319927297?ref_src=twsrc%5Etfw">February 5, 2019</a>
-        </blockquote>
+      <div class="row">
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet" data-lang="en">
+            <p lang="en" dir="ltr">Been using the great (and free!) <a
+                href="https://t.co/rtmu5GdIcu">https://t.co/rtmu5GdIcu</a> service by <a
+                href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a>! Great insight into all your
+              requests
+              and logs, easy to install with <a href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a>
+              Apps! Great job!</p>
+            &mdash; Matteo Manfredi (@itsmatteomanf) <a
+              href="https://twitter.com/itsmatteomanf/status/1126871444632346628?ref_src=twsrc%5Etfw">May 10, 2019</a>
+          </blockquote>
+        </div>
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet" data-lang="en">
+            <p lang="en" dir="ltr">You&#39;re using CloudFlare, right? If not, you should! However, sometimes the lack
+              of
+              logs on the free tier is annoying when debugging a specific problem. Enter Logflare! <a
+                href="https://t.co/lbODVip69c">https://t.co/lbODVip69c</a></p>
+            &mdash; Bryan Ross (@bryanrossUK) <a
+              href="https://twitter.com/bryanrossUK/status/1097417950800330752?ref_src=twsrc%5Etfw">February 18,
+              2019</a>
+          </blockquote>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet" data-lang="en">
-          <p lang="en" dir="ltr">Been using the great (and free!) <a
-              href="https://t.co/rtmu5GdIcu">https://t.co/rtmu5GdIcu</a> service by <a
-              href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a>! Great insight into all your
-            requests
-            and logs, easy to install with <a href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a>
-            Apps! Great job!</p>
-          &mdash; Matteo Manfredi (@itsmatteomanf) <a
-            href="https://twitter.com/itsmatteomanf/status/1126871444632346628?ref_src=twsrc%5Etfw">May 10, 2019</a>
-        </blockquote>
+      <div class="row">
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr">Logflare by <a href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> is
+              the missing link that every <a href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a>
+              customer should be using! Logflare has provided us with unprecedented visibility in monitoring and
+              debugging
+              our service. Check it out: <a href="https://t.co/jweR1rFFwq">https://t.co/jweR1rFFwq</a></p>
+            &mdash; TicketSource (@TicketSource) <a
+              href="https://twitter.com/TicketSource/status/1174614196803330049?ref_src=twsrc%5Etfw">September 19,
+              2019</a>
+          </blockquote>
+        </div>
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr">Hoorah. I finally managed to get Logflare going with Cloudflare and Data Studio to
+              pipe
+              server log files to Logflare. 🎉🎉🎉🎉🎉</p>
+            &mdash; Dawn Anderson (@dawnieando) <a
+              href="https://twitter.com/dawnieando/status/1167551594549977089?ref_src=twsrc%5Etfw">August 30, 2019</a>
+          </blockquote>
+        </div>
       </div>
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet" data-lang="en">
-          <p lang="en" dir="ltr">You&#39;re using CloudFlare, right? If not, you should! However, sometimes the lack
-            of
-            logs on the free tier is annoying when debugging a specific problem. Enter Logflare! <a
-              href="https://t.co/lbODVip69c">https://t.co/lbODVip69c</a></p>
-          &mdash; Bryan Ross (@bryanrossUK) <a
-            href="https://twitter.com/bryanrossUK/status/1097417950800330752?ref_src=twsrc%5Etfw">February 18,
-            2019</a>
-        </blockquote>
+      <div class="row">
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr">I&#39;m so much in love with <a
+                href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a> right now. What a
+              fantastic way to do log analysis for SEO. What a tremendous tool and <a
+                href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> you must be proud of this. Thanks
+              for
+              helping me set up and remind me to add a billing info 😄</p>&mdash; Suganthan Mohanadasan (@Suganthanmn)
+            <a href="https://twitter.com/Suganthanmn/status/1262421056360505345?ref_src=twsrc%5Etfw">May 18, 2020</a>
+          </blockquote>
+        </div>
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr">I&#39;ve got a setup with a custom <a
+                href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a> Worker + <a
+                href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@Logflare_logs</a> + Google Data Studio and
+              it works damn well if you want customised non-tracking website metrics.</p>&mdash; Ingvar Stepanyan
+            (@RReverser) <a href="https://twitter.com/RReverser/status/1261313259317202947?ref_src=twsrc%5Etfw">May 15,
+              2020</a>
+          </blockquote>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr">Logflare by <a href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> is
-            the missing link that every <a href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a>
-            customer should be using! Logflare has provided us with unprecedented visibility in monitoring and
-            debugging
-            our service. Check it out: <a href="https://t.co/jweR1rFFwq">https://t.co/jweR1rFFwq</a></p>
-          &mdash; TicketSource (@TicketSource) <a
-            href="https://twitter.com/TicketSource/status/1174614196803330049?ref_src=twsrc%5Etfw">September 19,
-            2019</a>
-        </blockquote>
-      </div>
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr">Hoorah. I finally managed to get Logflare going with Cloudflare and Data Studio to
-            pipe
-            server log files to Logflare. 🎉🎉🎉🎉🎉</p>
-          &mdash; Dawn Anderson (@dawnieando) <a
-            href="https://twitter.com/dawnieando/status/1167551594549977089?ref_src=twsrc%5Etfw">August 30, 2019</a>
-        </blockquote>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr">I&#39;m so much in love with <a
-              href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a> right now. What a
-            fantastic way to do log analysis for SEO. What a tremendous tool and <a
-              href="https://twitter.com/chasers?ref_src=twsrc%5Etfw">@chasers</a> you must be proud of this. Thanks
-            for
-            helping me set up and remind me to add a billing info 😄</p>&mdash; Suganthan Mohanadasan (@Suganthanmn)
-          <a href="https://twitter.com/Suganthanmn/status/1262421056360505345?ref_src=twsrc%5Etfw">May 18, 2020</a>
-        </blockquote>
-      </div>
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr">I&#39;ve got a setup with a custom <a
-              href="https://twitter.com/Cloudflare?ref_src=twsrc%5Etfw">@Cloudflare</a> Worker + <a
-              href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@Logflare_logs</a> + Google Data Studio and
-            it works damn well if you want customised non-tracking website metrics.</p>&mdash; Ingvar Stepanyan
-          (@RReverser) <a href="https://twitter.com/RReverser/status/1261313259317202947?ref_src=twsrc%5Etfw">May 15,
-            2020</a>
-        </blockquote>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr"><a href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a> is
-            fantastic! It really does a great job of providing a complete (and very flexible) analytics solution that
-            CloudFlare itself is missing!</p>&mdash; CheapShark (@CheapSharkDeals) <a
-            href="https://twitter.com/CheapSharkDeals/status/1292998684515471373?ref_src=twsrc%5Etfw">August 11,
-            2020</a>
-        </blockquote>
-      </div>
-      <div class="col-md-6">
-        <blockquote class="twitter-tweet">
-          <p lang="en" dir="ltr">Really impressed with <a
-              href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a>. We&#39;ve been on the
-            front page of <a
-              href="https://twitter.com/hashtag/hackernews?src=hash&amp;ref_src=twsrc%5Etfw">#hackernews</a> for 24
-            hours anticipating the HN hug of death. Looks like we made it through OK and Logflare has been ingesting
-            everything without breaking a sweat <a href="https://t.co/RWKHIgmWh6">https://t.co/RWKHIgmWh6</a> <a
-              href="https://t.co/dQ2xqFTdco">pic.twitter.com/dQ2xqFTdco</a></p>&mdash; Supabase (@supabase_io) <a
-            href="https://twitter.com/supabase_io/status/1265922290237071361?ref_src=twsrc%5Etfw">May 28, 2020</a>
-        </blockquote>
+      <div class="row">
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr"><a href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a> is
+              fantastic! It really does a great job of providing a complete (and very flexible) analytics solution that
+              CloudFlare itself is missing!</p>&mdash; CheapShark (@CheapSharkDeals) <a
+              href="https://twitter.com/CheapSharkDeals/status/1292998684515471373?ref_src=twsrc%5Etfw">August 11,
+              2020</a>
+          </blockquote>
+        </div>
+        <div class="col-md-6">
+          <blockquote class="twitter-tweet">
+            <p lang="en" dir="ltr">Really impressed with <a
+                href="https://twitter.com/logflare_logs?ref_src=twsrc%5Etfw">@logflare_logs</a>. We&#39;ve been on the
+              front page of <a
+                href="https://twitter.com/hashtag/hackernews?src=hash&amp;ref_src=twsrc%5Etfw">#hackernews</a> for 24
+              hours anticipating the HN hug of death. Looks like we made it through OK and Logflare has been ingesting
+              everything without breaking a sweat <a href="https://t.co/RWKHIgmWh6">https://t.co/RWKHIgmWh6</a> <a
+                href="https://t.co/dQ2xqFTdco">pic.twitter.com/dQ2xqFTdco</a></p>&mdash; Supabase (@supabase_io) <a
+              href="https://twitter.com/supabase_io/status/1265922290237071361?ref_src=twsrc%5Etfw">May 28, 2020</a>
+          </blockquote>
+        </div>
       </div>
     </div>
   </div>
-</div>
-<div class="container-fluid ctav2">
-  <div class="container">
-    <div class="row fordesk">
-      <div class="col-lg-10 order-lg-1">
-        <div class="row">
-          <div class="col-md-12">
-            <h1>Zero risk. Satisfaction guaranteed. Install now!</h1>
-            <div class="btns">
-              <p>
-                <iframe src="https://install.cloudflareapps.com?appId=K4MXdgCp7956" allowTransparency="true" scroll="no"
-                  frameBorder="0" loading="lazy">
-                </iframe>
-              </p>
-              <p><%= link "Sign up", to: Routes.auth_path(@conn, :login), class: "signup", role: "button" %></p>
-            </div>
-            <p>Install the
-              <%= link "Cloudflare app", to: "https://www.cloudflare.com/apps/logflare", target: "_blank" %></p>
-            <p>Setup our
-              <%= link "Elixir Logger backend", to: "https://github.com/Logflare/logflare_logger_backend", target: "_blank" %>
-            </p>
-            <p>Check out the
-              <%= link "Logflare Vercel app", to: "https://vercel.co/integrations/logflare", target: "_blank" %></p>
-          </div>
-        </div>
-      </div>
-      <div class="col-lg-1"></div>
-    </div>
-    <div class="row forphone3">
-      <div class="col-md-12">
-        <h1>Zero risk. Satisfaction guaranteed. Install now!</h1>
-        <div class="btns">
-          <p>
-            <iframe src="https://install.cloudflareapps.com?appId=K4MXdgCp7956" allowTransparency="true" scroll="no"
-              frameBorder="0" loading="lazy">
-            </iframe>
-          </p>
-          <p><a href="" class="signup">SIGN UP</a></p>
-        </div>
-        <p>Install the <%= link "Cloudflare app", to: "https://www.cloudflare.com/apps/logflare", target: "_blank" %>
-        </p>
-        <p>Setup our
-          <%= link "Elixir Logger backend", to: "https://github.com/Logflare/logflare_logger_backend", target: "_blank" %>
-        </p>
-        <p>Check out the
-          <%= link "Logflare Vercel app", to: "https://vercel.co/integrations/logflare", target: "_blank" %></p>
-      </div>
-    </div>
+
+  <div class="container-fluid banner-footer">
+    <h1>Zero risk. Satisfaction guaranteed. Install now!</h1>
+    <%= render("homepage_cta.html", assigns) %>
   </div>
+  <%= render LogflareWeb.SharedView, "footer.html", assigns %>
+
+<%# end of .homepage wrapper %>
 </div>
-<%= render LogflareWeb.SharedView, "footer.html", assigns %>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/lib/logflare_web/templates/source/no_logs_modal.html.eex
+++ b/lib/logflare_web/templates/source/no_logs_modal.html.eex
@@ -36,7 +36,7 @@
 
         <%= link to: "https://www.cloudflare.com/apps/logflare/install" do %>
             <button class="btn btn-primary" title="Install the Cloudflare integration" style="height: 40px;">
-            <img src="<%= Routes.static_path(@socket, "/images/logos/cloudflare-white.svg")%>" style="width: 120px;height: 30px;" />
+            <img src="<%= Routes.static_path(@conn, "/images/logos/cloudflare-white.svg")%>" style="width: 120px;height: 30px;" />
             </button>
         <% end %>
 

--- a/lib/logflare_web/templates/source/no_logs_modal.html.eex
+++ b/lib/logflare_web/templates/source/no_logs_modal.html.eex
@@ -35,8 +35,8 @@
         <p>Already on Cloudflare? Install the Cloudflare app and start sending logs now.</p>
 
         <%= link to: "https://www.cloudflare.com/apps/logflare/install" do %>
-            <button class="btn btn-primary" title="Install the Cloudflare integration">
-            <img src="<%= Routes.static_path(@conn, "/images/logos/cloudflare-white.svg")%>" class="cloudflare" />
+            <button class="btn btn-primary" title="Install the Cloudflare integration" style="height: 40px;">
+            <img src="<%= Routes.static_path(@socket, "/images/logos/cloudflare-white.svg")%>" style="width: 120px;height: 30px;" />
             </button>
         <% end %>
 

--- a/lib/logflare_web/templates/source/no_logs_modal.html.eex
+++ b/lib/logflare_web/templates/source/no_logs_modal.html.eex
@@ -33,9 +33,12 @@
 
         <h5 class="header-margin">Cloudflare App</h5>
         <p>Already on Cloudflare? Install the Cloudflare app and start sending logs now.</p>
-        <iframe src="https://install.cloudflareapps.com?appId=K4MXdgCp7956" allowtransparency="true" scroll="no"
-          frameborder="0" style="height: 48px; width: 180px">
-        </iframe>
+
+        <%= link to: "https://www.cloudflare.com/apps/logflare/install" do %>
+            <button class="btn btn-primary" title="Install the Cloudflare integration">
+            <img src="<%= Routes.static_path(@conn, "/images/logos/cloudflare-white.svg")%>" class="cloudflare" />
+            </button>
+        <% end %>
 
         <h5 class="header-margin">Heroku</h5>
         <p>Add our log drain with a simple command.</p>

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -69,7 +69,7 @@
 
 </div>
 <!-- Modal -->
-<%= render(LogflareWeb.SourceView, "no_logs_modal.html", user: @user, source: @source) %>
+<%= render(LogflareWeb.SourceView, "no_logs_modal.html", user: @user, source: @source, conn: @conn) %>
 <div
 id="__phx-assigns__"
 data-source-token="<%= @source.token %>"


### PR DESCRIPTION
Fix for broken cloudflare integration links throughout the app, now navigating directly to https://cloudflare.com/apps/logflare/install

I've also done a big-ish refactor for the marketing pages styling and removed a lot of duplicate code.

Might have some tiny styling changes on the home page here and there but i don't think it is very noticable.

Main large change in styling is the addition of 3 different fixed point media query mixins, which help to make all media query styling customizations consistent across the app. These are in `mixins.scss`. These responsiveness mixins are to be used for overriding from mobile upwards, as shown in example comments.
 
- `@include mobile { ...}` for backwards compat with setting max-width for mobile-only rules
- `@include tablet { ...}`  for tablet and larger screens
- `@include desktop { ...}` for desktop and larger screens

These are necessary all media queries replaced are all at different breakpoints which makes it very janky and hard to style when switching between resolutions.

In any case, since we are cutting sass usage, this is just a temp measure for further future refactoring to cut down more unused rulesets, and make the conversion to tailwind/react-powered styling easier.

Although pricing page sass file is updated, actual styling is not affected. I've also done a visual check of other marketing pages to verify that they have not been affected.

Demos:

https://user-images.githubusercontent.com/22714384/217914431-7e710e8e-12a3-4bf6-b7dc-9c80d3792603.mov


<img width="1270" alt="Screenshot 2023-02-10 at 3 03 31 AM" src="https://user-images.githubusercontent.com/22714384/217914415-624ce5d9-ec4b-4f23-9c5f-599f672d22cf.png">

[Ticket](https://www.notion.so/supabase/CLoudflare-App-integration-link-from-source-page-is-broken-b22ff9eb83474faa8f4318d464f177e4?pvs=4)