### PR TITLE
add - Override magic cookie via env var

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,13 @@ then
 
 fi
 
+if [[ "$OVERRIDE_MAGIC_COOKIE" ]]
+then 
+    echo "OVERRIDE_MAGIC_COOKIE is set, using it..."
+    export MAGIC_COOKIE=$OVERRIDE_MAGIC_COOKIE
+    echo $MAGIC_COOKIE > /tmp/.magic_cookie
+fi
+
 echo "LOGFLARE_NODE_HOST is: $LOGFLARE_NODE_HOST"
 
 ./logflare eval Logflare.Release.migrate


### PR DESCRIPTION
Adds a new env var to be used in instance groups to override the magic cookie env var in the secrets file