### PR TITLE
fix - Use Text instead of String on event_message

### DIFF
--- a/lib/logflare/backends/adaptor/postgres_adaptor/repo/migrations/add_log_events.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor/repo/migrations/add_log_events.ex
@@ -25,7 +25,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.Repo.Migrations.AddLogEvents
           create table(unquote(table_name), primary_key: false) do
             add(:id, :string, primary_key: true)
             add(:body, :map)
-            add(:event_message, :string)
+            add(:event_message, :text)
             add(:timestamp, :utc_datetime_usec)
           end
         end


### PR DESCRIPTION
`event_message` on LogEvent was using :string types which enforces a limit of 255 chars. Changing it to :text to use a type with no char limit