### PR TITLE
chore: allow concurrency for docker ci for building on each merge

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   settings:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adjusts the docker build to ensure that in progress builds are not cancelled.