### PR TITLE
fix: lql parsing of escaped double quotes for regex

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/lql/index.md
+++ b/docs/docs.logflare.com/docs/concepts/lql/index.md
@@ -21,6 +21,7 @@ Any string not matching a supported operator will search against the log event m
 | Message | match, regex                   | regex string                    | `~server\_\d`                                     |
 | Message | match regex with spaces        | double quoted regex string      | `~"log message \d\d"`                             |
 | Message | match regex, case insensitive  | regex string with `(?i)` prefix | `~(?i)server\_\d` <br/> `~"(?i)log message \d\d"` |
+| Message | match regex with double quotes | regex string with symbol        | `~some\"value` <br/> `~"msg with \" spaces"`      |
 | Message | match regex, with OR           | regex string with symbol        | <code>~"jpg$&#124;jpeg$&#124;png$"</code>         |
 
 #### Metadata Filtering
@@ -66,7 +67,6 @@ Chart aggregations rules will display the aggregated trends in the chart. Chart 
 | c     | `p50`       | `c:p50(m.latency)` |
 | c     | `p95`       | `c:p95(m.latency)` |
 | c     | `p99`       | `c:p99(m.latency)` |
-
 
 ## Beyond LQL
 

--- a/lib/logflare/logs/lql/lql_parser.ex
+++ b/lib/logflare/logs/lql/lql_parser.ex
@@ -72,7 +72,8 @@ defmodule Logflare.Lql.Parser do
 
       {:ok, rules}
     else
-      {:ok, _rules, rest, _, {_, _}, _} ->
+      {:ok, rules, rest, _, {_, _}, _} ->
+        dbg(rules)
         {:error, "LQL parser doesn't know how to handle this part: #{rest}"}
 
       {:error, err} ->

--- a/test/logflare/lql/lql_parser_test.exs
+++ b/test/logflare/lql/lql_parser_test.exs
@@ -48,6 +48,27 @@ defmodule Logflare.LqlParserTest do
       assert Lql.encode!(lql_rules) == qs
     end
 
+    test "regexp double-quote escaping" do
+      qs = ~S|~"user \"sign\" up" ~^er\"ror|
+
+      lql_rules = [
+        %FilterRule{
+          operator: :"~",
+          path: "event_message",
+          value: ~S(user \"sign\" up),
+          modifiers: %{quoted_string: true}
+        },
+        %FilterRule{
+          operator: :"~",
+          path: "event_message",
+          value: ~S(^er\"ror)
+        }
+      ]
+
+      assert {:ok, lql_rules} == Parser.parse(qs, @default_schema)
+      assert Lql.encode!(lql_rules) == qs
+    end
+
     test "range int/float" do
       schema = build_schema(%{"metadata" => %{"float" => 1.0, "int" => 1}})
       qs = ~S|m.float:30.1..300.1 m.int:50..200|


### PR DESCRIPTION
This PR fixes escaped double quotes parsing behaviour for regexp in LQL search queries.