### PR TITLE
feat: bq-to-pg translation, cte handling and value casting

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -1029,7 +1029,7 @@ defmodule Logflare.Sql do
   # handle references to table aliases
   defp traverse_convert_identifiers(
          {"CompoundIdentifier" = k, [%{"value" => table_ref}, field_map] = v},
-         %{cte_aliases: cte_aliases, from_table_aliases: from_table_aliases} = data
+         %{from_table_aliases: from_table_aliases} = data
        )
        when from_table_aliases != [] do
     if table_ref in from_table_aliases do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -515,7 +515,14 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
-    test "field references within a cast() are converted to ->>e syntax for string casting"
+    test "field references within a cast() are converted to ->> syntax for string casting" do
+      bq_query = ~s|select cast(col as timestamp) as date from my_table|
+      pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from "my_table" |
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+    end
+
     # test "order by json query"
     # test "cte WHERE identifiers are translated correctly"
 


### PR DESCRIPTION
this PR adds in two translation aspects:
- multiple from aliases field referencing, such that the table aliases are considered and omited/added to the json query syntax.
- cast handling, as json cannot be used to cast, hence we need to use LongArrow or HashLongArrow for the syntax