### PR TITLE
fix: translation for timestamp field should not convert to iso timestamp

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -917,6 +917,7 @@ defmodule Logflare.Sql do
       cte_from_aliases: cte_from_aliases,
       in_cte_tables_tree: false,
       in_cast: false,
+      in_projection_tree: false,
       from_table_aliases: [],
       from_table_values: [],
       in_binaryop: false
@@ -935,7 +936,7 @@ defmodule Logflare.Sql do
   # convert body.timestamp from unix microsecond to postgres timestamp
   defp convert_keys_to_json_query(
          %{"CompoundIdentifier" => [%{"value" => "timestamp"}]},
-         %{in_cte_tables_tree: in_cte_tables_tree, cte_aliases: cte_aliases} = _data,
+         %{in_cte_tables_tree: in_cte_tables_tree, cte_aliases: cte_aliases, in_projection_tree: false} = _data,
          [
            table,
            "body"
@@ -1195,6 +1196,9 @@ defmodule Logflare.Sql do
 
   defp traverse_convert_identifiers({"cte_tables" = k, v}, data) do
     {k, traverse_convert_identifiers(v, Map.put(data, :in_cte_tables_tree, true))}
+  end
+  defp traverse_convert_identifiers({"projection" = k, v}, data) do
+    {k, traverse_convert_identifiers(v, Map.put(data, :in_projection_tree, true))}
   end
 
   # handle top level queries

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -936,7 +936,11 @@ defmodule Logflare.Sql do
   # convert body.timestamp from unix microsecond to postgres timestamp
   defp convert_keys_to_json_query(
          %{"CompoundIdentifier" => [%{"value" => "timestamp"}]},
-         %{in_cte_tables_tree: in_cte_tables_tree, cte_aliases: cte_aliases, in_projection_tree: false} = _data,
+         %{
+           in_cte_tables_tree: in_cte_tables_tree,
+           cte_aliases: cte_aliases,
+           in_projection_tree: false
+         } = _data,
          [
            table,
            "body"
@@ -1197,6 +1201,7 @@ defmodule Logflare.Sql do
   defp traverse_convert_identifiers({"cte_tables" = k, v}, data) do
     {k, traverse_convert_identifiers(v, Map.put(data, :in_cte_tables_tree, true))}
   end
+
   defp traverse_convert_identifiers({"projection" = k, v}, data) do
     {k, traverse_convert_identifiers(v, Map.put(data, :in_projection_tree, true))}
   end

--- a/lib/logflare_web/views/endpoints_view.ex
+++ b/lib/logflare_web/views/endpoints_view.ex
@@ -2,17 +2,6 @@ defmodule LogflareWeb.EndpointsView do
   use LogflareWeb, :view
   alias Logflare.SingleTenant
   def render("query.json", %{result: data}) do
-  # if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend?() do
-  #   data = Enum.map(fn
-  #     %{"event_message"=> _, "timestamp"=> ts, "id"=> _} = datum->
-  #       %{datum | "timestamp" => }
-  #     datum ->datum
-  #   end)
-  #   %{result: data}
-
-  # else
-  #   %{result: data}
-  # end
     %{result: data}
   end
 

--- a/lib/logflare_web/views/endpoints_view.ex
+++ b/lib/logflare_web/views/endpoints_view.ex
@@ -1,7 +1,18 @@
 defmodule LogflareWeb.EndpointsView do
   use LogflareWeb, :view
-
+  alias Logflare.SingleTenant
   def render("query.json", %{result: data}) do
+  # if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend?() do
+  #   data = Enum.map(fn
+  #     %{"event_message"=> _, "timestamp"=> ts, "id"=> _} = datum->
+  #       %{datum | "timestamp" => }
+  #     datum ->datum
+  #   end)
+  #   %{result: data}
+
+  # else
+  #   %{result: data}
+  # end
     %{result: data}
   end
 

--- a/lib/logflare_web/views/endpoints_view.ex
+++ b/lib/logflare_web/views/endpoints_view.ex
@@ -1,6 +1,6 @@
 defmodule LogflareWeb.EndpointsView do
   use LogflareWeb, :view
-  alias Logflare.SingleTenant
+
   def render("query.json", %{result: data}) do
     %{result: data}
   end

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -718,8 +718,7 @@ defmodule Logflare.SqlTest do
     test "unix microsecond timestamp handling" do
       bq_query = ~s|select t.timestamp as ts from my_table t|
 
-      pg_query =
-        ~s|select (t.body -> 'timestamp') as ts from my_table t|
+      pg_query = ~s|select (t.body -> 'timestamp') as ts from my_table t|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -201,7 +201,10 @@ defmodule LogflareWeb.EndpointsControllerTest do
         |> put_req_header("x-api-key", user.api_key)
         |> get(~p"/endpoints/query/logs.all?#{params}")
 
-      assert [%{"event_message" => "some message"}] = json_response(conn, 200)["result"]
+      assert [%{"event_message" => "some message", "timestamp"=> timestamp}] = json_response(conn, 200)["result"]
+      # render as unix microsecond
+      assert inspect(timestamp) |> String.length() == 16
+      assert "16" <> _ = inspect(timestamp)
       assert conn.halted == false
 
       # test a logs ui query

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -201,7 +201,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
         |> put_req_header("x-api-key", user.api_key)
         |> get(~p"/endpoints/query/logs.all?#{params}")
 
-      assert [%{"event_message" => "some message", "timestamp"=> timestamp}] = json_response(conn, 200)["result"]
+      assert [%{"event_message" => "some message", "timestamp" => timestamp}] =
+               json_response(conn, 200)["result"]
+
       # render as unix microsecond
       assert inspect(timestamp) |> String.length() == 16
       assert "16" <> _ = inspect(timestamp)


### PR DESCRIPTION
This PR retains timestamp selection within the projection ast, so that timestamp rendering behaviour is kept to using unix microseconds.

