### PR TITLE
perf: reduce http2 pools to reduce chance of server throttling.

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -246,9 +246,9 @@ defmodule Logflare.Application do
   defp finch_pools do
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 200]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 100]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 150]}}
+      {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 10]}},
+      {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 10]}},
+      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 10]}}
     ]
   end
 


### PR DESCRIPTION
Reduction of http2 pool count reduces chances of connection throttling
![image](https://github.com/Logflare/logflare/assets/22714384/8b825fc5-3dd6-4368-b6f6-c87b8262e639)
