### PR TITLE
chore: allow versioned building on workflow dispatch

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -82,7 +82,7 @@ jobs:
           ${{ env.tag_amd64 }} ${{ env.tag_arm64 }}
       # only produce a versioned image if created from a release
       - name: Versioned - Merge multi-arch manifests and push (release only)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
           docker buildx imagetools create -t supabase/logflare:latest -t ${{ env.tag_ver }}  \
           ${{ env.tag_amd64 }} ${{ env.tag_arm64 }}


### PR DESCRIPTION
fix for triggering rebuilds of versioned image on workflow dispatch.
Currently we don't have v1.5.4 image built yet on dockerhub, causing downstream cloudbuild workflow to fail.