### PR TITLE
feat: cache count endpoints index

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -326,32 +326,6 @@ defmodule Logflare.Endpoints do
     end
   end
 
-  defp run_on_backend(:bigquery, _, endpoint_query, transformed_query, declared_params, params),
-    do: exec_sql_on_bq(endpoint_query, transformed_query, declared_params, params)
-
-  defp run_on_backend(
-         :postgres,
-         [source],
-         endpoint_query,
-         transformed_query,
-         declared_params,
-         params
-       ),
-       do: exec_sql_on_pg(source, endpoint_query, transformed_query, declared_params, params)
-
-  defp run_on_backend(:postgres, _, _, _, _, _),
-    do: {:error, "Postgres does not support multiple sources"}
-
-  defp exec_sql_on_pg(%{source_backends: [source_backend]}, _, transformed_query, _, input_params) do
-    with repo <- PostgresAdaptorRepo.new_repository_for_source_backend(source_backend),
-         :ok <- PostgresAdaptorRepo.connect_to_source_backend(repo, source_backend),
-         {:ok, result} <- SQL.query(repo, transformed_query, Map.to_list(input_params)),
-         %{columns: columns, rows: rows} <- result do
-      rows = Enum.map(rows, fn row -> columns |> Enum.zip(row) |> Map.new() end)
-      {:ok, %{rows: rows}}
-    end
-  end
-
   @doc """
   Calculates and sets the `:metrics` key with `Query.Metrics`, which contains info and stats relating to the endpoint
   """

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -361,7 +361,7 @@ defmodule Logflare.Endpoints do
   end
 
   def calculate_endpoint_metrics(%Query{} = endpoint) do
