### PR TITLE
feat: Partners.UserController metadata filtering

### DIFF
--- a/lib/logflare_web/controllers/api/partner/user_controller.ex
+++ b/lib/logflare_web/controllers/api/partner/user_controller.ex
@@ -2,14 +2,17 @@ defmodule LogflareWeb.Api.Partner.UserController do
   use LogflareWeb, :controller
 
   alias Logflare.Partners
+  alias Logflare.Users
   alias Logflare.Billing.BillingCounts
   alias Logflare.Auth
   alias Logflare.Users
 
   action_fallback(LogflareWeb.Api.FallbackController)
-  @allowed_fields [:api_quota, :company, :email, :name, :phone, :token]
-  def index(%{assigns: %{partner: partner}} = conn, _params) do
-    with users <- Users.list_users(partner_id: partner.id) do
+  @allowed_fields [:api_quota, :company, :email, :name, :phone, :token, :metadata]
+  def index(%{assigns: %{partner: partner}} = conn, params) do
+    metadata = Map.get(params, "metadata")
+
+    with users <- Users.list_users(partner_id: partner.id, metadata: metadata) do
       allowed_response = Enum.map(users, &sanitize_response/1)
       json(conn, allowed_response)
     end

--- a/lib/logflare_web/controllers/api/partner/user_controller.ex
+++ b/lib/logflare_web/controllers/api/partner/user_controller.ex
@@ -1,4 +1,4 @@
-defmodule LogflareWeb.Api.Partner.AccountController do
+defmodule LogflareWeb.Api.Partner.UserController do
   use LogflareWeb, :controller
 
   alias Logflare.Partners

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -388,13 +388,13 @@ defmodule LogflareWeb.Router do
   scope "/api/partner", LogflareWeb do
     pipe_through([:api, :partner_api])
 
-    get("/accounts", Api.Partner.AccountController, :index)
-    post("/accounts", Api.Partner.AccountController, :create)
+    get("/users", Api.Partner.UserController, :index)
+    post("/users", Api.Partner.UserController, :create)
 
-    get("/accounts/:user_token", Api.Partner.AccountController, :get_user)
-    get("/accounts/:user_token/usage", Api.Partner.AccountController, :get_user_usage)
+    get("/users/:user_token", Api.Partner.UserController, :get_user)
+    get("/users/:user_token/usage", Api.Partner.UserController, :get_user_usage)
 
-    delete("/accounts/:user_token", Api.Partner.AccountController, :delete_user)
+    delete("/users/:user_token", Api.Partner.UserController, :delete_user)
   end
 
   scope "/api" do

--- a/test/logflare_web/controllers/api/partner/user_controller_test.exs
+++ b/test/logflare_web/controllers/api/partner/user_controller_test.exs
@@ -1,11 +1,12 @@
-defmodule LogflareWeb.Api.Partner.AccountControllerTest do
+defmodule LogflareWeb.Api.Partner.UserControllerTest do
   use LogflareWeb.ConnCase
   alias Logflare.Partners
   alias Logflare.Auth
   alias Logflare.Users
 
   setup do
-    {:ok, %{partner: insert(:partner)}}
+      stub(Goth, :fetch, fn _mod -> {:ok, %Goth.Token{token: "auth-token"}} end)
+      {:ok, %{partner: insert(:partner)}}
   end
 
   @allowed_fields MapSet.new(~w(api_quota company email name phone token))
@@ -20,7 +21,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
       assert [user_response] =
                conn
                |> add_access_token(partner, ~w(partner))
-               |> get("/api/partner/accounts")
+               |> get("/api/partner/users")
                |> json_response(200)
 
       assert user_response["token"] == user.token
@@ -36,7 +37,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> put_req_header("authorization", "Bearer potato")
-             |> get("/api/partner/accounts", %{email: email})
+             |> get("/api/partner/users", %{email: email})
              |> json_response(401) == %{"error" => "Unauthorized"}
     end
   end
