### PR TITLE
feat: display whether endpoints auth is enabled on index page

### DIFF
--- a/lib/logflare_web/live/endpoints/actions/index.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/index.html.heex
@@ -41,7 +41,6 @@
           <i class="fas fa-lock-open"></i>
         </span>
         <span>caches: <%= endpoint.metrics.cache_count %></span>
-        <span>caches: <%= endpoint.metrics.cache_count %></span>
       </div>
     </li>
   </ul>

--- a/lib/logflare_web/live/endpoints/actions/index.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/index.html.heex
@@ -33,6 +33,14 @@
         <%= endpoint.description %>
       </p>
       <div class="tw-text-sm">
+        <span :if={endpoint.enable_auth} title="Auth enabled">
+          <i class="fas fa-lock"></i>
+        </span>
+
+        <span :if={!endpoint.enable_auth} title="Auth disabled">
+          <i class="fas fa-lock-open"></i>
+        </span>
+        <span>caches: <%= endpoint.metrics.cache_count %></span>
         <span>caches: <%= endpoint.metrics.cache_count %></span>
       </div>
     </li>

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -75,6 +75,13 @@ defmodule LogflareWeb.EndpointsLive do
           # set changeset
           |> assign(:endpoint_changeset, Endpoints.change_query(endpoint, %{}))
 
+        # index page
+        socket when params == %{} ->
+          socket
+          |> refresh_endpoints()
+          |> assign(:endpoint_changeset, nil)
+          |> assign(:query_result_rows, nil)
+
         other ->
           other
           # reset the changeset

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -76,7 +76,7 @@ defmodule LogflareWeb.EndpointsLive do
           |> assign(:endpoint_changeset, Endpoints.change_query(endpoint, %{}))
 
         # index page
-        socket when params == %{} ->
+        %{assigns: %{live_action: :index}} = socket ->
           socket
           |> refresh_endpoints()
           |> assign(:endpoint_changeset, nil)

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -26,6 +26,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
       # description
       assert has_element?(view, "ul li p", endpoint.description)
+      assert has_element?(view, "ul li *[title='Auth enabled']")
 
       # link to show
       view


### PR DESCRIPTION
<img width="668" alt="Screenshot 2023-09-21 at 11 20 12 PM" src="https://github.com/Logflare/logflare/assets/22714384/8314cb7a-933c-4838-851d-0b14ab7d0f7d">

so that one does not need to check each endpoint individually 

PR also adds in a bug fix for ensuring index page is always refreshed when navigated to.