### PR TITLE
feat: sql translation supabase mode

### DIFF
--- a/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
@@ -125,6 +125,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo do
     |> Atom.to_string()
     |> String.replace("-", "_")
     |> then(&"log_events_#{&1}")
+    |> dbg()
   end
 
   @doc """

--- a/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
@@ -56,9 +56,10 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo do
   Retrieves the repo module. Requires `:source` to be preloaded.
   """
   @spec get_repo_module(SourceBackend.t()) :: Ecto.Repo.t()
-  def get_repo_module(%SourceBackend{source: %Source{token: token}}) do
-    token = token |> Atom.to_string() |> String.replace("-", "")
-    Module.concat([Logflare.Repo.Postgres, "Adaptor#{token}"])
+  def get_repo_module(%SourceBackend{config: config, source: %Source{}}) do
+    data = inspect(config)
+    sha256 = :crypto.hash(:sha256, data) |> Base.encode16() |> String.downcase()
+    Module.concat([Logflare.Repo.Postgres, "Adaptor#{sha256}"])
   end
 
   @doc """
@@ -125,7 +126,6 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo do
     |> Atom.to_string()
     |> String.replace("-", "_")
     |> then(&"log_events_#{&1}")
-    |> dbg()
   end
 
   @doc """

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -165,13 +165,14 @@ defmodule Logflare.Endpoints do
     with {:ok, declared_params} <- Logflare.Sql.parameters(query_string),
          {:ok, transformed_query} <-
            Logflare.Sql.transform(endpoint_query.language, transform_input, user_id) do
-      {endpoint, query_string} = if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_url() != nil do
-        # translate the query
-        {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query) |> dbg()
-        {Map.put(endpoint_query, :language, :pg_sql), q}
-      else
-        {endpoint_query, transformed_query}
-      end
+      {endpoint, query_string} =
+        if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_url() != nil do
+          # translate the query
+          {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query) |> dbg()
+          {Map.put(endpoint_query, :language, :pg_sql), q}
+        else
+          {endpoint_query, transformed_query}
+        end
 
       exec_query_on_backend(endpoint, query_string, declared_params, params)
     end

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -9,6 +9,7 @@ defmodule Logflare.Endpoints do
   alias Logflare.Utils
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.PostgresAdaptor
+  alias Logflare.SingleTenant
 
   import Ecto.Query
   @typep run_query_return :: {:ok, %{rows: [map()]}} | {:error, String.t()}
@@ -163,10 +164,16 @@ defmodule Logflare.Endpoints do
 
     with {:ok, declared_params} <- Logflare.Sql.parameters(query_string),
          {:ok, transformed_query} <-
-           Logflare.Sql.transform(endpoint_query.language, transform_input, user_id),
-         {:ok, result} <-
-           exec_query_on_backend(endpoint_query, transformed_query, declared_params, params) do
-      {:ok, result}
+           Logflare.Sql.transform(endpoint_query.language, transform_input, user_id) do
+      {endpoint, query_string} = if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_url() != nil do
+        # translate the query
+        {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query) |> dbg()
+        {Map.put(endpoint_query, :language, :pg_sql), q}
+      else
+        {endpoint_query, transformed_query}
+      end
+
+      exec_query_on_backend(endpoint, query_string, declared_params, params)
     end
   end
 
@@ -232,6 +239,8 @@ defmodule Logflare.Endpoints do
         other ->
           other
       end)
+
+    # convert params to PG params style
 
     with {:ok, rows} <- PostgresAdaptor.execute_query(source_backend, transformed_query) do
       {:ok, %{rows: rows}}

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -166,9 +166,9 @@ defmodule Logflare.Endpoints do
          {:ok, transformed_query} <-
            Logflare.Sql.transform(endpoint_query.language, transform_input, user_id) do
       {endpoint, query_string} =
-        if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_url() != nil do
+        if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_opts() != nil do
           # translate the query
-          {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query) |> dbg()
+          {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query)
           {Map.put(endpoint_query, :language, :pg_sql), q}
         else
           {endpoint_query, transformed_query}

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -13,6 +13,7 @@ defmodule Logflare.SingleTenant do
   alias Logflare.Source.Supervisor
   alias Logflare.Source.BigQuery.Schema
   alias Logflare.LogEvent
