### PR TITLE
fix: sleep for 15 seconds for networking to be ready

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,5 +20,8 @@ then
 
 fi
 
+# wait for networking to be ready before starting Erlang
+sleep 15
+
 ./logflare eval Logflare.Release.migrate
 ./logflare start --sname logflare


### PR DESCRIPTION
Getting `16:49:49.117 [info]  Protocol 'inet_tcp': register/listen error: econnrefused` on boot sometimes which restarts Erlang in a loop a few times and then boots but this blows up the cluster.
