### PR TITLE
fix: tini installation on cloudbuild

### DIFF
--- a/cloudbuild/secret_setup.Dockerfile
+++ b/cloudbuild/secret_setup.Dockerfile
@@ -1,7 +1,7 @@
 ARG TAG_VERSION
 FROM supabase/logflare:${TAG_VERSION}
 
-RUN apk add tini
+RUN apt-get update && apt-get -y install tini
 RUN echo $RANDOM | md5sum | head -c 20 > /tmp/.magic_cookie
 COPY .secrets.env /tmp/.secrets.env
 COPY gcloud.json gcloud.json


### PR DESCRIPTION
This fixes installation of tini on cloudbuild

https://github.com/Logflare/logflare/actions/runs/7446084745/job/20256142362
<img width="906" alt="Screenshot 2024-01-08 at 6 47 53 PM" src="https://github.com/Logflare/logflare/assets/22714384/815d08b1-02e8-43cc-aee2-5cef15d74ec5">
