### PR TITLE
fix - Ensure proper startup on single instance

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -188,12 +188,13 @@ defmodule Logflare.Application do
     if SingleTenant.supabase_mode?() do
       SingleTenant.create_supabase_sources()
       SingleTenant.create_supabase_endpoints()
-      SingleTenant.ensure_supabase_sources_started()
-      # buffer time for all sources to init and create tables
-      # in case of latency.
-      :timer.sleep(3_000)
 
       unless SingleTenant.postgres_backend?() do
+        SingleTenant.ensure_supabase_sources_started()
+        # buffer time for all sources to init and create tables
+        # in case of latency.
+        :timer.sleep(3_000)
+
         SingleTenant.update_supabase_source_schemas()
       end
     end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -205,9 +205,14 @@ defmodule Logflare.SingleTenant do
   @spec supabase_mode? :: boolean()
   def supabase_mode?, do: !!Application.get_env(:logflare, :supabase_mode) and single_tenant?()
 
+  @doc "Returns postgres backend adapter url if single tenant and env is set"
+  @spec postgres_backend_adapter_url :: String.t() | nil
   def postgres_backend_adapter_url() do
     if single_tenant?() do
-      Application.get_env(:logflare, :postgres_backend_adapter) |> Keyword.get(:url)
+      case Application.get_env(:logflare, :postgres_backend_adapter) do
+        nil -> nil
+        opts -> Keyword.get(opts, :url)
+      end
     end
   end
 
@@ -276,7 +281,7 @@ defmodule Logflare.SingleTenant do
   """
   @spec postgres_backend? :: boolean()
   def postgres_backend?() do
-    single_tenant?() && Application.get_env(:logflare, :postgres_backend_adapter) != nil
+    single_tenant?() && postgres_backend_adapter_url() != nil
   end
 
   def supabase_mode_source_schemas_updated? do


### PR DESCRIPTION
We were not starting up properly when we were using Postgres as a backend for single instance mode

There was also a bug when POSTGRES_BACKEND_URL was not set which would fail proper creation of sources with SUPABASE_MODE enabled