### PR TITLE
ft: use stream processing of Cachex stream

### DIFF
--- a/lib/logflare/logs/rejected_log_events.ex
+++ b/lib/logflare/logs/rejected_log_events.ex
@@ -66,20 +66,11 @@ defmodule Logflare.Logs.RejectedLogEvents do
   def query(source_id) when is_atom(source_id) do
     @cache
     |> Cachex.stream!()
-    |> Enum.filter(fn x ->
-      case x do
-        {:entry, {^source_id, _le_id}, _ts, _, _le} ->
-          true
-
-        _ ->
-          false
-      end
+    |> Stream.filter(fn x ->
+      match?({:entry, {^source_id, _le_id}, _ts, _, _le}, x)
     end)
-    |> Enum.map(fn x ->
-      case x do
-        {:entry, {^source_id, _le_id}, _ts, _, le} ->
-          le
-      end
+    |> Stream.map(fn {:entry, {^source_id, _le_id}, _ts, _, le} ->
+      le
     end)
     |> Enum.reverse()
     |> Enum.take(100)


### PR DESCRIPTION
This should scale a little bit better in case of larger caches as it will compute the values lazily as long as possible.