### PR TITLE
chore: fix flaky cron validation test

### DIFF
--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -25,7 +25,7 @@ defmodule Logflare.AlertingTest do
     }
     @update_attrs %{
       name: "some updated name",
-      cron: "*/18 * * * *",
+      cron: "0 0 1 1 *",
       query: "select other from `some-source`",
       slack_hook_url: "some updated slack_hook_url",
       source_mapping: %{},


### PR DESCRIPTION
cron expression validation test was resulting in issues with ci tests.