### PR TITLE
fix: set kernel.nmi_watchdog=1

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ then
     echo 'Sleeping for 15 seconds for GCE networking to be ready...'
     sleep 15
 
-    sysctl -w net.ipv4.tcp_keepalive_time=60 net.ipv4.tcp_keepalive_intvl=60 net.ipv4.tcp_keepalive_probes=5
+    sysctl -w net.ipv4.tcp_keepalive_time=60 net.ipv4.tcp_keepalive_intvl=60 net.ipv4.tcp_keepalive_probes=5 kernel.nmi_watchdog=1
 
     export LOGFLARE_NODE_HOST=$(curl \
         -s "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip" \


### PR DESCRIPTION
Sets kernel.nmi_watchdog=1 so we can see if GCP is soft locking our CPUs.

Context:
- https://blog.railway.app/p/gcp-incidents
- https://stackoverflow.com/questions/49495429/google-cloud-engine-kernelnmi-watchdog-bug-soft-lockup
- https://medium.com/@yildirimabdrhm/nmi-watchdog-on-linux-ae3b4c86e8d8

To test I enabled it on this canary box: 10.156.0.56

Should maybe see logs for:

`kernel: NMI watchdog: BUG: soft lockup`

