### PR TITLE
fix: update_cluster_status bandit error

### DIFF
--- a/lib/logflare_web/live/admin/cluster_live.ex
+++ b/lib/logflare_web/live/admin/cluster_live.ex
@@ -12,7 +12,10 @@ defmodule LogflareWeb.Admin.ClusterLive do
       assign_cluster_status(socket)
       |> assign(:node_self, Node.self())
 
-    :timer.send_interval(1_000, self(), :update_cluster_status)
+    if connected?(socket) do
+      :timer.send_interval(2_000, self(), :update_cluster_status)
+    end
+
     {:ok, socket}
   end
 

--- a/lib/logflare_web/live/admin/cluster_live.html.heex
+++ b/lib/logflare_web/live/admin/cluster_live.html.heex
@@ -8,6 +8,7 @@
 </div>
 
 <div class="content dashboard container mx-auto">
+  <p>Updates every 2 seconds.</p>
   <h1>Self node</h1>
   <%= @node_self %> <%= link("shutdown", to: "#", phx_click: "shutdown", phx_value_node: @node_self, class: "btn btn-danger btn-sm form-button ml-4", data: [confirm: "Really?"]) %>
   <h1>Nodes</h1>

--- a/test/logflare_web/admin/cluster_live_test.exs
+++ b/test/logflare_web/admin/cluster_live_test.exs
@@ -1,0 +1,20 @@
+defmodule LogflareWeb.ClusterLiveTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+  import Phoenix.LiveViewTest
+
+  setup do
+    insert(:plan)
+    {:ok, user: insert(:user, admin: true)}
+  end
+  test "successfully for admin", %{conn: conn, user: user} do
+    assert {:ok, view, html} =
+      conn
+      |> assign(:user, user)
+      |> live(~p"/admin/cluster")
+
+    assert html =~ "#{Node.self()}"
+    html = render(view)
+    assert html =~ "#{Node.self()}"
+  end
+end


### PR DESCRIPTION
This PR fixes a bug in the cluster management dash, where the update message was sent on static render.


```
Bandit.HTTP1.Handler #PID<0.27316.0> received unexpected message in handle_info/2: :update_cluster_status 
```