### PR TITLE
Revert nivo version

### DIFF
--- a/assets/js/admin_dashboard_charts.jsx
+++ b/assets/js/admin_dashboard_charts.jsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { ResponsiveBarCanvas } from "@nivo/bar"
-import { ThemeProvider } from "@nivo/core"
 
 const brandLightBlack = "#1d1d1d"
 const brandGreen = "#5eeb8f"
@@ -34,25 +33,23 @@ const Chart = ({ data, keys }) => {
         height: 200,
       }}
     >
-      <ThemeProvider theme={theme}>
-        <ResponsiveBarCanvas
-          data={data}
-          margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
-          padding={0.3}
-          enableGridY={true}
-          keys={keys}
-          indexBy={"timestamp"}
-          tooltip={renderDefaultTooltip}
-          axisTop={null}
-          axisRight={null}
-          axisBottom={null}
-          enableLabel={false}
-          motionStiffness={90}
-          motionDamping={15}
-          theme={theme}
-          colors={(_) => brandGreen}
-        />
-      </ThemeProvider>
+      <ResponsiveBarCanvas
+        data={data}
+        margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
+        padding={0.3}
+        enableGridY={true}
+        keys={keys}
+        indexBy={"timestamp"}
+        tooltip={renderDefaultTooltip}
+        axisTop={null}
+        axisRight={null}
+        axisBottom={null}
+        enableLabel={false}
+        motionStiffness={90}
+        motionDamping={15}
+        theme={theme}
+        colors={(_) => brandGreen}
+      />
     </div>
   )
 }

--- a/assets/js/source_log_chart.jsx
+++ b/assets/js/source_log_chart.jsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { DateTime } from "luxon"
 import { ResponsiveBarCanvas } from "@nivo/bar"
-import { ThemeProvider } from '@nivo/core'
 
 import { BarLoader } from "react-spinners"
 
@@ -268,27 +267,25 @@ const LogEventsChart = ({
           />
         </div>
       ) : (
-        <ThemeProvider theme={theme} >
-          <ResponsiveBarCanvas
-            data={data}
-            margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
-            padding={0.3}
-            enableGridY={true}
-            indexBy={"timestamp"}
-            tooltip={renderTooltip}
-            axisTop={null}
-            axisRight={null}
-            axisBottom={null}
-            axisLeft={null}
-            enableLabel={false}
-            animate={true}
-            onClick={onClick}
-            motionStiffness={90}
-            motionDamping={15}
-            theme={theme}
-            {...chartSettings(chartDataShapeId)}
-          />
-        </ThemeProvider>
+        <ResponsiveBarCanvas
+          data={data}
+          margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
+          padding={0.3}
+          enableGridY={true}
+          indexBy={"timestamp"}
+          tooltip={renderTooltip}
+          axisTop={null}
+          axisRight={null}
+          axisBottom={null}
+          axisLeft={null}
+          enableLabel={false}
+          animate={true}
+          onClick={onClick}
+          motionStiffness={90}
+          motionDamping={15}
+          theme={theme}
+          {...chartSettings(chartDataShapeId)}
+        />
       )}
     </div>
   )

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,8 +6,8 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@nivo/bar": "^0.79.0",
-    "@nivo/core": "^0.79.0",
+    "@nivo/bar": "^0.62.0",
+    "@nivo/core": "^0.62.0",
     "bootstrap": "^4.3.1",
     "bootstrap-select": "^1.13.12",
     "clipboard": "^2.0.4",


### PR DESCRIPTION
Due to a bad UI element we're reverting to a previous nivo version that worked.

ThemeProvider doesn't seem to behave as expected.
<img width="447" alt="Screenshot 2023-02-24 at 01 03 11" src="https://user-images.githubusercontent.com/1697301/221066601-6f2b0da5-3c19-468c-8a4e-6650f3555620.png">
