### PR TITLE
fix: order by in sandboxed queries are not replaced correctly

### DIFF
--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -80,6 +80,12 @@ defmodule Logflare.SqlTest do
             {"with src as (select a from my_table), src2 as (select a from src where a > 5) select c from src",
              "select a, b, c from src2"},
             "with src as (select a from #{table}), src2 as (select a from src where a > 5) select a, b, c from src2"
+          },
+          # sandboxed queries with order by
+          {
+            {"with src as (select a from my_table) select c from src",
+             "select c from src order by c asc"},
+            "with src as (select a from #{table}) select c from src order by c asc"
           }
         ] do
       assert {:ok, v2} = SqlV2.transform(input, user)


### PR DESCRIPTION
fixed order by in sandboxed queries being broken, adds in relevant testing