### PR TITLE
chore: fix curl example formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -12,5 +12,6 @@
     :typed_ecto_schema,
     :open_api_spex
   ],
-  plugins: [Phoenix.LiveView.HTMLFormatter]
+  plugins: [Phoenix.LiveView.HTMLFormatter],
+  heex_line_length: 300
 ]

--- a/lib/logflare_web/live/admin/partner_live.html.heex
+++ b/lib/logflare_web/live/admin/partner_live.html.heex
@@ -24,11 +24,7 @@
       </p>
       <pre class="p-2" id="created_token"><%= @created_token.token %></pre>
       <pre class="p-2" id="description"><%= @created_token.description %></pre>
-      <button
-        id="dismiss-created-token"
-        phx-click="dismiss-created-token"
-        class="btn btn-sm btn-secondary form-button"
-      >
+      <button id="dismiss-created-token" phx-click="dismiss-created-token" class="btn btn-sm btn-secondary form-button">
         Dismiss
       </button>
     </div>
@@ -41,12 +37,7 @@
         <div>
           <div class="pr-2">Name: <%= name %></div>
           <div class="pr-2">Token: <%= token %></div>
-          <button
-            id={"delete-#{token}"}
-            phx-click="delete"
-            phx-value-token={token}
-            class="btn btn-sm btn-secondary form-button"
-          >
+          <button id={"delete-#{token}"} phx-click="delete" phx-value-token={token} class="btn btn-sm btn-secondary form-button">
             Delete
           </button>
           <form phx-submit="create-token" class="py-4 flex items-center" id={"generate-#{token}"}>

--- a/lib/logflare_web/live/alerts/actions/edit.html.heex
+++ b/lib/logflare_web/live/alerts/actions/edit.html.heex
@@ -1,9 +1,6 @@
 <.subheader {assigns}>
   <:path>
-    ~/<.subheader_path_link live_patch to={~p"/alerts"}>alerts</.subheader_path_link>/<.subheader_path_link
-      live_patch
-      to={~p"/alerts/#{@alert.id}"}
-    >
+    ~/<.subheader_path_link live_patch to={~p"/alerts"}>alerts</.subheader_path_link>/<.subheader_path_link live_patch to={~p"/alerts/#{@alert.id}"}>
       <%= @alert.name %>
     </.subheader_path_link>/edit
   </:path>

--- a/lib/logflare_web/live/alerts/actions/show.html.heex
+++ b/lib/logflare_web/live/alerts/actions/show.html.heex
@@ -49,13 +49,7 @@
             </div>
           <% else %>
             <a href={"https://slack.com/oauth/v2/authorize?client_id=#{Application.get_env(:ueberauth, Ueberauth.Strategy.SlackV2.OAuth)[:client_id]}&scope=incoming-webhook&install_redirect=update-to-granular-scopes&redirect_uri=#{url(~p"/auth/slack/callback")}&state=#{Jason.encode!(%{"action" => "save_hook_url", "alert_query" => @alert})}"}>
-              <img
-                alt="Add to Slack"
-                height="40"
-                width="139"
-                src="https://platform.slack-edge.com/img/add_to_slack.png"
-                srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
-              />
+              <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           <% end %>
         </span>

--- a/lib/logflare_web/live/alerts/components/alert_form.html.heex
+++ b/lib/logflare_web/live/alerts/components/alert_form.html.heex
@@ -2,13 +2,7 @@
   <.form :let={f} for={@changeset} as={:alert} id="alert" phx-submit="save" class="tw-w-full">
     <%= hidden_input(f, :language) %>
     <div class="tw-sticky tw-flex tw-justify-between tw-gap-4">
-      <button
-        :if={@alert}
-        data-confirm="Are you sure? This cannot be undone"
-        phx-click="delete"
-        phx-value-alert_id={@alert.id}
-        class="btn btn-outline-danger"
-      >
+      <button :if={@alert} data-confirm="Are you sure? This cannot be undone" phx-click="delete" phx-value-alert_id={@alert.id} class="btn btn-outline-danger">
         <i class="fas fa-trash"></i> Delete
       </button>
       <%= submit("Save changes", class: "btn btn-primary") %>
