### PR TITLE
fix - Add prefix to log events inserted in Postgres Backend

### DIFF
--- a/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
@@ -190,7 +190,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo do
 
     changeset =
       %PgLogEvent{}
-      |> Ecto.put_meta(source: table)
+      |> Ecto.put_meta(source: table, prefix: Map.get(source_backend.source, "schema"))
       |> PgLogEvent.changeset(params)
 
     repo.insert(changeset)


### PR DESCRIPTION
When using schemas, we required the prefix to be set on the LogEvent changeset so it knows where to be inserted