### PR TITLE
chore: exclude ci-related files from elixir ci

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: [staging, master]
+    paths:
+      - '!.github/**'
+      - '!cloudbuild/**'
   pull_request:
     branches: [staging]
 


### PR DESCRIPTION
So that we don't need to run elixir CI on actions changes