### PR TITLE
fix: adds goth partitioning, telemetry, adjustment in application children  position, options tweaks

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -32,38 +32,38 @@ defmodule Logflare.Application do
 
   defp get_children(:test) do
     finch_pools() ++
-    [
-      ContextCache,
-      Users.Cache,
-      Sources.Cache,
-      Billing.Cache,
-      SourceSchemas.Cache,
-      PubSubRates.Cache,
-      Logs.LogEvents.Cache,
-      Logs.RejectedLogEvents,
-      {Phoenix.PubSub, name: Logflare.PubSub},
-      Logflare.Repo,
-      {Registry,
-       name: Logflare.V1SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
-      {Registry,
-       name: Logflare.CounterRegistry, keys: :unique, partitions: System.schedulers_online()},
-      LogflareWeb.Endpoint,
-      {Task.Supervisor, name: Logflare.TaskSupervisor},
-      {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
+      [
+        ContextCache,
+        Users.Cache,
+        Sources.Cache,
+        Billing.Cache,
+        SourceSchemas.Cache,
+        PubSubRates.Cache,
+        Logs.LogEvents.Cache,
+        Logs.RejectedLogEvents,
+        {Phoenix.PubSub, name: Logflare.PubSub},
+        Logflare.Repo,
+        {Registry,
+         name: Logflare.V1SourceRegistry, keys: :unique, partitions: System.schedulers_online()},
+        {Registry,
+         name: Logflare.CounterRegistry, keys: :unique, partitions: System.schedulers_online()},
+        LogflareWeb.Endpoint,
+        {Task.Supervisor, name: Logflare.TaskSupervisor},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
 
-      # v2 ingestion pipelines
-      {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.SourcesSup},
-      {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.RecentLogsSup},
-      {DynamicSupervisor,
-       strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
-      {DynamicSupervisor,
-       strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
-      {Registry,
-       name: Logflare.Backends.SourceRegistry,
-       keys: :unique,
-       partitions: System.schedulers_online()},
-      {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
-    ]
+        # v2 ingestion pipelines
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.SourcesSup},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.RecentLogsSup},
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.Supervisor},
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: Logflare.Backends.Adaptor.PostgresAdaptor.PgRepoSupervisor},
+        {Registry,
+         name: Logflare.Backends.SourceRegistry,
+         keys: :unique,
+         partitions: System.schedulers_online()},
+        {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
+      ]
   end
 
   defp get_children(_) do
@@ -187,7 +187,6 @@ defmodule Logflare.Application do
               refresh_before: 60 * 15,
               prefetch: :sync,
               http_client: &goth_finch_http_client/1,
-
               retry_delay: fn
                 n when n < 3 ->
                   1000

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -31,6 +31,7 @@ defmodule Logflare.Application do
   end
 
   defp get_children(:test) do
+    finch_pools() ++
     [
       ContextCache,
       Users.Cache,

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -62,7 +62,7 @@ defmodule Logflare.Application do
        keys: :unique,
        partitions: System.schedulers_online()},
       {Registry, name: Logflare.Backends.SourceDispatcher, keys: :duplicate}
-    ] ++ common_children()
+    ]
   end
 
   defp get_children(_) do
@@ -82,7 +82,8 @@ defmodule Logflare.Application do
     pool_size = Application.get_env(:logflare, Logflare.PubSub)[:pool_size]
 
     # set goth early in the supervision tree
-    conditional_children() ++
+    finch_pools() ++
+      conditional_children() ++
       [
         Logflare.ErlSysMon,
         {Task.Supervisor, name: Logflare.TaskSupervisor},
@@ -158,7 +159,7 @@ defmodule Logflare.Application do
 
         # citrine scheduler for alerts
         Logflare.AlertsScheduler
-      ] ++ common_children()
+      ]
   end
 
   def conditional_children do
@@ -228,7 +229,7 @@ defmodule Logflare.Application do
     :ok
   end
 
-  defp common_children do
+  defp finch_pools do
     [
       # Finch connection pools, using http2
       {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 200]}},

--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -76,7 +76,7 @@ defmodule Logflare.Google.BigQuery.GenUtils do
     partition_count = System.schedulers_online()
     partition = :erlang.phash2(self(), partition_count)
 
-    metadata = %{partition_count: partition_count}
+    metadata = %{partition: partition}
 
     :telemetry.span([:logflare, :goth, :fetch], metadata, fn ->
       result =

--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -79,12 +79,7 @@ defmodule Logflare.Google.BigQuery.GenUtils do
     metadata = %{partition: partition}
 
     :telemetry.span([:logflare, :goth, :fetch], metadata, fn ->
-      result =
-        Goth.fetch({Logflare.Goth, partition},
-          http_client: &goth_finch_http_client/1,
-          receive_timeout: 15_000
-        )
-
+      result = Goth.fetch({Logflare.Goth, partition})
       {result, metadata}
     end)
     |> case do
@@ -98,18 +93,6 @@ defmodule Logflare.Google.BigQuery.GenUtils do
     end
     # dynamically set tesla adapter
     |> Map.update!(:adapter, fn _value -> build_tesla_adapter_call(conn_type) end)
-  end
-
-  # tell goth to use our finch pool
-  # https://github.com/peburrows/goth/blob/master/lib/goth/token.ex#L144
-  defp goth_finch_http_client(options) do
-    {method, options} = Keyword.pop!(options, :method)
-    {url, options} = Keyword.pop!(options, :url)
-    {headers, options} = Keyword.pop!(options, :headers)
-    {body, options} = Keyword.pop!(options, :body)
-
-    Finch.build(method, url, headers, body)
-    |> Finch.request(Logflare.FinchDefault, options)
   end
 
   # copy over runtime adapter building from Tesla.client/2

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,12 +32,13 @@ Mimic.copy(ConfigCat)
 Mimic.copy(Finch)
 Mimic.copy(ExTwilio.Message)
 
-# stub all outgoing requests
-Mimic.stub(Goth)
-Mimic.stub(Finch)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 {:ok, _} = Application.ensure_all_started(:mimic)
+
+# stub all outgoing requests
+Mimic.stub(Goth)
+Mimic.stub(Finch)
 
 ExUnit.configure(exclude: [integration: true, failing: true])
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,7 +32,6 @@ Mimic.copy(ConfigCat)
 Mimic.copy(Finch)
 Mimic.copy(ExTwilio.Message)
 
-
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 {:ok, _} = Application.ensure_all_started(:mimic)
 


### PR DESCRIPTION
Adds in the following Goth tweaks:
- telemetry span for fetch execution
- partitioning, had to hack around Goth's internal use of registry.
- shifted Goth up in the sup children
- reduced retry cap to 10s, added logging as well
- made server startup to be sync so that it fetches token on startup before continuing.