### PR TITLE
add - Move from SQL to Migrations

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Application do
 
   def start(_type, _args) do
     env = Application.get_env(:logflare, :env)
-
+    ensure_loaded_postgres_backend_migrations()
     # TODO: Set node status in GCP when sigterm is received
     :ok =
       :gen_event.swap_sup_handler(
@@ -60,8 +60,7 @@ defmodule Logflare.Application do
       {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.SourcesSup},
       {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.RecentLogsSup},
       {DynamicSupervisor,
-       strategy: :one_for_one,
-       name: Logflare.Backends.Logflare.Backends.Adaptor.Postgres.Supervisor},
+       strategy: :one_for_one, name: Logflare.Backends.Adaptor.Postgres.Supervisor},
       {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
     ]
@@ -198,5 +197,15 @@ defmodule Logflare.Application do
       :timer.sleep(3_000)
       SingleTenant.update_supabase_source_schemas()
     end
+  end
+
+  defp ensure_loaded_postgres_backend_migrations do
+    # Needed to ensure that the migrations are properly loaded
+    # This was found during tests where the use Ecto.Migration apparently wasn't
+    # loading the migrations properly, triggering errors when running Ecto.Migrator
+
+    # Similar error found in Realtime: https://github.com/supabase/realtime/pull/520/files#diff-1de8846d5d70df4b816a1b2bca51468d6c8386bc81f9efe82df2bf837367497d
+    Logflare.Backends.Adaptor.Postgres.Repo.migrations()
+    |> Enum.map(fn {_, migration} -> Code.ensure_loaded!(migration) end)
   end
 end

--- a/lib/logflare/backends/adaptor/postgres/repo/migrations/add_log_events.ex
+++ b/lib/logflare/backends/adaptor/postgres/repo/migrations/add_log_events.ex
@@ -1,0 +1,16 @@
+defmodule Logflare.Backends.Adaptor.Postgres.Repo.Migrations.AddLogEvents do
+  use Ecto.Migration
+
+  def up do
+    create table(:log_events, primary_key: false) do
+      add(:id, :string, primary_key: true)
+      add(:metadata, :map)
+      add(:event_message, :string)
+      add(:timestamp, :utc_datetime_usec)
+    end
+  end
+
+  def down do
+    drop(table(:log_events))
+  end
+end

--- a/test/logflare/backends/adaptor/postgres/repo_test.exs
+++ b/test/logflare/backends/adaptor/postgres/repo_test.exs
@@ -1,6 +1,8 @@
 defmodule Logflare.Backends.Adaptor.Postgres.RepoTest do
   use Logflare.DataCase, async: false
   alias Logflare.Backends.Adaptor.Postgres.Repo
+  alias Logflare.Backends.Adaptor.Postgres.LogEvent
+  alias Logflare.Backends.Adaptor.Postgres.RepoTest.BadMigration
 
   setup do
     %{username: username, password: password, database: database, hostname: hostname} =
@@ -16,33 +18,59 @@ defmodule Logflare.Backends.Adaptor.Postgres.RepoTest do
 
   describe "new_repository_for_source_backend/1" do
     test "creates a new Ecto.Repo for given source_backend", %{source_backend: source_backend} do
-      repository = Repo.new_repository_for_source_backend(source_backend)
-      assert Keyword.get(repository.__info__(:attributes), :behaviour) == [Ecto.Repo]
+      repository_module = Repo.new_repository_for_source_backend(source_backend)
+      assert Keyword.get(repository_module.__info__(:attributes), :behaviour) == [Ecto.Repo]
     end
 
     test "name of the module uses source_id", %{source_backend: source_backend} do
-      repository = Repo.new_repository_for_source_backend(source_backend)
+      repository_module = Repo.new_repository_for_source_backend(source_backend)
 
-      assert repository ==
+      assert repository_module ==
                Module.concat([Logflare.Repo.Postgres, "Adaptor#{source_backend.source_id}"])
     end
   end
 
   describe "create_log_event_table/1" do
     setup %{source_backend: source_backend} do
-      repository = Repo.new_repository_for_source_backend(source_backend)
-      Repo.connect_to_source_backend(repository, source_backend, pool: Ecto.Adapters.SQL.Sandbox)
-      Ecto.Adapters.SQL.Sandbox.mode(repository, :auto)
+      repository_module = Repo.new_repository_for_source_backend(source_backend)
+
+      Repo.connect_to_source_backend(
+        repository_module,
+        source_backend,
+        pool: Ecto.Adapters.SQL.Sandbox
+      )
+
+      Ecto.Adapters.SQL.Sandbox.mode(repository_module, :auto)
 
       on_exit(fn ->
-        Ecto.Adapters.SQL.query(repository, "DROP TABLE log_events;")
+        Ecto.Migrator.run(repository_module, Repo.migrations(), :down, all: true)
       end)
 
-      %{repository: repository}
+      %{repository_module: repository_module}
     end
 
-    test "creates a new table for log_events in target repository", %{repository: repository} do
-      assert Repo.create_log_event_table(repository) == :ok
+    test "runs migration for the newly created connection", %{
+      repository_module: repository_module
+    } do
+      assert Repo.create_log_event_table(repository_module) == :ok
+      assert repository_module.all(LogEvent)
+    end
+
+    test "handle migration errors", %{repository_module: repository_module} do
+      bad_migration = [{0, BadMigration}]
+
+      assert Repo.create_log_event_table(repository_module, bad_migration) ==
+               {:error, :failed_migration}
+    end
+  end
+
+  defmodule BadMigration do
+    use Ecto.Migration
+
+    def up do
+      alter table(:none) do
+        add(:none, :string)
+      end
     end
   end
 end


### PR DESCRIPTION
To properly support users, we need to migrate whatever changes are needed to support postgres backends

On connection, we will run migrations against the URL provided