### PR TITLE
fix: default node host value

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -15,4 +15,5 @@
 # export RELEASE_DISTRIBUTION=name
 # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@$LOGFLARE_NODE_HOST
+HOST="${LOGFLARE_NODE_HOST:-127.0.0.1}"
+export RELEASE_NODE="<%= @release.name %>@$HOST


### PR DESCRIPTION
Ensures that the node host value is always set so that the server can start with long node name.

Closes #1807