### PR TITLE
chore: expose more ports for cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,11 @@ RUN cp -r /opt/app/rel/logflare/bin/priv/static /opt/app/rel/logflare/lib/logfla
 RUN rm -r /opt/app/rel/logflare/bin/priv
 
 WORKDIR /opt/app/rel/logflare/bin
+
+# expose specific ports, because for some reason
+# when using docker api with supabase-cli, port bindings don't work without exposing them first
+EXPOSE 4000
+EXPOSE 4002
+
 COPY run.sh ./run.sh
 CMD ["sh", "run.sh"]


### PR DESCRIPTION
for cli testing

Replication:
1. build local docker image using `docker-compose build` without the ports exposed.
2. add the following line to the cli logflare service startup [here](https://github.com/supabase/cli/commit/573f69c7baa04bcdb3b11ce42c807ec53ec40850)
```
PortBindings:  nat.PortMap{"4002/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(4002, 10)}}},
```
3. Run the cli `INTERNAL_IMAGE_REGISTRY=docker.io go run . start`
4. Verify that there is no port mapping `docker-compose ps`. The supposedly exposed port will also not be available on localhost `https://localhost:4002`
5. Repeat steps 1-4 with the expose ports, and it will now bind.

On a separate note, it seems like all images that ports via the cli have an `EXPOSE` in their dockerfiles. Might be an issue with the docker api.