### PR TITLE
fix: oauth2 callback redirect fix

### DIFF
--- a/test/logflare_web/controllers/oauth_controller_tests.exs
+++ b/test/logflare_web/controllers/oauth_controller_tests.exs
@@ -12,4 +12,27 @@ defmodule LogflareWeb.OAuthControllerTests do
       assert get_flash(conn)["error"] =~ "Authentication error"
     end
   end
+
+  test "oauth2 callback redirect work correctly post-sign in", %{conn: conn} do
+    insert(:plan)
+    user = insert(:user)
+    conn = login_user(conn, user)
+
+    search =
+      URI.encode_query(%{
+        scope: "read write",
+        response_type: "code",
+        redirect_uri: "www.cloudflare.com/apps/oauth/",
+        client_id: "my-client-id",
+        # additional app metadata should be forwarded
+        "user.email": "test@logflare.app",
+        "site.name": "test.logflare.app"
+      })
+
+    uri = "/oauth/authorize?#{search}"
+    conn = get(conn, uri, %{})
+    assert html_response(conn, 302)
+    assert get_flash(conn)["error"] == nil
+    assert redirected_to(conn) =~ "www.cloudflare.com"
+  end
 end


### PR DESCRIPTION
This PR adds additional test coverage for the Oauth2 bug when cloudflare app redirects. 

Fix is implemented in our fork of PhoenixOauth2Provider, whose tests does not account for Application level configs.
The conn.private phoenix_view format had changed in Phoenix 1.7 and this had resulted in a breakage in behaviour.

the bugfix as implemented  in [this commit](https://github.com/Logflare/phoenix_oauth2_provider/commit/36e757920e54bffa0f603bf985aff91bb8b28f2d) essentially new pattern match for the new phoenix version, while retaining the old match format for older versions.

We can PR to upstream as well, but upstream seems unmaintained at the moment and it would only affect projects >= phoenix 1.7, which is not supported yet on upstream.


