### PR TITLE
fix: update thousand island options

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,8 +6,9 @@ config :logflare, env: :prod
 config :logflare, LogflareWeb.Endpoint,
   http: [
     port: 4000,
+    # https://hexdocs.pm/thousand_island/ThousandIsland.html#t:options/0
     thousand_island_options: [
-      max_connections: 64_000,
+      num_connections: 64_000,
       num_acceptors: 1_000
     ]
   ],


### PR DESCRIPTION
fix for wrong option:
```
11:56:45.121 [notice] Application logflare exited: Logflare.Application.start(:normal, []) returned an error: shutdown: failed to start child: LogflareWeb.Endpoint
    ** (EXIT) shutdown: failed to start child: {LogflareWeb.Endpoint, :http}
        ** (EXIT) an exception was raised:
            ** (RuntimeError) Unsupported keys(s) in thousand_island_options config: [:max_connections]
                (bandit 0.7.7) lib/bandit.ex:382: Bandit.validate_options/3
                (bandit 0.7.7) lib/bandit.ex:288: Bandit.start_link/1
                (stdlib 5.1.1) supervisor.erl:420: :supervisor.do_start_child_i/3
                (stdlib 5.1.1) supervisor.erl:406: :supervisor.do_start_child/2
                (stdlib 5.1.1) supervisor.erl:390: anonymous fn/3 in :supervisor.start_children/2
                (stdlib 5.1.1) supervisor.erl:1258: :supervisor.children_map/4
                (stdlib 5.1.1) supervisor.erl:350: :supervisor.init_children/2
                (stdlib 5.1.1) gen_server.erl:962: :gen_server.init_it/2
```