### PR TITLE
(fix) Fix tooltip missing background

### DIFF
--- a/assets/js/admin_dashboard_charts.jsx
+++ b/assets/js/admin_dashboard_charts.jsx
@@ -1,5 +1,6 @@
 import React from "react"
-import {ResponsiveBarCanvas} from "@nivo/bar"
+import { ResponsiveBarCanvas } from "@nivo/bar"
+import { ThemeProvider } from "@nivo/core"
 
 const brandLightBlack = "#1d1d1d"
 const brandGreen = "#5eeb8f"
@@ -12,49 +13,46 @@ const theme = {
       strokeDasharray: "4 4",
     },
   },
-  axis: {ticks: {text: {fill: brandGreen}}},
-
-  tooltip: {
-    container: {
-      background: brandLightBlack,
-    },
-  },
+  axis: { ticks: { text: { fill: brandGreen } } },
+  tooltip: { container: { background: brandLightBlack, }, },
 }
 
-const renderDefaultTooltip = ({value, color, indexValue}) => {
+const renderDefaultTooltip = ({ value, color, indexValue }) => {
   return (
     <div>
-      <strong style={{color}}>Timestamp: {indexValue}</strong>
+      <strong style={{ color }}>Timestamp: {indexValue}</strong>
       <br />
-      <strong style={{color}}>Value: {value}</strong>
+      <strong style={{ color }}>Value: {value}</strong>
     </div>
   )
 }
 
-const Chart = ({data, keys}) => {
+const Chart = ({ data, keys }) => {
   return (
     <div
       style={{
         height: 200,
       }}
     >
-      <ResponsiveBarCanvas
-        data={data}
-        margin={{top: 30, right: 30, bottom: 30, left: 30}}
-        padding={0.3}
-        enableGridY={true}
-        keys={keys}
-        indexBy={"timestamp"}
-        tooltip={renderDefaultTooltip}
-        axisTop={null}
-        axisRight={null}
-        axisBottom={null}
-        enableLabel={false}
-        motionStiffness={90}
-        motionDamping={15}
-        theme={theme}
-        colors={(_) => brandGreen}
-      />
+      <ThemeProvider theme={theme}>
+        <ResponsiveBarCanvas
+          data={data}
+          margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
+          padding={0.3}
+          enableGridY={true}
+          keys={keys}
+          indexBy={"timestamp"}
+          tooltip={renderDefaultTooltip}
+          axisTop={null}
+          axisRight={null}
+          axisBottom={null}
+          enableLabel={false}
+          motionStiffness={90}
+          motionDamping={15}
+          theme={theme}
+          colors={(_) => brandGreen}
+        />
+      </ThemeProvider>
     </div>
   )
 }

--- a/assets/js/source_log_chart.jsx
+++ b/assets/js/source_log_chart.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { DateTime } from "luxon"
 import { ResponsiveBarCanvas } from "@nivo/bar"
+import { ThemeProvider } from '@nivo/core'
 
 import { BarLoader } from "react-spinners"
 
@@ -26,20 +27,16 @@ const theme = {
       strokeDasharray: "4 4",
     },
   },
-  tooltip: {
-    container: {
-      background: brandLightBlack,
-    },
-  },
+  tooltip: { container: { background: brandLightBlack } },
 }
 
 const renderDefaultTooltip = ({ value, color, indexValue }) => {
   return (
-    <div>
+    <div style={{ backgroundColor: brandLightBlack }}>
       <strong style={{ color }}>Timestamp: {indexValue}</strong>
       <br />
       <strong style={{ color }}>Value: {value}</strong>
-    </div>
+    </div >
   )
 }
 
@@ -271,25 +268,27 @@ const LogEventsChart = ({
           />
         </div>
       ) : (
-        <ResponsiveBarCanvas
-          data={data}
-          margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
-          padding={0.3}
-          enableGridY={true}
-          indexBy={"timestamp"}
-          tooltip={renderTooltip}
-          axisTop={null}
-          axisRight={null}
-          axisBottom={null}
-          axisLeft={null}
-          enableLabel={false}
-          animate={true}
-          onClick={onClick}
-          motionStiffness={90}
-          motionDamping={15}
-          theme={theme}
-          {...chartSettings(chartDataShapeId)}
-        />
+        <ThemeProvider theme={theme} >
+          <ResponsiveBarCanvas
+            data={data}
+            margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
+            padding={0.3}
+            enableGridY={true}
+            indexBy={"timestamp"}
+            tooltip={renderTooltip}
+            axisTop={null}
+            axisRight={null}
+            axisBottom={null}
+            axisLeft={null}
+            enableLabel={false}
+            animate={true}
+            onClick={onClick}
+            motionStiffness={90}
+            motionDamping={15}
+            theme={theme}
+            {...chartSettings(chartDataShapeId)}
+          />
+        </ThemeProvider>
       )}
     </div>
   )


### PR DESCRIPTION
Due to the update of nivo, theme of tooltips are applied using ThemeProvider but we still require the theme attribute to set the theme of the bar chart.