### PR TITLE
fix: malformed name translation when global project id is not set

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -708,7 +708,7 @@ defmodule Logflare.Sql do
         # TODO: remove once sqlparser-rs bug is fixed
         # parser for postgres adds parenthesis to the end for postgres
         |> String.replace(~r/current\_timestamp\(\)/im, "current_timestamp")
-        |> String.replace(~r/\"([\w\_\-]+\.[\w\_\-]+)\.([\w_]{36})"/im, "\"log_events_\\g{2}\"")
+        |> String.replace(~r/\"([\w\_\-]*\.[\w\_\-]+)\.([\w_]{36})"/im, "\"log_events_\\g{2}\"")
 
       {:ok, converted}
     end)

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -687,6 +687,15 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
+    test "malformed table name when global bq project id is not set" do
+      # if global bq project id is not set, the first part will be empty
+      input =
+        "SELECT body, event_message, timestamp FROM `.1_prod.b658a216_0aef_427e_bae8_9dfc68aad6dd`"
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, input)
+      assert translated =~ ~s("log_events_b658a216_0aef_427e_bae8_9dfc68aad6dd")
+    end
+
     # functions metrics
     # test "APPROX_QUANTILES is translated"
     # tes "offset() and indexing is translated"


### PR DESCRIPTION
When global project id is not set, the regex replacement fails.