### PR TITLE
fix: :buffer_counter_not_found bug

### DIFF
--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -242,7 +242,7 @@ defmodule Logflare.Source.RecentLogsServer do
 
   def terminate(reason, state) do
     # Do Shutdown Stuff
-    Logger.error("Going Down - #{inspect(reason)} - #{state.source_id}", %{
+    Logger.info("[#{__MODULE__}] Going Down - #{inspect(reason)} - #{state.source_id}", %{
       source_id: state.source_id
     })
 

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -126,6 +126,8 @@ defmodule Logflare.Source.RecentLogsServer do
   ## Client
   @spec init(RLS.t()) :: {:ok, RLS.t(), {:continue, :boot}}
   def init(%__MODULE__{source_id: _source_id, source: source} = rls) do
+    Process.flag(:trap_exit, true)
+
     user =
       source.user_id
       |> Users.get()

--- a/test/logflare/source/bigquery/buffer_test.exs
+++ b/test/logflare/source/bigquery/buffer_test.exs
@@ -1,15 +1,12 @@
 defmodule Logflare.Source.BigQuery.BufferTest do
   @moduledoc false
+  use Logflare.DataCase
   alias Logflare.Source.BigQuery
   alias Logflare.Source.RecentLogsServer
   alias Logflare.Sources.Counters
   alias Logflare.Sources.RateCounters
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.LogEvent
-
-  use Logflare.DataCase
-
-  doctest(BigQuery.BufferCounter)
 
   setup do
     Goth
@@ -18,7 +15,6 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     start_supervised!(AllLogsLogged)
     start_supervised!(Counters)
     start_supervised!(RateCounters)
-
     insert(:plan)
     user = insert(:user)
 
@@ -26,7 +22,6 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     rls = %RecentLogsServer{source: source, source_id: source.token}
     start_supervised!({RecentLogsServer, rls}, id: :source)
 
-    :timer.sleep(250)
     [source: source]
   end
 
@@ -36,6 +31,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     BigQuery.BufferCounter.push(le)
 
     assert 1 = BigQuery.BufferCounter.len(source)
+    :timer.sleep(2000)
   end
 
   test "ack a log event", %{source: source} do
@@ -46,6 +42,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     BigQuery.BufferCounter.ack(source.token, "some-uuid")
 
     assert 0 = BigQuery.BufferCounter.len(source)
+    :timer.sleep(2000)
   end
 
   test "ack a batch of log events", %{source: source} do
@@ -61,6 +58,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     BigQuery.BufferCounter.ack_batch(source.token, [message])
 
     assert 0 = BigQuery.BufferCounter.len(source)
+    :timer.sleep(2000)
   end
 
   test "push a batch of log events", %{source: source} do
@@ -80,6 +78,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
     BigQuery.BufferCounter.push_batch(%{source: source, batch: batch, count: 2})
 
     assert 2 = BigQuery.BufferCounter.len(source)
+    :timer.sleep(2000)
   end
 
   test "errors when buffer is full", %{source: source} do
@@ -108,5 +107,6 @@ defmodule Logflare.Source.BigQuery.BufferTest do
       BigQuery.BufferCounter.push_batch(%{source: source, batch: batch, count: 2})
 
     assert %{len: 4, discarded: 2} = BigQuery.BufferCounter.get_counts(source.token)
+    :timer.sleep(2000)
   end
 end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -206,7 +206,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
 
       # render as unix microsecond
       assert inspect(timestamp) |> String.length() == 16
-      assert "16" <> _ = inspect(timestamp)
       assert conn.halted == false
 
       # test a logs ui query


### PR DESCRIPTION
This error gets thrown when the RLS does not start up fast enough for incoming requests. This change ensures that the startup of the critical genservers are performed in the init and is blocking.