### PR TITLE
chore: cancel in-progerss jobs for multi-platform build

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   settings:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This cancels in-progress jobs, so that we don't waste time waiting for multiple jobs to be done when we only need the latest build for staging builds.
should not affect master builds as we do releases separately.