### PR TITLE
feat: increase max search row return

### DIFF
--- a/lib/logflare/logs/search/logs_search_operations.ex
+++ b/lib/logflare/logs/search/logs_search_operations.ex
@@ -24,7 +24,8 @@ defmodule Logflare.Logs.SearchOperations do
   @type chart_period :: :day | :hour | :minute | :second
   @type dt_or_ndt :: DateTime.t() | NaiveDateTime.t()
 
-  @default_limit 100
+  # BigQuery max row return
+  @default_limit 1_000
   @default_max_n_chart_ticks 1_000
   @tailing_timestamp_filter_minutes 10
   # Note that this is only a timeout for the request, not the query.


### PR DESCRIPTION
This PR increase the max resultset of the search query. It is a first step for adding in infinite scroll style pagination.
If amount of scrolling is a concern, we can drop it down to 500. 
I think having it at 1k reduces the amount of queries that a user would possibly make.