### PR TITLE
fix - Increases text area for Queries in Endpoints

### DIFF
--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -48,7 +48,8 @@
           class: "form-control form-control-margin",
           "phx-change": "parse-query",
           id: "endpoint-query",
-          value: Map.get(@params_form.params, "query")
+          value: Map.get(@params_form.params, "query"),
+          style: "height: 20rem"
         ) %>
         <%= error_tag(f, :query) %>
         <.alert :if={@parse_error_message} variant="warning"><%= @parse_error_message %></.alert>


### PR DESCRIPTION
Increases the size of the Query textarea in the Endpoints UI form.

<img width="2032" alt="Screenshot 2023-08-01 at 13 14 29" src="https://github.com/Logflare/logflare/assets/1697301/13ac5245-433d-4c0c-a3e1-ca9927a422e9">
