### PR TITLE
Revert "perf: reduce http2 pools to reduce chance of server throttling."

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -252,9 +252,9 @@ defmodule Logflare.Application do
   defp finch_pools do
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 10]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 10]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 10]}}
+      {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 200]}},
+      {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 100]}},
+      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 150]}}
     ]
   end
 


### PR DESCRIPTION
This reverts commit 16a5bc146c31b1f0d1d5f22bee5eb8e9322627db.

This is a tenative fix for the max concurrent streams issue that we are facing when deploying