### PR TITLE
chore: revert sandbox query id removal

### DIFF
--- a/priv/repo/migrations/20231027221103_revert_sandbox_query_id_column_removal.exs
+++ b/priv/repo/migrations/20231027221103_revert_sandbox_query_id_column_removal.exs
@@ -1,0 +1,10 @@
+defmodule Logflare.Repo.Migrations.RevertSandboxQueryIdColumnRemoval do
+  use Ecto.Migration
+
+  def change do
+
+    alter table(:endpoint_queries) do
+      add :sandbox_query_id, references(:endpoint_queries, on_delete: :nothing)
+    end
+  end
+end

--- a/priv/repo/migrations/20231027221103_revert_sandbox_query_id_column_removal.exs
+++ b/priv/repo/migrations/20231027221103_revert_sandbox_query_id_column_removal.exs
@@ -1,10 +1,12 @@
 defmodule Logflare.Repo.Migrations.RevertSandboxQueryIdColumnRemoval do
   use Ecto.Migration
 
-  def change do
-
+  def up do
     alter table(:endpoint_queries) do
-      add :sandbox_query_id, references(:endpoint_queries, on_delete: :nothing)
+      add_if_not_exists :sandbox_query_id, references(:endpoint_queries, on_delete: :nothing)
     end
+  end
+  def down do
+
   end
 end


### PR DESCRIPTION
This PR reverts the non-backwards compatible migration where the `sandbox_query_id` column was removed without backwards compat for rolling updates 