### PR TITLE
feat: telemetry ingestion api stats

### DIFF
--- a/lib/logflare/logs/logs.ex
+++ b/lib/logflare/logs/logs.ex
@@ -14,6 +14,12 @@ defmodule Logflare.Logs do
 
   @spec ingest_logs(list(map), Source.t()) :: :ok | {:error, term}
   def ingest_logs(log_params_batch, %Source{rules: rules} = source) when is_list(rules) do
+    :telemetry.execute(
+      [:logflare, :logs, :ingest_logs],
+      %{batch_size: length(log_params_batch)},
+      %{source_id: source.id, source_token: source.token}
+    )
+
     log_params_batch
     |> Enum.map(fn log ->
       log

--- a/lib/logflare/logs/logs.ex
+++ b/lib/logflare/logs/logs.ex
@@ -14,12 +14,6 @@ defmodule Logflare.Logs do
 
   @spec ingest_logs(list(map), Source.t()) :: :ok | {:error, term}
   def ingest_logs(log_params_batch, %Source{rules: rules} = source) when is_list(rules) do
-    :telemetry.execute(
-      [:logflare, :logs, :ingest_logs],
-      %{batch_size: length(log_params_batch)},
-      %{source_id: source.id, source_token: source.token}
-    )
-
     log_params_batch
     |> Enum.map(fn log ->
       log

--- a/lib/logflare_web/controllers/plugs/rate_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/rate_limiter.ex
@@ -21,6 +21,7 @@ defmodule LogflareWeb.Plugs.RateLimiter do
         |> put_x_rate_limit_headers(metrics)
 
       {:error, %{message: message, metrics: metrics}} ->
+
         conn
         |> put_x_rate_limit_headers(metrics)
         |> send_resp(429, message)

--- a/lib/logflare_web/controllers/plugs/rate_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/rate_limiter.ex
@@ -21,6 +21,13 @@ defmodule LogflareWeb.Plugs.RateLimiter do
         |> put_x_rate_limit_headers(metrics)
 
       {:error, %{message: message, metrics: metrics}} ->
+        :telemetry.execute(
+          [:logflare, :rate_limiter],
+          %{
+            rejected: true
+          },
+          %{user_id: user.id, source_id: source.id, source_token: source.token}
+        )
 
         conn
         |> put_x_rate_limit_headers(metrics)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -74,8 +74,22 @@ defmodule Logflare.Telemetry do
         tags: [:processor],
         unit: {:native, :millisecond}
       ),
-      counter("logflare.logs.processor.ingest.stop.duration", tags: [:processor]),
-      sum("logflare.logs.processor.ingest.logs.count", tags: [:processor]),
+      counter("logflare.logs.processor.ingest.stop.duration",
+        tags: [:processor],
+        description: "Ingestion counts by processor"
+      ),
+      counter("logflare.logs.processor.ingest.stop.duration",
+        tags: [:source_token],
+        description: "Ingestion counts by source"
+      ),
+      summary("logflare.logs.processor.ingest.logs.count",
+        tags: [:processor],
+        description: "Ingestion batch size by processor"
+      ),
+      summary("logflare.logs.processor.ingest.logs.count",
+        tags: [:source_token],
+        description: "Ingestion batch size by source"
+      ),
       summary("logflare.logs.processor.ingest.store.stop.duration",
         tags: [:processor],
         unit: {:native, :millisecond}
@@ -88,10 +102,22 @@ defmodule Logflare.Telemetry do
       summary("logflare.ingest.common_pipeline.handle_batch.batch_size", tags: [:pipeline]),
       counter("logflare.context_cache.busted.count", tags: [:schema, :table]),
       counter("logflare.context_cache.handle_record.count", tags: [:schema, :table]),
-      counter("logflare.logs.ingest_logs.drop"),
-      counter("logflare.logs.ingest_logs.rejected"),
-      counter("logflare.logs.ingest_logs.buffer_full"),
-      counter("logflare.rate_limiter.rejected", tags: [:user_id, :source_token])
+      counter("logflare.logs.ingest_logs.drop",
+        tags: [:source_token],
+        description: "Ingest drops by source"
+      ),
+      counter("logflare.logs.ingest_logs.rejected",
+        tags: [:source_token],
+        description: "Ingest rejects by source"
+      ),
+      counter("logflare.logs.ingest_logs.buffer_full",
+        tags: [:source_token],
+        description: "Ingest buffer fulls by source"
+      ),
+      counter("logflare.rate_limiter.rejected",
+        tags: [:user_id, :source_token],
+        description: "Rate limited API hits"
+      )
     ]
 
     Enum.concat([

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -90,7 +90,8 @@ defmodule Logflare.Telemetry do
       counter("logflare.context_cache.handle_record.count", tags: [:schema, :table]),
       counter("logflare.logs.ingest_logs.drop"),
       counter("logflare.logs.ingest_logs.rejected"),
-      counter("logflare.logs.ingest_logs.buffer_full")
+      counter("logflare.logs.ingest_logs.buffer_full"),
+      summary("logflare.logs.ingest_logs.batch_size")
     ]
 
     Enum.concat([

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -75,20 +75,12 @@ defmodule Logflare.Telemetry do
         unit: {:native, :millisecond}
       ),
       counter("logflare.logs.processor.ingest.stop.duration",
-        tags: [:processor],
-        description: "Ingestion counts by processor"
-      ),
-      counter("logflare.logs.processor.ingest.stop.duration",
-        tags: [:source_token],
-        description: "Ingestion counts by source"
+        tags: [:processor, :source_token],
+        description: "Ingestion execution counts"
       ),
       summary("logflare.logs.processor.ingest.logs.count",
-        tags: [:processor],
-        description: "Ingestion batch size by processor"
-      ),
-      summary("logflare.logs.processor.ingest.logs.count",
-        tags: [:source_token],
-        description: "Ingestion batch size by source"
+        tags: [:processor, :source_token],
+        description: "Ingestion batch size"
       ),
       summary("logflare.logs.processor.ingest.store.stop.duration",
         tags: [:processor],

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -91,7 +91,8 @@ defmodule Logflare.Telemetry do
       counter("logflare.logs.ingest_logs.drop"),
       counter("logflare.logs.ingest_logs.rejected"),
       counter("logflare.logs.ingest_logs.buffer_full"),
-      summary("logflare.logs.ingest_logs.batch_size")
+      summary("logflare.logs.ingest_logs.batch_size"),
+      counter("logflare.rate_limiter.rejected", tags: [:user_id, :source_token])
     ]
 
     Enum.concat([

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -91,7 +91,6 @@ defmodule Logflare.Telemetry do
       counter("logflare.logs.ingest_logs.drop"),
       counter("logflare.logs.ingest_logs.rejected"),
       counter("logflare.logs.ingest_logs.buffer_full"),
-      summary("logflare.logs.ingest_logs.batch_size"),
       counter("logflare.rate_limiter.rejected", tags: [:user_id, :source_token])
     ]
 


### PR DESCRIPTION
This PR adds in telemetry ingestion metrics:
- rate limiter drop rate
- ingest  counts by source

This also tweaks the metrics for batch size counting by adjusting the tags to be by source.