### PR TITLE
fix: prevent name that is raw uuid to be mistaken  as endpoint token

### DIFF
--- a/lib/logflare_web/controllers/plugs/fetch_resource.ex
+++ b/lib/logflare_web/controllers/plugs/fetch_resource.ex
@@ -61,7 +61,7 @@ defmodule LogflareWeb.Plugs.FetchResource do
 
   # returns true if it is a valid uuid4 string
   defp is_uuid?(value) when is_binary(value) do
-    case Ecto.UUID.cast(value) do
+    case Ecto.UUID.dump(value) do
       {:ok, _} -> true
       _ -> false
     end


### PR DESCRIPTION
[ticket](https://www.notion.so/supabase/bug-Logflare-endpoint-query-by-name-sometimes-mistakes-a-string-for-a-uuid-0034097613954fafab27ed608e287f70?pvs=4)

Bug relates to endpoint names getting mistaken as raw uuids when using Ecto.cast. By using Ecto.dump, we can more consistently check if a string is a uuid.