### PR TITLE
chore: move task running to Makefile

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run compilation warnings check
         run: mix test.compile
       - name: Run unit tests with code coverage check
-        run: mix test.coverage
+        run: make test
     # - name: Test - security
     #   run: mix test.security
       - name: Code quality - formatting

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,18 +3,19 @@
 ## Dev Env Setup
 
 1. Install dependencies with `asdf` using `asdf install`
-2. Decrypt secrets with `mix decrypt.dev`. It will decrypt two files:
+2. Decrypt secrets with `make decrypt.dev`. It will decrypt two files:
    1. Dev secrets - `.dev.env`
    2. Google JWT key - `.gcloud.json`
 3. Start dev dependencies: `docker compose up -d db stripe-mock`
-4. Run `mix setup` for deps, migrations, and seed data.
-5. Run `(cd assets; npm i)` from project root, to install js dependencies
-6. Start server with `mix start`
-7. Sign in as a user
-8. Create a source
-9. Update `.dev.env`, search for the `LOGFLARE_LOGGER_BACKEND_API_KEY` and `LOGFLARE_LOGGER_BACKEND_SOURCE_ID` and update them accordingly
-10. Set user api key can be retrieved from dashboard or from database `users` table, source id is from the source page
-11. In `iex` console, test that everything works:
+4. Run `make setup` for dependencies, migrations, and seed data.
+5. Start server with `make start`
+6. Sign in as a user
+7. Create a source
+8. Update `.dev.env`, search for the `LOGFLARE_LOGGER_BACKEND_API_KEY` and
+   `LOGFLARE_LOGGER_BACKEND_SOURCE_ID` and update them accordingly
+9. Set user API key can be retrieved from dashboard or from database `users`
+   table, source id is from the source page
+10. In `iex` console, test that everything works:
 
 ```elixir
 iex> LogflareLogger.info("testing log message")
@@ -24,7 +25,8 @@ iex> LogflareLogger.info("testing log message")
 
 Run the local database with `docker-compose up -d db`.
 
-To run the full docker setup, run `docker-compose up -d`. This will load the GCP jwt and the `.docker.env`. Ensure that both files exist.
+To run the full docker setup, run `docker-compose up -d`. This will load the GCP
+JWT and the `.docker.env`. Ensure that both files exist.
 
 To build images only, use `docker-compose build`
 
@@ -35,13 +37,13 @@ To build images only, use `docker-compose build`
 To run the dev env in Supabase mode, adjust the `.docker.env` config:
 
 ```
