### PR TITLE
chore: remove endpoint name duplication

### DIFF
--- a/lib/logflare_web/live/endpoints/actions/show.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/show.html.heex
@@ -11,9 +11,6 @@
   />
 </.subheader>
 <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-4">
-  <h2>
-    <%= @show_endpoint.name %>
-  </h2>
   <div>
     id: <%= @show_endpoint.token %>
   </div>


### PR DESCRIPTION
This removes the duplicate name when viewing a logflare endpoint