### PR TITLE
fix: test cluster machine types, disk size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ deploy.staging.versioned:
 	
 	gcloud builds submit . \
 		--config=./cloudbuild/staging/deploy.yaml \
-		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION),_INSTANCE_TYPE=c2d-standard-2,_CLUSTER=versioned \
+		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION),_CLUSTER=versioned \
 		--region=us-west1 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -19,7 +19,7 @@ steps:
       - --container-privileged
       - --container-restart-policy=always
       - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=1,OVERRIDE_MAGIC_COOKIE=${_COOKIE}
-      - --create-disk=auto-delete=yes,device-name=logflare-staging-cluster-privileged-e2-cos-89-shutdown-12,image=projects/cos-cloud/global/images/cos-stable-105-17412-156-59,mode=rw,size=100,type=pd-ssd
+      - --create-disk=auto-delete=yes,device-name=logflare-staging-cluster-privileged-e2-cos-89-shutdown-12,image=projects/cos-cloud/global/images/cos-stable-105-17412-156-59,mode=rw,size=25,type=pd-ssd
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring
@@ -49,7 +49,7 @@ substitutions:
   _CLUSTER: main
   _COOKIE: default-${_CLUSTER}
   _NORMALIZED_IMAGE_TAG: ${_IMAGE_TAG}
-  _INSTANCE_TYPE: e2-standard-4
+  _INSTANCE_TYPE: c2d-standard-2
   _INSTANCE_GROUP: instance-group-staging-${_CLUSTER}
   _IMAGE_TAG: $SHORT_SHA
   _TEMPLATE_NAME: logflare-staging-${_CLUSTER}-cluster-${_NORMALIZED_IMAGE_TAG}


### PR DESCRIPTION
<img width="1229" alt="Screenshot 2023-12-19 at 3 23 41 PM" src="https://github.com/Logflare/logflare/assets/22714384/a34b91c8-4e49-4e50-a96d-a3952c9147c8">

Seems like there are some restrictions with e2 instances, this switches all staging instances to `c2d-standard-2`, and reduces disk size to match prod at 25GB. This brings the per-instance cost to around US$68, so we can spin up a few more for better simulation of prod.

