### PR TITLE
chore: reorganise backend adaptor behaviour

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -1,5 +1,7 @@
 defmodule Logflare.Backends do
   @moduledoc false
+
+  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.WebhookAdaptor
   alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.Backends.RecentLogs
@@ -84,7 +86,7 @@ defmodule Logflare.Backends do
     mod = @adaptor_mapping[type]
 
     Ecto.Changeset.validate_change(changeset, :config, fn :config, config ->
-      case mod.cast_and_validate_config(config) do
+      case Adaptor.cast_and_validate_config(mod, config) do
         %{valid?: true} -> []
         %{valid?: false, errors: errors} -> for {key, err} <- errors, do: {:"config.#{key}", err}
       end

--- a/lib/logflare/backends/adaptor.ex
+++ b/lib/logflare/backends/adaptor.ex
@@ -31,30 +31,13 @@ defmodule Logflare.Backends.Adaptor do
   """
   @callback validate_config(changeset :: Ecto.Changeset.t()) :: Ecto.Changeset.t()
 
-  defmacro __using__(_opts) do
-    quote do
-      @behaviour unquote(__MODULE__)
-
-      @impl true
-      def ingest(_pid, _log_events), do: raise("Ingest callback not implemented!")
-
-      @impl true
-      def validate_config(_config_changeset),
-        do: raise("Config validation callback not implemented!")
-
-      @impl true
-      def execute_query(_identifier, _query), do: {:error, :not_implemented}
-
-      @impl true
-      def cast_config(_config), do: raise("Config casting callback not implemented!")
-
-      def cast_and_validate_config(params) do
-        params
-        |> cast_config()
-        |> validate_config()
-      end
-
-      defoverridable unquote(__MODULE__)
-    end
+  @doc """
+  Validate configuration for given adaptor implementation
+  """
+  @spec cast_and_validate_config(module(), map()) :: Ecto.Changeset.t()
+  def cast_and_validate_config(mod, params) do
+    params
+    |> mod.cast_config()
+    |> mod.validate_config()
   end
 end

--- a/lib/logflare/backends/adaptor/postgres_adaptor.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor.ex
@@ -9,7 +9,6 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor do
   """
   use GenServer
   use TypedStruct
-  use Logflare.Backends.Adaptor
 
   alias Logflare.Backends.Adaptor.PostgresAdaptor.Pipeline
   alias Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo
@@ -17,6 +16,8 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor do
   alias Logflare.Backends.SourceBackend
   alias Logflare.Backends.SourceDispatcher
   alias Logflare.Buffers.MemoryBuffer
+
+  @behaviour Logflare.Backends.Adaptor
 
   import Ecto.Changeset
 


### PR DESCRIPTION
This moves dynamic calls to inside of behaviour module to have coherent view on how behaviour will be used. Additionally this remove the code duplication that happened with template functions and reduce the compilation times (no compile time dependency).