### PR TITLE
fix: conditionally run grpc server if port is provided

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -207,5 +207,15 @@ config :stripity_stripe,
 
 if config_env() != :test do
   config :goth, json: File.read!("gcloud.json")
-  config :grpc, port: System.get_env("LOGFLARE_GRPC_PORT") |> String.to_integer()
+
+  config :grpc,
+         [
+           port:
+             System.get_env("LOGFLARE_GRPC_PORT")
+             |> then(fn
+               nil -> nil
+               value -> String.to_integer(value)
+             end)
+         ]
+         |> filter_nil_kv_pairs.()
 end


### PR DESCRIPTION
When `LOGFLARE_GRPC_PORT` is not set, it will result in server crash.  This makes the GRPC usage opt-in, and would not crash the standalone image when config is not provided.

runtime.exs parsing error:
<img width="800" alt="Screenshot 2023-05-07 at 7 02 12 PM" src="https://user-images.githubusercontent.com/22714384/236670912-f909553d-13b5-43fa-9ab1-aecf069eea56.png">

application startup error:
<img width="1003" alt="Screenshot 2023-05-07 at 7 02 02 PM" src="https://user-images.githubusercontent.com/22714384/236670928-2b06bfaf-82c6-4d8b-aa2f-b94e8136d4c9.png">
