### PR TITLE
fix - Send grpc trailer headers and change to use streams vs unary requests

### DIFF
--- a/lib/logflare_grpc/opentelemetry/proto/collector/trace/v1/trace_service.pb.ex
+++ b/lib/logflare_grpc/opentelemetry/proto/collector/trace/v1/trace_service.pb.ex
@@ -2,27 +2,29 @@ defmodule Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
-  field :resource_spans, 1,
+  field(:resource_spans, 1,
     repeated: true,
     type: Opentelemetry.Proto.Trace.V1.ResourceSpans,
     json_name: "resourceSpans"
+  )
 end
 
 defmodule Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
-  field :partial_success, 1,
+  field(:partial_success, 1,
     type: Opentelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess,
     json_name: "partialSuccess"
+  )
 end
 
 defmodule Opentelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
-  field :rejected_spans, 1, type: :int64, json_name: "rejectedSpans"
-  field :error_message, 2, type: :string, json_name: "errorMessage"
+  field(:rejected_spans, 1, type: :int64, json_name: "rejectedSpans")
+  field(:error_message, 2, type: :string, json_name: "errorMessage")
 end
 
 defmodule Opentelemetry.Proto.Collector.Trace.V1.TraceService.Service do
@@ -33,8 +35,8 @@ defmodule Opentelemetry.Proto.Collector.Trace.V1.TraceService.Service do
 
   rpc(
     :Export,
-    Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest,
-    Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
+    stream(Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest),
+    stream(Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse)
   )
 end
 


### PR DESCRIPTION
Due to a timeout in staging when fetching trailers from a unary request, we'll implement streams to see if this mitigates the issue.

We'll need to improve error handling also since a failed span insert should return a better error to the consumer.

Note: Generated protobufs do not have streams and that change had to be mad by hand