### PR TITLE
fix: add hostname check for wildcard cacert

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -216,7 +216,12 @@ if(File.exists?("cacert.pem") && File.exists?("cert.pem") && File.exists?("cert.
       cacertfile: "cacert.pem",
       certfile: "cert.pem",
       keyfile: "cert.key",
-      verify: :verify_peer
+      verify: :verify_peer,
+      versions: [:"tlsv1.2"],
+      # support wildcard
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
     ]
 end
 


### PR DESCRIPTION
fix for otp26 cacert changes

see:
- https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
- https://elixirforum.com/t/httpoison-error-sending-a-mail-with-brevo-options-incompatible-verify-verify-peer-cacerts-undefined/57129/7
