### PR TITLE
Change from editor to build in Cloudbuild SA

### DIFF
--- a/lib/logflare/google/resource_manager.ex
+++ b/lib/logflare/google/resource_manager.ex
@@ -112,7 +112,7 @@ defmodule Logflare.Google.CloudResourceManager do
       %Model.Binding{
         condition: nil,
         members: ["serviceAccount:#{env_cloud_build_sa()}"],
-        role: "roles/cloudbuild.builds.editor"
+        role: "roles/cloudbuild.builds.create"
       },
       %Model.Binding{
         condition: nil,

--- a/test/logflare/google/resource_manager_test.exs
+++ b/test/logflare/google/resource_manager_test.exs
@@ -113,7 +113,7 @@ defmodule Logflare.Google.CloudResourceManagerTest do
       },
       %Binding{
         members: ["serviceAccount:#{google_configs.cloud_build_sa}"],
-        role: "roles/cloudbuild.builds.editor"
+        role: "roles/cloudbuild.builds.create"
       },
       %Binding{
         members: ["serviceAccount:#{google_configs.cloud_build_sa}"],


### PR DESCRIPTION
Editor wasn't enough to make the builds work and according to this docs https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers/run what we need is create.