### PR TITLE
fix: Alerts changeset bug referencing Endpoints instead of AlertQuery

### DIFF
--- a/lib/logflare_web/live/alerts/alerts_live.ex
+++ b/lib/logflare_web/live/alerts/alerts_live.ex
@@ -33,7 +33,6 @@ defmodule LogflareWeb.AlertsLive do
   def mount(%{}, %{"user_id" => user_id}, socket) do
     user = Users.get(user_id)
 
-
     socket =
       socket
       |> assign(:user_id, user_id)

--- a/lib/logflare_web/live/alerts/alerts_live.ex
+++ b/lib/logflare_web/live/alerts/alerts_live.ex
@@ -6,7 +6,6 @@ defmodule LogflareWeb.AlertsLive do
   require Logger
 
   alias Logflare.Users
-  alias LogflareWeb.Utils
   alias Logflare.Alerting
   alias Logflare.Alerting.AlertQuery
 

--- a/lib/logflare_web/live/alerts/components/alert_form.html.heex
+++ b/lib/logflare_web/live/alerts/components/alert_form.html.heex
@@ -44,7 +44,6 @@
             "select timestamp, event_message from `YourApp.SourceName` \nwhere regexp_contains(event_message, 'error')",
           class: "form-control form-control-margin",
           id: "alert-query",
-          value: Map.get(@params_form.params, "query"),
           style: "height: 20rem"
         ) %>
         <%= error_tag(f, :query) %>


### PR DESCRIPTION
Alerts ui does not show correct changset data.

Fixes the changeset bug which was referencing Endpoints.