### PR TITLE
fix: access tokens path scope

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -155,6 +155,7 @@ defmodule LogflareWeb.Router do
   scope "/", LogflareWeb do
     pipe_through([:browser, :require_auth])
     get("/dashboard", SourceController, :dashboard)
+    live("/access-tokens", AccessTokensLive, :index)
   end
 
   scope "/endpoints", LogflareWeb do
@@ -235,6 +236,7 @@ defmodule LogflareWeb.Router do
     get("/", TeamUserController, :change_team)
   end
 
+
   scope "/account", LogflareWeb do
     pipe_through([:browser, :require_auth])
 
@@ -249,9 +251,6 @@ defmodule LogflareWeb.Router do
     delete("/", UserController, :delete)
     get("/edit/api-key", UserController, :new_api_key)
     put("/edit/owner", UserController, :change_owner)
-
-    # access token management
-    live("/access-tokens", AccessTokensLive, :index)
   end
 
   scope "/integrations", LogflareWeb do

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -236,7 +236,6 @@ defmodule LogflareWeb.Router do
     get("/", TeamUserController, :change_team)
   end
 
-
   scope "/account", LogflareWeb do
     pipe_through([:browser, :require_auth])
 


### PR DESCRIPTION
Moves allow access to all users

This PR does not add this to the dashboard subnav as of yet, as access tokens do not support ingest routes yet. (need to switch over the plug pipeline).