### PR TITLE
fix: query results should be nested in an array to mimic bigquery behaviour

### DIFF
--- a/lib/logflare/backends/adaptor/postgres_adaptor.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor.ex
@@ -137,8 +137,8 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor do
 
   defp nested_map_update(value), do: value
 
-  defp nested_map_update({"metadata", value}, acc) do
-    Map.put(acc, "metadata", [nested_map_update(value)])
+  defp nested_map_update({key, value}, acc) when is_map(value) do
+    Map.put(acc, key, [nested_map_update(value)])
   end
 
   defp nested_map_update({key, value}, acc) do


### PR DESCRIPTION
This PR adds in array nested to the postgres adaptor to mimic bigquery querying behaviour.

This might change in a future version as we may remove this array nested to standardize payload returning across backends (and follow the ingested json structure as close as possible)