### PR TITLE
(fix) Source Log graph drill down

### DIFF
--- a/assets/js/source_log_chart.jsx
+++ b/assets/js/source_log_chart.jsx
@@ -1,3 +1,4 @@
+import $ from "jquery"
 import React from "react"
 import { DateTime } from "luxon"
 import { ResponsiveBarCanvas } from "@nivo/bar"


### PR DESCRIPTION
Due to a lack of jquery import the source log graph drill down wasn't working.