### PR TITLE
fix: custom schema postgres backend creates schema correctly

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -192,13 +192,11 @@ end
 cond do
   System.get_env("LOGFLARE_SINGLE_TENANT", "false") == "true" &&
       not is_nil(System.get_env("POSTGRES_BACKEND_URL")) ->
-    postgres_backend_url = System.get_env("POSTGRES_BACKEND_URL")
-
     config :logflare,
            :postgres_backend_adapter,
            filter_nil_kv_pairs.(
-             url: postgres_backend_url,
-             schema: System.get_env("DB_SCHEMA"),
+             url: System.get_env("POSTGRES_BACKEND_URL"),
+             schema: System.get_env("POSTGRES_BACKEND_SCHEMA"),
              pool_size: 3
            )
 

--- a/test/logflare/backends/postgres_adaptor_test.exs
+++ b/test/logflare/backends/postgres_adaptor_test.exs
@@ -97,24 +97,18 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
       }
 
       source_backend = insert(:source_backend, type: :postgres, source: source, config: config)
-      #
-      assert {:ok, [%{"setting" => "my_schema"}]} =
-               PostgresAdaptor.execute_query(
-                 source_backend,
-                 "SELECT setting FROM pg_settings WHERE name = 'search_path'"
-               )
+      PostgresAdaptor.create_repo(source_backend)
 
-      # should create schema on connect
       assert :ok = PostgresAdaptor.connect_to_repo(source_backend)
 
       assert {:ok, [%{"schema_name" => "my_schema"}]} =
-        PostgresAdaptor.execute_query(
-          source_backend,
-          "select schema_name from information_schema.schemata where schema_name = 'my_schema'"
-        )
+               PostgresAdaptor.execute_query(
+                 source_backend,
+                 "select schema_name from information_schema.schemata where schema_name = 'my_schema'"
+               )
 
+      assert :ok = PostgresAdaptor.create_log_events_table(source_backend)
 
-      # insert a log event into schema
       log_event = build(:log_event, source: source_backend.source, test: "data")
       assert {:ok, %_{}} = PostgresAdaptor.insert_log_event(source_backend, log_event)
     end


### PR DESCRIPTION
Fix usage of Schemas when using Postgres Backends by:
* Use a new env var to properly setup the schema for Single Tenant mode
* Create schema on connect instead of migrations
* Remove prefix from log insertion since it should not be needed