### PR TITLE
(fix) Docker environment wasn't properly handlign docker hostname

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -1,6 +1,6 @@
 PHX_STATIC_PATH=/opt/app/rel/logflare/bin/priv/static
 DB_DATABASE=logflare_docker
-DB_HOSTNAME=localhost
+DB_HOSTNAME=db
 DB_PORT=5432
 DB_PASSWORD=postgres
 DB_USERNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
+      POSTGRES_DB: logflare_docker
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
The way we have our settings setup wouldn't work due to a bad hostname and a bad database name.