### PR TITLE
fix - Fixes endpoints UI on save and on query run bugs

### DIFF
--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Endpoints.Query do
     field(:token, Ecto.UUID, autogenerate: true)
     field(:name, :string)
     field(:query, :string)
-    field(:language, Ecto.Enum, values: [:bq_sql, :pg_sql, :lql])
+    field(:language, Ecto.Enum, values: [:bq_sql, :pg_sql, :lql], default: :bq_sql)
     field(:source_mapping, :map)
     field(:sandboxable, :boolean)
     field(:cache_duration_seconds, :integer, default: 3_600)
@@ -31,7 +31,7 @@ defmodule Logflare.Endpoints.Query do
     field(:max_limit, :integer, default: 1_000)
     field(:enable_auth, :boolean, default: true)
 
-    field :metrics, :map, virtual: true
+    field(:metrics, :map, virtual: true)
 
     belongs_to(:user, Logflare.User)
     has_many(:sandboxed_queries, Query, foreign_key: :sandbox_query_id)
@@ -45,7 +45,7 @@ defmodule Logflare.Endpoints.Query do
     use TypedEctoSchema
 
     embedded_schema do
-      field :cache_count, :integer
+      field(:cache_count, :integer)
     end
   end
 

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -46,7 +46,8 @@
           placeholder: "select timestamp, event_message from `YourApp.SourceName`",
           class: "form-control form-control-margin",
           "phx-change": "parse-query",
-          id: "endpoint-query"
+          id: "endpoint-query",
+          value: Map.get(@params_form.params, "query")
         ) %>
         <%= error_tag(f, :query) %>
         <.alert :if={@parse_error_message} variant="warning"><%= @parse_error_message %></.alert>

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -80,7 +80,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> post("/api/endpoints")
         |> json_response(422)
 
-      assert %{"errors" => %{"name" => _, "query" => _, "language" => _}} = resp
+      assert %{"errors" => %{"name" => _, "query" => _}} = resp
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
@@ -90,7 +90,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> post("/api/endpoints", %{name: 123})
         |> json_response(422)
 
-      assert %{"errors" => %{"name" => _, "query" => _, "language" => _}} = resp
+      assert %{"errors" => %{"name" => _, "query" => _}} = resp
     end
   end
 


### PR DESCRIPTION
* On save, the lack of a default language on Query creation made a changeset fail
* On query test, the input would be deleted since the value was not being set and assigns were being removed

> Note: Endpoints are behaving weirdly due to other reasons in my dev environment so take that into account in the gifs below 😅 

## Before
![before](https://github.com/Logflare/logflare/assets/1697301/3c80c3eb-5227-4f54-864f-247f9acee317)
## After
![after](https://github.com/Logflare/logflare/assets/1697301/99263929-2647-430e-8691-7915e1aade27)

