### PR TITLE
fix: endpoints edit ui - nil language update error

### DIFF
--- a/lib/logflare_web/live/endpoints/actions/show.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/show.html.heex
@@ -29,7 +29,14 @@
   </div>
 
   <div class="tw-w-full tw-bg-zinc-800 tw-p-4 tw-rounded-lg tw-min-h-[100px]">
-    <code class="tw-whitespace-pre-wrap "><%= @show_endpoint.query %></code>
+    <span>
+      <%= case @show_endpoint.language do
+        :bq_sql -> "BigQuery SQL"
+        :pg_sql -> "Postgres SQL"
+        :lql -> "Logflare Query Language"
+      end %>
+    </span>
+    <code class="tw-whitespace-pre-wrap"><%= @show_endpoint.query %></code>
   </div>
 
   <div>

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -7,6 +7,7 @@
     phx-submit="save-endpoint"
     class="tw-w-1/2 tw-border-r-1 pr-2 tw-border-l-0 tw-border-t-0 tw-border-b-0 tw-border-solid tw-border-gray-600"
   >
+    <%= hidden_input(f, :language) %>
     <div class="tw-sticky tw-flex tw-justify-between tw-gap-4">
       <button
         :if={@show_endpoint}

--- a/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
+++ b/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
@@ -1,0 +1,8 @@
+defmodule Logflare.Repo.Migrations.UpdateEndpointQueryLanguageDefaultValue do
+  use Ecto.Migration
+
+  def up do
+    # set all current values
+    Logflare.Repo.update_all("endpoint_queries", set: [language: :bq_sql])
+  end
+end

--- a/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
+++ b/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
@@ -1,8 +1,14 @@
 defmodule Logflare.Repo.Migrations.UpdateEndpointQueryLanguageDefaultValue do
   use Ecto.Migration
 
-  def up do
-    # set all current existing endpoints
-    Logflare.Repo.update_all("endpoint_queries", set: [language: :bq_sql])
+  def change do
+    execute(fn ->
+      # set all current existing endpoints
+      Logflare.Repo.update_all("endpoint_queries", set: [language: "bq_sql"])
+    end, fn -> end)
+
+    alter table("endpoint_queries") do
+      modify :language, :string, null: false, from: {:string, null: true}
+    end
   end
 end

--- a/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
+++ b/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
@@ -2,7 +2,7 @@ defmodule Logflare.Repo.Migrations.UpdateEndpointQueryLanguageDefaultValue do
   use Ecto.Migration
 
   def up do
-    # set all current values
+    # set all current existing endpoints
     Logflare.Repo.update_all("endpoint_queries", set: [language: :bq_sql])
   end
 end

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -310,17 +310,4 @@ defmodule LogflareWeb.EndpointsLiveTest do
              }) =~ "results-123"
     end
   end
-
-  test "bug: endpoints with language set to nil", %{conn: conn, user: user} do
-    endpoint = insert(:endpoint, user: user, language: nil)
-    {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}/edit")
-
-    assert view
-           |> element("form#endpoint")
-           |> render_submit(%{
-             endpoint: %{
-               query: "select current_datetime() as updated"
-             }
-           }) =~ "BigQuery SQL"
-  end
 end

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -312,7 +312,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
   end
 
   test "bug: endpoints with language set to nil", %{conn: conn, user: user} do
-    endpoint = insert(:endpoint, user: user,  language: nil)
+    endpoint = insert(:endpoint, user: user, language: nil)
     {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}/edit")
 
     assert view

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -310,4 +310,17 @@ defmodule LogflareWeb.EndpointsLiveTest do
              }) =~ "results-123"
     end
   end
+
+  test "bug: endpoints with language set to nil", %{conn: conn, user: user} do
+    endpoint = insert(:endpoint, user: user,  language: nil)
+    {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}/edit")
+
+    assert view
+           |> element("form#endpoint")
+           |> render_submit(%{
+             endpoint: %{
+               query: "select current_datetime() as updated"
+             }
+           }) =~ "BigQuery SQL"
+  end
 end


### PR DESCRIPTION
This PR fixes endpoint updating, where the existing field is null.

As an additional measure, I've added in a migration to fill in the default values and enforce not null