### PR TITLE
chore: remove provisioning-model option

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -13,7 +13,6 @@ steps:
       - --project=logflare-232118
       - --network-interface=network=global,network-tier=PREMIUM
       - --maintenance-policy=TERMINATE
-      - --provisioning-model=STANDARD
       - --service-account=compute-engine-2022@logflare-232118.iam.gserviceaccount.com
       - --scopes=https://www.googleapis.com/auth/cloud-platform
       - --tags=phoenix-http,https-server

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -13,7 +13,6 @@ steps:
       - --project=logflare-staging
       - --network-interface=network=default,network-tier=PREMIUM
       - --maintenance-policy=TERMINATE
-      - --provisioning-model=STANDARD
       - --service-account=compute-engine-2022@logflare-staging.iam.gserviceaccount.com
       - --scopes=https://www.googleapis.com/auth/cloud-platform
       - --tags=phoenix-http,https-server


### PR DESCRIPTION
apparently it is not a valid option despite being generated in the gcp console.