### PR TITLE
fix: cut down schema update wait time by making init_table async

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -12,6 +12,7 @@ defmodule Logflare.Application do
     ContextCache,
     SourceSchemas
   }
+  alias Logflare.Utils.Tasks
 
   alias Logflare.SingleTenant
 
@@ -184,8 +185,9 @@ defmodule Logflare.Application do
       if SingleTenant.supabase_mode?() do
         SingleTenant.create_supabase_sources()
         SingleTenant.create_supabase_endpoints()
-        # wait for all sources to init and create tables, takes really long
-        :timer.sleep(15_000)
+        # buffer time for all sources to init and create tables
+        # in case of latency.
+        :timer.sleep(3_000)
         SingleTenant.update_supabase_source_schemas()
       end
     end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -194,7 +194,7 @@ defmodule Logflare.SingleTenant do
         for source <- sources do
           Task.async(fn ->
             source = Sources.refresh_source_metrics_for_ingest(source)
-            Logger.debug("Ingesting sample logs for #{source.name}")
+            Logger.debug("Updating schemas for for #{source.name}")
             event = read_ingest_sample_json(source.name)
             log_event = LogEvent.make(event, %{source: source})
             Schema.update(source.token, log_event)


### PR DESCRIPTION
Drops init wait time by around 10s by making BQ table initialization async. Kept a 3s buffer wait time in case of user latency issues or slow compute. In my local testing, 2s worked fine, but will leave it in to minimize race conditions.

