### PR TITLE
perf: add Registry partitioning for v2 ingest pipeline

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -66,7 +66,7 @@ defmodule Logflare.Application do
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
       {DynamicSupervisor,
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
-      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique},
+      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
     ] ++ common_children()
   end
@@ -154,7 +154,7 @@ defmodule Logflare.Application do
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
       {DynamicSupervisor,
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
-      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique},
+      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate},
 
       # citrine scheduler for alerts

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -66,7 +66,10 @@ defmodule Logflare.Application do
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
       {DynamicSupervisor,
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
-      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
+      {Registry,
+       name: Logflare.Backends.SourceRegistry,
+       keys: :unique,
+       partitions: System.schedulers_online()},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
     ] ++ common_children()
   end
@@ -154,7 +157,10 @@ defmodule Logflare.Application do
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
       {DynamicSupervisor,
        strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
-      {Registry, name: Logflare.Backends.SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
+      {Registry,
+       name: Logflare.Backends.SourceRegistry,
+       keys: :unique,
+       partitions: System.schedulers_online()},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate},
 
       # citrine scheduler for alerts


### PR DESCRIPTION
add partitioning for unique Registry.
Adding partition for duplicate key Registry has minimal benefits as all partitions would need to be looked up