### PR TITLE
chore: fix shutdown scripts, drop min cluster size for prod, and increase staging min ready time

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -18,7 +18,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=3
+      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2
       - --create-disk=auto-delete=yes,device-name=logflare-c2-16cpu-docker-global-cos89-13,image=projects/cos-cloud/global/images/cos-stable-101-17162-40-52,mode=rw,size=25,type=pd-ssd
       - --no-shielded-secure-boot
       - --shielded-vtpm

--- a/cloudbuild/shutdown.sh
+++ b/cloudbuild/shutdown.sh
@@ -12,10 +12,10 @@ echo "Stopping node $NODE"
 
 curl -X "POST" "https://api.logflarestaging.com/api/logs?source=$LOGFLARE_LOGGER_BACKEND_SOURCE_ID" \
     -H 'Content-Type: application/json' \
-    -H 'X-API-KEY: $LOGFLARE_LOGGER_BACKEND_API_KEY' \
-    -d $'{
-      "message": "Stopping node $NODE"
-    }'
+    -H "X-API-KEY: $LOGFLARE_LOGGER_BACKEND_API_KEY" \
+    -d $"{
+      \"message\": \"Stopping node $NODE\"
+    }"
 
 curl -X "PUT" "http://localhost:4000/admin/shutdown?code=$LOGFLARE_NODE_SHUTDOWN_CODE"
 

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -39,15 +39,15 @@ steps:
       - --type=proactive
       - --max-surge=1
       - --max-unavailable=0
-      - --min-ready=60
+      - --min-ready=300
       - --minimal-action=replace
       - --most-disruptive-allowed-action=replace
       - --replacement-method=substitute
       - --version=template=projects/logflare-staging/global/instanceTemplates/${_TEMPLATE_NAME}
 
 substitutions:
-  _COOKIE: default
   _CLUSTER: main
+  _COOKIE: default-${_CLUSTER}
   _NORMALIZED_IMAGE_TAG: ${_IMAGE_TAG}
   _INSTANCE_TYPE: e2-standard-4
   _INSTANCE_GROUP: instance-group-staging-${_CLUSTER}


### PR DESCRIPTION
Increase min ready time for staging to let nodes be more stable before shutting down old nodes.

Drop cluster size to allow for 2 node canarying.

fix shutdown script which is breaking the node shutdown.