### PR TITLE
fix - Avoid Schema update when using Postgres as a backend

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -192,7 +192,10 @@ defmodule Logflare.Application do
       # buffer time for all sources to init and create tables
       # in case of latency.
       :timer.sleep(3_000)
-      SingleTenant.update_supabase_source_schemas()
+
+      unless SingleTenant.postgres_backend?() do
+        SingleTenant.update_supabase_source_schemas()
+      end
     end
   end
 end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -271,6 +271,14 @@ defmodule Logflare.SingleTenant do
     }
   end
 
+  @doc """
+  Returns true if postgres backend is enabled for single tenant
+  """
+  @spec postgres_backend? :: boolean()
+  def postgres_backend?() do
+    single_tenant?() && Application.get_env(:logflare, :postgres_backend_adapter) != nil
+  end
+
   def supabase_mode_source_schemas_updated? do
     user = get_default_user()
 


### PR DESCRIPTION
Avoids schema update when using Postgres as a backend since this makes the CLI fail.