### PR TITLE
add - Suggestion field for sources

### DIFF
--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -124,7 +124,7 @@ defmodule Logflare.Source do
     field(:drop_lql_filters, Ecto.Term, default: [])
     field(:drop_lql_string, :string)
     field(:v2_pipeline, :boolean, default: false)
-    field(:suggested_fields, :string, default: "")
+    field(:suggested_keys, :string, default: "")
     # Causes a shitstorm
     # field :bigquery_schema, Ecto.Term
 
@@ -168,7 +168,7 @@ defmodule Logflare.Source do
       :drop_lql_filters,
       :drop_lql_string,
       :v2_pipeline,
-      :suggested_fields
+      :suggested_keys
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> default_validations(source)
@@ -191,7 +191,7 @@ defmodule Logflare.Source do
       :drop_lql_filters,
       :drop_lql_string,
       :v2_pipeline,
-      :suggested_fields
+      :suggested_keys
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> default_validations(source)

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -48,16 +48,16 @@ defmodule Logflare.Source do
              ]}
 
     typed_embedded_schema do
-      field :rate, :integer
-      field :latest, :integer
-      field :avg, :integer
-      field :max, :integer
-      field :buffer, :integer
-      field :inserts, :integer
-      field :inserts_string, :string
-      field :recent, :integer
-      field :rejected, :integer
-      field :fields, :integer
+      field(:rate, :integer)
+      field(:latest, :integer)
+      field(:avg, :integer)
+      field(:max, :integer)
+      field(:buffer, :integer)
+      field(:inserts, :integer)
+      field(:inserts_string, :string)
+      field(:recent, :integer)
+      field(:rejected, :integer)
+      field(:fields, :integer)
     end
   end
 
@@ -77,13 +77,13 @@ defmodule Logflare.Source do
              ]}
 
     embedded_schema do
-      field :team_user_ids_for_email, {:array, :string}, default: []
-      field :team_user_ids_for_sms, {:array, :string}, default: []
-      field :other_email_notifications, :string
-      field :user_email_notifications, :boolean, default: false
-      field :user_text_notifications, :boolean, default: false
-      field :user_schema_update_notifications, :boolean, default: true
-      field :team_user_ids_for_schema_updates, {:array, :string}, default: []
+      field(:team_user_ids_for_email, {:array, :string}, default: [])
+      field(:team_user_ids_for_sms, {:array, :string}, default: [])
+      field(:other_email_notifications, :string)
+      field(:user_email_notifications, :boolean, default: false)
+      field(:user_text_notifications, :boolean, default: false)
+      field(:user_schema_update_notifications, :boolean, default: true)
+      field(:team_user_ids_for_schema_updates, {:array, :string}, default: [])
     end
 
     def changeset(notifications, attrs) do
@@ -101,43 +101,43 @@ defmodule Logflare.Source do
   end
 
   schema "sources" do
