### PR TITLE
feat: increase accepted byte length

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -56,7 +56,8 @@ defmodule LogflareWeb.Router do
     plug(Plug.Parsers,
       parsers: [:json, :bert, :syslog, :ndjson],
       json_decoder: Jason,
-      body_reader: {PlugCaisson, :read_body, []}
+      body_reader: {PlugCaisson, :read_body, []},
+      length: 12_000_000
     )
 
     plug(:accepts, ["json", "bert"])


### PR DESCRIPTION
This increases the accepted byte length per request, to allow for integration with tooling that default to 10MB batching (vector)