### PR TITLE
fix: update publication migration to not require superuser

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -96,7 +96,15 @@ config :scrivener_html,
 
 config :logflare, Logflare.CacheBuster,
   replication_slot: :temporary,
-  publications: ["logflare_pub"]
+  publications: ["logflare_pub"],
+  publication_tables: [
+    "billing_accounts",
+    "plans",
+    "rules",
+    "source_schemas",
+    "sources",
+    "users"
+  ]
 
 config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.PersistentTermCache
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -97,6 +97,7 @@ config :scrivener_html,
 config :logflare, Logflare.CacheBuster,
   replication_slot: :temporary,
   publications: ["logflare_pub"],
+  # remember to add an ALTER PUBLICATION ... migration when changing published tables!
   publication_tables: [
     "billing_accounts",
     "plans",

--- a/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
+++ b/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
@@ -28,7 +28,7 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
       execute("ALTER USER #{@username} WITH REPLICATION;")
     end
 
-    # execute on specific tables so that we don't need superuser priviledge
+    # execute on specific tables so that we don't need superuser privilege
     # to update the publication in the future, we rerun in another migration ALTER PUBLICATIONS .. FOR TABLE users, sources ...
     for p <- @publications do
       tables = Enum.join(@publication_tables, ", ")


### PR DESCRIPTION
This PR fixes superuser requirement for migrations, which makes it possible to run migrations using a postgres user without superuser privilege.

The DB will still need to have `wal_level = 'logical'` and replication enabled for the user, but that should be executed at db setup and not during migrations.