@@ -40,8 +34,7 @@
           This alert will execute this query periodically. If a non-zero number of rows are returned from this query, the notification will be triggered.
         </p>
         <%= textarea(f, :query,
-          placeholder:
-            "select timestamp, event_message from `YourApp.SourceName` \nwhere regexp_contains(event_message, 'error')",
+          placeholder: "select timestamp, event_message from `YourApp.SourceName` \nwhere regexp_contains(event_message, 'error')",
           class: "form-control form-control-margin",
           id: "alert-query",
           style: "height: 20rem"

--- a/lib/logflare_web/live/billingaccount_live/custom_field_component.ex
+++ b/lib/logflare_web/live/billingaccount_live/custom_field_component.ex
@@ -119,14 +119,7 @@ defmodule LogflareWeb.BillingAccountLive.CustomFieldComponent do
           <% end %>
         </ul>
       <% end %>
-      <.form
-        :let={f}
-        for={@custom_fields_form}
-        action="#"
-        phx-change="validate"
-        phx-submit="add"
-        phx-target={@myself}
-      >
+      <.form :let={f} for={@custom_fields_form} action="#" phx-change="validate" phx-submit="add" phx-target={@myself}>
         <div class="row">
           <div class="col-sm">
             <%= label(f, :name, class: "label-padding") %>
@@ -153,14 +146,7 @@ defmodule LogflareWeb.BillingAccountLive.CustomFieldComponent do
     }
 
     ~H"""
-    <a
-      href="#"
-      phx-click="delete"
-      phx-disable-with="deleting..."
-      phx-value-key={@key}
-      phx-target={@myself}
-      class="small"
-    >
+    <a href="#" phx-click="delete" phx-disable-with="deleting..." phx-value-key={@key} phx-target={@myself} class="small">
       delete
     </a>
     """

--- a/lib/logflare_web/live/billingaccount_live/payment_method_component.ex
+++ b/lib/logflare_web/live/billingaccount_live/payment_method_component.ex
@@ -196,15 +196,7 @@ defmodule LogflareWeb.BillingAccountLive.PaymentMethodComponent do
         <% end %>
       </ul>
       <div id="stripe-elements-form" class="mt-4">
-        <form
-          id="payment-form"
-          action="#"
-          phx-submit="submit"
-          phx-hook="PaymentMethodForm"
-          data-stripe-key={@stripe_key}
-          data-stripe-customer={@user.billing_account.stripe_customer}
-          phx-target={@myself}
-        >
+        <form id="payment-form" action="#" phx-submit="submit" phx-hook="PaymentMethodForm" data-stripe-key={@stripe_key} data-stripe-customer={@user.billing_account.stripe_customer} phx-target={@myself}>
           <div id="card-element">
             <!-- Elements will create input elements here -->
           </div>
@@ -214,12 +206,7 @@ defmodule LogflareWeb.BillingAccountLive.PaymentMethodComponent do
             Add payment method
           </button>
         </form>
-        <button
-          phx-click="sync"
-          phx-disable-with="Syncing..."
-          phx-target={@myself}
-          class="btn btn-dark btn-sm"
-        >
+        <button phx-click="sync" phx-disable-with="Syncing..." phx-target={@myself} class="btn btn-dark btn-sm">
           Sync payment methods
         </button>
       </div>
@@ -234,13 +221,7 @@ defmodule LogflareWeb.BillingAccountLive.PaymentMethodComponent do
     }
 
     ~H"""
-    <button
-      phx-click="delete"
-      phx-disable-with="Deleting..."
-      phx-value-id={@stripe_id}
-      phx-target={@myself}
-      class="btn btn-danger btn-sm m-3"
-    >
+    <button phx-click="delete" phx-disable-with="Deleting..." phx-value-id={@stripe_id} phx-target={@myself} class="btn btn-danger btn-sm m-3">
       Delete
     </button>
     """
@@ -253,13 +234,7 @@ defmodule LogflareWeb.BillingAccountLive.PaymentMethodComponent do
     }
 
     ~H"""
-    <button
-      phx-click="make-default"
-      phx-disable-with="Updating..."
-      phx-value-stripe-id={@stripe_id}
-      phx-target={@myself}
-      class="btn btn-dark btn-sm"
-    >
+    <button phx-click="make-default" phx-disable-with="Updating..." phx-value-stripe-id={@stripe_id} phx-target={@myself} class="btn btn-dark btn-sm">
       Make default
     </button>
     """

