### PR TITLE
Fix/ueberauth callback url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ setup.node:
 start: start.orange
 
 start.orange: ERL_NAME = orange
-start.orange: PORT = 4000
+start.orange: PORT ?= 4000
 start.orange: LOGFLARE_GRPC_PORT = 50051
 start.orange: __start__
 

--- a/test/logflare_web/controllers/oauth_controller_tests.exs
+++ b/test/logflare_web/controllers/oauth_controller_tests.exs
@@ -86,4 +86,22 @@ defmodule LogflareWeb.OAuthControllerTests do
     assert conn.assigns.flash["info"] =~ "Alert connected to Slack!"
     assert redirected_to(conn) == ~p"/alerts/#{alert_query.id}"
   end
+
+
+  describe "bug: ueberauth port does not match url config" do
+    setup do
+      start_supervised!(Logflare.SystemMetricsSup)
+      url = Application.get_env(:logflare, Logflare.Endpoint)[:url]
+        Application.put_env(:logflare, Logflare.Endpoint, [host: "test.com", port: 3232])
+        on_exit(fn ->
+        Application.put_env(:logflare, Logflare.Endpoint, url)
+      end)
+      :ok
+    end
+    test " navbar OAuth2 link should exclude port if host is provided", %{conn: conn} do
+      conn = conn |> get(Routes.oauth_path(conn, :request, "google"))
+
+      assert redirected_to(conn, 302) =~ "3232"
+    end
+  end
 end

--- a/test/logflare_web/controllers/oauth_controller_tests.exs
+++ b/test/logflare_web/controllers/oauth_controller_tests.exs
@@ -87,17 +87,19 @@ defmodule LogflareWeb.OAuthControllerTests do
     assert redirected_to(conn) == ~p"/alerts/#{alert_query.id}"
   end
 
-
   describe "bug: ueberauth port does not match url config" do
     setup do
       start_supervised!(Logflare.SystemMetricsSup)
       url = Application.get_env(:logflare, Logflare.Endpoint)[:url]
-        Application.put_env(:logflare, Logflare.Endpoint, [host: "test.com", port: 3232])
-        on_exit(fn ->
+      Application.put_env(:logflare, Logflare.Endpoint, host: "test.com", port: 3232)
+
+      on_exit(fn ->
         Application.put_env(:logflare, Logflare.Endpoint, url)
       end)
+
       :ok
     end
+
     test " navbar OAuth2 link should exclude port if host is provided", %{conn: conn} do
       conn = conn |> get(Routes.oauth_path(conn, :request, "google"))
 


### PR DESCRIPTION
This PR fixes oauth2 redirect uri bug, which is occurring due to Ueberauth's behaviour of using the server port instead of the phoenix configured port.
We are also not able to configure the callback_path at runtime, hence the need for this convoluted way of setting the server port. We also cannot use the `x-forwarded-host` header to set the value, as the conn.port takes precedence in the Ueberauth source code.