### PR TITLE
(fix) Change mirror action to have proper permissions

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,7 +12,9 @@ on:
         description: "Image tag"
         required: true
         type: string
-
+permissions:
+  packages: write
+  id-token: write
 jobs:
   mirror:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Change the permissions from the GH action to add package write and id-token write.

https://github.com/Logflare/logflare/pull/1423