-    field :name, :string
-    field :token, Ecto.UUID.Atom, autogenerate: true
-    field :public_token, :string
-    field :favorite, :boolean, default: false
-    field :bigquery_table_ttl, :integer
-    field :api_quota, :integer, default: @default_source_api_quota
-    field :webhook_notification_url, :string
-    field :slack_hook_url, :string
-    field :metrics, :map, virtual: true
-    field :has_rejected_events, :boolean, default: false, virtual: true
-    field :bq_table_id, :string, virtual: true
-    field :bq_dataset_id, :string, virtual: true
-    field :bq_table_schema, :any, virtual: true
-    field :bq_table_typemap, :any, virtual: true
-    field :bq_table_partition_type, Ecto.Enum, values: [:pseudo, :timestamp], default: :timestamp
-    field :custom_event_message_keys, :string
-    field :log_events_updated_at, :naive_datetime
-    field :notifications_every, :integer, default: :timer.hours(4)
-    field :lock_schema, :boolean, default: false
-    field :validate_schema, :boolean, default: true
-    field :drop_lql_filters, Ecto.Term, default: []
-    field :drop_lql_string, :string
-    field :v2_pipeline, :boolean, default: false
-
+    field(:name, :string)
+    field(:token, Ecto.UUID.Atom, autogenerate: true)
+    field(:public_token, :string)
+    field(:favorite, :boolean, default: false)
+    field(:bigquery_table_ttl, :integer)
+    field(:api_quota, :integer, default: @default_source_api_quota)
+    field(:webhook_notification_url, :string)
+    field(:slack_hook_url, :string)
+    field(:metrics, :map, virtual: true)
+    field(:has_rejected_events, :boolean, default: false, virtual: true)
+    field(:bq_table_id, :string, virtual: true)
+    field(:bq_dataset_id, :string, virtual: true)
+    field(:bq_table_schema, :any, virtual: true)
+    field(:bq_table_typemap, :any, virtual: true)
+    field(:bq_table_partition_type, Ecto.Enum, values: [:pseudo, :timestamp], default: :timestamp)
+    field(:custom_event_message_keys, :string)
+    field(:log_events_updated_at, :naive_datetime)
+    field(:notifications_every, :integer, default: :timer.hours(4))
+    field(:lock_schema, :boolean, default: false)
+    field(:validate_schema, :boolean, default: true)
+    field(:drop_lql_filters, Ecto.Term, default: [])
+    field(:drop_lql_string, :string)
+    field(:v2_pipeline, :boolean, default: false)
+    field(:suggested_fields, :string, default: "")
     # Causes a shitstorm
     # field :bigquery_schema, Ecto.Term
 
-    belongs_to :user, Logflare.User
+    belongs_to(:user, Logflare.User)
 
-    has_many :rules, Logflare.Rule
-    has_many :source_backends, Logflare.Backends.SourceBackend
-    has_many :saved_searches, Logflare.SavedSearch
-    has_many :billing_counts, Logflare.Billing.BillingCount, on_delete: :nothing
+    has_many(:rules, Logflare.Rule)
+    has_many(:source_backends, Logflare.Backends.SourceBackend)
+    has_many(:saved_searches, Logflare.SavedSearch)
+    has_many(:billing_counts, Logflare.Billing.BillingCount, on_delete: :nothing)
 
-    embeds_one :notifications, Notifications, on_replace: :update
+    embeds_one(:notifications, Notifications, on_replace: :update)
 
-    has_one :source_schema, Logflare.SourceSchemas.SourceSchema
+    has_one(:source_schema, Logflare.SourceSchemas.SourceSchema)
 
     timestamps()
   end
@@ -167,7 +167,8 @@ defmodule Logflare.Source do
       :validate_schema,
       :drop_lql_filters,
       :drop_lql_string,
-      :v2_pipeline
+      :v2_pipeline,
+      :suggested_fields
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> default_validations(source)
@@ -189,7 +190,8 @@ defmodule Logflare.Source do
       :validate_schema,
       :drop_lql_filters,
       :drop_lql_string,
-      :v2_pipeline
+      :v2_pipeline,
+      :suggested_fields
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> default_validations(source)

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -243,7 +243,15 @@
   <p>Add a Google Cloud Platform project ID to get started!</p>
   <%= link "Setup custom backend", to: Routes.user_path(@conn, :edit) <> "#bigquery-backend", class: "btn btn-primary form-button", role: "button" %>
   <% end %>
-
+  <%= section_header("Suggested fields") %>
+  <p>Set suggested fields for this source (comma separated) for better query performance</p>
+  <%= form_for @changeset, Routes.source_path(@conn, :update, @source),fn f -> %>
+    <div class="form-group">
+      <%= text_input f, :suggested_fields , class: "form-control form-control-margin" %>
+      <%= error_tag f, :suggested_fields %>
+    </div>
+    <%= submit "Save", class: "btn btn-primary form-button" %>
+  <% end %>
   <%= if LogflareWeb.Utils.flag("multibackend") == true do %>
     <%= section_header("Multi Backends") %>
     <%= form_for @changeset, Routes.source_path(@conn, :update, @source),fn f -> %>

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -243,12 +243,12 @@
   <p>Add a Google Cloud Platform project ID to get started!</p>
   <%= link "Setup custom backend", to: Routes.user_path(@conn, :edit) <> "#bigquery-backend", class: "btn btn-primary form-button", role: "button" %>
   <% end %>
