### PR TITLE
Feat/mgmt api verify api access

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -76,7 +76,7 @@ defmodule LogflareWeb.Router do
   end
 
   pipeline :require_mgmt_api_auth do
-    plug(LogflareWeb.Plugs.VerifyApiAccess)
+    plug(LogflareWeb.Plugs.VerifyApiAccess, scopes: ~w(private))
   end
 
   pipeline :require_auth do

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -18,7 +18,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     } do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> get("/api/endpoints")
         |> json_response(200)
 
@@ -37,7 +37,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     } do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> get("/api/endpoints/#{endpoint.token}")
         |> json_response(200)
 
@@ -51,7 +51,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, ~w(private))
       |> get("/api/endpoints/#{endpoint.token}")
       |> response(404)
     end
@@ -66,7 +66,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> post("/api/endpoints", %{name: name, query: "select a from logs"})
         |> json_response(201)
 
@@ -76,7 +76,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     test "returns 422 on missing arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> post("/api/endpoints")
         |> json_response(422)
 
@@ -86,7 +86,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> post("/api/endpoints", %{name: 123})
         |> json_response(422)
 
@@ -104,7 +104,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> patch("/api/endpoints/#{endpoint.token}", %{name: name})
         |> json_response(204)
 
@@ -118,7 +118,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, ~w(private))
       |> patch("/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
       |> response(404)
     end
@@ -130,7 +130,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     } do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, ~w(private))
         |> patch("/api/endpoints/#{endpoint.token}", %{name: 123})
         |> json_response(422)
 
@@ -147,12 +147,12 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       name = TestUtils.random_string()
 
       assert conn
-             |> add_access_token(user)
+             |> add_access_token(user, ~w(private))
              |> delete("/api/endpoints/#{endpoint.token}", %{name: name})
              |> response(204)
 
       assert conn
-             |> add_access_token(user)
+             |> add_access_token(user, ~w(private))
              |> get("/api/endpoints/#{endpoint.token}")
              |> response(404)
     end
@@ -164,7 +164,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       invalid_user = insert(:user)
 
       assert conn
-             |> add_access_token(invalid_user)
+             |> add_access_token(invalid_user, ~w(private))
              |> delete("/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
              |> response(404)
     end

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -19,7 +19,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
     test "returns list of sources for given user", %{conn: conn, user: user, sources: sources} do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> get("/api/sources")
         |> json_response(200)
 
@@ -34,7 +34,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
     test "returns single sources for given user", %{conn: conn, user: user, sources: [source | _]} do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> get("/api/sources/#{source.token}")
         |> json_response(200)
 
@@ -45,7 +45,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, "private")
       |> get("/api/sources/#{source.token}")
       |> response(404)
     end
@@ -57,7 +57,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/sources", %{name: name})
         |> json_response(201)
 
@@ -67,7 +67,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
     test "returns 422 on missing arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/sources")
         |> json_response(422)
 
@@ -77,7 +77,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/sources", %{name: 123})
         |> json_response(422)
 
@@ -95,7 +95,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> patch("/api/sources/#{source.token}", %{name: name})
         |> json_response(204)
 
@@ -106,7 +106,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, "private")
       |> patch("/api/sources/#{source.token}", %{name: TestUtils.random_string()})
       |> response(404)
     end
@@ -114,7 +114,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
     test "returns 422 on bar arguments", %{conn: conn, user: user, sources: [source | _]} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> patch("/api/sources/#{source.token}", %{name: 123})
         |> json_response(422)
 
@@ -131,12 +131,12 @@ defmodule LogflareWeb.Api.SourceControllerTest do
       name = TestUtils.random_string()
 
       assert conn
-             |> add_access_token(user)
+             |> add_access_token(user, "private")
              |> delete("/api/sources/#{source.token}", %{name: name})
              |> response(204)
 
       assert conn
-             |> add_access_token(user)
+             |> add_access_token(user, "private")
              |> get("/api/sources/#{source.token}")
              |> response(404)
     end
@@ -148,7 +148,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
       invalid_user = insert(:user)
 
       assert conn
-             |> add_access_token(invalid_user)
+             |> add_access_token(invalid_user, "private")
              |> delete("/api/sources/#{source.token}", %{name: TestUtils.random_string()})
              |> response(404)
     end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -29,7 +29,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     } do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> get("/api/teams")
         |> json_response(200)
 
@@ -46,7 +46,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     } do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> get("/api/teams/#{token}")
         |> json_response(200)
 
@@ -60,7 +60,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     } do
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> get("/api/teams/#{non_owner_team.token}")
         |> json_response(200)
 
@@ -75,12 +75,12 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, "private")
       |> get("/api/teams/#{main_team.token}")
       |> response(404)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, "private")
       |> get("/api/teams/#{non_owner_team.token}")
       |> response(404)
     end
@@ -93,7 +93,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/teams", %{name: name})
         |> json_response(201)
 
@@ -103,7 +103,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/teams", %{name: 123})
         |> json_response(422)
 
@@ -113,7 +113,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     test "returns 422 on missing arguments", %{conn: conn, user: user} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> post("/api/teams")
         |> json_response(422)
 
@@ -131,7 +131,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
 
       response =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> patch("/api/teams/#{main_team.token}", %{name: name})
         |> json_response(204)
 
@@ -142,7 +142,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       invalid_user = insert(:user)
 
       conn
-      |> add_access_token(invalid_user)
+      |> add_access_token(invalid_user, "private")
       |> patch("/api/teams/#{main_team.token}", %{name: TestUtils.random_string()})
       |> response(404)
     end
@@ -150,7 +150,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     test "returns 422 on bad arguments", %{conn: conn, user: user, main_team: main_team} do
       resp =
         conn
-        |> add_access_token(user)
+        |> add_access_token(user, "private")
         |> patch("/api/teams/#{main_team.token}", %{name: 123})
         |> json_response(422)
 
@@ -165,7 +165,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       main_team: main_team
     } do
       assert conn
-             |> add_access_token(user)
+             |> add_access_token(user, "private")
              |> delete("/api/teams/#{main_team.token}")
              |> response(204)
     end
@@ -174,7 +174,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       invalid_user = insert(:user)
 
       assert conn
-             |> add_access_token(invalid_user)
+             |> add_access_token(invalid_user, "private")
              |> delete("/api/teams/#{main_team.token}")
              |> response(404)
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -56,11 +56,11 @@ defmodule LogflareWeb.ConnCase do
       end
 
       # for api use
-      def add_access_token(conn, user) do
-        {:ok, access_token} = Logflare.Auth.create_access_token(user)
+      def add_access_token(conn, user, scopes \\ ~w(public)) do
+        scopes = if is_list(scopes), do: Enum.join(scopes, " "), else: scopes
+        {:ok, access_token} = Logflare.Auth.create_access_token(user, %{scopes: scopes})
 
-        conn
-        |> put_req_header("authorization", "Bearer #{access_token.token}")
+        put_req_header(conn, "authorization", "Bearer #{access_token.token}")
       end
     end
   end


### PR DESCRIPTION
Moves management api auth checking to common `VerifyApiAccess` plug, which will be the defacto api verification plug.

relies on #1392 