### PR TITLE
chore: shutdown script for instance template deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,10 @@ deploy.staging.versioned:
 		--region=europe-west1 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 	
-	gcloud builds submit \
-		--no-source \
+	gcloud builds submit . \
 		--config=./cloudbuild/staging/deploy.yaml \
 		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION),_INSTANCE_TYPE=c2d-standard-2,_CLUSTER=versioned \
-		--region=us-central1 \
+		--region=us-west1 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 
 
@@ -158,8 +157,7 @@ deploy.prod.versioned:
 		--region=europe-west3 \
 		--gcs-log-dir="gs://logflare-prod_cloudbuild-logs/logs"
 	
-	gcloud builds submit \
-		--no-source \
+	gcloud builds submit . \
 		--config=./cloudbuild/prod/pre-deploy.yaml \
 		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION) \
 		--region=europe-west3 \

--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -14,6 +14,7 @@ steps:
       - --service-account=compute-engine-2022@logflare-232118.iam.gserviceaccount.com
       - --scopes=https://www.googleapis.com/auth/cloud-platform
       - --tags=phoenix-http,https-server
+      - --metadata-from-file=shutdown-script=./cloudbuild/shutdown.sh
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always

--- a/cloudbuild/shutdown.sh
+++ b/cloudbuild/shutdown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash  
+
+# echo $PWD
+
+NODE_IP=$(curl \
+    -s "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip" \
+    -H "Metadata-Flavor: Google")
+
+NODE=logflare@$NODE_IP
+
+echo "Stopping node $NODE"
+
+curl -X "POST" "https://api.logflarestaging.com/api/logs?source=$LOGFLARE_LOGGER_BACKEND_SOURCE_ID" \
+    -H 'Content-Type: application/json' \
+    -H 'X-API-KEY: $LOGFLARE_LOGGER_BACKEND_API_KEY' \
+    -d $'{
+      "message": "Stopping node $NODE"
+    }'
+
+curl -X "PUT" "http://localhost:4000/admin/shutdown?code=$LOGFLARE_NODE_SHUTDOWN_CODE"
+
+sleep 20
+
+echo "Stopped node $NODE"

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -15,6 +15,7 @@ steps:
       - --scopes=https://www.googleapis.com/auth/cloud-platform
       - --tags=phoenix-http,https-server
       - --container-image=${_CONTAINER_IMAGE}
+      - --metadata-from-file=shutdown-script=./cloudbuild/shutdown.sh
       - --container-privileged
       - --container-restart-policy=always
       - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=1,OVERRIDE_MAGIC_COOKIE=${_COOKIE}


### PR DESCRIPTION
This PR adds in the shutdown script to CD, and uses env vars instead of hardcoded values.