### PR TITLE
feat: tweak buffer size

### DIFF
--- a/lib/logflare/source/bigquery/buffer_counter.ex
+++ b/lib/logflare/source/bigquery/buffer_counter.ex
@@ -12,7 +12,7 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   require Logger
 
   @broadcast_every 5_000
-  @max_buffer_len 5_000
+  @max_buffer_len 40_000
   @pool_size Application.compile_env(:logflare, Logflare.PubSub)[:pool_size]
 
   def start_link(%RLS{source_id: source_uuid}) when is_atom(source_uuid) do

--- a/lib/logflare/source/bigquery/buffer_producer.ex
+++ b/lib/logflare/source/bigquery/buffer_producer.ex
@@ -12,7 +12,7 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
      %{
        demand: 0,
        source_id: source_id
-     }}
+     }, buffer_size: 50_000}
   end
 
   @impl true


### PR DESCRIPTION
This bumps up the buffer size, to manage spikes due to large batches better.
It is quite unlikely that source events would hit this level of queuing, but it is not impossible given current growth.
This future proofs broadway buffering while optimizations are being made.