### PR TITLE
chore: fix logger json backend metadata filtering

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,6 +39,11 @@ config :logger,
   handle_sasl_reports: false,
   level: :info
 
+config :logger_json, :backend,
+  metadata: :all,
+  json_encoder: Jason,
+  formatter: LoggerJSON.Formatters.GoogleCloudLogger
+
 config :ueberauth, Ueberauth,
   providers: [
     github: {Ueberauth.Strategy.Github, [default_scope: "user:email"]},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -36,8 +36,4 @@ config :logflare_logger_backend,
   flush_interval: 2_000,
   max_batch_size: 250
 
-config :logger_json, :backend,
-  json_encoder: Jason,
-  formatter: LoggerJSON.Formatters.GoogleCloudLogger
-
 import_config "telemetry.exs"


### PR DESCRIPTION
tweaks metadata logging, seems like gcp is not receiving the metadata key still