+  alias Logflare.Backends
   require Logger
 
   @user_attrs %{
@@ -168,7 +169,11 @@ defmodule Logflare.SingleTenant do
 
     if user do
       for source <- Sources.list_sources_by_user(user) do
-        Supervisor.ensure_started(source.token)
+        if postgres_backend?() do
+          Backends.start_source_sup(source)
+        else
+          Supervisor.ensure_started(source.token)
+        end
       end
     end
 

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -900,8 +900,8 @@ defmodule Logflare.Sql do
       cte_from_aliases: cte_from_aliases,
       in_cte_tables_tree: false,
       in_cast: false,
-      from_table_aliases: nil,
-      from_table_values: nil
+      from_table_aliases: [],
+      from_table_values: []
     })
     |> then(fn
       ast when joins != [] ->

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -656,6 +656,13 @@ defmodule Logflare.Sql do
     end
   end
 
+  @doc """
+  Determine positions of all parameters
+
+  ### Example
+  iex> parameter_positions("select @test as testing")
+  %{1 => "test"}
+  """
   def parameter_positions(string) when is_binary(string) do
     {:ok, parameters} = parameters(string)
     {:ok, do_parameter_positions_mapping(string, parameters)}

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -663,6 +663,7 @@ defmodule Logflare.Sql do
   iex> parameter_positions("select @test as testing")
   %{1 => "test"}
   """
+  @spec parameter_positions(String.t()):: %{integer() => String.t()}
   def parameter_positions(string) when is_binary(string) do
     {:ok, parameters} = parameters(string)
     {:ok, do_parameter_positions_mapping(string, parameters)}

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -1103,10 +1103,13 @@ defmodule Logflare.Sql do
         value_map["value"]
       end
 
+    alias_path_mappings = get_bq_alias_path_mappings(%{"Query" => v})
+
     data =
       Map.merge(data, %{
         from_table_aliases: aliases,
-        from_table_values: values
+        from_table_values: values,
+        alias_path_mappings: alias_path_mappings
       })
 
     {k, traverse_convert_identifiers(v, data)}

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -700,6 +700,7 @@ defmodule Logflare.Sql do
         # TODO: remove once sqlparser-rs bug is fixed
         # parser for postgres adds parenthesis to the end for postgres
         |> String.replace(~r/current\_timestamp\(\)/im, "current_timestamp")
+        |> String.replace(~r/\"([\w\_\-]+\.[\w\_\-]+)\.([\w_]{36})"/im, "\"log_events_\\g{2}\"")
 
       {:ok, converted}
     end)

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -697,6 +697,9 @@ defmodule Logflare.Sql do
       converted =
         query_string
         |> bq_to_pg_convert_parameters(params)
+        # TODO: remove once sqlparser-rs bug is fixed
+        # parser for postgres adds parenthesis to the end for postgres
+        |> String.replace(~r/current\_timestamp\(\)/im, "current_timestamp")
 
       {:ok, converted}
     end)

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -663,7 +663,7 @@ defmodule Logflare.Sql do
   iex> parameter_positions("select @test as testing")
   %{1 => "test"}
   """
-  @spec parameter_positions(String.t()):: %{integer() => String.t()}
+  @spec parameter_positions(String.t()) :: %{integer() => String.t()}
   def parameter_positions(string) when is_binary(string) do
     {:ok, parameters} = parameters(string)
     {:ok, do_parameter_positions_mapping(string, parameters)}

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -1021,7 +1021,6 @@ defmodule Logflare.Sql do
       end)
 
     for from <- from_list,
-        table_alias = get_in(from, ["relation", "Table"]),
         %{
           "relation" => %{
             "UNNEST" => %{
@@ -1029,37 +1028,13 @@ defmodule Logflare.Sql do
               "alias" => %{"name" => %{"value" => alias_name}}
             }
           }
-        } = join <- from["joins"] || [],
+        } <- from["joins"] || [],
         into: %{} do
       arr_path = for i <- identifiers, value = i["value"], value not in table_aliases, do: value
 
       str_path = Enum.join(arr_path, ",")
       {alias_name, str_path}
     end
