### PR TITLE
fix: Cloudbuild script

### DIFF
--- a/cloudbuild/prod/cloudbuild.yaml
+++ b/cloudbuild/prod/cloudbuild.yaml
@@ -3,34 +3,44 @@ steps:
     args:
       - kms
       - decrypt
-      - --ciphertext-file=gcloud_prod.json.enc
-      - --plaintext-file=gcloud.json
-      - --location=us-central1
-      - --keyring=logflare-prod-keyring-us-central1
-      - --key=logflare-prod-secrets-key
+      - '--ciphertext-file=gcloud_prod.json.enc'
+      - '--plaintext-file=gcloud.json'
+      - '--location=us-central1'
+      - '--keyring=logflare-prod-keyring-us-central1'
+      - '--key=logflare-prod-secrets-key'
   - name: gcr.io/cloud-builders/gcloud
     args:
       - kms
       - decrypt
-      - --ciphertext-file=./.prod.env.enc
-      - --plaintext-file=./.secrets.env
-      - --location=us-central1
-      - --keyring=logflare-prod-keyring-us-central1
-      - --key=logflare-prod-secrets-key
-  - name: "gcr.io/cloud-builders/docker"
-    entrypoint: 'sh'
+      - '--ciphertext-file=./.prod.env.enc'
+      - '--plaintext-file=./.secrets.env'
+      - '--location=us-central1'
+      - '--keyring=logflare-prod-keyring-us-central1'
+      - '--key=logflare-prod-secrets-key'
+  - name: gcr.io/cloud-builders/docker
     args:
-      [
-        "-c", "docker build --build-arg TAG_VERSION=$(cat ./VERSION) -t gcr.io/$PROJECT_ID/logflare_app:$COMMIT_SHA -t gcr.io/$PROJECT_ID/logflare_app:latest -f docker/secret_setup.Dockerfile .",
-      ]
-  - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "gcr.io/$PROJECT_ID/logflare_app:$COMMIT_SHA"]
-  - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "gcr.io/$PROJECT_ID/logflare_app:latest"]
-secrets:
-  - kmsKeyName: projects/logflare-232118/locations/us-central1/keyRings/logflare-prod-secrets-key/cryptoKeys/logflare-prod-secrets-key
+      - '-c'
+      - >-
+        docker build --build-arg $$MAGIC_COOKIE --build-arg TAG_VERSION=$(cat ./VERSION) -t gcr.io/$PROJECT_ID/logflare_app:$COMMIT_SHA -t
+        gcr.io/$PROJECT_ID/logflare_app:latest -f docker/secret_setup.Dockerfile
+        .
+    entrypoint: sh
     secretEnv:
-      MAGIC_COOKIE: "CiQAaKkB6bwW6k2L9NxnoxLiSerCpIeLBGlN54tyvdAtGmTqBeISSQA/IRNwMsuZjfo6o1os4UkkFYG3eJzzxp6hDWbI+6El6HxSZLWLDy3ousxpSU8hip3hLypJ9aSjOLlj4zrnXFxS6qzwLA3/pEE="
-options:
-  machineType: "N1_HIGHCPU_32"
+      - MAGIC_COOKIE
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - 'gcr.io/$PROJECT_ID/logflare_app:$COMMIT_SHA'
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - 'gcr.io/$PROJECT_ID/logflare_app:latest'
 timeout: 1800s
+options:
+  machineType: N1_HIGHCPU_32
+secrets:
+  - kmsKeyName: >-
+      projects/logflare-232118/locations/us-central1/keyRings/logflare-prod-secrets-key/cryptoKeys/logflare-prod-secrets-key
+    secretEnv:
+      MAGIC_COOKIE: >-
+        CiQAaKkB6bwW6k2L9NxnoxLiSerCpIeLBGlN54tyvdAtGmTqBeISSQA/IRNwMsuZjfo6o1os4UkkFYG3eJzzxp6hDWbI+6El6HxSZLWLDy3ousxpSU8hip3hLypJ9aSjOLlj4zrnXFxS6qzwLA3/pEE=

--- a/docker/secret_setup.Dockerfile
+++ b/docker/secret_setup.Dockerfile
@@ -1,3 +1,4 @@
+ARG TAG_VERSION
 FROM supabase/logflare:${TAG_VERSION}
 
 RUN apk add tini


### PR DESCRIPTION
Currently we're still using the inline trigger instead of the file to build the final docker image.

This will allow us to use the file in our repo vs inlined