### PR TITLE
chore: remove footer messages

### DIFF
--- a/lib/logflare/source/slack_hook_server/client.ex
+++ b/lib/logflare/source/slack_hook_server/client.ex
@@ -141,7 +141,7 @@ defmodule Logflare.Source.SlackHookServer.Client do
           type: "context",
           elements: [
             %{
-              type: "mrkdwn",
+              type: "mrkdwn"
             }
           ]
         }

--- a/lib/logflare/source/slack_hook_server/client.ex
+++ b/lib/logflare/source/slack_hook_server/client.ex
@@ -142,7 +142,6 @@ defmodule Logflare.Source.SlackHookServer.Client do
           elements: [
             %{
               type: "mrkdwn",
-              text: "Thanks for using Logflare 🙏"
             }
           ]
         }

--- a/lib/logflare/source/webhook_notification_server/discord_client.ex
+++ b/lib/logflare/source/webhook_notification_server/discord_client.ex
@@ -43,7 +43,6 @@ defmodule Logflare.Source.WebhookNotificationServer.DiscordClient do
             icon_url: "https://logflare.app/images/logos/logflare-logo.png"
           },
           title: "#{rate} new event(s)",
-          footer: %{text: "Thanks for using Logflare 🙏"},
           fields: prepped_recent_events
         }
       ]


### PR DESCRIPTION
This PR removes the "Thanks for using Logflare" footer, as feedbacked by users.