### PR TITLE
chore: include only source identifiers  in metadata.

### DIFF
--- a/lib/logflare/logs/processor.ex
+++ b/lib/logflare/logs/processor.ex
@@ -23,7 +23,8 @@ defmodule Logflare.Logs.Processor do
       when is_list(data) and is_atom(processor) do
     metadata = %{
       processor: processor,
-      source: source
+      source_token: source.token,
+      source_id: source.id
     }
 
     :telemetry.span([:logflare, :logs, :processor, :ingest], metadata, fn ->


### PR DESCRIPTION
Metadata should not include entire structs, as this metadata would eventually get sent to Logflare staging as is.