--- a/lib/logflare_web/live/billingaccount_live/templates/edit.html.heex
+++ b/lib/logflare_web/live/billingaccount_live/templates/edit.html.heex
@@ -18,8 +18,7 @@
     Manage your subscription, update credit card info and download your Logflare invoices all in one place.
   </p>
   <p>
-    <i class="fas fa-exclamation-circle"></i>
-    All team members can now access the billing account. You can invite someone in accounting as a team member to subscribe to Logflare if needed.
+    <i class="fas fa-exclamation-circle"></i> All team members can now access the billing account. You can invite someone in accounting as a team member to subscribe to Logflare if needed.
   </p>
   <div class="sub-form">
     <%= section_header("Summary") %>
@@ -34,8 +33,7 @@
             </p>
           <% @plan.name != "Free" -> %>
             <p>
-              You're currently on the <u><%= @plan.name %> plan</u>. You have
-              <u><%= count_for_billing(@user.sources) %> source(s)</u><sup>1</sup>
+              You're currently on the <u><%= @plan.name %> plan</u>. You have <u><%= count_for_billing(@user.sources) %> source(s)</u><sup>1</sup>
               added to your account. Each source is costing you <u><%= @plan.price |> Money.new(:USD) |> Money.to_string(fractional_unit: false) %> per <%= @plan.period %></u>.
               Your total estimated total cost is <u><%= count_for_billing(@user.sources) * @plan.price |> Money.new(:USD) |> Money.to_string(fractional_unit: false) %>
         per <%= @plan.period %></u>.

--- a/lib/logflare_web/live/endpoints/actions/edit.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/edit.html.heex
@@ -1,17 +1,10 @@
 <.subheader {assigns}>
   <:path>
-    ~/<.subheader_path_link live_patch to={~p"/endpoints"}>endpoints</.subheader_path_link>/<.subheader_path_link
-      live_patch
-      to={~p"/endpoints/#{@show_endpoint.id}"}
-    >
+    ~/<.subheader_path_link live_patch to={~p"/endpoints"}>endpoints</.subheader_path_link>/<.subheader_path_link live_patch to={~p"/endpoints/#{@show_endpoint.id}"}>
       <%= @show_endpoint.name %>
     </.subheader_path_link>/edit
   </:path>
-  <.subheader_link
-    to="https://docs.logflare.app/concepts/endpoints#crafting-a-query"
-    text="docs"
-    fa_icon="book"
-  />
+  <.subheader_link to="https://docs.logflare.app/concepts/endpoints#crafting-a-query" text="docs" fa_icon="book" />
 </.subheader>
 
 <section class="mx-auto container">

--- a/lib/logflare_web/live/endpoints/actions/show.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/show.html.heex
@@ -69,7 +69,7 @@
       curl "<%= "https://api.logflare.app" <> ~p"/api/endpoints/query/#{@show_endpoint.token}" %>" \
       -H 'X-API-KEY: YOUR-ACCESS-TOKEN' \
       -H 'Content-Type: application/json; charset=utf-8' <span :if={length(@declared_params) > 0}>\</span>
-      <span :if={length(@declared_params) > 0}> -G <%= Enum.map(@declared_params, fn p -> "-d \"#{p}=VALUE\"" end) |> Enum.join(" ") %></span>
+      <span :if={length(@declared_params) > 0}>-G <%= Enum.map(@declared_params, fn p -> "-d \"#{p}=VALUE\"" end) |> Enum.join(" ") %></span>
     </code>
 
     <code :if={@show_endpoint.enable_auth} class="tw-whitespace-pre-wrap">

--- a/lib/logflare_web/live/endpoints/actions/show.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/show.html.heex
@@ -3,12 +3,7 @@
     ~/<.subheader_path_link live_patch to={~p"/endpoints"}>endpoints</.subheader_path_link>/<%= @show_endpoint.name %>
   </:path>
   <.subheader_link to={~p"/access-tokens"} text="access tokens" fa_icon="key" />
