### PR TITLE
chore: remove github compilation warning

### DIFF
--- a/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
+++ b/priv/repo/migrations/20230727111150_update_endpoint_query_language_default_value.exs
@@ -5,7 +5,9 @@ defmodule Logflare.Repo.Migrations.UpdateEndpointQueryLanguageDefaultValue do
     execute(fn ->
       # set all current existing endpoints
       Logflare.Repo.update_all("endpoint_queries", set: [language: "bq_sql"])
-    end, fn -> end)
+    end, fn ->
+      nil
+    end)
 
     alter table("endpoint_queries") do
       modify :language, :string, null: false, from: {:string, null: true}


### PR DESCRIPTION
This removes the github compilation warning, as shown in this PR [here](https://github.com/Logflare/logflare/pull/1701/files) 

