### PR TITLE
(fix) Avoid missing event_message to fully break the UI

### DIFF
--- a/lib/logflare_web/live/search_live/templates/logs_list.html.leex
+++ b/lib/logflare_web/live/search_live/templates/logs_list.html.leex
@@ -6,18 +6,20 @@
     <% else %>
       <div id="logs-list" class="list-unstyled console-text-list">
         <%= for log <- @search_op_log_events.rows do %>
-          <li id="log-event_<%= log.id || log.body["timestamp"] %>">
-            <% %{"timestamp"=> timestamp, "event_message"=> message} = log.body %>
-            <%= if @use_local_time do %>
-              <mark class="log-datestamp" data-timestamp="<%= timestamp %>"> <%= format_timestamp(timestamp, @user_local_timezone) %></mark>
-            <% else %>
-              <mark class="log-datestamp" data-timestamp="<%= timestamp %>"> <%= format_timestamp(timestamp) <> " UTC"%></mark>
-            <% end %>
-            <%= message %>
-            <%= live_modal_show_link(component: LogflareWeb.Search.LogEventViewerComponent, modal_id: :log_event_viewer, title: "Log Event", phx_value_log_event_id: log.id, phx_value_log_event_timestamp: log.body["timestamp"]) do %>
-              <span>event body</span>
-            <% end %>
-          </li>
+          <%= if Map.has_key?(log.body, "event_message") do  %> <!-- TODO: TO BE DELETED WHEN UNDERLYING ISSUE IS FOUND -->
+            <li id="log-event_<%= log.id || log.body["timestamp"] %>">
+              <% %{"timestamp"=> timestamp, "event_message"=> message} = log.body %>
+              <%= if @use_local_time do %>
+                <mark class="log-datestamp" data-timestamp="<%= timestamp %>"> <%= format_timestamp(timestamp, @user_local_timezone) %></mark>
+              <% else %>
+                <mark class="log-datestamp" data-timestamp="<%= timestamp %>"> <%= format_timestamp(timestamp) <> " UTC"%></mark>
+              <% end %>
+              <%= message %>
+              <%= live_modal_show_link(component: LogflareWeb.Search.LogEventViewerComponent, modal_id: :log_event_viewer, title: "Log Event", phx_value_log_event_id: log.id, phx_value_log_event_timestamp: log.body["timestamp"]) do %>
+                <span>event body</span>
+              <% end %>
+            </li>
+          <% end %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
Some logs seem to be missing the event_message key making the UI break with a non-matching error.

This will avoid the UI breaking but does not fix the underlying issue.