### PR TITLE
Fix/timestamp conversion unix microsecond

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -932,6 +932,105 @@ defmodule Logflare.Sql do
 
   defp convert_keys_to_json_query(identifiers, data, base \\ "body")
 
+  # convert body.timestamp from unix microsecond to postgres timestamp
+  defp convert_keys_to_json_query(%{"CompoundIdentifier" => [%{"value" => "timestamp"}]}, data, [
+         table,
+         "body"
+       ]) do
+    %{
+      "Nested" => %{
+        "AtTimeZone" => %{
+          "time_zone" => "UTC",
+          "timestamp" => %{
+            "Function" => %{
+              "args" => [
+                %{
+                  "Unnamed" => %{
+                    "Expr" => %{
+                      "BinaryOp" => %{
+                        "left" => %{
+                          "Cast" => %{
+                            "data_type" => %{"BigInt" => nil},
+                            "expr" => %{
+                              "Nested" => %{
+                                "JsonAccess" => %{
+                                  "left" => %{
+                                    "CompoundIdentifier" => [
+                                      %{"quote_style" => nil, "value" => table},
+                                      %{"quote_style" => nil, "value" => "body"}
+                                    ]
+                                  },
+                                  "operator" => "LongArrow",
+                                  "right" => %{"Value" => %{"SingleQuotedString" => "timestamp"}}
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "op" => "Divide",
+                        "right" => %{"Value" => %{"Number" => ["1000000.0", false]}}
+                      }
+                    }
+                  }
+                }
+              ],
+              "distinct" => false,
+              "name" => [%{"quote_style" => nil, "value" => "to_timestamp"}],
+              "over" => nil,
+              "special" => false
+            }
+          }
+        }
+      }
+    }
+  end
+
+  defp convert_keys_to_json_query(%{"Identifier" => %{"value" => "timestamp"}}, data, "body") do
+    %{
+      "Nested" => %{
+        "AtTimeZone" => %{
+          "time_zone" => "UTC",
+          "timestamp" => %{
+            "Function" => %{
+              "args" => [
+                %{
+                  "Unnamed" => %{
+                    "Expr" => %{
+                      "BinaryOp" => %{
+                        "left" => %{
+                          "Cast" => %{
+                            "data_type" => %{"BigInt" => nil},
+                            "expr" => %{
+                              "Nested" => %{
+                                "JsonAccess" => %{
+                                  "left" => %{
+                                    "Identifier" => %{"quote_style" => nil, "value" => "body"}
+                                  },
+                                  "operator" => "LongArrow",
+                                  "right" => %{"Value" => %{"SingleQuotedString" => "timestamp"}}
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "op" => "Divide",
+                        "right" => %{"Value" => %{"Number" => ["1000000.0", false]}}
+                      }
+                    }
+                  }
+                }
+              ],
+              "distinct" => false,
+              "name" => [%{"quote_style" => nil, "value" => "to_timestamp"}],
+              "over" => nil,
+              "special" => false
+            }
+          }
+        }
+      }
+    }
+  end
+
   defp convert_keys_to_json_query(
          %{"CompoundIdentifier" => [%{"value" => key}]},
          data,

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -933,7 +933,7 @@ defmodule Logflare.Sql do
   defp convert_keys_to_json_query(identifiers, data, base \\ "body")
 
   # convert body.timestamp from unix microsecond to postgres timestamp
-  defp convert_keys_to_json_query(%{"CompoundIdentifier" => [%{"value" => "timestamp"}]}, data, [
+  defp convert_keys_to_json_query(%{"CompoundIdentifier" => [%{"value" => "timestamp"}]}, _data, [
          table,
          "body"
        ]) do
@@ -985,7 +985,7 @@ defmodule Logflare.Sql do
     }
   end
 
-  defp convert_keys_to_json_query(%{"Identifier" => %{"value" => "timestamp"}}, data, "body") do
+  defp convert_keys_to_json_query(%{"Identifier" => %{"value" => "timestamp"}}, _data, "body") do
     %{
       "Nested" => %{
         "AtTimeZone" => %{

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -190,7 +190,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
 
       params = %{
         iso_timestamp_start:
-          DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.to_iso8601() |> dbg(),
+          DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.to_iso8601(),
         project: "default",
         project_tier: "ENTERPRISE",
         sql: "select  timestamp,  event_message, metadata from edge_logs"

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -1,10 +1,8 @@
 defmodule LogflareWeb.EndpointsControllerTest do
   use LogflareWeb.ConnCase
   alias Logflare.SingleTenant
-  alias Logflare.Backends.SourceBackend
   alias Logflare.Backends
   alias Logflare.Source
-  alias Logflare.Backends.Adaptor.PostgresAdaptor
 
   describe "query" do
     setup :set_mimic_global

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -1,6 +1,10 @@
 defmodule LogflareWeb.EndpointsControllerTest do
   use LogflareWeb.ConnCase
   alias Logflare.SingleTenant
+  alias Logflare.Backends.SourceBackend
+  alias Logflare.Backends
+  alias Logflare.Source
+  alias Logflare.Backends.Adaptor.PostgresAdaptor
 
   describe "query" do
     setup :set_mimic_global
@@ -176,15 +180,30 @@ defmodule LogflareWeb.EndpointsControllerTest do
       assert conn.halted == false
     end
 
-    test "GET a basic sandboxed query with fromt able", %{conn: conn, user: user} do
-      conn =
-        conn
-        |> put_req_header("x-api-key", user.api_key)
-        |> get(
-          ~p"/endpoints/query/logs.all?#{%{iso_timestamp_start: "2023-08-01T16:00:00.000Z", iso_timestamp_end: "2023-08-01T16:00:00.000Z", project: "123abc", project_tier: "ENTERPRISE", sql: ~s(select 'hello' as world from edge_logs)}}"
+    test "GET a basic sandboxed query with fromt able", %{conn: initial_conn, user: user} do
+      for source <- Logflare.Repo.all(Source) do
+        Backends.ingest_logs(
+          [%{"event_message" => "some message", "project" => "default"}],
+          source
         )
+      end
 
-      assert [] = json_response(conn, 200)["result"]
+      :timer.sleep(2000)
+
+      params = %{
+        iso_timestamp_start:
+          DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.to_iso8601() |> dbg(),
+        project: "default",
+        project_tier: "ENTERPRISE",
+        sql: "select  timestamp,  event_message, metadata from edge_logs"
+      }
+
+      conn =
+        initial_conn
+        |> put_req_header("x-api-key", user.api_key)
+        |> get(~p"/endpoints/query/logs.all?#{params}")
+
+      assert [%{"event_message" => "some message"}] = json_response(conn, 200)["result"]
       assert conn.halted == false
     end
   end


### PR DESCRIPTION
This PR handles timestamp querying conversion when querying the `body -> 'timestamp'`. This special field will have additional unix microsecond conversion logic added to it.

For consistency, the timestamp field will always be stored as a unix microsecond. However, as PG does not automatically convert it to a timestamp (unlike BigQuery), we need to transparently convert the field for translated BQ queries. This a date/time overflow error that Postgres will throw when trying to convert 16 digit unix timestamps.