### PR TITLE
chore: add timeouts for all docker ci build workflows

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   publish:
+    timeout-minutes: 120
     name: Build and publish amd64 and arm64 image
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   publish:
+    timeout-minutes: 120
     name: Build and publish amd64 image
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
So that we don't have hours long actions running without us noticing...