### PR TITLE
feat: OpenAPI routes updating - Ingestion, Querying

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/endpoints.md
+++ b/docs/docs.logflare.com/docs/concepts/endpoints.md
@@ -23,6 +23,8 @@ GET  https://api.logflare.app/api/endpoints/query/my.custom.endpoint
 
 Querying by name requires authentication to be enabled and for a valid access token to be provided.
 
+OpenAPI documentation for querying Logflare Endpoints can be found [here](https://logflare.app/swaggerui#/Public).
+
 ## Crafting a Query
 
 Queries will be passed to the underlying backend to perform the querying.

--- a/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
+++ b/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
@@ -26,6 +26,8 @@ POST https://api.logflare.app/api/logs?source=9dd9a6f6-8e9b-4fa4-b682-4f2f5cd99d
 POST https://api.logflare.app/api/logs?source_name=my.logs.source
 ```
 
+OpenAPI documentation for ingestion can be found [here](https://logflare.app/swaggerui#/Public).
+
 ### Batching Your Events
 
 You can ingest events individually, or via a batch.

--- a/lib/logflare_web/api_spec.ex
+++ b/lib/logflare_web/api_spec.ex
@@ -19,12 +19,18 @@ defmodule LogflareWeb.ApiSpec do
         title: to_string(Application.spec(:logflare, :description)),
         version: to_string(Application.spec(:logflare, :vsn))
       },
-      paths: Paths.from_router(Router),
+      paths: Paths.from_router(Router) |> filter_routes(),
       components: %Components{
         securitySchemes: %{
           "authorization" => %SecurityScheme{type: "http", scheme: "bearer", bearerFormat: "JWT"}
         }
       }
     })
+  end
+
+  defp filter_routes(routes_map) do
+    for {"/api" <> _path = k, v} <- routes_map, into: %{} do
+      {k, v}
+    end
   end
 end

--- a/lib/logflare_web/controllers/endpoints_controller.ex
+++ b/lib/logflare_web/controllers/endpoints_controller.ex
@@ -5,7 +5,6 @@ defmodule LogflareWeb.EndpointsController do
   require Logger
   alias Logflare.Endpoints
 
-  alias LogflareWeb.OpenApi.Accepted
   alias LogflareWeb.OpenApi.ServerError
   alias LogflareWeb.OpenApiSchemas.EndpointQuery
 

--- a/lib/logflare_web/controllers/endpoints_controller.ex
+++ b/lib/logflare_web/controllers/endpoints_controller.ex
@@ -1,9 +1,16 @@
 defmodule LogflareWeb.EndpointsController do
   use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
   require Logger
   alias Logflare.Endpoints
 
+  alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.ServerError
+  alias LogflareWeb.OpenApiSchemas.EndpointQuery
+
   action_fallback(LogflareWeb.Api.FallbackController)
+  tags(["Public"])
 
   plug CORSPlug,
     origin: "*",
@@ -17,6 +24,25 @@ defmodule LogflareWeb.EndpointsController do
     ],
     methods: ["GET", "POST", "OPTIONS"],
     send_preflight_response?: true
+
+  operation(:query,
+    summary: "Query a Logflare Endpoint",
+    description:
+      "Full details are available in the [Logflare Endpoints documentation](https://docs.logflare.app/concepts/endpoints/)",
+    parameters: [
+      token_or_name: [
+        in: :path,
+        description: "Endpoint UUID or name",
+        type: :string,
+        example: "a040ae88-3e27-448b-9ee6-622278b23193",
+        required: true
+      ]
+    ],
+    responses: %{
+      200 => EndpointQuery.response(),
+      500 => ServerError.response()
+    }
+  )
 
   def query(%{assigns: %{endpoint: endpoint}} = conn, _params) do
     endpoint_query = Endpoints.map_query_sources(endpoint)

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -1,8 +1,18 @@
 defmodule LogflareWeb.LogController do
   use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Logflare.Logs.IngestTypecasting
   alias Logflare.Backends
+
+  alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.Created
+  alias LogflareWeb.OpenApi.ServerError
+  alias LogflareWeb.OpenApiSchemas.LogsCreated
+
+  action_fallback(LogflareWeb.Api.FallbackController)
+
+  tags(["Ingestion"])
 
   plug(
     CORSPlug,
@@ -24,6 +34,19 @@ defmodule LogflareWeb.LogController do
   alias Logflare.Logs
 
   @message "Logged!"
+
+  operation(:create,
+    summary: "Create log event",
+    description: "Full details are available in the [ingestion documentation](https://docs.logflare.app/concepts/ingestion/)",
+    parameters: [
+      source: [in: :query, description: "Source UUID", type: :string, example: "a040ae88-3e27-448b-9ee6-622278b23193", required: false],
+      source_name: [in: :query, description: "Source name", type: :string, example: "MyApp.MySource", required: false]
+      ],
+    responses: %{
+      201 => Created.response(LogsCreated),
+      500 => ServerError.response()
+    }
+  )
 
   def create(%{assigns: %{source: source}} = conn, %{"batch" => batch}) when is_list(batch) do
     ingest_and_render(conn, batch, source)

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -5,7 +5,6 @@ defmodule LogflareWeb.LogController do
   alias Logflare.Logs.IngestTypecasting
   alias Logflare.Backends
 
-  alias LogflareWeb.OpenApi.Accepted
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.ServerError
   alias LogflareWeb.OpenApiSchemas.LogsCreated

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -12,7 +12,7 @@ defmodule LogflareWeb.LogController do
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
-  tags(["Ingestion"])
+  tags(["Public"])
 
   plug(
     CORSPlug,
@@ -37,11 +37,24 @@ defmodule LogflareWeb.LogController do
 
   operation(:create,
     summary: "Create log event",
-    description: "Full details are available in the [ingestion documentation](https://docs.logflare.app/concepts/ingestion/)",
+    description:
+      "Full details are available in the [ingestion documentation](https://docs.logflare.app/concepts/ingestion/)",
     parameters: [
-      source: [in: :query, description: "Source UUID", type: :string, example: "a040ae88-3e27-448b-9ee6-622278b23193", required: false],
-      source_name: [in: :query, description: "Source name", type: :string, example: "MyApp.MySource", required: false]
+      source: [
+        in: :query,
+        description: "Source UUID",
+        type: :string,
+        example: "a040ae88-3e27-448b-9ee6-622278b23193",
+        required: false
       ],
+      source_name: [
+        in: :query,
+        description: "Source name",
+        type: :string,
+        example: "MyApp.MySource",
+        required: false
+      ]
+    ],
     responses: %{
       201 => Created.response(LogsCreated),
       500 => ServerError.response()

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -52,4 +52,11 @@ defmodule LogflareWeb.OpenApi do
 
     def response(), do: {"Not found", "text/plain", __MODULE__}
   end
+
+  defmodule ServerError do
+    require OpenApiSpex
+    OpenApiSpex.schema(%{})
+
+    def response(), do: {"Server error", "text/plain", __MODULE__}
+  end
 end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -1,6 +1,12 @@
 defmodule LogflareWeb.OpenApiSchemas do
   alias OpenApiSpex.Schema
 
+  defmodule LogsCreated do
+    @properties %{
+      message: %Schema{type: :string, example: "Logged!"},
+    }
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
   defmodule Endpoint do
     @properties %{
       token: %Schema{type: :string},

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -1,12 +1,27 @@
 defmodule LogflareWeb.OpenApiSchemas do
   alias OpenApiSpex.Schema
 
-  defmodule LogsCreated do
+  defmodule EndpointQuery do
     @properties %{
-      message: %Schema{type: :string, example: "Logged!"},
+      result: %Schema{type: :string, example: "Logged!"},
+      errors: %Schema{
+        required: false,
+        oneOf: [
+          %Schema{type: :object},
+          %Schema{type: :string}
+        ]
+      }
     }
     use LogflareWeb.OpenApi, properties: @properties, required: []
   end
+
+  defmodule LogsCreated do
+    @properties %{
+      message: %Schema{type: :string, example: "Logged!"}
+    }
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
   defmodule Endpoint do
     @properties %{
       token: %Schema{type: :string},


### PR DESCRIPTION
This PR adds in the main `/api/logs` and `/api/endpoints/query` routes.

I have also added in filtering logic to only display routes that begin with the `/api` prefix.

note: the `/api/endpoints/query/name` route is to be removed in separate PR.


<img width="1468" alt="Screenshot 2023-09-21 at 11 00 45 PM" src="https://github.com/Logflare/logflare/assets/22714384/c1ebbc2e-660d-43fc-8e96-5fd9e2ce52c6">