-  <%= section_header("Suggested fields") %>
-  <p>Set suggested fields for this source (comma separated) for better query performance</p>
+  <%= section_header("Suggested search keys") %>
+  <p>Set suggested search keys for this source (comma separated) for better query performance</p>
   <%= form_for @changeset, Routes.source_path(@conn, :update, @source),fn f -> %>
     <div class="form-group">
-      <%= text_input f, :suggested_fields , class: "form-control form-control-margin" %>
-      <%= error_tag f, :suggested_fields %>
+      <%= text_input f, :suggested_keys , class: "form-control form-control-margin" %>
+      <%= error_tag f, :suggested_keys %>
     </div>
     <%= submit "Save", class: "btn btn-primary form-button" %>
   <% end %>

--- a/priv/repo/migrations/20230622160150_add_suggested_fields_to_sources.exs
+++ b/priv/repo/migrations/20230622160150_add_suggested_fields_to_sources.exs
@@ -3,7 +3,7 @@ defmodule Logflare.Repo.Migrations.AddSuggestedFieldsToSources do
 
   def change do
     alter table(:sources) do
-      add(:suggested_fields, :string)
+      add(:suggested_keys, :string)
     end
   end
 end

--- a/priv/repo/migrations/20230622160150_add_suggested_fields_to_sources.exs
+++ b/priv/repo/migrations/20230622160150_add_suggested_fields_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddSuggestedFieldsToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add(:suggested_fields, :string)
+    end
+  end
+end

--- a/priv/repo/migrations/20230622160250_set_suggested_fields_default.exs
+++ b/priv/repo/migrations/20230622160250_set_suggested_fields_default.exs
@@ -3,7 +3,7 @@ defmodule Logflare.Repo.Migrations.SetSuggestedFieldsDefault do
 
   def change do
     alter table(:sources) do
-      modify(:suggested_fields, :string, default: "")
+      modify(:suggested_keys, :string, default: "")
     end
   end
 end

--- a/priv/repo/migrations/20230622160250_set_suggested_fields_default.exs
+++ b/priv/repo/migrations/20230622160250_set_suggested_fields_default.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.SetSuggestedFieldsDefault do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      modify(:suggested_fields, :string, default: "")
+    end
+  end
+end

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -402,7 +402,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
   describe "source suggestion fields handling" do
     setup do
       user = insert(:user)
-      source = insert(:source, user: user, suggested_fields: "event_message")
+      source = insert(:source, user: user, suggested_keys: "event_message")
       source_without_suggestion = insert(:source, user: user)
       plan = insert(:plan)
 
@@ -439,10 +439,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
              |> Floki.find("a")
              |> Floki.attribute("href")
              |> hd ==
-               "/sources/#{source.id}/search?force=true&querystring=c%3Acount%28%2A%29+c%3Agroup_by%28t%3A%3Aminute%29"
+               "/sources/#{source.id}/search?force=true&tailing%3F=true&loading=true&chart_loading=true&querystring=c%3Acount%28%2A%29+c%3Agroup_by%28t%3A%3Aminute%29"
 
       assert Floki.text(content) ==
-               "\nQuery does not include suggested fields, perfomance will be degraded. Do you want to proceed? Click to force query"
+               "\nQuery does not include suggested keys, perfomance will be degraded. Do you want to proceed? Click to force query"
     end
 
     test "on source with suggestion fields, does not create a flash when query includes field", %{


### PR DESCRIPTION
Suggestion fields can now be added to sources so users can define which fields are suggested to achieve the best performance.

This can be bypassed if the user desires.
<img width="958" alt="Screenshot 2023-06-22 at 23 53 35" src="https://github.com/Logflare/logflare/assets/1697301/36622b52-bd41-47f5-ba8e-7f73d55086f1">
<img width="958" alt="Screenshot 2023-06-22 at 23 52 53" src="https://github.com/Logflare/logflare/assets/1697301/8885ae59-d1f4-4e0f-8e6c-8998488d7168">
