### PR TITLE
fix: don't hit SourceSchemas cache here

### DIFF
--- a/lib/logflare/logs/search/logs_search_operations.ex
+++ b/lib/logflare/logs/search/logs_search_operations.ex
@@ -129,7 +129,7 @@ defmodule Logflare.Logs.SearchOperations do
 
   def put_chart_data_shape_id(%SO{} = so) do
     flat_type_map =
-      SourceSchemas.Cache.get_source_schema_by(source_id: so.source.id)
+      SourceSchemas.get_source_schema_by(source_id: so.source.id)
       |> Map.get(:schema_flat_map)
 
     [%{path: path}] = so.chart_rules


### PR DESCRIPTION
Bug: if source schema gets cached incorrectly it can prevent you from querying a field even though the field is present when you view the schema.

This should fix that.