### PR TITLE
fix: cte table alias handling for compound identifier for translations

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -811,18 +811,6 @@ defmodule Logflare.Sql do
                   }
                 }
               }
-              #  bq_to_pg_convert_functions(to_trunc)
-              #  %{s
-              #   "Unnamed"=>%{"Expr"=>%{
-              #    "Value"=> %{
-              #      "Cast" => %{
-              #        "data_type" => %{"Timestamp" => nil},
-              #        "expr" =>   bq_to_pg_convert_functions(to_trunc)
-              #      }
-              #    }
-              #  },
-              #  }
-              # }
              ],
              "name" => [%{"quote_style" => nil, "value" => "date_trunc"}]
          }}

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -770,6 +770,21 @@ defmodule Logflare.SqlTest do
       assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
     end
 
+    test "should not convert to body json query if referencing cte field" do
+      bq_query = ~s"""
+      with edge_logs as (select t.id from  `cloudflare.logs.prod` t)
+      select t.id from edge_logs t
+      """
+
+      pg_query = ~s"""
+      with edge_logs as ( select (t.body -> 'id') as id from  "cloudflare.logs.prod" t )
+      SELECT t.id AS id FROM edge_logs t
+      """
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+    end
+
     # functions metrics
     # test "APPROX_QUANTILES is translated"
     # tes "offset() and indexing is translated"


### PR DESCRIPTION
Fix for CTE table alias handling for outside of CTE.
Expected translation behaviour is as so: 
<img width="582" alt="Screenshot 2023-08-06 at 3 26 19 AM" src="https://github.com/Logflare/logflare/assets/22714384/ebc0b018-136a-48fb-9599-8dafe2ebe151">
