### PR TITLE
Fix: even more translation errors

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -169,7 +169,9 @@ defmodule Logflare.Endpoints do
         if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend_adapter_opts() != nil do
           # translate the query
           schema_prefix = Keyword.get(SingleTenant.postgres_backend_adapter_opts(), :schema)
+
           {:ok, q} = Logflare.Sql.translate(:bq_sql, :pg_sql, transformed_query, schema_prefix)
+
           {Map.put(endpoint_query, :language, :pg_sql), q}
         else
           {endpoint_query, transformed_query}
@@ -255,7 +257,8 @@ defmodule Logflare.Endpoints do
         Map.get(params, parameter)
       end
 
-    with {:ok, rows} <- PostgresAdaptor.execute_query(source_backend, {transformed_query, args}) do
+    with {:ok, rows} <-
+           PostgresAdaptor.execute_query(source_backend, {transformed_query, args}) do
       {:ok, %{rows: rows}}
     end
   end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -51,42 +51,45 @@ defmodule Logflare.SingleTenant do
     "postgREST.logs.prod",
     "pgbouncer.logs.prod"
   ]
-  @endpoint_params [
-    %{
-      name: "logs.all",
-      query:
-        Application.app_dir(:logflare, "priv/supabase/endpoints/logs.all.sql") |> File.read!(),
-      sandboxable: true,
-      max_limit: 1000,
-      language: :bq_sql,
-      enable_auth: true,
-      cache_duration_seconds: 0
-    },
-    %{
-      name: "usage.api-counts",
-      query:
-        Application.app_dir(:logflare, "priv/supabase/endpoints/usage.api-counts.sql")
-        |> File.read!(),
-      sandboxable: true,
-      max_limit: 1000,
-      language: :bq_sql,
-      enable_auth: true,
-      cache_duration_seconds: 900,
-      proactive_requerying_seconds: 300
-    },
-    %{
-      name: "functions.invocation-stats",
-      query:
-        Application.app_dir(:logflare, "priv/supabase/endpoints/functions.invocation-stats.sql")
-        |> File.read!(),
-      sandboxable: true,
-      max_limit: 1000,
-      language: :bq_sql,
-      enable_auth: true,
-      cache_duration_seconds: 900,
-      proactive_requerying_seconds: 300
-    }
-  ]
+
+  defp endpoint_params do
+    [
+      %{
+        name: "logs.all",
+        query:
+          Application.app_dir(:logflare, "priv/supabase/endpoints/logs.all.sql") |> File.read!(),
+        sandboxable: true,
+        max_limit: 1000,
+        language: :bq_sql,
+        enable_auth: true,
+        cache_duration_seconds: 0
+      },
+      %{
+        name: "usage.api-counts",
+        query:
+          Application.app_dir(:logflare, "priv/supabase/endpoints/usage.api-counts.sql")
+          |> File.read!(),
+        sandboxable: true,
+        max_limit: 1000,
+        language: :bq_sql,
+        enable_auth: true,
+        cache_duration_seconds: 900,
+        proactive_requerying_seconds: 300
+      },
+      %{
+        name: "functions.invocation-stats",
+        query:
+          Application.app_dir(:logflare, "priv/supabase/endpoints/functions.invocation-stats.sql")
+          |> File.read!(),
+        sandboxable: true,
+        max_limit: 1000,
+        language: :bq_sql,
+        enable_auth: true,
+        cache_duration_seconds: 900,
+        proactive_requerying_seconds: 300
+      }
+    ]
+  end
 
   @doc """
   Retrieves the default user
@@ -191,7 +194,7 @@ defmodule Logflare.SingleTenant do
 
     if count == 0 do
       endpoints =
-        for params <- @endpoint_params do
+        for params <- endpoint_params() do
           {:ok, endpoint} = Endpoints.create_query(user, params)
           endpoint
         end

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -730,7 +730,7 @@ defmodule Logflare.Sql do
     |> Map.to_list()
     |> Enum.sort_by(fn {i, _v} -> i end, :asc)
     |> Enum.reduce(string, fn {index, param}, acc ->
-      Regex.replace(~r/@#{param}(?!:\s|$)/, acc, "$#{index}", global: false)
+      Regex.replace(~r/@#{param}(?!:\s|$)/, acc, "$#{index}::text", global: false)
     end)
   end
 

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -918,7 +918,8 @@ defmodule Logflare.Sql do
       in_cte_tables_tree: false,
       in_cast: false,
       from_table_aliases: [],
-      from_table_values: []
+      from_table_values: [],
+      in_binaryop: false
     })
     |> then(fn
       ast when joins != [] ->
@@ -945,7 +946,7 @@ defmodule Logflare.Sql do
               %{"quote_style" => nil, "value" => field}
             ]
           },
-          "operator" => if(data.in_cast, do: "LongArrow", else: "Arrow"),
+          "operator" => if(data.in_cast or data.in_binaryop, do: "LongArrow", else: "Arrow"),
           "right" => %{"Value" => %{"SingleQuotedString" => key}}
         }
       }
@@ -961,7 +962,7 @@ defmodule Logflare.Sql do
       "Nested" => %{
         "JsonAccess" => %{
           "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
-          "operator" => if(data.in_cast, do: "LongArrow", else: "Arrow"),
+          "operator" => if(data.in_cast or data.in_binaryop, do: "LongArrow", else: "Arrow"),
           "right" => %{"Value" => %{"SingleQuotedString" => key}}
         }
       }
@@ -979,7 +980,8 @@ defmodule Logflare.Sql do
       "Nested" => %{
         "JsonAccess" => %{
           "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
-          "operator" => if(data.in_cast, do: "HashLongArrow", else: "HashArrow"),
+          "operator" =>
+            if(data.in_cast or data.in_binaryop, do: "HashLongArrow", else: "HashArrow"),
           "right" => %{"Value" => %{"SingleQuotedString" => path}}
         }
       }
@@ -995,7 +997,7 @@ defmodule Logflare.Sql do
       "Nested" => %{
         "JsonAccess" => %{
           "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
-          "operator" => if(data.in_cast, do: "LongArrow", else: "Arrow"),
+          "operator" => if(data.in_cast or data.in_binaryop, do: "LongArrow", else: "Arrow"),
           "right" => %{"Value" => %{"SingleQuotedString" => name}}
         }
       }
@@ -1043,6 +1045,10 @@ defmodule Logflare.Sql do
       str_path = Enum.join(arr_path, ",")
       {alias_name, str_path}
     end
+  end
+
+  defp traverse_convert_identifiers({"BinaryOp" = k, v}, data) do
+    {k, traverse_convert_identifiers(v, Map.put(data, :in_binaryop, true))}
   end
 
   defp traverse_convert_identifiers({"cte_tables" = k, v}, data) do

--- a/priv/supabase/endpoints/logs.all.sql
+++ b/priv/supabase/endpoints/logs.all.sql
@@ -22,7 +22,7 @@ where
   -- project then timestamp then everything else
   t.project = @project
   AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > cast(@iso_timestamp_start as timestamp) END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= cast(@iso_timestamp_start as timestamp) END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= cast(@iso_timestamp_end as timestamp) END
   AND cast(t.timestamp as timestamp) > retention.date
 order by
   cast(t.timestamp as timestamp) desc
@@ -92,8 +92,8 @@ where
   -- project then timestamp then everything else
   -- m.project = @project
   t.project = @project
-  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > @iso_timestamp_start END
-  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= @iso_timestamp_end END
+  AND CASE WHEN COALESCE(@iso_timestamp_start, '') = '' THEN  TRUE ELSE  cast(t.timestamp as timestamp) > cast(@iso_timestamp_start as timestamp) END
+  AND CASE WHEN COALESCE(@iso_timestamp_end, '') = '' THEN TRUE ELSE cast(t.timestamp as timestamp) <= cast(@iso_timestamp_end as timestamp) END
   AND cast(t.timestamp as timestamp) > retention.date
 order by cast(t.timestamp as timestamp) desc
 ),

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -669,7 +669,7 @@ defmodule Logflare.SqlTest do
       bq_query =
         ~s|select @test as arg1, @test_another as arg2, coalesce(@test, '') > @test as arg_copy|
 
-      pg_query = ~s|select $1 as arg1, $2 as arg2, coalesce($3, '') > $4 as arg_copy|
+      pg_query = ~s|select $1::text as arg1, $2::text as arg2, coalesce($3::text, '') > $4::text as arg_copy|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -181,7 +181,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
         conn
         |> put_req_header("x-api-key", user.api_key)
         |> get(
-          ~p"/endpoints/query/logs.all?#{%{sql: ~s(select 'hello' as world from edge_logs)}}"
+          ~p"/endpoints/query/logs.all?#{%{iso_timestamp_start: "2023-08-01T16:00:00.000Z", iso_timestamp_end: "2023-08-01T16:00:00.000Z", project: "123abc", project_tier: "ENTERPRISE", sql: ~s(select 'hello' as world from edge_logs)}}"
         )
 
       assert [] = json_response(conn, 200)["result"]


### PR DESCRIPTION
This PR adds test coverage for parameter translation, and handles cases where Postgrex expects a certain elixir data type.
In order to get around Postgrex typechecking for query preparation encoding checks, we use `$1::text` explicit typecasting on the postgres translation in order for Postgrex to accept the string parameters.

This error occurs mostly when timestamps are passed as parameters.

This PR also fixes the handling of field references in binary operators, as we cannot compare jsonb against other text values. We would need to use LongArrow in order to compare the text value against the parameter. 