### PR TITLE
feat: display source ttl

### DIFF
--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -304,7 +304,7 @@ defmodule Logflare.Billing do
         raise "No Free Plan created yet in database."
 
       is_nil(plan) ->
-        Logger.error(
+        Logger.warning(
           "Customer is on a Stripe plan which doesn't exist in our plan list, defaulting to Free"
         )
 

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -19,7 +19,6 @@ defmodule Logflare.Sources do
   alias Logflare.Source.BigQuery.SchemaBuilder
   alias Logflare.SourceSchemas
   alias Logflare.User
-  alias Logflare.Billing
 
   require Logger
 

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -19,6 +19,7 @@ defmodule Logflare.Sources do
   alias Logflare.Source.BigQuery.SchemaBuilder
   alias Logflare.SourceSchemas
   alias Logflare.User
+  alias Logflare.Billing
 
   require Logger
 

--- a/lib/logflare_web/templates/shared/dashboard_source_metadata.html.eex
+++ b/lib/logflare_web/templates/shared/dashboard_source_metadata.html.eex
@@ -44,5 +44,8 @@
   </small>
   <small class="source-details">
     cached: <%= @source.metrics.recent %></span>
+  </small>
+  <small class="source-details">
+    ttl: <%= @source_ttl_days %> day</span>
 </small>
 </div>

--- a/lib/logflare_web/templates/shared/dashboard_source_metadata.html.eex
+++ b/lib/logflare_web/templates/shared/dashboard_source_metadata.html.eex
@@ -45,7 +45,7 @@
   <small class="source-details">
     cached: <%= @source.metrics.recent %></span>
   </small>
-  <small class="source-details">
+  <small class="source-details tw-inline-block">
     ttl: <%= @source_ttl_days %> day</span>
 </small>
 </div>

--- a/lib/logflare_web/templates/source/dashboard.html.eex
+++ b/lib/logflare_web/templates/source/dashboard.html.eex
@@ -113,7 +113,7 @@
                 </span>
               </div>
             </div>
-            <%= render(LogflareWeb.SharedView, "dashboard_source_metadata.html", conn: @conn, source: source) %>
+            <%= render(LogflareWeb.SharedView, "dashboard_source_metadata.html", conn: @conn, source: source, source_ttl_days: source_ttl_to_days(source, @plan)) %>
           </li>
           <% end %>
         </ul>

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -1,6 +1,8 @@
 defmodule LogflareWeb.SourceView do
   import LogflareWeb.Helpers.Forms
   alias LogflareWeb.Router.Helpers, as: Routes
+  alias Logflare.Billing.Plan
+  alias Logflare.Source
   use LogflareWeb, :view
 
   def log_url(route) do
@@ -16,5 +18,17 @@ defmodule LogflareWeb.SourceView do
         url
     end
     |> URI.to_string()
+  end
+
+  @doc """
+  Formats a source TTL to the specified unit
+  """
+  @spec source_ttl_to_days(Source.t(), Plan.t()) :: integer()
+  def source_ttl_to_days(%Source{bigquery_table_ttl: nil} = source, %Plan{} = plan) do
+    source_ttl_to_days(%{source | bigquery_table_ttl: plan.limit_source_ttl}, :day)
+  end
+
+  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl} = source, _plan) do
+    round(ttl / :timer.hours(24))
   end
 end

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -28,7 +28,7 @@ defmodule LogflareWeb.SourceView do
     source_ttl_to_days(%{source | bigquery_table_ttl: plan.limit_source_ttl}, :day)
   end
 
-  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl} = source, _plan) do
+  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl}, _plan) do
     round(ttl / :timer.hours(24))
   end
 end

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -41,6 +41,9 @@ defmodule LogflareWeb.SourceControllerTest do
       assert html =~ "Saved Searches"
       assert html =~ "Dashboard"
       assert html =~ source.name
+
+      # default ttl
+      assert html =~ "ttl: 3 day"
     end
 
     test "show source", %{conn: conn, source: source} do


### PR DESCRIPTION
This display source ttl in the dashboard, which would help dx.
This is a result from internal feedback and customer feedback, and should make a source TTL more obvious to the dev managing the source.

<img width="823" alt="Screenshot 2023-12-04 at 7 51 32 AM" src="https://github.com/Logflare/logflare/assets/22714384/da5e290c-49b6-40de-bde9-4cfb8a2c2285">
