### PR TITLE
chore: prevent api requests during tests

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -27,6 +27,12 @@ Mimic.copy(GoogleApi.BigQuery.V2.Api.Datasets)
 Mimic.copy(GoogleApi.CloudResourceManager.V1.Api.Projects)
 Mimic.copy(Goth)
 Mimic.copy(ConfigCat)
+Mimic.copy(Finch)
+
+# stub all outgoing requests
+Mimic.stub(Goth)
+Mimic.stub(Finch)
+
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 {:ok, _} = Application.ensure_all_started(:mimic)
 


### PR DESCRIPTION
Noticed that tests were emitting these errors:
```
01:38:12.079 erl_level=error application=finch domain=elixir file=lib/finch/http2/pool.ex function=disconnected/3 line=233 mfa=Finch.HTTP2.Pool.disconnected/3 module=Finch.HTTP2.Pool pid=<0.5735.0> [error] Failed to connect to https://bigquery.googleapis.com:443: timeout
```
This PR will prevent all outgoing requests using the api clients.