### PR TITLE
fix: log dist buffer and increase dist buffer limit

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -84,6 +84,7 @@ defmodule Logflare.Application do
     pool_size = Application.get_env(:logflare, Logflare.PubSub)[:pool_size]
 
     [
+      Logflare.ErlSysMon,
       {Task.Supervisor, name: Logflare.TaskSupervisor},
       {Cluster.Supervisor, [topologies, [name: Logflare.ClusterSupervisor]]},
       Logflare.Repo,

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -21,7 +21,7 @@ defmodule Logflare.ErlSysMon do
   end
 
   def handle_info(msg, state) do
-    Logger.warning("#{__MODULE__} message: " <> msg)
+    Logger.warning("#{__MODULE__} message: " <> inspect(msg))
 
     {:noreply, state}
   end

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -13,7 +13,7 @@ defmodule Logflare.ErlSysMon do
     :erlang.system_monitor(self(), [
       :busy_dist_port,
       :busy_port,
-      {:long_gc, 100},
+      {:long_gc, 1_000},
       {:long_schedule, 100}
     ])
 

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -1,0 +1,26 @@
+defmodule Logflare.ErlSysMon do
+  @moduledoc """
+  Logs Erlang System Monitor events.
+  """
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(_args) do
+    :erlang.system_monitor(self(), [
+      :busy_dist_port,
+      :busy_port,
+      {:long_gc, 100},
+      {:long_schedule, 100}
+    ])
+
+    {:ok, []}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warning("#{__MODULE__} message: " <> msg)
+
+    {:noreply, state}
+  end
+end

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -13,7 +13,7 @@ defmodule Logflare.ErlSysMon do
     :erlang.system_monitor(self(), [
       :busy_dist_port,
       :busy_port,
-      {:long_gc, 1_000},
+      {:long_gc, 250},
       {:long_schedule, 100}
     ])
 

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -3,6 +3,8 @@ defmodule Logflare.ErlSysMon do
   Logs Erlang System Monitor events.
   """
 
+  require Logger
+
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end

--- a/lib/logflare/system_metrics/system_metrics_sup.ex
+++ b/lib/logflare/system_metrics/system_metrics_sup.ex
@@ -12,7 +12,8 @@ defmodule Logflare.SystemMetricsSup do
   def init(_init_arg) do
     children = [
       SystemMetrics.Observer.Poller,
-      SystemMetrics.Procs.Poller,
+      # This calls :erlang.process_info which may not be good to call for all proces frequently
+      # SystemMetrics.Procs.Poller,
       SystemMetrics.AllLogsLogged,
       SystemMetrics.AllLogsLogged.Poller,
       SystemMetrics.Schedulers.Poller,

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -16,7 +16,7 @@
 +sbwtdio medium
 
 ## Set distribution buffer limit - default is 1024
-+zdbbl 10240
++zdbbl 1028000
 
 ## Set process limit
 +P 1000000


### PR DESCRIPTION
I verified on prod this won't create excess log messages in normal ops:

```elixir
iex> :erlang.system_monitor(self(), [:busy_dist_port, :busy_port, {:long_gc, 1_000}, {:long_schedule, 100}])
iex> flush()
```