@@ -52,7 +53,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
       assert response =
                conn
                |> add_access_token(partner, ~w(partner))
-               |> post("/api/partner/accounts", %{email: email})
+               |> post("/api/partner/users", %{email: email})
                |> json_response(201)
 
       assert response["user"]["email"] == String.downcase(email)
@@ -78,7 +79,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> put_req_header("authorization", "Bearer potato")
-             |> post("/api/partner/accounts", %{email: email})
+             |> post("/api/partner/users", %{email: email})
              |> json_response(401) == %{"error" => "Unauthorized"}
     end
   end
@@ -90,7 +91,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
       assert response =
                conn
                |> add_access_token(partner, ~w(partner))
-               |> get("/api/partner/accounts/#{user.token}")
+               |> get("/api/partner/users/#{user.token}")
                |> json_response(200)
 
       assert response["token"] == user.token
@@ -106,7 +107,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> put_req_header("authorization", "Bearer potato")
-             |> get("/api/partner/accounts/#{user.token}")
+             |> get("/api/partner/users/#{user.token}")
              |> json_response(401) == %{"error" => "Unauthorized"}
     end
 
@@ -121,7 +122,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> add_access_token(partner, ~w(partner))
-             |> get("/api/partner/accounts/#{user.token}")
+             |> get("/api/partner/users/#{user.token}")
              |> response(404)
     end
   end
@@ -137,7 +138,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> add_access_token(partner, ~w(partner))
-             |> get("/api/partner/accounts/#{user.token}/usage")
+             |> get("/api/partner/users/#{user.token}/usage")
              |> json_response(200) == %{"usage" => count}
     end
 
@@ -147,7 +148,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> put_req_header("authorization", "Bearer potato")
-             |> get("/api/partner/accounts/#{user.token}/usage")
+             |> get("/api/partner/users/#{user.token}/usage")
              |> json_response(401) == %{"error" => "Unauthorized"}
     end
 
@@ -160,21 +161,20 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> add_access_token(partner, ~w(partner))
-             |> get("/api/partner/accounts/#{user.token}/usage")
+             |> get("/api/partner/users/#{user.token}/usage")
              |> response(404)
     end
   end
 
   describe "delete_user/2" do
     test "returns 204 and deletes the user", %{conn: conn, partner: partner} do
-      stub(Goth, :fetch, fn _ -> {:error, ""} end)
 
       {:ok, user} = Partners.create_user(partner, %{"email" => TestUtils.gen_email()})
 
       assert response =
                conn
                |> add_access_token(partner, ~w(partner))
-               |> delete("/api/partner/accounts/#{user.token}")
+               |> delete("/api/partner/users/#{user.token}")
                |> json_response(204)
 
       assert response["token"] == user.token
@@ -196,7 +196,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> put_req_header("authorization", "Bearer potato")
-             |> delete("/api/partner/accounts/#{user.token}")
+             |> delete("/api/partner/users/#{user.token}")
              |> json_response(401) == %{"error" => "Unauthorized"}
     end
 
@@ -209,7 +209,7 @@ defmodule LogflareWeb.Api.Partner.AccountControllerTest do
 
       assert conn
              |> add_access_token(partner, ~w(partner))
-             |> get("/api/partner/accounts/#{user.token}")
+             |> get("/api/partner/users/#{user.token}")
              |> response(404)
     end
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -79,6 +79,10 @@ defmodule LogflareWeb.ConnCase do
   end
 
   # for api use
+  def add_partner_access_token(conn, partner) do
+    add_access_token(conn, partner, ~w(partner))
+  end
+
   def add_access_token(conn, user, scopes \\ ~w(public))
 
   def add_access_token(conn, %Logflare.User{} = user, scopes) do


### PR DESCRIPTION
- renames AccountController to UserController to match resource name
- adds GET users metadata filtering, relies on #1879 
