### PR TITLE
chore: remove jar copying from cloudbulid

### DIFF
--- a/cloudbuild/staging/cloudbuild.yaml
+++ b/cloudbuild/staging/cloudbuild.yaml
@@ -17,14 +17,6 @@ steps:
       - --location=us-central1
       - --keyring=logflare-keyring-us-central1
       - --key=logflare-secrets-key
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    args:
-      [
-        "gsutil",
-        "cp",
-        "gs://logflare-build-support/gudusoft.gsqlparser-2.5.2.5.jar",
-        "sql/gsp/gudusoft.gsqlparser-2.5.2.5.jar",
-      ]
   - name: "gcr.io/cloud-builders/docker"
     args:
       [


### PR DESCRIPTION
removes old jar copying from previous parser