### PR TITLE
chore: gcloud should ignore deps folder

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -12,6 +12,7 @@ test/
 _build/
 .elixir_ls/
 tmp/
+deps/
 
 
 .*.key


### PR DESCRIPTION
deps folder is not ignored, so triggering the build locally causes issues.