### PR TITLE
feat: persist endpoint query params form values

### DIFF
--- a/lib/logflare_web/live/endpoints/components/run_query_form.heex
+++ b/lib/logflare_web/live/endpoints/components/run_query_form.heex
@@ -4,7 +4,7 @@
   <.inputs_for :let={params_f} field={f[:params]}>
     <div :for={key <- @declared_params}>
       <%= label(params_f, key, key) %>
-      <%= text_input(params_f, key) %>
+      <%= text_input(params_f, key, value: Map.get(@prev_params, key, "")) %>
     </div>
   </.inputs_for>
   <%= submit("Test query", class: "btn btn-secondary") %>

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -49,6 +49,7 @@ defmodule LogflareWeb.EndpointsLive do
       |> assign(:base_url, LogflareWeb.Endpoint.url())
       |> assign(:parse_error_message, nil)
       |> assign(:query_string, nil)
+      |> assign(:prev_params, %{})
       |> assign(:params_form, to_form(%{"query" => "", "params" => %{}}, as: "run"))
       |> assign(:declared_params, %{})
 
@@ -152,6 +153,7 @@ defmodule LogflareWeb.EndpointsLive do
         {:noreply,
          socket
          |> put_flash(:info, "Ran query successfully")
+         |> assign(:prev_params, query_params)
          |> assign(:query_result_rows, rows)}
 
       {:error, err} ->

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -298,7 +298,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
     end
 
     test "show endpoint, with params", %{conn: conn, user: user} do
-      endpoint = insert(:endpoint, user: user, query: "select 'id' as id;\n\n")
+      endpoint = insert(:endpoint, user: user, query: "select 'id' as id, @test_param as param;\n\n")
       {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}")
       refute render(view) =~ "results-123"
       # sow declared params
@@ -319,6 +319,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
                  params: %{"test_param" => "my_param_value"}
                }
              }) =~ "results-123"
+      assert has_element?(view, "input[value='my_param_value']")
     end
   end
 end


### PR DESCRIPTION
This persists endpoint query params form values for testing usability.