### PR TITLE
(fix) Moves permission request to parent workflow

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   publish_latest:


### PR DESCRIPTION
Moves permissions request to parent workflow so mirror and docker ci can use this higher permissions token

https://github.com/Logflare/logflare/actions/runs/4554988706