### PR TITLE
chore: job-specific permissions for mirror action

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -71,6 +71,10 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
   mirror_image:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     needs:
       - publish_version
     # Mirror image only if new version is published


### PR DESCRIPTION
permissions fix for mirroring docker image

fix for this error: https://github.com/Logflare/logflare/actions/runs/4545211587/workflow

```
 The nested job 'mirror' is requesting 'packages: write, id-token: write', but is only allowed 'packages: none, id-token: none'.
```