-  <.subheader_link
-    live_patch
-    to={~p"/endpoints/#{@show_endpoint.id}/edit"}
-    text="edit"
-    fa_icon="edit"
-  />
+  <.subheader_link live_patch to={~p"/endpoints/#{@show_endpoint.id}/edit"} text="edit" fa_icon="edit" />
 </.subheader>
 <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-4">
   <div>
@@ -69,30 +64,20 @@
 
   <h3>Call your endpoint</h3>
   <div class="tw-bg-zinc-800 tw-rounded tw-p-2 tw-flex tw-flex-col tw-gap-2">
-    <code class="tw-whitespace-pre-wrap">
+    <code class="tw-whitespace-pre-line">
       # By UUID
-      curl "<%= url(~p"/api/endpoints/query/#{@show_endpoint.token}") %>" \
+      curl "<%= "https://api.logflare.app" <> ~p"/api/endpoints/query/#{@show_endpoint.token}" %>" \
       -H 'X-API-KEY: YOUR-ACCESS-TOKEN' \
-      -H 'Content-Type: application/json; charset=utf-8'
-      <%= if not Enum.empty?(@declared_params) do %>
-        <span>\</span>
-        <span>
-          -G <%= Enum.map_join(@declared_params, " ", fn p -> "-d \"#{p}=VALUE\"" end) %>
-        </span>
-      <% end %>
+      -H 'Content-Type: application/json; charset=utf-8' <span :if={length(@declared_params) > 0}>\</span>
+      <span :if={length(@declared_params) > 0}> -G <%= Enum.map(@declared_params, fn p -> "-d \"#{p}=VALUE\"" end) |> Enum.join(" ") %></span>
     </code>
 
     <code :if={@show_endpoint.enable_auth} class="tw-whitespace-pre-wrap">
       # By name
-      curl "<%= url(~p"/api/endpoints/query/#{@show_endpoint.name}") %>" \
+      curl "<%= "https://api.logflare.app" <> ~p"/api/endpoints/query/#{@show_endpoint.name}" %>" \
       -H 'X-API-KEY: YOUR-ACCESS-TOKEN' \
-      -H 'Content-Type: application/json; charset=utf-8'
-      <%= if not Enum.empty?(@declared_params) do %>
-        <span>\</span>
-        <span>
-          -G <%= Enum.map_join(@declared_params, " ", fn p -> "-d \"#{p}=VALUE\"" end) %>
-        </span>
-      <% end %>
+      -H 'Content-Type: application/json; charset=utf-8' <span :if={length(@declared_params) > 0}>\</span>
+      <span :if={length(@declared_params) > 0}>-G <%= Enum.map(@declared_params, fn p -> "-d \"#{p}=VALUE\"" end) |> Enum.join(" ") %></span>
     </code>
   </div>
 </section>

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -1,21 +1,8 @@
 <div class="tw-flex tw-my-10 tw-gap-2">
-  <.form
-    :let={f}
-    for={@endpoint_changeset}
-    as={:endpoint}
-    id="endpoint"
-    phx-submit="save-endpoint"
-    class="tw-w-1/2 tw-border-r-1 pr-2 tw-border-l-0 tw-border-t-0 tw-border-b-0 tw-border-solid tw-border-gray-600"
-  >
+  <.form :let={f} for={@endpoint_changeset} as={:endpoint} id="endpoint" phx-submit="save-endpoint" class="tw-w-1/2 tw-border-r-1 pr-2 tw-border-l-0 tw-border-t-0 tw-border-b-0 tw-border-solid tw-border-gray-600">
     <%= hidden_input(f, :language) %>
     <div class="tw-sticky tw-flex tw-justify-between tw-gap-4">
-      <button
-        :if={@show_endpoint}
-        data-confirm="Are you sure? This cannot be undone"
-        phx-click="delete-endpoint"
-        phx-value-endpoint_id={@show_endpoint.id}
-        class="btn btn-outline-danger"
-      >
+      <button :if={@show_endpoint} data-confirm="Are you sure? This cannot be undone" phx-click="delete-endpoint" phx-value-endpoint_id={@show_endpoint.id} class="btn btn-outline-danger">
         <i class="fas fa-trash"></i> Delete
       </button>
       <%= submit("Save changes", class: "btn btn-primary") %>
@@ -50,10 +37,8 @@
     <section class="tw-flex tw-flex-col">
       <div class="form-group">
         <p>
