### PR TITLE
fix: gzip payload chunking for large batches

### DIFF
--- a/test/logflare_web/plugs/compressed_body_reader_test.exs
+++ b/test/logflare_web/plugs/compressed_body_reader_test.exs
@@ -15,19 +15,40 @@ defmodule LogflareWeb.Plugs.CompressedBodyReaderTest do
   end
 
   property "with no `content-encoding` header data is passed through as is" do
-    check all(data <- binary()) do
+    check all(data <- gen_payloads()) do
       assert {:ok, read, _} = @subject.read_body(conn(data))
       assert read == data
     end
   end
 
   property "with `content-encoding: gzip` header data is passed through as is" do
-    check all(data <- binary()) do
+    check all(data <- gen_payloads()) do
       compressed = :zlib.gzip(data)
       conn = conn(compressed, [{"content-encoding", "gzip"}])
 
       assert {:ok, read, _} = @subject.read_body(conn)
       assert read == data
+    end
+
+    check all(data <- gen_max_chunk_payloads()) do
+      compressed = :zlib.gzip(data)
+      conn = conn(compressed, [{"content-encoding", "gzip"}])
+
+      assert_raise RuntimeError, "max chunks reached", fn ->
+        @subject.read_body(conn)
+      end
+    end
+  end
+
+  defp gen_payloads do
+    gen all(res <- scale(binary(), &(&1 * 500))) do
+      res
+    end
+  end
+
+  defp gen_max_chunk_payloads do
+    gen all(res <- binary(max_length: 110_000, min_length: 100_000)) do
+      res
     end
   end
 end


### PR DESCRIPTION
This PR fixes errors occured when inflating gzipped payloads that are chunked by :zlib, but are not correctly handled.

If gzip payloads are too large, an error will be raised.

