### PR TITLE
fix - Using single tenant with BigQuery failing to start

### DIFF
--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -291,7 +291,9 @@ defmodule Logflare.SingleTenant do
   """
   @spec postgres_backend? :: boolean()
   def postgres_backend?() do
-    url = postgres_backend_adapter_opts() |> Keyword.get(:url)
+    opts = postgres_backend_adapter_opts() || []
+
+    url = Keyword.get(opts, :url)
     single_tenant?() && url != nil
   end
 


### PR DESCRIPTION
Due to the way we were checking which backend to load in single tenant mode when we wanted to use BigQuery it was failing.