### PR TITLE
Fix/supabase sources ensure source started on create

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -185,6 +185,7 @@ defmodule Logflare.Application do
     if SingleTenant.supabase_mode?() do
       SingleTenant.create_supabase_sources()
       SingleTenant.create_supabase_endpoints()
+      SingleTenant.ensure_supabase_sources_started()
       # buffer time for all sources to init and create tables
       # in case of latency.
       :timer.sleep(3_000)

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -154,7 +154,6 @@ defmodule Logflare.SingleTenant do
     end
   end
 
-
   @doc """
   Starts supabase sources if present.
   Note: not tested as `Logflare.Source.Supervisor` is a pain to mock.
@@ -163,9 +162,11 @@ defmodule Logflare.SingleTenant do
   @spec ensure_supabase_sources_started() :: :ok
   def ensure_supabase_sources_started do
     user = get_default_user()
-    for source <-  Sources.list_sources_by_user(user) do
+
+    for source <- Sources.list_sources_by_user(user) do
       Supervisor.ensure_started(source.token)
     end
+
     :ok
   end
 
@@ -178,12 +179,13 @@ defmodule Logflare.SingleTenant do
   @spec list_supabase_sources_pids() :: [pid()]
   def list_supabase_sources_pids do
     user = get_default_user()
-    for source <-  Sources.list_sources_by_user(user),
-    pid = Process.whereis(source.token), is_pid(pid) do
+
+    for source <- Sources.list_sources_by_user(user),
+        pid = Process.whereis(source.token),
+        is_pid(pid) do
       pid
     end
   end
-
 
   @doc """
   Inserts supabase endpoints via SQL files under priv/supabase.any()
@@ -265,7 +267,8 @@ defmodule Logflare.SingleTenant do
 
     source_schemas_updated = if supabase_mode_source_schemas_updated?(), do: :ok
 
-    sources_sup_running = if (list_supabase_sources_pids() |> length()) > 0, do: :ok
+    sources_sup_running = if list_supabase_sources_pids() |> length() > 0, do: :ok
+
     %{
       seed_user: seed_user,
       seed_plan: seed_plan,
@@ -301,6 +304,4 @@ defmodule Logflare.SingleTenant do
     |> File.read!()
     |> Jason.decode!()
   end
-
-
 end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -172,24 +172,6 @@ defmodule Logflare.SingleTenant do
     :ok
   end
 
-  # Lists supabase sources pids if processes have been started
-  # Note: not tested as `Logflare.Source.Supervisor` is a pain to mock.
-  # TODO: add testing for v2
-  @spec list_supabase_sources_pids() :: [pid()]
-  defp list_supabase_sources_pids do
-    user = get_default_user()
-
-    if user do
-      for source <- Sources.list_sources_by_user(user),
-          pid = Process.whereis(source.token),
-          is_pid(pid) do
-        pid
-      end
-    else
-      []
-    end
-  end
-
   @doc """
   Inserts supabase endpoints via SQL files under priv/supabase.any()
   These SQL scripts are directly exported from logflare prod.

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -273,13 +273,12 @@ defmodule Logflare.SingleTenant do
 
     source_schemas_updated = if supabase_mode_source_schemas_updated?(), do: :ok
 
-
     %{
       seed_user: seed_user,
       seed_plan: seed_plan,
       seed_sources: seed_sources,
       seed_endpoints: seed_endpoints,
-      source_schemas_updated: source_schemas_updated,
+      source_schemas_updated: source_schemas_updated
     }
   end
 

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -172,14 +172,11 @@ defmodule Logflare.SingleTenant do
     :ok
   end
 
-  @doc """
-  Lists supabase sources pids if processes have been started
-
-  Note: not tested as `Logflare.Source.Supervisor` is a pain to mock.
-  TODO: add testing for v2
-  """
+  # Lists supabase sources pids if processes have been started
+  # Note: not tested as `Logflare.Source.Supervisor` is a pain to mock.
+  # TODO: add testing for v2
   @spec list_supabase_sources_pids() :: [pid()]
-  def list_supabase_sources_pids do
+  defp list_supabase_sources_pids do
     user = get_default_user()
 
     if user do

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -163,8 +163,10 @@ defmodule Logflare.SingleTenant do
   def ensure_supabase_sources_started do
     user = get_default_user()
 
-    for source <- Sources.list_sources_by_user(user) do
-      Supervisor.ensure_started(source.token)
+    if user do
+      for source <- Sources.list_sources_by_user(user) do
+        Supervisor.ensure_started(source.token)
+      end
     end
 
     :ok
@@ -180,10 +182,14 @@ defmodule Logflare.SingleTenant do
   def list_supabase_sources_pids do
     user = get_default_user()
 
-    for source <- Sources.list_sources_by_user(user),
-        pid = Process.whereis(source.token),
-        is_pid(pid) do
-      pid
+    if user do
+      for source <- Sources.list_sources_by_user(user),
+          pid = Process.whereis(source.token),
+          is_pid(pid) do
+        pid
+      end
+    else
+      []
     end
   end
 
@@ -267,7 +273,6 @@ defmodule Logflare.SingleTenant do
 
     source_schemas_updated = if supabase_mode_source_schemas_updated?(), do: :ok
 
-    sources_sup_running = if list_supabase_sources_pids() |> length() > 0, do: :ok
 
     %{
       seed_user: seed_user,
@@ -275,7 +280,6 @@ defmodule Logflare.SingleTenant do
       seed_sources: seed_sources,
       seed_endpoints: seed_endpoints,
       source_schemas_updated: source_schemas_updated,
-      sources_sup_running: sources_sup_running
     }
   end
 


### PR DESCRIPTION
fix for https://github.com/supabase/cli/issues/1177 , handles startup of RLS processes for v1 ingest for when supabase sources are already inserted from a backup.

[ticket](https://www.notion.so/supabase/bug-logflare-supabase-mode-startup-does-not-start-source-processes-if-source-already-exists-609e66b4c4b340fc8c1ff62dfb7eb72d?pvs=4)