### PR TITLE
fix - Adapt healthcheck for Postgres backend

### DIFF
--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -265,7 +265,12 @@ defmodule Logflare.SingleTenant do
         if Endpoints.list_endpoints_by(user_id: default_user.id) |> length() > 0, do: :ok
       end
 
-    source_schemas_updated = if supabase_mode_source_schemas_updated?(), do: :ok
+    source_schemas_updated =
+      cond do
+        postgres_backend?() -> :ok
+        supabase_mode_source_schemas_updated?() -> :ok
+        true -> nil
+      end
 
     %{
       seed_user: seed_user,

--- a/test/logflare/single_tenant_test.exs
+++ b/test/logflare/single_tenant_test.exs
@@ -197,7 +197,7 @@ defmodule Logflare.SingleTenantTest do
                seed_plan: :ok,
                seed_sources: :ok,
                seed_endpoints: nil,
-               source_schemas_updated: nil
+               source_schemas_updated: :ok
              } = SingleTenant.supabase_mode_status()
 
       stub(Schema, :get_state, fn _ -> %{field_count: 5} end)


### PR DESCRIPTION
Takes into account that at the moment the Postgres Backend does not use Schemas