### PR TITLE
fix: preload sources for VerifyApiAccess plug

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -62,11 +62,11 @@ config :logflare,
            )
        )
 
-config :logflare,
-       Logflare.Cluster.Utils,
-       filter_nil_kv_pairs.(
-         min_cluster_size: System.get_env("LOGFLARE_MIN_CLUSTER_SIZE", "3") |> String.to_integer()
-       )
+if System.get_env("LOGFLARE_MIN_CLUSTER_SIZE") do
+  config :logflare,
+         Logflare.Cluster.Utils,
+         min_cluster_size: System.get_env("LOGFLARE_MIN_CLUSTER_SIZE") |> String.to_integer()
+end
 
 config :logflare_logger_backend,
        filter_nil_kv_pairs.(

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,7 +6,10 @@ config :logflare, LogflareWeb.Endpoint,
   http: [port: 4001],
   server: false
 
-config :logflare, env: :test
+config :logflare,
+  env: :test
+
+config :logflare, Logflare.Cluster.Utils, min_cluster_size: 1
 
 config :logger, :console, metadata: :all, level: :error
 

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -24,6 +24,12 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
         if "partner" in opts.scopes do
           assign(conn, :partner, owner)
         else
+          owner =
+            owner
+            |> Users.preload_team()
+            |> Users.preload_billing_account()
+            |> Users.preload_sources()
+
           assign(conn, :user, owner)
         end
 

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -33,13 +33,11 @@ defmodule LogflareWeb.LogControllerTest do
       source = insert(:source, user_id: user.id, v2_pipeline: true)
       _plan = insert(:plan, name: "Free")
 
+      start_supervised!(Counters)
+      start_supervised!(RateCounters)
+
       source_backend =
         insert(:source_backend, source_id: source.id, type: :webhook, config: %{url: "some url"})
-
-      # stub out rate limiting logic for now
-      # TODO: remove once rate limiting logic is refactored
-      LogflareWeb.Plugs.RateLimiter
-      |> stub(:call, fn x, _ -> x end)
 
       {:ok, source: source, user: user, source_backend: source_backend}
     end
@@ -54,7 +52,7 @@ defmodule LogflareWeb.LogControllerTest do
         |> post(Routes.log_path(conn, :create, source: source.token), @valid)
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
   end
 
@@ -73,7 +71,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
 
     test ":create ingestion", %{conn: conn, source: source} do
@@ -83,7 +81,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
 
     test ":create ingestion batch with `batch` key", %{conn: conn, source: source} do
@@ -93,7 +91,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
 
     test ":create ingestion batch with array body", %{conn: conn, source: source} do
@@ -104,7 +102,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
 
     test ":cloudflare ingestion", %{conn: new_conn, source: source} do
@@ -119,7 +117,7 @@ defmodule LogflareWeb.LogControllerTest do
              }
 
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
   end
 
@@ -139,7 +137,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
   end
 
@@ -158,12 +156,7 @@ defmodule LogflareWeb.LogControllerTest do
       start_supervised!(Counters)
       start_supervised!(RateCounters)
       start_supervised!({RecentLogsServer, rls})
-      :timer.sleep(1000)
-
-      # stub out rate limiting logic for now
-      # TODO: remove once rate limiting logic is refactored
-      LogflareWeb.Plugs.RateLimiter
-      |> stub(:call, fn x, _ -> x end)
+      :timer.sleep(500)
 
       Logflare.Logs
       |> expect(:broadcast, 1, fn le ->
@@ -185,7 +178,7 @@ defmodule LogflareWeb.LogControllerTest do
       assert json_response(conn, 200) == %{"message" => "Logged!"}
 
       # wait for all logs to be ingested before removing all stubs
-      :timer.sleep(1500)
+      :timer.sleep(2000)
     end
   end
 
@@ -198,12 +191,7 @@ defmodule LogflareWeb.LogControllerTest do
     start_supervised!(Counters)
     start_supervised!(RateCounters)
     start_supervised!({RecentLogsServer, rls})
-    :timer.sleep(1000)
-
-    # stub out rate limiting logic for now
-    # TODO: remove once rate limiting logic is refactored
-    LogflareWeb.Plugs.RateLimiter
-    |> stub(:call, fn x, _ -> x end)
+    :timer.sleep(500)
 
     Logflare.Logs
     |> expect(:broadcast, 1, fn le ->


### PR DESCRIPTION
This PR fixes a bug in the rate limiter which requires `:sources` key to be preloaded for the User struct
![image](https://github.com/Logflare/logflare/assets/22714384/0b29af93-2515-4206-befa-8baa670d6d8c)
