### PR TITLE
fix: use dataset_id_append instead of env for sql query

### DIFF
--- a/lib/logflare/sql_v2.ex
+++ b/lib/logflare/sql_v2.ex
@@ -55,8 +55,7 @@ defmodule Logflare.SqlV2 do
 
     dataset_id =
       if is_nil(dataset_id) do
-        env = Application.get_env(:logflare, :env)
-        "#{user.id}_#{env}"
+        User.generate_bq_dataset_id(user)
       else
         dataset_id
       end


### PR DESCRIPTION
SqlV2 module was building dataset id append using env instead of the correct config