### PR TITLE
chore: add self-hosted label for docker building workflows

### DIFF
--- a/.github/workflows/arm-docker-latest-push.yml
+++ b/.github/workflows/arm-docker-latest-push.yml
@@ -2,7 +2,7 @@
 # The platforms tag in the steps using docker/build-push-action@v3 will be moved to .github/workflows/docker-ci.yml
 
 name: Build Latest ARM Docker Image
-
+runs-on: [self-hosted]
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/arm-docker-versioned-push.yml
+++ b/.github/workflows/arm-docker-versioned-push.yml
@@ -2,6 +2,7 @@
 # The platforms tag in the steps using docker/build-push-action@v3 will be moved to .github/workflows/docker-ci.yml
 
 name: Build Versioned ARM Docker Image
+runs-on: [self-hosted]
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,5 @@
 name: Docker CI
+runs-on: [self-hosted]
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
So that our docker builds run on self-hosted infra for faster builds. Still retaining current build steps for now.