### PR TITLE
fix: revert batch size

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -36,7 +36,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         default: [concurrency: max_batchers]
       ],
       batchers: [
-        bq: [concurrency: max_batchers, batch_size: 500, batch_timeout: 1_500]
+        bq: [concurrency: max_batchers, batch_size: 250, batch_timeout: 1_500]
       ],
       context: rls
     )


### PR DESCRIPTION
This reverts the broadway max batch size, as discussed. We will add more metrics around this before deciding to increase the batch size as a means for increasing throughput.