-    cache_count = Resolver.resolve(endpoint) |> length()
+    cache_count = endpoint |> Resolver.resolve() |> length()
 
     %{
       endpoint

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -325,4 +325,49 @@ defmodule Logflare.Endpoints do
         message
     end
   end
+
+  defp run_on_backend(:bigquery, _, endpoint_query, transformed_query, declared_params, params),
+    do: exec_sql_on_bq(endpoint_query, transformed_query, declared_params, params)
+
+  defp run_on_backend(
+         :postgres,
+         [source],
+         endpoint_query,
+         transformed_query,
+         declared_params,
+         params
+       ),
+       do: exec_sql_on_pg(source, endpoint_query, transformed_query, declared_params, params)
+
+  defp run_on_backend(:postgres, _, _, _, _, _),
+    do: {:error, "Postgres does not support multiple sources"}
+
+  defp exec_sql_on_pg(%{source_backends: [source_backend]}, _, transformed_query, _, input_params) do
+    with repo <- PostgresAdaptorRepo.new_repository_for_source_backend(source_backend),
+         :ok <- PostgresAdaptorRepo.connect_to_source_backend(repo, source_backend),
+         {:ok, result} <- SQL.query(repo, transformed_query, Map.to_list(input_params)),
+         %{columns: columns, rows: rows} <- result do
+      rows = Enum.map(rows, fn row -> columns |> Enum.zip(row) |> Map.new() end)
+      {:ok, %{rows: rows}}
+    end
+  end
+
+  @doc """
+  Calculates and sets the `:metrics` key with `Query.Metrics`, which contains info and stats relating to the endpoint
+  """
+  @spec calculate_endpoint_metrics(Query.t() | [Query.t()]) :: Query.t() | [Query.t()]
+  def calculate_endpoint_metrics(endpoints) when is_list(endpoints) do
+    for endpoint <- endpoints, do: calculate_endpoint_metrics(endpoint)
+  end
+
+  def calculate_endpoint_metrics(%Query{} = endpoint) do
+    cache_count = Resolver.resolve(endpoint) |> length()
+
+    %{
+      endpoint
+      | metrics: %Query.Metrics{
+          cache_count: cache_count
+        }
+    }
+  end
 end

--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -31,11 +31,22 @@ defmodule Logflare.Endpoints.Query do
     field(:max_limit, :integer, default: 1_000)
     field(:enable_auth, :boolean, default: true)
 
+    field :metrics, :map, virtual: true
+
     belongs_to(:user, Logflare.User)
     has_many(:sandboxed_queries, Query, foreign_key: :sandbox_query_id)
     belongs_to(:sandbox_query, Query)
 
     timestamps()
+  end
+
+  defmodule Metrics do
+    @moduledoc false
+    use TypedEctoSchema
+
+    embedded_schema do
+      field :cache_count, :integer
+    end
   end
 
   @doc false

--- a/lib/logflare_web/live/endpoints/actions/index.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/index.html.heex
@@ -28,6 +28,9 @@
   <ul :for={endpoint <- Enum.sort_by(@endpoints, & &1.name)} class="list-group">
     <li class="list-group-item">
       <%= live_patch(endpoint.name, to: ~p"/endpoints/#{endpoint.id}", class: "tw-text-white") %>
+      <div class="tw-text-sm">
+        caches: <%= endpoint.metrics.cache_count %>
+      </div>
     </li>
   </ul>
 </section>

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -215,7 +215,6 @@ defmodule LogflareWeb.EndpointsLive do
       Endpoints.list_endpoints_by(user_id: assigns.user_id)
       |> Endpoints.calculate_endpoint_metrics()
 
-    socket
-    |> assign(:endpoints, endpoints)
+    assign(socket, :endpoints, endpoints)
   end
 end

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -30,7 +30,6 @@ defmodule LogflareWeb.EndpointsLive do
   end
 
   def mount(%{}, %{"user_id" => user_id}, socket) do
-    endpoints = Endpoints.list_endpoints_by(user_id: user_id)
     user = Users.get(user_id)
 
     allow_access =
@@ -41,9 +40,10 @@ defmodule LogflareWeb.EndpointsLive do
 
     {:ok,
      socket
-     |> assign(:endpoints, endpoints)
      |> assign(:user_id, user_id)
      |> assign(:user, user)
+     #  must be below user_id assign
+     |> refresh_endpoints()
      |> assign(:query_result_rows, nil)
      |> assign(:show_endpoint, nil)
      |> assign(:endpoint_changeset, Endpoints.change_query(%Endpoints.Query{}))
@@ -129,11 +129,10 @@ defmodule LogflareWeb.EndpointsLive do
       ) do
     endpoint = Endpoints.get_endpoint_query(id)
     {:ok, _} = Endpoints.delete_query(endpoint)
-    endpoints = Endpoints.list_endpoints_by(user_id: assigns.user_id)
 
     {:noreply,
      socket
-     |> assign(:endpoints, endpoints)
+     |> refresh_endpoints()
      |> assign(:show_endpoint, nil)
      |> put_flash(
        :info,
@@ -209,5 +208,14 @@ defmodule LogflareWeb.EndpointsLive do
       )
     )
     |> assign(:declared_params, parameters)
+  end
+
+  defp refresh_endpoints(%{assigns: assigns} = socket) do
+    endpoints =
+      Endpoints.list_endpoints_by(user_id: assigns.user_id)
+      |> Endpoints.calculate_endpoint_metrics()
+
+    socket
+    |> assign(:endpoints, endpoints)
   end
 end

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -125,7 +125,7 @@ defmodule LogflareWeb.EndpointsLive do
   def handle_event(
         "delete-endpoint",
         %{"endpoint_id" => id},
-        %{assigns: assigns} = socket
+        %{assigns: _assigns} = socket
       ) do
     endpoint = Endpoints.get_endpoint_query(id)
     {:ok, _} = Endpoints.delete_query(endpoint)

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -249,4 +249,33 @@ defmodule Logflare.EndpointsTest do
       assert {:ok, %{rows: []}} = Endpoints.run_cached_query(endpoint)
     end
   end
+
+  test "endpoint metrics - cache count" do
+    user = insert(:user)
+    endpoint = insert(:endpoint, user: user)
+    assert endpoint.metrics == nil
+
+    assert %_{
+             metrics: %Query.Metrics{
+               cache_count: 0
+             }
+           } = Endpoints.calculate_endpoint_metrics(endpoint)
+
+    _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+
+    assert %_{
+             metrics: %Query.Metrics{
+               cache_count: 1
+             }
+           } = Endpoints.calculate_endpoint_metrics(endpoint)
+
+    # accepts lists
+    assert [
+             %_{
+               metrics: %Query.Metrics{
+                 cache_count: 1
+               }
+             }
+           ] = Endpoints.calculate_endpoint_metrics([endpoint])
+  end
 end

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -85,6 +85,15 @@ defmodule LogflareWeb.EndpointsLiveTest do
     assert_patch(view, "/endpoints/new")
   end
 
+  test "index - show cache count", %{conn: conn, user: user} do
+    endpoint = insert(:endpoint, user: user)
+    _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+
+    {:ok, view, _html} = live(conn, "/endpoints")
+
+    assert render(view) =~ ~r/caches:.+1/
+  end
+
   test "new endpoint", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/endpoints/new")
     assert view |> has_element?("form#endpoint")


### PR DESCRIPTION
This PR adds cache counts to the Endpoints index page.
This is the first step to live stats for endpoints.

The PR depends on #1541 


<img width="1503" alt="Screenshot 2023-07-07 at 1 15 24 PM" src="https://github.com/Logflare/logflare/assets/22714384/8587f8ac-a41e-4ce3-9187-fac2e9a19926">

[ticket](https://www.notion.so/supabase/feat-display-cache-count-for-each-endpoint-in-index-page-c927581815d74833af62b28110c9f8ee?pvs=4)