### PR TITLE
feat: partner api - allow impersonation of user

### DIFF
--- a/lib/logflare/partners.ex
+++ b/lib/logflare/partners.ex
@@ -80,8 +80,7 @@ defmodule Logflare.Partners do
     query =
       from(p in Partner,
         join: u in assoc(p, :users),
-        where: p.token == ^token,
-        where: u.token == ^user_token,
+        where: p.token == ^token and u.token == ^user_token,
         select: u
       )
 

--- a/lib/logflare/partners/cache.ex
+++ b/lib/logflare/partners/cache.ex
@@ -11,6 +11,7 @@ defmodule Logflare.Partners.Cache do
   end
 
   def get_partner(id), do: apply_repo_fun(__ENV__.function, [id])
+  def get_user_by_token(partner, token), do: apply_repo_fun(__ENV__.function, [partner, token])
 
   defp apply_repo_fun(arg1, arg2) do
     Logflare.ContextCache.apply_fun(Partners, arg1, arg2)

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -13,6 +13,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
   alias Logflare.Users
   alias Logflare.User
   alias Logflare.Partners.Partner
+  alias Logflare.Partners
   alias LogflareWeb.Api.FallbackController
 
   def init(args), do: args |> Enum.into(%{})
@@ -20,26 +21,34 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
   def call(conn, opts) do
     opts = Enum.into(opts, %{scopes: []})
     resource_type = Map.get(conn.assigns, :resource_type)
-    partner_scope = "partner" in opts.scopes
 
-    impersonate_user_token = get_req_header(conn, "x-lf-partner-user") |> List.first() |> dbg()
+    impersonate_user_token = get_req_header(conn, "x-lf-partner-user") |> List.first()
     # generic access
-    scopes_to_check = if impersonate_user_token != nil do
-      ~w(partner)
-    else
-      opts.scopes
-    end
+    scopes_to_check =
+      if impersonate_user_token != nil do
+        ~w(partner)
+      else
+        opts.scopes
+      end
 
-    case identify_requestor(conn, scopes_to_check) |> dbg() do
-      {:ok, %Partner{} = partner} ->
-        # maybe get the user target
-
-        user = if impersonate_user_token do
-          Users.Cache.get_by(token: impersonate_user_token)
-        end
+    case identify_requestor(conn, scopes_to_check) do
+      {:ok, %Partner{} = partner} when impersonate_user_token == nil ->
         conn
         |> assign(:partner, partner)
-        |> assign(:user, user)
+
+      {:ok, %Partner{} = partner} when impersonate_user_token != nil ->
+        # maybe get the user target
+
+        Partners.Cache.get_user_by_token(partner, impersonate_user_token)
+        |> then(fn
+          %User{} = u ->
+            conn
+            |> assign(:partner, partner)
+            |> assign(:user, Users.Cache.preload_defaults(u))
+
+          _ ->
+            FallbackController.call(conn, {:error, :unauthorized})
+        end)
 
       {:ok, %User{} = user} ->
         assign(conn, :user, user)


### PR DESCRIPTION
This PR allows partners to impersonate users when querying the management api. Requires partners to have the user token uuid.

depends on #1878 