### PR TITLE
chore: use bash for GH workflow scripts

### DIFF
--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -15,6 +15,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Versioned - Merge multi-arch manifests and push (release only)
+        shell: bash
         run: |
           make tag-versioned
 


### PR DESCRIPTION
seems like exit trapping on GH workflow doesn't work  and is ci to fail
https://github.com/Logflare/logflare/actions/runs/6948416156/job/18904352532