### PR TITLE
fix: fully qualified names cte fixes

### DIFF
--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -22,11 +22,22 @@ defmodule Logflare.TestUtils do
     opts =
       Enum.into(opts, %{
         seed_user: false,
-        supabase_mode: false
+        supabase_mode: false,
+        bigquery_project_id: random_string()
       })
 
     quote do
       setup do
+        # conditionally update bigquery project id
+        initial_google_config = Application.get_env(:logflare, Logflare.Google)
+        replacement_project_id = unquote(opts.bigquery_project_id)
+        updated = Keyword.put(initial_google_config, :project_id, replacement_project_id)
+        Application.put_env(:logflare, Logflare.Google, updated)
+
+        on_exit(fn ->
+          Application.put_env(:logflare, Logflare.Google, initial_google_config)
+        end)
+
         # perform application env adjustments at runtime
         initial_single_tenant = Application.get_env(:logflare, :single_tenant)
         Application.put_env(:logflare, :single_tenant, true)


### PR DESCRIPTION
This fixes the fully qualified naming issue where sources with the same naming pattern as bigquery entities were getting disallowed.

This PR changes the logic and takes a different approach. Instead of explicitly checking for disallowed specific patterns  (i.e. disallow-listing), we reverse the checking logic to allow-list certain patterns and treat everything else as an unknown entity. This makes the logic much easier to read and less prone to bugs, since the allow-list conditions are very clear.

I have added in tests for naming patterns that are similar to the bigquery entity naming pattern to ensure we transform everything correctly.


Included in this PR is also additional tests for single tenant mode and fully-quallified names, ensuring that users that set a global bigquery project will be able to reference entities within that project **ONLY** in single tenant mode. 

