### PR TITLE
chore: rename MY_NODE_IP, make it optional with default value.

### DIFF
--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -172,3 +172,9 @@ This ENV variable sets the search path to a custom database schema. This allows 
 > string, defualts to `info`. Options: `error|warn|info|debug`
 
 Allows the setting of the log level at runtime. For production settings, we advise `warn`.
+
+### `LOGFLARE_NODE_HOST`
+
+> string, defaults to `127.0.0.1`
+
+Sets the node's host on startup. The nodes name will be set as `logflare@<host>` where `host` is determined by this environment variable.

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -15,4 +15,4 @@
 # export RELEASE_DISTRIBUTION=name
 # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@$MY_POD_IP
+export RELEASE_NODE=<%= @release.name %>@${$LOGFLARE_NODE_HOST-127.0.0.1}

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ then
 
     sysctl -w net.ipv4.tcp_keepalive_time=60 net.ipv4.tcp_keepalive_intvl=60 net.ipv4.tcp_keepalive_probes=5
 
-    export MY_POD_IP=$(curl \
+    export LOGFLARE_NODE_HOST=$(curl \
         -s "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip" \
         -H "Metadata-Flavor: Google")
 


### PR DESCRIPTION
Removes `MY_NODE_IP` as a required environment variable. Defaults it to `127.0.0.1` in the release shell script.