### PR TITLE
feat: tweaks broadway pipeline batch size, batch timeout

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -36,7 +36,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         default: [concurrency: max_batchers]
       ],
       batchers: [
-        bq: [concurrency: max_batchers, batch_size: 500, batch_timeout: 800]
+        bq: [concurrency: max_batchers, batch_size: 500, batch_timeout: 1_500]
       ],
       context: rls
     )

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -27,15 +27,16 @@ defmodule Logflare.Source.BigQuery.Pipeline do
 
     Broadway.start_link(__MODULE__,
       name: name(source.token),
+      max_restarts: 10,
       producer: [
         module: {BufferProducer, rls},
         hibernate_after: 30_000
       ],
       processors: [
-        default: [concurrency: 1]
+        default: [concurrency: max_batchers]
       ],
       batchers: [
-        bq: [concurrency: max_batchers, batch_size: 250, batch_timeout: 1000]
+        bq: [concurrency: max_batchers, batch_size: 500, batch_timeout: 800]
       ],
       context: rls
     )

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -124,7 +124,8 @@ defmodule Logflare.LogsTest do
       ]
 
       assert :ok = Logs.ingest_logs(batch, source)
-      :timer.sleep(1_500)
+      # batcher timneout is 1_500
+      :timer.sleep(2_000)
     end
   end
 


### PR DESCRIPTION
This PR doubles the batch size for each streaming insert. It also reduces the batch timeout slightly, so that flushing occurs slightly faster.

On dev, this effectively doubles throughput.

Also adds in a max_restart option, to prolong restart attempts in the event pipeline goes down due to api errors.