### PR TITLE
perf: remove tailing on initial load

### DIFF
--- a/lib/logflare_web/live/search_live/templates/logs_search.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.heex
@@ -216,7 +216,7 @@
         </div>
 
         <div class="pr-2 pt-1 pb-1">
-          <%= link to: Routes.live_path(@socket, LogflareWeb.Source.SearchLV, @source, querystring: "c:count(*) c:group_by(t::minute)", tailing?: true), class: "btn btn-primary" do %>
+          <%= link to: Routes.live_path(@socket, LogflareWeb.Source.SearchLV, @source, querystring: "c:count(*) c:group_by(t::minute)"), class: "btn btn-primary" do %>
             <i class="fas fa-redo"></i>
             <span class="hide-on-mobile fas-in-button">Reset</span>
           <% end %>
@@ -268,19 +268,14 @@
       </div>
       <div id="observer-target"></div>
     </.form>
-    <%= if @last_query_completed_at do %>
-      <small
-        class="form-text text-muted"
-        id="last-query-completed-at"
-        data-timestamp={Timex.to_unix(@last_query_completed_at)}
-      >
-        Elapsed since last query: <span id="elapsed" phx-update="ignore"> 0.0 </span> seconds
-      </small>
-    <% else %>
-      <small class="form-text text-muted">
-        Elapsed since last query: 0.0 seconds
-      </small>
-    <% end %>
+    <small
+      :if={!!@last_query_completed_at and !!@tailing?}
+      class="form-text text-muted"
+      id="last-query-completed-at"
+      data-timestamp={Timex.to_unix(@last_query_completed_at)}
+    >
+      Elapsed since last query: <span id="elapsed" phx-update="ignore"> 0.0 </span> seconds
+    </small>
   </div>
   <div
     id="user-idle"

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -54,7 +54,6 @@
       <%= form_for @conn, Routes.live_path(@conn, LogflareWeb.Source.SearchLV, @source), [method: :get], fn f -> %>
       <div class="form-group form-text">
         <%= text_input f, :querystring, placeholder: "404", class: "form-control form-control-margin", autofocus: true %>
-        <%= hidden_input f, :tailing?, value: "true" %>
       </div>
       <div id="observer-target">
       </div>

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -149,7 +149,6 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert html =~ "some event message"
 
       html = render(view)
-      assert html =~ "Elapsed since last query"
 
       # default input values
       assert find_selected_chart_period(html) == "minute"
@@ -346,13 +345,13 @@ defmodule LogflareWeb.Source.SearchLVTest do
       {:ok, view, _html} = live(conn, Routes.live_path(conn, SearchLV, source))
       # post-init fetching
       :timer.sleep(500)
+      html = render(view)
+      refute html =~ "Elapsed since last query"
+      html = render_click(view, "soft_play", %{})
+      assert html =~ "Elapsed since last query"
 
-      assert get_view_assigns(view).tailing?
-      render_click(view, "soft_pause", %{})
-      refute get_view_assigns(view).tailing?
-
-      render_click(view, "soft_play", %{})
-      assert get_view_assigns(view).tailing?
+      html = render_click(view, "soft_pause", %{})
+      refute html =~ "Elapsed since last query"
     end
 
     test "datetime_update", %{conn: conn, source: source} do


### PR DESCRIPTION
This PR removes the tailing on load feature for the log search liveview.
As the log tailing logic is not optimized, it is not uncommon for search processes to take up over 600+MB. This is exacerbated by the initial load kicking off the search multiple times on connection and initial load. This will be addressed in future PRs, but a good first step to cutting down our slot usage is to remove log tailing and make it an explicit toggle.

