### PR TITLE
fix: sql parser error on save is not returning correct error tuple

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -460,12 +460,12 @@ defmodule Logflare.Sql do
         {source.name, source}
       end
 
-    sources =
-      with {:ok, ast} <- Parser.parse(opts.dialect, query),
-           names <-
-             ast
-             |> find_all_source_names()
-             |> Enum.filter(fn name -> name in source_names end) do
+    with {:ok, ast} <- Parser.parse(opts.dialect, query),
+         names <-
+           ast
+           |> find_all_source_names()
+           |> Enum.filter(fn name -> name in source_names end) do
+      sources =
         names
         |> Enum.map(fn name ->
           token =
@@ -480,9 +480,9 @@ defmodule Logflare.Sql do
           {name, token}
         end)
         |> Map.new()
-      end
 
-    {:ok, sources}
+      {:ok, sources}
+    end
   end
 
   defp find_all_source_names(ast),

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -305,6 +305,13 @@ defmodule Logflare.SqlTest do
     assert {:ok, ^expected} = Sql.sources(input, user)
   end
 
+  test "sources/2 raises error on invalid query" do
+    user = insert(:user)
+
+    input = "select a from my_table, `other"
+    assert {:error, "sql parser error" <> _} = Sql.sources(input, user)
+  end
+
   test "source_mapping/3 updates an SQL string with renamed sources" do
     user = insert(:user)
     source = insert(:source, user: user, name: "my_table")


### PR DESCRIPTION
Errors when saving alerts is not thrown, resulting in a full page refresh instead of feedback to the user. 
occurs only when sql parser cannot parse the query.