-
-    # joins =
-    #   ast
-    #   |> get_in(["Query", "body", "Select", "from", Access.at(0), "joins"]) || []
-
-    # Enum.reduce(joins, %{}, fn
-    #   %{
-    #     "relation" => %{
-    #       "UNNEST" => %{
-    #         "array_expr" => %{"CompoundIdentifier" => identifiers},
-    #         "alias" => %{"name" => %{"value" => alias_name}}
-    #       }
-    #     }
-    #   },
-    #   acc ->
-    #     arr_path = for i <- identifiers, value = i["value"], value != table_alias, do: value
-
-    #     str_path = Enum.join(arr_path, ",")
-
-    #     Map.put(acc, alias_name, str_path)
-
-    #   _join, acc ->
-    #     acc
-    # end)
   end
 
   defp traverse_convert_identifiers({"cte_tables" = k, v}, data) do

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -666,10 +666,10 @@ defmodule Logflare.Sql do
   def do_parameter_positions_mapping(string, params) when is_binary(string) and is_list(params) do
     str =
       params
-      |> Enum.map(&(&1 <> "(?:\\s|$)"))
+      |> Enum.uniq()
       |> Enum.join("|")
 
-    regexp = Regex.compile!("@(#{str})")
+    regexp = Regex.compile!("@(#{str})(?:\\s|$|\\,|\\,|\\)|\\()")
 
     Regex.scan(regexp, string)
     |> Enum.with_index(1)

--- a/priv/supabase/endpoints/logs.all.sql
+++ b/priv/supabase/endpoints/logs.all.sql
@@ -17,16 +17,15 @@ select
   t.metadata 
 from retention, `cloudflare.logs.prod` as t
   cross join unnest(metadata) as m
-  cross join unnest(m.request) as r
 where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   t.project = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
 order by