-LOGFLARE_SINGLE_TENANT=true
-LOGFLARE_SUPABASE_MODE=true
+LOGFLARE_SINGLE_TENANT=true LOGFLARE_SUPABASE_MODE=true
 ```
 
-This will tell Logflare to perform data seeding and disable ui auth.
+This will tell Logflare to perform data seeding and disable UI auth.
 
-Thereafter, run `mix start.docker` to run the dev server with docker config. This is useful for testing supabase mode and single tenant mode.
+Thereafter, run `mix start.docker` to run the dev server with docker config.
+This is useful for testing supabase mode and single tenant mode.
 
 ### Developing Logflare alongside Supabase CLI
 
@@ -49,30 +51,34 @@ In order to test all changes locally, perform the following steps:
 
 1. Build logflare docker image locally: `docker-compose build`
    - the compose file tags the image locally.
-2. CLI repo: run the cli locally `go run . start`
-   - prefix all cli commands with `go run .`
-   - run `go run . init` to create a local supabase project
-3. Update the test supabase project's config under `supabase/config.toml`
-   - logflare uses the `analytics` namespace.
+2. CLI repo: run the CLI locally `go run . start`
+   - prefix all CLI commands with `go run .`
+   - run `go run . init` to create a local Supabase project
+3. Update the test Supabase project's config under `supabase/config.toml`
+   - Logflare uses the `analytics` namespace.
 
 ## Release Management
 
 Logflare's `VERSION` file is bumped on each release.
 
-The `master` branch reflects what is on production on https://logflare.app
+The `master` branch reflects what is on production on <https://logflare.app>
 
 The `staging` branch reflects what is on the staging environment.
 
 Version bumping policy is as follows:
 
-- **Patch**: For any changes that do not affect external api. ui changes, refactoring, docs, etc. Is the default.
-- **Minor**: Non-breaking external api changes, changes in config, major changes to core features.
-- **Major**: External api breaking changes, major code changes.
+- **Patch**: For any changes that do not affect external API. UI changes,
+  refactoring, docs, etc. Is the default.
+- **Minor**: Non-breaking external API changes, changes in config, major changes
+  to core features.
+- **Major**: External API breaking changes, major code changes.
 
 ## Development Code Style
 
 ### Logging
 
-Use the `:error_string` metadata key when logging, which is for additional information that we want to log but don't necessarily want searchable or parsed for schema updating.
+Use the `:error_string` metadata key when logging, which is for additional
+information that we want to log but don't necessarily want searchable or parsed
+for schema updating.
 
-For example, do `Logger.error("Some error", error_string: inspect(params) )`
+For example, do `Logger.error("Some error", error_string: inspect(params))`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,100 @@
+GCLOUD_LOCATION ?= us-central1
+GCLOUD_KEYRING ?= logflare-keyring-us-central1
+GCLOUD_KEY ?= logflare-secrets-key
+GCLOUD_PROJECT ?= logflare-staging
+
+ERL_COOKIE ?= monster
+
+ENV ?= dev
+
+help:
+	@cat DEVELOPMENT.md
+
+test:
+	-epmd -daemon
+	mix test.coverage
+
+.PHONY: test
+
+setup: setup.node
+	mix setup
+
+setup.node:
+	npm --prefix ./assets install
+
+.PHONY: setup setup.node
+
+start: start.orange
+
+start.orange: ERL_NAME = orange
+start.orange: PORT = 4000
+start.orange: LOGFLARE_GRPC_PORT = 50051
+start.orange: __start__
+
+start.pink: ERL_NAME = pink
+start.pink: PORT = 4001
+start.pink: LOGFLARE_GRPC_PORT = 50052
+start.pink: __start__
+
+__start__: decrypt.${ENV}
+	@env $$(cat .${ENV}.env | xargs) PORT=${PORT} LOGFLARE_GRPC_PORT=${LOGFLARE_GRPC_PORT} iex --sname ${ERL_NAME} --cookie ${ERL_COOKIE} -S mix phx.server
+
+.PHONY: __start__
+
+# Encryption and decryption of secrets
+# Usage:
+#
+#     make decrypt.{dev,staging,prod} # Decrypt secrets for given environment
+#     make encrypt.{dev,staging,prod} # Encrypt secrets for given environment
+
+%: %.enc
+	@gcloud kms decrypt --ciphertext-file=$< --plaintext-file=$@ \
+		--location=${GCLOUD_LOCATION} \
+		--keyring=${GCLOUD_KEYRING} \
+		--key=${GCLOUD_KEY} \
+		--project=${GCLOUD_PROJECT}
+
+%.enc:
+	@gcloud kms encrypt --ciphertext-file=$@ --plaintext-file=$(@:.enc=) \
+		--location=${GCLOUD_LOCATION} \
+		--keyring=${GCLOUD_KEYRING} \
+		--key=${GCLOUD_KEY} \
+		--project=${GCLOUD_PROJECT}
+
+.PRECIOUS: %.enc
+
+decrypt.dev: .dev.env
+encrypt.dev: .dev.env.enc
+
+.PHONY: decrypt.dev encrypt.dev
+
+envs = staging prod
+
+.SECONDEXPANSION:
+$(addprefix decrypt.,${envs}): decrypt.%: \
+ 	@gcloud_$$*.json \
+ 	.$$*.env \
+ 	.$$*.cacert.key \
+ 	.$$*.cacert.pem \
+ 	.$$*.cert.key \
+ 	.$$*.cert.pem
+
+.PHONY: $(addprefix decrypt.,${envs})
+
+$(addprefix encrypt.,${envs}): encrypt.%: \
+	@gcloud_$$*.json.enc \
+	.$$*.env.enc \
+	.$$*.cacert.key.enc \
+	.$$*.cacert.pem.enc \
+	.$$*.cert.key.enc \
+	.$$*.cert.pem.enc
+
+.PHONY: $(addprefix encrypt.,${envs})
+
+# OpenTelemetry Protobufs
+
+grpc.protoc:
+	dir=$$(mktemp -d); \
+	trap 'rm -rf "$$dir"' EXIT; \
+	git clone https://github.com/open-telemetry/opentelemetry-proto.git $$dir; \
+	protoc -I=$$dir --elixir_out=plugins=grpc:$(PWD)/lib/logflare_grpc $$(find $$dir -iname '*.proto')

--- a/mix.exs
+++ b/mix.exs
@@ -204,30 +204,10 @@ defmodule Logflare.Mixfile do
 
   defp aliases do
     [
-      setup: [
-        "cmd env $(cat .dev.env|xargs) elixir --sname orange --cookie monster -S mix do deps.get, ecto.setup, ecto.seed"
-      ],
-      start: [
-        "cmd env $(cat .dev.env|xargs) PORT=4000 iex --sname orange --cookie monster -S mix phx.server"
-      ],
-      "start.docker": [
-        "cmd env $(cat .docker.env|xargs) iex --sname blue --cookie monster -S mix phx.server"
-      ],
-      "start.orange": [
-        "cmd env $(cat .dev.env | xargs) PORT=4000 iex --name orange@127.0.0.1 --cookie monster -S mix phx.server"
-      ],
-      "start.pink": [
-        "cmd env $(cat .dev.env|xargs) PORT=4001 LOGFLARE_GRPC_PORT=50052 iex --name pink@127.0.0.1 --cookie monster -S mix phx.server"
-      ],
-      "grpc.protoc": [
-        "cmd rm -rf opentelemetry-proto",
-        "cmd git clone https://github.com/open-telemetry/opentelemetry-proto.git",
-        "cmd protoc -I=./opentelemetry-proto --elixir_out=plugins=grpc:./lib/logflare_grpc $(find ./opentelemetry-proto -iname \"*.proto\")",
-        "cmd rm -rf opentelemetry-proto"
-      ],
+      setup: ["deps.get", "ecto.setup", "ecto.seed"],
       # coveralls will trigger unit tests as well
-      test: ["cmd epmd -daemon", "ecto.create --quiet", "ecto.migrate", "test --no-start"],
-      "test.watch": ["cmd epmd -daemon", "test.watch --no-start"],
+      test: ["ecto.create --quiet", "ecto.migrate", "test --no-start"],
+      "test.watch": ["test.watch --no-start"],
       "test.compile": ["compile --warnings-as-errors"],
       "test.format": ["format --check-formatted"],
       "test.security": ["sobelow --threshold high --ignore Config.HTTPS"],
@@ -238,45 +218,7 @@ defmodule Logflare.Mixfile do
       "lint.all": ["credo --strict"],
       "ecto.seed": ["run priv/repo/seeds.exs"],
       "ecto.setup": ["ecto.create", "ecto.migrate"],
-      "ecto.reset": [
-        "cmd elixir --sname orange --cookie monster -S mix do ecto.drop, ecto.setup"
-      ],
-      "decrypt.dev":
-        "cmd gcloud kms decrypt --ciphertext-file='./.dev.env.enc' --plaintext-file=./.dev.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-      "encrypt.dev":
-        "cmd gcloud kms encrypt --ciphertext-file='./.dev.env.enc' --plaintext-file=./.dev.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-      "decrypt.staging": [
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.staging.env.enc' --plaintext-file=./.staging.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/gcloud_staging.json.enc' --plaintext-file=./gcloud_staging.json --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.staging.cacert.key.enc' --plaintext-file=./.staging.cacert.key --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.staging.cacert.pem.enc' --plaintext-file=./.staging.cacert.pem --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.staging.cert.key.enc' --plaintext-file=./.staging.cert.key --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.staging.cert.pem.enc' --plaintext-file=./.staging.cert.pem --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging"
-      ],
-      "encrypt.staging": [
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.staging.env.enc' --plaintext-file=./.staging.env --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/gcloud_staging.json.enc' --plaintext-file=./gcloud_staging.json --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.staging.cacert.key.enc' --plaintext-file=./.staging.cacert.key --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.staging.cacert.pem.enc' --plaintext-file=./.staging.cacert.pem --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.staging.cert.key.enc' --plaintext-file=./.staging.cert.key --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.staging.cert.pem.enc' --plaintext-file=./.staging.cert.pem --location=us-central1 --keyring=logflare-keyring-us-central1 --key=logflare-secrets-key --project=logflare-staging"
-      ],
-      "decrypt.prod": [
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.prod.env.enc' --plaintext-file=./.prod.env --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/gcloud_prod.json.enc' --plaintext-file=./gcloud_prod.json --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.prod.cacert.key.enc' --plaintext-file=./.prod.cacert.key --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.prod.cacert.pem.enc' --plaintext-file=./.prod.cacert.pem --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.prod.cert.key.enc' --plaintext-file=./.prod.cert.key --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms decrypt --ciphertext-file='./cloudbuild/.prod.cert.pem.enc' --plaintext-file=./.prod.cert.pem --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118"
-      ],
-      "encrypt.prod": [
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.prod.env.enc' --plaintext-file=./.prod.env --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/gcloud_prod.json.enc' --plaintext-file=./gcloud_prod.json --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.prod.cacert.key.enc' --plaintext-file=./.prod.cacert.key --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.prod.cacert.pem.enc' --plaintext-file=./.prod.cacert.pem --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.prod.cert.key.enc' --plaintext-file=./.prod.cert.key --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118",
-        "cmd gcloud kms encrypt --ciphertext-file='./cloudbuild/.prod.cert.pem.enc' --plaintext-file=./.prod.cert.pem --location=us-central1 --keyring=logflare-prod-keyring-us-central1 --key=logflare-prod-secrets-key --project=logflare-232118"
-      ]
+      "ecto.reset": ["ecto.drop", "ecto.setup"]
     ]
   end
 


### PR DESCRIPTION
Using `mix cmd` for long running tasks is problematic, as killing such process will later leave zombies running in the background which can affect the ability to retry such commands (especially visible with `mix start`). This instead use `make` to run such commands.

This change also adds dependency tracking to the decryption of the secrets, which mean that we can try to decrypt them on each run and prevent accidentally running application with old secrets.