### PR TITLE
chore: refactor docker ci

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -69,9 +69,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup tags
         run: |
-          echo "tag_amd64=supabase/logflare:${{ needs.settings.outputs.version }}-amd64" >> "$GITHUB_ENV"
-          echo "tag_arm64=supabase/logflare:${{ needs.settings.outputs.version }}-arm64" >> "$GITHUB_ENV"
-          echo "tag_ver=supabase/logflare:${{ needs.settings.outputs.version }}" >> "$GITHUB_ENV"
+          echo "tag_amd64=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-amd64" >> "$GITHUB_ENV"
+          echo "tag_arm64=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-arm64" >> "$GITHUB_ENV"
           echo "tag_sha=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}" >> "$GITHUB_ENV"
       - name: Staging - Merge multi-arch manifests and push the dev image
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,6 @@ tag-versioned:
 
 	@echo "Retagging dev image to supabase/logflare:$(VERSION) ..."
 	docker buildx imagetools create -t supabase/logflare:$(VERSION) -t supabase/logflare:latest supabase/logflare:$(SHA_IMAGE_TAG) 
-	docker push supabase/logflare:$(VERSION)
-	docker push supabase/logflare:latest
 	@echo "OK"
 
 .PHONY: tag-versioned


### PR DESCRIPTION
This PR adds two changes to the CI:
- removal of the redundant docker image pushing on the retagging script
- adjusting the intermediate mutli-arch image tags to make it clear that they are dev images.