-  t.timestamp desc
+  cast(t.timestamp as timestamp) desc
 ),
 
 postgres_logs as (
@@ -40,11 +39,10 @@ where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   t.project = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
-  order by
-  timestamp desc
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
+  order by cast(t.timestamp as timestamp) desc
 ),
 
 function_edge_logs as (
@@ -56,12 +54,11 @@ select
 from retention, `deno-relay-logs` as t
   cross join unnest(t.metadata) as m
 where
-  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
+  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
   and m.project_ref = @project
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 function_logs as (
@@ -76,11 +73,10 @@ where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   m.project_ref = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 auth_logs as (
@@ -96,11 +92,10 @@ where
   -- project then timestamp then everything else
   -- m.project = @project
   t.project = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 realtime_logs as (
@@ -113,11 +108,10 @@ from retention, `realtime.logs.prod` as t
   cross join unnest(t.metadata) as m
 where
   m.project = @project 
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 storage_logs as (
@@ -130,11 +124,10 @@ from retention, `storage.logs.prod.2` as t
   cross join unnest(t.metadata) as m
 where
   m.project = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 postgrest_logs as (
@@ -146,12 +139,11 @@ select
 from retention, `postgREST.logs.prod` as t
   cross join unnest(t.metadata) as m
 where
-  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
+  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
   AND t.project = @project
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 ),
 
 pgbouncer_logs as (
@@ -163,12 +155,11 @@ select
 from retention, `pgbouncer.logs.prod` as t
   cross join unnest(t.metadata) as m
 where
-  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
+  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
   AND t.project = @project
-  AND t.timestamp > retention.date
-order by
-  t.timestamp desc
+  AND cast(t.timestamp as timestamp) > retention.date
+order by cast(t.timestamp as timestamp) desc
 )
 
 SELECT id, timestamp, event_message, metadata

--- a/priv/supabase/endpoints/logs.all.sql
+++ b/priv/supabase/endpoints/logs.all.sql
@@ -22,12 +22,8 @@ where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   t.project = @project
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
 order by
   t.timestamp desc
@@ -44,12 +40,8 @@ where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   t.project = @project
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
   order by
   timestamp desc
@@ -64,12 +56,8 @@ select
 from retention, `deno-relay-logs` as t
   cross join unnest(t.metadata) as m
 where
-   CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
+  CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   and m.project_ref = @project
   AND t.timestamp > retention.date
 order by
@@ -88,12 +76,8 @@ where
   -- order of the where clauses matters
   -- project then timestamp then everything else
   m.project_ref = @project
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
 order by
   t.timestamp desc
@@ -112,12 +96,8 @@ where
   -- project then timestamp then everything else
   -- m.project = @project
   t.project = @project
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
 order by
   t.timestamp desc
@@ -133,12 +113,8 @@ from retention, `realtime.logs.prod` as t
   cross join unnest(t.metadata) as m
 where
   m.project = @project 
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
 order by
   t.timestamp desc
@@ -154,12 +130,8 @@ from retention, `storage.logs.prod.2` as t
   cross join unnest(t.metadata) as m
 where
   m.project = @project
-  AND CASE WHEN COALESCE(@period_start, '') = '' THEN  TRUE ELSE  t.timestamp > @period_start END
-  AND CASE WHEN COALESCE(@period_end, '') = '' THEN TRUE ELSE t.timestamp <= @period_end END
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > @iso_timestamp_start END
   AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= @iso_timestamp_end END
-  AND CASE WHEN COALESCE(@timestamp_start, '') = '' THEN  TRUE ELSE  t.timestamp > TIMESTAMP_MICROS(CAST(@timestamp_start as int64)) END
-  AND CASE WHEN COALESCE(@timestamp_end, '') = '' THEN TRUE ELSE t.timestamp <= TIMESTAMP_MICROS(CAST(@timestamp_end as int64)) END
   AND t.timestamp > retention.date
 order by
   t.timestamp desc

--- a/test/logflare/backends/postgres_adaptor_test.exs
+++ b/test/logflare/backends/postgres_adaptor_test.exs
@@ -78,14 +78,8 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
       assert Keyword.get(repo.__info__(:attributes), :behaviour) == [Ecto.Repo]
       env = Application.get_env(:logflare, repo)
 
-      # module name should use source token
-      expected =
-        source_backend.source.token
-        |> Atom.to_string()
-        |> String.replace("-", "")
-        |> String.to_atom()
-
-      assert Atom.to_string(repo) =~ Atom.to_string(expected)
+      # module name should have a prefix
+      assert "Elixir.Logflare.Repo.Postgres.Adaptor" <> _ =  Atom.to_string(repo)
 
       assert env[:migration_source] == PostgresAdaptor.migrations_table_name(source_backend)
     end

--- a/test/logflare/backends/postgres_adaptor_test.exs
+++ b/test/logflare/backends/postgres_adaptor_test.exs
@@ -79,7 +79,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
       env = Application.get_env(:logflare, repo)
 
       # module name should have a prefix
-      assert "Elixir.Logflare.Repo.Postgres.Adaptor" <> _ =  Atom.to_string(repo)
+      assert "Elixir.Logflare.Repo.Postgres.Adaptor" <> _ = Atom.to_string(repo)
 
       assert env[:migration_source] == PostgresAdaptor.migrations_table_name(source_backend)
     end

--- a/test/logflare/single_tenant_test.exs
+++ b/test/logflare/single_tenant_test.exs
@@ -111,7 +111,7 @@ defmodule Logflare.SingleTenantTest do
   end
 
   describe "single tenant mode using Postgres" do
-    TestUtils.setup_single_tenant(mode: :postgres)
+    TestUtils.setup_single_tenant(backend_type: :postgres)
 
     test "create_default_plan/0 creates default enterprise plan if not present" do
       assert {:ok, plan} = SingleTenant.create_default_plan()
@@ -158,7 +158,7 @@ defmodule Logflare.SingleTenantTest do
   end
 
   describe "supabase_mode=true using Postgres" do
-    TestUtils.setup_single_tenant(mode: :postgres, seed_user: true, supabase_mode: true)
+    TestUtils.setup_single_tenant(backend_type: :postgres, seed_user: true, supabase_mode: true)
 
     setup do
       stub(Schema, :update, fn _token, _le -> :ok end)

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -580,6 +580,27 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
+    test "CTE order by without from " do
+      bq_query = ~s"""
+      with a as (
+        select 'test' as col
+        from my_table t
+        order by cast(t.timestamp as timestamp) desc
+      ) select 'tester' as col
+      """
+
+      pg_query = ~s"""
+      with a as (
+        select 'test' as col
+        from my_table t
+        order by cast( (t.body ->> 'timestamp') as timestamp) desc
+        ) select 'tester' as col
+      """
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+    end
+
     test "field references within a cast() are converted to ->> syntax for string casting" do
       bq_query = ~s|select cast(col as timestamp) as date from my_table|
       pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from my_table|

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -536,13 +536,14 @@ defmodule Logflare.SqlTest do
     # test "cte WHERE identifiers are translated correctly"
 
     test "parameters are translated" do
-      bq_query = ~s|select @test as arg1, @another as arg2|
+      # test that substring of another arg is replaced correctly
+      bq_query = ~s|select @test as arg1, @test_another as arg2|
       pg_query = ~s|select $1 as arg1, $2 as arg2|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
       # determines sequence of parameters
-      assert {:ok, %{1 => "test", 2 => "another"}} = Sql.parameter_positions(bq_query)
+      assert {:ok, %{1 => "test", 2 => "test_another"}} = Sql.parameter_positions(bq_query)
     end
 
     test "REGEXP_CONTAINS is translated" do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -523,7 +523,16 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
-    # test "order by json query"
+    test "order by json query" do
+      bq_query = ~s|select id from my_source t order by t.timestamp|
+
+      pg_query =
+        ~s|select (body -> 'id') as id from "my_source" t order by (t.body -> 'timestamp')|
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+    end
+
     # test "cte WHERE identifiers are translated correctly"
 
     test "parameters are translated" do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -456,11 +456,19 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
-    test "current_timestamp" do
+    test "current_timestamp handling " do
       bq_query = "select current_timestamp() as t"
       pg_query = ~s|select current_timestamp as t|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      refute translated =~ "current_timestamp()"
+
+      # in cte
+      bq_query = "with a as (select current_timestamp() as t) select a.t"
+      pg_query = ~s|with a as (select current_timestamp as t) select a.t as t|
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      refute translated =~ "current_timestamp()"
     end
 
     test "timestamp_sub" do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -601,6 +601,28 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
+    test "CTE cross join UNNESTs with filter reference" do
+      bq_query = ~s"""
+      with a as (
+        select 'test' as col
+        from my_table t
+        cross join unnest(t.metadata) as m
+        where m.project = '123'
+      ) select a.col from a
+      """
+
+      pg_query = ~s"""
+      with a as (
+        select 'test' as col
+        from my_table t
+        where (body #> '{metadata,project}') = '123'
+        ) select a.col as col from a
+      """
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+    end
+
     test "field references within a cast() are converted to ->> syntax for string casting" do
       bq_query = ~s|select cast(col as timestamp) as date from my_table|
       pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from my_table|

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -574,7 +574,7 @@ defmodule Logflare.SqlTest do
 
     test "field references within a cast() are converted to ->> syntax for string casting" do
       bq_query = ~s|select cast(col as timestamp) as date from my_table|
-      pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from my_table |
+      pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from my_table|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -151,28 +151,27 @@ defmodule LogflareWeb.EndpointsControllerTest do
     end
   end
 
-
   describe "single tenant supabase mode" do
     TestUtils.setup_single_tenant(seed_user: true, supabase_mode: true, backend_type: :postgres)
 
     setup do
       SingleTenant.create_supabase_sources()
-      SingleTenant.create_supabase_endpoints
+      SingleTenant.create_supabase_endpoints()
       %{user: SingleTenant.get_default_user()}
     end
+
     test "GET a basic query", %{conn: conn, user: user} do
       # query the logs.all endpoint
 
       conn =
         conn
         |> put_req_header("x-api-key", user.api_key)
-        |> get(~p"/endpoints/query/logs.all?#{%{
-          sql: ~s(select "hello" as world from edge_logs)
-        }}")
+        |> get(
+          ~p"/endpoints/query/logs.all?#{%{sql: ~s(select 'hello' as world from edge_logs)}}"
+        )
 
       assert [%{"world" => "hello"}] = json_response(conn, 200)["result"]
       assert conn.halted == false
     end
   end
-
 end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -150,4 +150,29 @@ defmodule LogflareWeb.EndpointsControllerTest do
       assert html_response(conn, 200) =~ "/endpoints"
     end
   end
+
+
+  describe "single tenant supabase mode" do
+    TestUtils.setup_single_tenant(seed_user: true, supabase_mode: true, backend_type: :postgres)
+
+    setup do
+      SingleTenant.create_supabase_sources()
+      SingleTenant.create_supabase_endpoints
+      %{user: SingleTenant.get_default_user()}
+    end
+    test "GET a basic query", %{conn: conn, user: user} do
+      # query the logs.all endpoint
+
+      conn =
+        conn
+        |> put_req_header("x-api-key", user.api_key)
+        |> get(~p"/endpoints/query/logs.all?#{%{
+          sql: ~s(select "hello" as world from edge_logs)
+        }}")
+
+      assert [%{"world" => "hello"}] = json_response(conn, 200)["result"]
+      assert conn.halted == false
+    end
+  end
+
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -48,7 +48,6 @@ defmodule Logflare.TestUtils do
         initial_api_key = Application.get_env(:logflare, :api_key)
         Application.put_env(:logflare, :api_key, Logflare.TestUtils.random_string(12))
 
-
         on_exit(fn ->
           Application.put_env(:logflare, :single_tenant, initial_single_tenant)
           Application.put_env(:logflare, :api_key, initial_api_key)

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -23,11 +23,12 @@ defmodule Logflare.TestUtils do
       Enum.into(opts, %{
         seed_user: false,
         supabase_mode: false,
-        bigquery_project_id: random_string()
+        bigquery_project_id: random_string(),
+        backend_type: :bigquery
       })
 
     quote do
-      unquote(setup_single_tenant_env(opts))
+      unquote(setup_single_tenant_backend(opts))
 
       setup do
         if unquote(opts.seed_user) do
@@ -38,7 +39,6 @@ defmodule Logflare.TestUtils do
         if unquote(opts.supabase_mode) do
           initial_supabase_mode = Application.get_env(:logflare, :supabase_mode)
           Application.put_env(:logflare, :supabase_mode, true)
-
           on_exit(fn -> Application.put_env(:logflare, :supabase_mode, initial_supabase_mode) end)
         end
 
@@ -47,6 +47,7 @@ defmodule Logflare.TestUtils do
 
         initial_api_key = Application.get_env(:logflare, :api_key)
         Application.put_env(:logflare, :api_key, Logflare.TestUtils.random_string(12))
+
 
         on_exit(fn ->
           Application.put_env(:logflare, :single_tenant, initial_single_tenant)
@@ -58,7 +59,7 @@ defmodule Logflare.TestUtils do
     end
   end
 
-  defp setup_single_tenant_env(%{mode: :postgres}) do
+  defp setup_single_tenant_backend(%{backend_type: :postgres}) do
     quote do
       setup do
         %{username: username, password: password, database: database, hostname: hostname} =
@@ -73,7 +74,7 @@ defmodule Logflare.TestUtils do
     end
   end
 
-  defp setup_single_tenant_env(opts) do
+  defp setup_single_tenant_backend(%{backend_type: :bigquery} = opts) do
     quote do
       setup do
         # conditionally update bigquery project id

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -66,7 +66,7 @@ defmodule Logflare.TestUtils do
 
         url = "postgresql://#{username}:#{password}@#{hostname}/#{database}"
         previous = Application.get_env(:logflare, :postgres_backend_adapter)
-        Application.put_env(:logflare, :postgres_backend_adapter, url: url, schema: "_analytics")
+        Application.put_env(:logflare, :postgres_backend_adapter, url: url)
         on_exit(fn -> Application.put_env(:logflare, :postgres_backend_adapter, previous) end)
         :ok
       end


### PR DESCRIPTION
Implements BQ sql translation when both supabase mode and postgres backend is enabled.

Fixes the following areas for BQ->PG translation:
- table name translation
- CTE order by translation
- parameter replacement to positional
- CTE table/field referencing behaviour