### PR TITLE
chore: add erlang to asdf deps.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 elixir 1.14.4-otp-25
 nodejs 18.13.0
 rust 1.64.0
+erlang 25.3.1


### PR DESCRIPTION
Contributors would need to install the correct otp version with:
```bash
asdf install
```

This fixes the deps bump, which now requires otp 25.

