### PR TITLE
fix: nil email for team_user

### DIFF
--- a/lib/logflare/account_email.ex
+++ b/lib/logflare/account_email.ex
@@ -201,22 +201,6 @@ defmodule Logflare.AccountEmail do
     |> text_body(part_one <> part_two <> unsuscribe_part)
   end
 
-  def schema_updated(
-        email,
-        %Source{token: token},
-        _new_schema,
-        _old_schema,
-        _opts
-      )
-      when is_nil(email) do
-    Logger.error(
-      "Email schema notification not sent. Email is nil for source user source token: #{inspect(token)}",
-      source_id: token
-    )
-
-    {:error, :nil_email}
-  end
-
   defp notification_email(email, rate, source_name, source_link, unsubscribe_link) do
     new()
     |> to(email)

--- a/lib/logflare/account_email.ex
+++ b/lib/logflare/account_email.ex
@@ -201,6 +201,22 @@ defmodule Logflare.AccountEmail do
     |> text_body(part_one <> part_two <> unsuscribe_part)
   end
 
+  def schema_updated(
+        email,
+        %Source{token: token},
+        _new_schema,
+        _old_schema,
+        _opts
+      )
+      when is_nil(email) do
+    Logger.error(
+      "Email schema notification not sent. Email is nil for source user source token: #{inspect(token)}",
+      source_id: token
+    )
+
+    {:error, :nil_email}
+  end
+
   defp notification_email(email, rate, source_name, source_link, unsubscribe_link) do
     new()
     |> to(email)

--- a/lib/logflare/source/bigquery/schema.ex
+++ b/lib/logflare/source/bigquery/schema.ex
@@ -314,7 +314,7 @@ defmodule Logflare.Source.BigQuery.Schema do
   end
 
   defp notify_maybe(source_token, new_schema, old_schema) do
-    %Source{user: user} = source = Sources.Cache.get_by_and_preload(token: source_token)
+    %Source{user: user} = source = Sources.get_by_and_preload(token: source_token)
 
     if source.notifications.user_schema_update_notifications do
       AccountEmail.schema_updated(user, source, new_schema, old_schema)

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -48,7 +48,7 @@ defmodule Logflare.Source.BigQuery.SchemaTest do
     Logflare.Mailer
     |> expect(:deliver, 1, fn _ -> :ok end)
 
-    Logflare.Sources.Cache
+    Logflare.Sources
     |> expect(:get_by_and_preload, fn _ -> source end)
     |> expect(:get_by, fn _ -> source end)
 


### PR DESCRIPTION
Getting lots of errors for:

```
no function clause matching in Logflare.AccountEmail.schema_updated/4 (logflare 1.4.5) lib/logflare/account_email.ex:113: Logflare.AccountEmail.schema_updated(nil, %Logflare.Source{__meta_
```