### PR TITLE
fix: remove alter user from migrations, shift it to conditional scope.

### DIFF
--- a/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
+++ b/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
@@ -24,9 +24,8 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
   def up do
     if @env in [:dev, :test] do
       execute("ALTER SYSTEM SET wal_level = 'logical';")
+      execute("ALTER USER #{@username} WITH REPLICATION;")
     end
-
-    execute("ALTER USER #{@username} WITH REPLICATION;")
 
     for p <- @publications, do: execute("CREATE PUBLICATION #{p} FOR ALL TABLES;")
 
@@ -41,12 +40,11 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
       execute("SELECT pg_drop_replication_slot('#{@slot}');")
     end
 
-    execute("ALTER USER #{@username} WITH NOREPLICATION;")
-
     # This is happening in `20210810182003_set_rules_to_replica_identity_full.exs`
     # execute("alter table rules replica identity default")
 
     if @env in [:dev, :test] do
+      execute("ALTER USER #{@username} WITH NOREPLICATION;")
       execute("ALTER SYSTEM RESET wal_level;")
     end
   end

--- a/priv/setup.sql
+++ b/priv/setup.sql
@@ -1,2 +1,9 @@
-ALTER SYSTEM SET wal_level = 'logical'; -- for wal
-create schema if not exists analytics; -- for custom schema, cli integration
+-- for wal
+ALTER SYSTEM SET wal_level = 'logical'; 
+
+-- allow user access to replication
+-- originally from priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
+ALTER USER postgres WITH REPLICATION;
+
+ -- create a custom db schema, mainly for testing cli integration
+create schema if not exists analytics;


### PR DESCRIPTION
Fixes migration error integrating on cli, due to change in role not permitted. Moving this to external schema setup.

Originally discussed [here](https://supabase.slack.com/archives/C01KSDNKNCW/p1679814598657469) during cli team sync.

In any case, as the username used for the migration is only at compile time, this change would not have a material effect when using a different pg username, and should actually be executed separately by the self-hoster.