### PR TITLE
feat: query endpoints by name

### DIFF
--- a/lib/logflare_web/controllers/plugs/verify_resource_ownership.ex
+++ b/lib/logflare_web/controllers/plugs/verify_resource_ownership.ex
@@ -11,23 +11,24 @@ defmodule LogflareWeb.Plugs.VerifyResourceOwnership do
   alias LogflareWeb.Api.FallbackController
   def init(_opts), do: nil
 
-  # no user set. (handles endpoints with no auth)
-  def call(%{assigns: assigns} = conn, _opts) when is_map_key(assigns, :user) == false, do: conn
+  def call(%{assigns: %{endpoint: %Query{enable_auth: false}}} = conn, _opts) do
+    conn
+  end
 
   # check source
   def call(%{assigns: %{user: %User{id: id}, source: %Source{user_id: user_id}}} = conn, _opts)
-      when id == user_id,
-      do: conn
+      when id == user_id do
+    conn
+  end
 
   # check endpoint
   def call(%{assigns: %{user: %User{id: id}, endpoint: %Query{user_id: user_id}}} = conn, _opts)
-      when id == user_id,
-      do: conn
+      when id == user_id do
+    conn
+  end
 
   # halts all others
-  def call(%{assigns: assigns} = conn, _)
-      when is_map_key(assigns, :source) or is_map_key(assigns, :endpoint) do
-    # halt all unmatching
+  def call(%{assigns: assigns} = conn, _) when is_map_key(assigns, :resource_type) do
     FallbackController.call(conn, {:error, :unauthorized})
   end
 

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -61,8 +61,8 @@ defmodule LogflareWeb.Router do
   end
 
   pipeline :require_endpoint_auth do
-    plug(LogflareWeb.Plugs.FetchResource)
     plug(LogflareWeb.Plugs.VerifyApiAccess, scopes: ~w(public))
+    plug(LogflareWeb.Plugs.FetchResource)
     plug(LogflareWeb.Plugs.VerifyResourceOwnership)
   end
 
@@ -388,6 +388,7 @@ defmodule LogflareWeb.Router do
   scope "/api/endpoints", LogflareWeb, assigns: %{resource_type: :endpoint} do
     pipe_through([:api, :require_endpoint_auth])
     get("/query/:token", EndpointsController, :query)
+    get("/query/name/:name", EndpointsController, :query)
   end
 
   # legacy route

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -50,6 +50,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
 
       assert [%{"event_message" => "some event message"}] = json_response(conn, 200)["result"]
       assert conn.halted == false
+
+      # should be able to query with endpoint name
+      conn =
+        init_conn
+        |> put_req_header("x-api-key", user.api_key)
+        |> get("/api/endpoints/query/name/#{endpoint.name}")
+
+      assert [%{"event_message" => "some event message"}] = json_response(conn, 200)["result"]
+      assert conn.halted == false
     end
 
     test "GET query with other user's api key", %{conn: init_conn, user: user} do

--- a/test/logflare_web/plugs/verify_api_access_test.exs
+++ b/test/logflare_web/plugs/verify_api_access_test.exs
@@ -138,12 +138,12 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
     setup %{endpoint_open: endpoint} do
       conn =
         build_conn(:get, "/endpoints/query/#{endpoint.token}", %{"token" => endpoint.token})
-        |> assign(:endpoint, endpoint)
+        |> assign(:resource_type, :endpoint)
 
       {:ok, conn: conn}
     end
 
-    test "does not halt request", %{conn: conn} do
+    test "does not halt request if resource type is specified", %{conn: conn} do
       conn = VerifyApiAccess.call(conn, %{})
       assert conn.halted == false
       assert Map.get(conn.assigns, :user) == nil

--- a/test/logflare_web/plugs/verify_resource_ownership_test.exs
+++ b/test/logflare_web/plugs/verify_resource_ownership_test.exs
@@ -5,7 +5,7 @@ defmodule LogflareWeb.Plugs.VerifyResourceOwnershipTest do
 
   setup do
     user = insert(:user)
-    endpoint = insert(:endpoint, user: user)
+    endpoint = insert(:endpoint, user: user, enable_auth: true)
     source = insert(:source, user: user)
     {:ok, user: user, source: source, endpoint: endpoint}
   end
@@ -16,15 +16,13 @@ defmodule LogflareWeb.Plugs.VerifyResourceOwnershipTest do
         build_conn(:post, "/logs", %{"source" => Atom.to_string(source.token)})
         |> assign(:user, user)
         |> assign(:source, source)
+        |> assign(:resource_type, :source)
 
       [conn: conn]
     end
 
     test "valid", %{conn: conn} do
-      conn =
-        conn
-        |> assign(:resource_type, :source)
-        |> VerifyResourceOwnership.call(%{})
+      conn = VerifyResourceOwnership.call(conn, %{})
 
       refute conn.halted
     end
@@ -45,6 +43,7 @@ defmodule LogflareWeb.Plugs.VerifyResourceOwnershipTest do
       conn =
         build_conn(:get, "/endpoints/query/#{endpoint.token}", %{"token" => endpoint.token})
         |> assign(:user, user)
+        |> assign(:resource_type, :endpoint)
         |> assign(:endpoint, endpoint)
 
       [conn: conn]


### PR DESCRIPTION
adds a new api route `/api/endpoints/query/name/:name` for an endpoint by name. Requires an api key to be provided, and does not apply to endpoints where auth is disabled `enable_auth=false`