### PR TITLE
fix - Set Self Hosted to run on Docker CI job

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,5 +1,4 @@
 name: Docker CI
-runs-on: [self-hosted]
 
 on:
   workflow_dispatch:
@@ -12,7 +11,7 @@ permissions:
 jobs:
   publish:
     name: Build and publish amd64 image
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     env:
       PUSH_TO_DOCKER: ${{github.ref == 'refs/heads/staging'}}
     steps:


### PR DESCRIPTION
Properly set the runs-on tag for Docker CI GH job.