### PR TITLE
fix: gcloud ignore only takes the cloudbuild dir

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,5 +17,4 @@ tmp/
 .*.key
 .*.pem
 .*.env
-!cloudbuild/.*.*.enc
-!cloudbuild/*.yaml
+!cloudbuild/*


### PR DESCRIPTION
gcloudignore was ignoring the shutdown script file. This ensures that the entire directory is added to the tarball on run of `gcloud build submit` 