### PR TITLE
fix: ttl dashboard display

### DIFF
--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -11,6 +11,14 @@ defmodule Logflare.Google.BigQuery.GenUtils do
 
   @table_ttl 604_800_000
   @default_dataset_location "US"
+
+  @doc """
+  Returns the default TTL used (in days) for initializing the table.
+  """
+  def default_table_ttl_days() do
+    @table_ttl / :timer.hours(24)
+  end
+
   defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
 
   defp env_default_table_name_append,

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -24,11 +24,11 @@ defmodule LogflareWeb.SourceView do
   Formats a source TTL to the specified unit
   """
   @spec source_ttl_to_days(Source.t(), Plan.t()) :: integer()
-  def source_ttl_to_days(%Source{bigquery_table_ttl: nil} = source, %Plan{} = plan) do
-    source_ttl_to_days(%{source | bigquery_table_ttl: plan.limit_source_ttl}, :day)
+  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl} = source, _plan) when ttl >= 0 and ttl != nil do
+    ttl
   end
-
-  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl}, _plan) do
+  # fallback to plan value
+  def source_ttl_to_days(_source, %Plan{limit_source_ttl: ttl}) do
     round(ttl / :timer.hours(24))
   end
 end

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -3,6 +3,7 @@ defmodule LogflareWeb.SourceView do
   alias LogflareWeb.Router.Helpers, as: Routes
   alias Logflare.Billing.Plan
   alias Logflare.Source
+  alias Logflare.Google.BigQuery.GenUtils
   use LogflareWeb, :view
 
   def log_url(route) do
@@ -24,11 +25,17 @@ defmodule LogflareWeb.SourceView do
   Formats a source TTL to the specified unit
   """
   @spec source_ttl_to_days(Source.t(), Plan.t()) :: integer()
-  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl} = source, _plan) when ttl >= 0 and ttl != nil do
-    ttl
+  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl}, _plan)
+      when ttl >= 0 and ttl != nil do
+    round(ttl)
   end
-  # fallback to plan value
+
+  # fallback to plan value or default init value
+  # use min to avoid misrepresenting what user should see, in cases where actual is more than plan.
   def source_ttl_to_days(_source, %Plan{limit_source_ttl: ttl}) do
-    round(ttl / :timer.hours(24))
+    min(
+      round(GenUtils.default_table_ttl_days()),
+      round(ttl / :timer.hours(24))
+    )
   end
 end

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -53,6 +53,19 @@ defmodule LogflareWeb.SourceControllerTest do
       assert html =~ "ttl: 3 day"
     end
 
+    test "renders default plan ttl correctly", %{conn: conn, source: source} do
+        conn
+        |> get(Routes.source_path(conn, :dashboard))
+        |> html_response(200) =~ "ttl: 3 day"
+    end
+
+    test "renders default bigquery ttl correctly", %{conn: conn, source: source} do
+      conn
+      |> get(Routes.source_path(conn, :dashboard))
+      |> html_response(200) =~ "ttl: 3 day"
+    end
+
+
     test "show source", %{conn: conn, source: source} do
       html =
         conn


### PR DESCRIPTION
This PR adjusts the rendering logic for source ttl, the `source.bigquery_table_ttl` field is in days, whereas the plan value is in ms.