-          This endpoint will execute this query on each <code>GET</code>
-          request.
-          Declare parameters using <code>@parameter_name</code>
-          and pass it to the endpoint via query parameters <code>?parameter_name=some-value</code>
+          This endpoint will execute this query on each <code>GET</code> request.
+          Declare parameters using <code>@parameter_name</code> and pass it to the endpoint via query parameters <code>?parameter_name=some-value</code>
         </p>
         <%= textarea(f, :query,
           placeholder: "select timestamp, event_message from `YourApp.SourceName`",
@@ -104,8 +89,7 @@
         ) %>
         <%= error_tag(f, :sandboxable) %>
         <small class="form-text text-muted">
-          Endpoints with sandboxing enabled will accept an <code>?sql=</code>
-          query parameter that will be inserted as the outer query of the defined CTE.
+          Endpoints with sandboxing enabled will accept an <code>?sql=</code> query parameter that will be inserted as the outer query of the defined CTE.
           This restricts users of the endpoint to only query within the defined CTE result sets.
         </small>
       </div>
@@ -126,8 +110,7 @@
         </div>
         <%= error_tag(f, :cache_duration_seconds) %>
         <small class="form-text text-muted">
-          Endpoint results are cached on a per-request basis. Set Cache TTL to <code>0</code>
-          to disable caching completely.
+          Endpoint results are cached on a per-request basis. Set Cache TTL to <code>0</code> to disable caching completely.
         </small>
       </div>
       <div>

--- a/lib/logflare_web/live/modal_component.ex
+++ b/lib/logflare_web/live/modal_component.ex
@@ -5,17 +5,7 @@ defmodule LogflareWeb.ModalComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div
-      id={@id}
-      class="modal fade show"
-      phx-hook="LiveModal"
-      phx-capture-click="close"
-      phx-window-keydown="close"
-      phx-key="escape"
-      phx-target={"##{@id}"}
-      phx-page-loading
-      style="display: block;"
-    >
+    <div id={@id} class="modal fade show" phx-hook="LiveModal" phx-capture-click="close" phx-window-keydown="close" phx-key="escape" phx-target={"##{@id}"} phx-page-loading style="display: block;">
       <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
           <div class="modal-header lf-modal-header">

--- a/lib/logflare_web/live/search_live/templates/debug.html.heex
+++ b/lib/logflare_web/live/search_live/templates/debug.html.heex
@@ -17,12 +17,10 @@
             Total rows: <span class="my-badge my-badge-info"><%= stats[:total_rows] %></span>
           </li>
           <li class="list-group-item flex-fill">
-            Total bytes processed:
-            <span class="my-badge my-badge-info"><%= stats[:total_bytes_processed] %></span>
+            Total bytes processed: <span class="my-badge my-badge-info"><%= stats[:total_bytes_processed] %></span>
           </li>
           <li class="list-group-item flex-fill">
-            Total duration:
-            <span class="my-badge my-badge-info"><%= stats[:total_duration] %>ms</span>
+            Total duration: <span class="my-badge my-badge-info"><%= stats[:total_duration] %>ms</span>
           </li>
         </ul>
       </div>

--- a/lib/logflare_web/live/search_live/templates/logs_list.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_list.html.heex
@@ -1,10 +1,5 @@
 <%= if @search_op_log_events do %>
-  <div
-    id="source-logs-search-list"
-    data-last-query-completed-at={@last_query_completed_at}
-    phx-hook="SourceLogsSearchList"
-    class="mt-4"
-  >
+  <div id="source-logs-search-list" data-last-query-completed-at={@last_query_completed_at} phx-hook="SourceLogsSearchList" class="mt-4">
     <%= if @loading do %>
       <div id="logs-list" class="blurred list-unstyled console-text-list"></div>
     <% else %>

--- a/lib/logflare_web/live/search_live/templates/logs_search.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.heex
@@ -13,12 +13,7 @@
     return_to: @modal.body.return_to
   ) %>
 <% end %>
-<div
-  id="user-preferences"
-  data-user-local-timezone={@user_local_timezone}
-  data-use-local-time={@use_local_time}
->
-</div>
+<div id="user-preferences" data-user-local-timezone={@user_local_timezone} data-use-local-time={@use_local_time}></div>
 <div id="source-logs-search-control" class="subhead " phx-hook="SourceLogsSearch">
   <div class="container mx-auto">
     <h5>
