### PR TITLE
feat: explicit schema prefixing for translated queries

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -168,7 +168,8 @@ defmodule Logflare.Endpoints do
       {endpoint, query_string} =
         if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_opts() != nil do
           # translate the query
-          {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query)
+          schema_prefix = Keyword.get(SingleTenant.postgres_backend_adapter_opts(), :schema)
+          {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query, schema_prefix)
           {Map.put(endpoint_query, :language, :pg_sql), q}
         else
           {endpoint_query, transformed_query}

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -696,6 +696,16 @@ defmodule Logflare.SqlTest do
       assert translated =~ ~s("log_events_b658a216_0aef_427e_bae8_9dfc68aad6dd")
     end
 
+    test "custom schema prefixing" do
+      input =
+        "SELECT body, event_message, timestamp FROM `.1_prod.b658a216_0aef_427e_bae8_9dfc68aad6dd`"
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, input)
+      assert translated =~ ~s("log_events_b658a216_0aef_427e_bae8_9dfc68aad6dd")
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, input, "my_schema")
+      assert translated =~ ~s("my_schema"."log_events_b658a216_0aef_427e_bae8_9dfc68aad6dd")
+    end
+
     # functions metrics
     # test "APPROX_QUANTILES is translated"
     # tes "offset() and indexing is translated"

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -152,7 +152,12 @@ defmodule LogflareWeb.EndpointsControllerTest do
   end
 
   describe "single tenant supabase mode" do
-    TestUtils.setup_single_tenant(seed_user: true, supabase_mode: true, backend_type: :postgres)
+    TestUtils.setup_single_tenant(
+      seed_user: true,
+      supabase_mode: true,
+      backend_type: :postgres,
+      pg_schema: "my_schema"
+    )
 
     setup do
       SingleTenant.create_supabase_sources()

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -24,7 +24,8 @@ defmodule Logflare.TestUtils do
         seed_user: false,
         supabase_mode: false,
         bigquery_project_id: random_string(),
-        backend_type: :bigquery
+        backend_type: :bigquery,
+        pg_schema: nil
       })
 
     quote do
@@ -58,7 +59,7 @@ defmodule Logflare.TestUtils do
     end
   end
 
-  defp setup_single_tenant_backend(%{backend_type: :postgres}) do
+  defp setup_single_tenant_backend(%{backend_type: :postgres, pg_schema: schema}) do
     quote do
       setup do
         %{username: username, password: password, database: database, hostname: hostname} =
@@ -66,7 +67,12 @@ defmodule Logflare.TestUtils do
 
         url = "postgresql://#{username}:#{password}@#{hostname}/#{database}"
         previous = Application.get_env(:logflare, :postgres_backend_adapter)
-        Application.put_env(:logflare, :postgres_backend_adapter, url: url)
+
+        Application.put_env(:logflare, :postgres_backend_adapter,
+          url: url,
+          schema: unquote(schema)
+        )
+
         on_exit(fn -> Application.put_env(:logflare, :postgres_backend_adapter, previous) end)
         :ok
       end


### PR DESCRIPTION
This PR explicitly prefixes a postgres table name with the schema prefix.

This does not prevent issues where the accessing user does not have permissions, but it mitigates search path issues.

```sql
-- before
select id from "log_events_123a_234f_r43fs"

-- after, with a schema called my_schema
select id from "my_schema"."log_events_123a_234f_r43fs"
```