### PR TITLE
chore: switch to europe-west3 for staging deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ grpc.protoc:
 deploy.staging.main:
 	@gcloud config set project logflare-staging
 	gcloud builds submit \
-		projects/logflare-staging/locations/us-central1/connections/github-logflare/repositories/Logflare-logflare \
+		projects/logflare-staging/locations/europe-west3/connections/github-logflare/repositories/Logflare-logflare \
 		--revision=main  \
 		--config=cloudbuild/staging/build-image.yaml \
 		--substitutions=_IMAGE_TAG=$(SHA_IMAGE_TAG) \
-		--region=us-central1 \
+		--region=europe-west3 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 	
 	gcloud builds submit \
@@ -135,11 +135,11 @@ deploy.staging.main:
 deploy.staging.versioned:
 	@gcloud config set project logflare-staging
 	gcloud builds submit \
-		projects/logflare-staging/locations/us-central1/connections/github-logflare/repositories/Logflare-logflare \
+		projects/logflare-staging/locations/europe-west3/connections/github-logflare/repositories/Logflare-logflare \
 		--revision=main  \
 		--config=cloudbuild/staging/build-image.yaml \
 		--substitutions=_IMAGE_TAG=$(VERSION) \
-		--region=us-central1 \
+		--region=europe-west3 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 	
 	gcloud builds submit \


### PR DESCRIPTION
Seems like europe-west3 works, but us-central1 doesn't. Very weird, seems like a data center issue.