@@ -43,12 +38,7 @@
           <%= LqlHelpers.bq_source_schema_modal_link() %>
         </li>
         <li>
-          <a
-            href="#"
-            phx-click="toggle_local_time"
-            id="toggle_local_time"
-            phx-value-use_local_time={@use_local_time}
-          >
+          <a href="#" phx-click="toggle_local_time" id="toggle_local_time" phx-value-use_local_time={@use_local_time}>
             <span>
               <%= if @use_local_time do %>
                 <i class="fa fa-toggle-on pointer-cursor" aria-hidden="true"></i>
@@ -65,24 +55,13 @@
             <span class="hide-on-mobile">
               timezone
               <%= if @user_local_timezone do %>
-                <%= DateTimeUtils.humanize_timezone_offset(
-                  Timex.Timezone.get(@user_local_timezone).offset_utc
-                ) %>
+                <%= DateTimeUtils.humanize_timezone_offset(Timex.Timezone.get(@user_local_timezone).offset_utc) %>
               <% end %>
             </span>
           <% end %>
         </li>
         <li>
-          <span
-            id="search-uri-query"
-            class="pointer-cursor"
-            data-trigger="hover focus"
-            data-delay="0"
-            data-toggle="tooltip"
-            data-html="true"
-            data-placement="top"
-            data-title="<span id=&quot;copy-tooltip&quot;>Copy uri</span>"
-          >
+          <span id="search-uri-query" class="pointer-cursor" data-trigger="hover focus" data-delay="0" data-toggle="tooltip" data-html="true" data-placement="top" data-title="<span id=&quot;copy-tooltip&quot;>Copy uri</span>">
             <span>
               <i class="fas fa-copy"></i>
             </span>
@@ -142,14 +121,7 @@
     ) %>
   </div>
   <div class="search-control">
-    <.form
-      :let={f}
-      for={@search_form}
-      action="#"
-      phx-submit="start_search"
-      phx-change="form_update"
-      class="form-group"
-    >
+    <.form :let={f} for={@search_form} action="#" phx-submit="start_search" phx-change="form_update" class="form-group">
       <div class="form-group form-text">
         <%= text_input(f, :querystring,
           phx_focus: :form_focus,
@@ -246,14 +218,7 @@
               class: "form-control form-control-sm"
             ) %>
           <% else %>
