### PR TITLE
fix: prompt user to switch teams on 403

### DIFF
--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -98,7 +98,23 @@
   background-color: #1d1d1d;
   border: 0;
   overflow: hidden;
+  &.active {
+    background-color: $brand-black;
+
+  }
 }
+
+.badge {
+  &.badge-primary {
+    background-color: $brand-fuscia;
+    color: $brand-black;
+  }
+  &.badge-secondary {
+    background-color: $brand-light-gray;
+    color: $brand-black;
+  }
+}
+
 /* Fixes artifacts in Chrome */
 .list-group-item:focus,
 .list-group-item:hover {

--- a/lib/logflare/teams.ex
+++ b/lib/logflare/teams.ex
@@ -99,12 +99,13 @@ defmodule Logflare.Teams do
     |> Repo.one()
   end
 
-  defp query_teams_by_user_access(%User{email: email, id: id}) do
+  defp query_teams_by_user_access(%User{id: id, provider_uid: uid}) do
     from t in Team,
-      join: tu in TeamUser,
-      on: tu.email == ^email,
-      where: t.user_id == ^id or tu.email == ^email,
+      left_join: tu in TeamUser,
+      on: t.id == tu.team_id,
+      where: t.user_id == ^id or tu.provider_uid == ^uid,
       distinct: true,
-      preload: [:user, :team_users]
+      preload: [:user, :team_users],
+      select: t
   end
 end

--- a/lib/logflare_web/controllers/plugs/set_team.ex
+++ b/lib/logflare_web/controllers/plugs/set_team.ex
@@ -18,7 +18,10 @@ defmodule LogflareWeb.Plugs.SetTeam do
       Teams.get_team_by(user_id: user.id)
       |> Teams.preload_team_users()
 
+    teams = Teams.list_teams_by_user_access(user)
+
     conn
     |> assign(:team, team)
+    |> assign(:teams, teams)
   end
 end

--- a/lib/logflare_web/controllers/plugs/set_verify_source.ex
+++ b/lib/logflare_web/controllers/plugs/set_verify_source.ex
@@ -14,7 +14,7 @@ defmodule LogflareWeb.Plugs.SetVerifySource do
     set_source_for_public(public_token, conn, opts)
   end
 
-  def call(%{assigns: %{user: user}, params: params} = conn, _opts) do
+  def call(%{assigns: %{user: user, teams: _teams}, params: params} = conn, _opts) do
     id = params["source_id"] || params["id"]
     source = Sources.get_by_and_preload(id: id)
 

--- a/lib/logflare_web/controllers/team_user_controller.ex
+++ b/lib/logflare_web/controllers/team_user_controller.ex
@@ -65,35 +65,44 @@ defmodule LogflareWeb.TeamUserController do
     end
   end
 
-  def change_team(%{assigns: %{team_user: _team_user, user: _user}} = conn, %{
-        "user_id" => user_id,
-        "team_user_id" => team_user_id
-      }) do
+  def change_team(
+        %{assigns: %{team_user: _team_user, user: _user}} = conn,
+        %{
+          "user_id" => user_id,
+          "team_user_id" => team_user_id
+        } = params
+      ) do
     conn
     |> put_session(:user_id, user_id)
     |> put_session(:team_user_id, team_user_id)
     |> put_resp_cookie("_logflare_user_id", user_id, max_age: 2_592_000)
     |> put_resp_cookie("_logflare_team_user_id", team_user_id, max_age: 2_592_000)
     |> put_flash(:info, "Welcome to this Logflare team!")
-    |> redirect(to: Routes.source_path(conn, :dashboard))
+    |> redirect(to: Map.get(params, "redirect_to", ~p"/dashboard"))
   end
 
-  def change_team(%{assigns: %{team_user: _team_user, user: _user}} = conn, %{
-        "user_id" => user_id
-      }) do
+  def change_team(
+        %{assigns: %{team_user: _team_user, user: _user}} = conn,
+        %{
+          "user_id" => user_id
+        } = params
+      ) do
     conn
     |> put_session(:user_id, user_id)
     |> delete_session(:team_user_id)
     |> delete_resp_cookie("_logflare_user_id")
     |> delete_resp_cookie("_logflare_team_user_id")
     |> put_flash(:info, "Welcome to this Logflare team!")
-    |> redirect(to: Routes.source_path(conn, :dashboard))
+    |> redirect(to: Map.get(params, "redirect_to", ~p"/dashboard"))
   end
 
-  def change_team(%{assigns: %{user: user}} = conn, %{
-        "user_id" => user_id,
-        "team_user_id" => team_user_id
-      }) do
+  def change_team(
+        %{assigns: %{user: user}} = conn,
+        %{
+          "user_id" => user_id,
+          "team_user_id" => team_user_id
+        } = params
+      ) do
     {:ok, _team_user} = TeamUsers.update_team_user_on_change_team(user, team_user_id)
 
     conn
@@ -102,6 +111,6 @@ defmodule LogflareWeb.TeamUserController do
     |> put_resp_cookie("_logflare_user_id", user_id, max_age: 2_592_000)
     |> put_resp_cookie("_logflare_team_user_id", team_user_id, max_age: 2_592_000)
     |> put_flash(:info, "Welcome to this Logflare team!")
-    |> redirect(to: Routes.source_path(conn, :dashboard))
+    |> redirect(to: Map.get(params, "redirect_to", ~p"/dashboard"))
   end
 end

--- a/lib/logflare_web/templates/error/403_page.html.eex
+++ b/lib/logflare_web/templates/error/403_page.html.eex
@@ -1,8 +1,0 @@
-<%= render_in "error_container.html", assigns do %>
-  <div class="col-lg-7">
-    <h1>403</h1>
-    <h2 class="text-white mb-3">Forbidden</h2>
-    <p>You may have access to this resource in another team<p>
-    <p>Get back to <a href="/dashboard">your dashboard</a> to change teams</p>
-  </div>
-<% end %>

--- a/lib/logflare_web/templates/error/403_page.html.heex
+++ b/lib/logflare_web/templates/error/403_page.html.heex
@@ -15,9 +15,9 @@
         <%= link(t.name,
           to:
             ~p"/profile/switch?#{cond do
-              t.user_id == @user.id -> %{user_id: t.user_id}
+              t.user_id == @user.id -> %{user_id: t.user_id, redirect_to: @conn.request_path}
               true -> tu = Enum.find(t.team_users, &(&1.provider_uid == @user.provider_uid))
-                %{user_id: t.user_id, team_user_id: tu.id}
+                %{user_id: t.user_id, team_user_id: tu.id, redirect_to: @conn.request_path}
             end}"
         ) %>
         <small :if={t.id == @team.id} class="badge badge-secondary badge-pill">

