### PR TITLE
chore: use e2-standard-4 for load test cluster

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,6 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths:
+      - 'native/**'
+      - 'priv/**'
+      - 'rel/**'
+      - 'config/**'
+      - 'assets/**'
+      - 'Dockerfile'
+      - '!assets/**'
+      - '*.sh'
+      - '.tool-versions'
 
 permissions:
   contents: read

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -2,13 +2,18 @@ name: Elixir CI
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches: [main]
     paths:
       - '!.github/**'
       - '!cloudbuild/**'
-  pull_request:
-    branches: [main]
+      - '!assets/**'
+      - '!Dockerfile'
+      - '!*.yml'
+      - '!*.md'
+      - '!*.sh'
+      - '!*.env'
+      - '!Makefile'
 
 permissions:
   contents: read

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -48,7 +48,7 @@ substitutions:
   _COOKIE: default
   _CLUSTER: main
   _NORMALIZED_IMAGE_TAG: ${_IMAGE_TAG}
-  _INSTANCE_TYPE: e2-standard-2
+  _INSTANCE_TYPE: e2-standard-4
   _INSTANCE_GROUP: instance-group-staging-${_CLUSTER}
   _IMAGE_TAG: $SHORT_SHA
   _TEMPLATE_NAME: logflare-staging-${_CLUSTER}-cluster-${_NORMALIZED_IMAGE_TAG}


### PR DESCRIPTION
e2-standard-8 is quite expensive (almost US$200 per node per month, lets try with e2-standard-4 first before going with higher vcpus.

also adds in some ci improvements