### PR TITLE
chore: use pd-balanced boot disks

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -7,8 +7,8 @@ steps:
       - instance-templates
       - create-with-container
       - $_TEMPLATE_NAME
-      - --boot-disk-size=10GB
-      - --boot-disk-type=local-ssd
+      - --boot-disk-size=25GB
+      - --boot-disk-type=pd-balanced
       - --machine-type=c2d-standard-56
       - --project=logflare-232118
       - --network-interface=network=global,network-tier=PREMIUM

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -7,8 +7,8 @@ steps:
       - instance-templates
       - create-with-container
       - $_TEMPLATE_NAME
-      - --boot-disk-size=10GB
-      - --boot-disk-type=local-ssd
+      - --boot-disk-size=25GB
+      - --boot-disk-type=pd-balanced
       - --machine-type=${_INSTANCE_TYPE}
       - --project=logflare-staging
       - --network-interface=network=default,network-tier=PREMIUM


### PR DESCRIPTION
apparently local-ssd can't be used for boot disks. also bumps the size of the boot disk just in case.