-            <span
-              class="d-inline-block"
-              tabindex="0"
-              data-toggle="tooltip"
-              title="Chart aggregate setting requires usage of chart: operator"
-              trigger="hover click"
-              delay="0"
-            >
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="Chart aggregate setting requires usage of chart: operator" trigger="hover click" delay="0">
               <%= select(
                 f,
                 :chart_aggregate,
@@ -269,11 +234,7 @@
       <div id="observer-target"></div>
     </.form>
     <%= if @last_query_completed_at do %>
-      <small
-        class="form-text text-muted"
-        id="last-query-completed-at"
-        data-timestamp={Timex.to_unix(@last_query_completed_at)}
-      >
+      <small class="form-text text-muted" id="last-query-completed-at" data-timestamp={Timex.to_unix(@last_query_completed_at)}>
         Elapsed since last query: <span id="elapsed" phx-update="ignore"> 0.0 </span> seconds
       </small>
     <% else %>
@@ -282,11 +243,5 @@
       </small>
     <% end %>
   </div>
-  <div
-    id="user-idle"
-    phx-click="user_idle"
-    class="d-none"
-    data-user-idle-interval={@user_idle_interval}
-  >
-  </div>
+  <div id="user-idle" phx-click="user_idle" class="d-none" data-user-idle-interval={@user_idle_interval}></div>
 </div>

--- a/lib/logflare_web/live/search_live/templates/user_prefs_component.html.heex
+++ b/lib/logflare_web/live/search_live/templates/user_prefs_component.html.heex
@@ -5,14 +5,7 @@
   <%= if @user_type == :user do %>
     <div>Set your local timezone for your account <%= @user.email %></div>
   <% end %>
-  <.form
-    :let={f}
-    for={@user_preferences}
-    action="#"
-    id="user-tz-form"
-    phx-submit="update-preferences"
-    phx-target={@myself}
-  >
+  <.form :let={f} for={@user_preferences} action="#" id="user-tz-form" phx-submit="update-preferences" phx-target={@myself}>
     <div class="form-group">
       <%= hidden_input(f, :id) %>
       <%= label(f, :timezone, "Timezone", class: "col-form-label") %>

--- a/lib/logflare_web/live/source_backends_live.ex
+++ b/lib/logflare_web/live/source_backends_live.ex
@@ -10,14 +10,7 @@ defmodule LogflareWeb.SourceBackendsLive do
       <%= if !@show_create_form do %>
         <button class="btn btn-primary" phx-click="toggle-create-form">Add a backend</button>
       <% else %>
-        <.form
-          :let={f}
-          for={%{}}
-          as={:backend_form}
-          action="#"
-          phx-submit="save_source_backend"
-          class="mt-4"
-        >
+        <.form :let={f} for={%{}} as={:backend_form} action="#" phx-submit="save_source_backend" class="mt-4">
           <p>Add backend</p>
           <%= select(f, :type, ["", Webhook: :webhook, Postgres: :postgres],
             phx_change: :change_create_form_type,
@@ -38,8 +31,7 @@ defmodule LogflareWeb.SourceBackendsLive do
 
                 <%= text_input(f, :url, class: "form-control form-control-margin") %>
                 <small class="form-text text-muted">
-                  Postgres URL with the following format, for example:
-                  <code>postgresql://user:password@host:port/database</code>
+                  Postgres URL with the following format, for example: <code>postgresql://user:password@host:port/database</code>
                 </small>
                 <%= label f, :schema do %>
                   Schema where data should be store, if blank the database defaults will be used

--- a/lib/logflare_web/templates/layout/inline_live.html.heex
+++ b/lib/logflare_web/templates/layout/inline_live.html.heex
@@ -1,11 +1,6 @@
 <%= for {key, alert_class} <- [success: "success", info: "info", error: "danger", warning: "warning"] do %>
   <%= if inner_block = live_flash(@flash, key) do %>
-    <.live_component
-      module={LogflareWeb.AlertComponent}
-      key={key}
-      alert_class={alert_class}
-      id={"#{key}_flash_alert"}
-    >
+    <.live_component module={LogflareWeb.AlertComponent} key={key} alert_class={alert_class} id={"#{key}_flash_alert"}>
       <%= inner_block %>
     </.live_component>
   <% end %>

--- a/lib/logflare_web/templates/layout/live.html.heex
+++ b/lib/logflare_web/templates/layout/live.html.heex
@@ -1,11 +1,6 @@
 <%= for {key, alert_class} <- [success: "success", info: "info", error: "danger", warning: "warning"] do %>
   <%= if inner_block = live_flash(@flash, key) do %>
-    <.live_component
-      module={LogflareWeb.AlertComponent}
-      key={key}
-      alert_class={alert_class}
-      id={"#{key}_flash_alert"}
-    >
+    <.live_component module={LogflareWeb.AlertComponent} key={key} alert_class={alert_class} id={"#{key}_flash_alert"}>
       <%= inner_block %>
     </.live_component>
   <% end %>

--- a/lib/logflare_web/templates/log/log_event_body.html.heex
+++ b/lib/logflare_web/templates/log/log_event_body.html.heex
@@ -9,8 +9,7 @@
             <%= link(@local_timestamp,
               to:
                 Routes.live_path(LogflareWeb.Endpoint, LogflareWeb.Source.SearchLV, @source,
-                  querystring:
-                    "t:>#{Timex.format!(Timex.shift(@local_timestamp, seconds: -30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} t:<#{Timex.format!(Timex.shift(@local_timestamp, seconds: 30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} c:count(*) c:group_by(t::second)",
+                  querystring: "t:>#{Timex.format!(Timex.shift(@local_timestamp, seconds: -30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} t:<#{Timex.format!(Timex.shift(@local_timestamp, seconds: 30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} c:count(*) c:group_by(t::second)",
                   tailing?: false
                 )
             ) %>
@@ -37,13 +36,7 @@
     <li class="list-group-item">
       <ul class="nav d-flex" id="metadata-nav" role="tablist">
         <li class="nav-item">
-          <a
-            class="nav-link active"
-            id="metadata-viewer-link"
-            data-toggle="tab"
-            href="#metadata-viewer"
-            role="tab"
-          >
+          <a class="nav-link active" id="metadata-viewer-link" data-toggle="tab" href="#metadata-viewer" role="tab">
             Event Body
           </a>
         </li>
@@ -52,15 +45,7 @@
         </li>
         <li class="nav-item ml-auto">
           <a class="nav-link fas-copy" href="#" id="copy-metadata-raw">
-            <span
-              class="pointer-cursor logflare-tooltip"
-              data-trigger="hover focus"
-              data-delay="0"
-              data-toggle="tooltip"
-              data-html="true"
-              data-placement="top"
-              data-title="<span id=&quot;copy-tooltip&quot;>Click to copy</span>"
-            >
+            <span class="pointer-cursor logflare-tooltip" data-trigger="hover focus" data-delay="0" data-toggle="tooltip" data-html="true" data-placement="top" data-title="<span id=&quot;copy-tooltip&quot;>Click to copy</span>">
               <i class="fas fa-copy"></i>
             </span>
           </a>
@@ -68,12 +53,7 @@
       </ul>
       <ul class="list-group list-group-horizontal" id="metadata-viewer-tabs">
         <div class="tab-content">
-          <div
-            class="tab-pane active"
-            id="metadata-viewer"
-            role="tabpanel"
-            style="font-size: 14px;"
-          >
+          <div class="tab-pane active" id="metadata-viewer" role="tabpanel" style="font-size: 14px;">
             <pre class="blurred"><code><%= String.replace(@fmt_body, ~r/[\{\}]/, "") %></code></pre>
           </div>
           <div class="tab-pane" id="metadata-raw" role="tabpanel">

--- a/lib/logflare_web/templates/shared/bq_schema.html.heex
+++ b/lib/logflare_web/templates/shared/bq_schema.html.heex
@@ -32,16 +32,7 @@
             <tr>
               <td class="metadata-field">
                 <span class="pointer-cursor" style="text-decoration: none">
-                  <span
-                    class="copy-metadata-field"
-                    data-trigger="hover focus"
-                    data-delay="0"
-                    data-toggle="tooltip"
-                    data-html="true"
-                    data-placement="top"
-                    data-title="<span id=&quot;copy-tooltip&quot;>Copy this</span>"
-                    data-clipboard-text={field}
-                  >
+                  <span class="copy-metadata-field" data-trigger="hover focus" data-delay="0" data-toggle="tooltip" data-html="true" data-placement="top" data-title="<span id=&quot;copy-tooltip&quot;>Copy this</span>" data-clipboard-text={field}>
                     <span class="metadata-field-value"><kbd><%= field %></kbd></span>
                     <i class="fas fa-copy"></i>
                   </span>

--- a/lib/logflare_web/templates/shared/modal.html.heex
+++ b/lib/logflare_web/templates/shared/modal.html.heex
@@ -1,15 +1,5 @@
 <div class="source-logs-search-modals" id="logflare-modal-dialog">
-  <div
-    class="modal"
-    id="logflare-modal"
-    phx-hook="ModalHook"
-    tabindex="-1"
-    role="dialog"
-    aria-labelledby="modal"
-    aria-hidden="true"
-    style="display: block;"
-    data-modal-type={@type}
-  >
+  <div class="modal" id="logflare-modal" phx-hook="ModalHook" tabindex="-1" role="dialog" aria-labelledby="modal" aria-hidden="true" style="display: block;" data-modal-type={@type}>
     <div class="modal-dialog modal-xl" role="document">
       <div class="modal-content">
         <div class="modal-header">


### PR DESCRIPTION
This PR fixes curl formatting for endpoints

Before:

<img width="852" alt="Screenshot 2023-11-02 at 2 53 42 AM" src="https://github.com/Logflare/logflare/assets/22714384/ee4c6fe5-4e08-484c-b2bb-d2977985a355">

After:
<img width="858" alt="Screenshot 2023-11-02 at 3 01 45 AM" src="https://github.com/Logflare/logflare/assets/22714384/3ac5faff-fc6e-4a32-9378-1de29a12444f">
