### PR TITLE
feat: switch cluster warning to telemetry poller

### DIFF
--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -9,24 +9,11 @@ defmodule Logflare.Cluster.Utils do
 
   @spec cluster_size() :: non_neg_integer()
   def cluster_size() do
-    lib_cluster_size = actual_cluster_size()
-    min_size = env_min_cluster_size()
-
-    if lib_cluster_size >= min_size do
-      lib_cluster_size
-    else
-      Logger.warning("Cluster size is #{lib_cluster_size} but expected #{min_size}",
-        cluster_size: lib_cluster_size
-      )
-
-      min_size
-    end
+    max(actual_cluster_size(), min_cluster_size())
   end
 
   @spec actual_cluster_size() :: non_neg_integer()
-  def actual_cluster_size() do
-    Enum.count(node_list_all())
-  end
+  def actual_cluster_size(), do: Enum.count(node_list_all())
 
-  defp env_min_cluster_size, do: Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
+  def min_cluster_size, do: Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
 end

--- a/lib/logflare/system_metrics/cluster_size.ex
+++ b/lib/logflare/system_metrics/cluster_size.ex
@@ -1,5 +1,5 @@
 defmodule Logflare.SystemMetrics.Cluster do
-  @modueldoc false
+  @moduledoc false
   require Logger
   alias Logflare.Cluster.Utils
 

--- a/lib/logflare/system_metrics/cluster_size.ex
+++ b/lib/logflare/system_metrics/cluster_size.ex
@@ -1,6 +1,6 @@
 defmodule Logflare.SystemMetrics.Cluster do
   @modueldoc false
-
+  require Logger
   alias Logflare.Cluster.Utils
 
   def dispatch_cluster_size() do

--- a/lib/logflare/system_metrics/cluster_size.ex
+++ b/lib/logflare/system_metrics/cluster_size.ex
@@ -1,0 +1,19 @@
+defmodule Logflare.SystemMetrics.Cluster do
+  @modueldoc false
+
+  alias Logflare.Cluster.Utils
+
+  def dispatch_cluster_size() do
+    # emit a telemetry event when called
+    min = Utils.min_cluster_size()
+    actual = Utils.actual_cluster_size()
+
+    if actual < min do
+      Logger.warning("Cluster size is #{actual} but expected #{min}",
+        cluster_size: actual
+      )
+    end
+
+    :telemetry.execute([:logflare, :cluster_size], %{count: actual}, %{min: min})
+  end
+end

--- a/lib/logflare/system_metrics/system_metrics_sup.ex
+++ b/lib/logflare/system_metrics/system_metrics_sup.ex
@@ -1,6 +1,7 @@
 defmodule Logflare.SystemMetricsSup do
   @moduledoc false
   alias Logflare.SystemMetrics
+  alias Logflare.SystemMetrics.Cluster
 
   use Supervisor
 
@@ -17,7 +18,20 @@ defmodule Logflare.SystemMetricsSup do
       SystemMetrics.AllLogsLogged,
       SystemMetrics.AllLogsLogged.Poller,
       SystemMetrics.Schedulers.Poller,
-      SystemMetrics.Cachex.Poller
+      SystemMetrics.Cachex.Poller,
+      # telemetry poller
+      {
+        :telemetry_poller,
+        # include custom measurement as an MFA tuple
+        # configure sampling period - default is :timer.seconds(5)
+        # configure sampling initial delay - default is 0
+        measurements: [
+          {Cluster, :dispatch_cluster_size, []}
+        ],
+        period: :timer.seconds(10),
+        init_delay: :timer.seconds(30),
+        name: Logflare.TelemetryPoller.Perodic
+      }
     ]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
This PR moves the cluster warning to a period 10s check, together with a telemetry event.
This reduces log emission on high request load, as cluster warning log was being emitted on each rate limit check