### PR TITLE
fix - Revert to non self hosted runners

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   publish:
     name: Build and publish amd64 image
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     env:
       PUSH_TO_DOCKER: ${{github.ref == 'refs/heads/staging'}}
     steps:


### PR DESCRIPTION
Reverted to use non self hosted runners so we can build docker images for release purposes.