--- a/lib/logflare_web/templates/error/403_page.html.heex
+++ b/lib/logflare_web/templates/error/403_page.html.heex
@@ -5,7 +5,7 @@
     <p>You may need to switch teams to access this resource</p>
     <ul class="list-group">
       <li
-        :for={t <- @teams}
+        :for={t <- assigns[:teams] || []}
         class={[
           "list-group-item d-flex justify-content-between align-items-center",
           if(t.id == @team.id, do: "active"),

--- a/lib/logflare_web/templates/error/403_page.html.heex
+++ b/lib/logflare_web/templates/error/403_page.html.heex
@@ -1,0 +1,29 @@
+<%= render_in "error_container.html", assigns do %>
+  <div class="col-lg-7">
+    <h1>403</h1>
+    <h2 class="text-white mb-3">Forbidden</h2>
+    <p>You may need to switch teams to access this resource</p>
+    <ul class="list-group">
+      <li
+        :for={t <- @teams}
+        class={[
+          "list-group-item d-flex justify-content-between align-items-center",
+          if(t.id == @team.id, do: "active"),
+          "tw-mx-auto tw-w-96"
+        ]}
+      >
+        <%= link(t.name,
+          to:
+            ~p"/profile/switch?#{cond do
+              t.user_id == @user.id -> %{user_id: t.user_id}
+              true -> tu = Enum.find(t.team_users, &(&1.provider_uid == @user.provider_uid))
+                %{user_id: t.user_id, team_user_id: tu.id}
+            end}"
+        ) %>
+        <small :if={t.id == @team.id} class="badge badge-secondary badge-pill">
+          Current
+        </small>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/test/logflare/teams_test.exs
+++ b/test/logflare/teams_test.exs
@@ -71,21 +71,21 @@ defmodule Logflare.TeamsTest do
   end
 
   test "list_teams_by_user_access/1 lists all teams of a given user" do
+    insert(:team, user: build(:user))
     user = insert(:user)
-    teams = insert_list(2, :team_user, email: user.email)
+    insert_list(2, :team_user, provider_uid: user.provider_uid)
 
-    expected = Enum.map(teams, & &1.team.id) |> Enum.sort()
-    result = Enum.map(Teams.list_teams_by_user_access(user), & &1.id) |> Enum.sort()
-
-    assert expected == result
+    # 2 items, :team_users preloaded
+    assert [%{team_users: [_|_]}, _] = Teams.list_teams_by_user_access(user)
   end
 
   test "get_team_by_user_access/2 gets a team for a given user and token" do
     user = insert(:user)
     team = insert(:team)
-    _team_user = insert(:team_user, email: user.email, team: team)
+    _team_user = insert(:team_user, provider_uid: user.provider_uid, team: team)
     insert_list(2, :team_user)
 
     assert team.id == Teams.get_team_by_user_access(user, team.token).id
+
   end
 end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -11,9 +11,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     main_team = insert(:team, user: user)
 
     another_user_team_with_main_user = insert(:team, user: insert(:user))
-    insert(:team_user, team: another_user_team_with_main_user, email: user.email)
+    insert(:team_user, team: another_user_team_with_main_user, provider_uid: user.provider_uid)
 
-    _non_relevant_to_main_user = insert(:team_user, team: main_team, email: insert(:user).email)
+    _non_relevant_to_main_user = insert(:team_user, team: main_team, provider_uid: insert(:user).provider_uid)
 
     Counters.start_link()
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -35,7 +35,7 @@ defmodule Logflare.Factory do
       bigquery_processed_bytes_limit: 10_000_000_000,
       token: TestUtils.random_string(64),
       api_key: TestUtils.random_string(10),
-      provider_uid: "provider_uid",
+      provider_uid: "provider_uid_#{TestUtils.random_string()}",
       bigquery_udfs_hash: ""
     }
   end


### PR DESCRIPTION
This PR adds in user prompting to switch teams when encoutering 403, most common when viewing a different team's source.

It also adds redirection to the resource on profile switch, for less clicks needed.

This PR also resolves some bugs found in the Teams context.


https://github.com/Logflare/logflare/assets/22714384/f217defb-0bbb-4a2b-8d4e-9de68218d01a


<img width="1217" alt="Screenshot 2023-12-11 at 5 54 26 PM" src="https://github.com/Logflare/logflare/assets/22714384/b8d6888b-1d45-40b2-9911-a9f0813ccacd">

