### PR TITLE
fix: better error handling for JsonParser

### DIFF
--- a/lib/logflare_web/controllers/plugs/bert_parser.ex
+++ b/lib/logflare_web/controllers/plugs/bert_parser.ex
@@ -1,4 +1,4 @@
-defmodule Plug.Parsers.BERT do
+defmodule LogflareWeb.BertParser do
   @moduledoc """
   Parses BERT (http://bert-rpc.org) request body
   """

--- a/lib/logflare_web/controllers/plugs/json_parser.ex
+++ b/lib/logflare_web/controllers/plugs/json_parser.ex
@@ -1,0 +1,61 @@
+defmodule LogflareWeb.JsonParser do
+  @moduledoc false
+  require Logger
+  @behaviour Plug.Parsers
+
+  @impl true
+  defdelegate init(opts), to: Plug.Parsers.JSON
+
+  @impl true
+  def parse(conn, "application", subtype, _headers, {{mod, fun, args}, decoder, opts}) do
+    if subtype == "json" or String.ends_with?(subtype, "+json") do
+      apply(mod, fun, [conn, opts | args]) |> decode(decoder, opts)
+    else
+      {:next, conn}
+    end
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    {:next, conn}
+  end
+
+  defp decode({:ok, "", conn}, _decoder, _opts) do
+    {:ok, %{}, conn}
+  end
+
+  defp decode({:ok, body, conn}, {module, fun, args}, opts) do
+    nest_all = Keyword.get(opts, :nest_all_json, false)
+
+    try do
+      apply(module, fun, [body | args])
+    rescue
+      e -> raise Plug.Parsers.ParseError, exception: e
+    else
+      terms when is_map(terms) and not nest_all ->
+        {:ok, terms, conn}
+
+      terms ->
+        {:ok, %{"_json" => terms}, conn}
+    end
+  end
+
+  defp decode({:more, _, conn}, _decoder, _opts) do
+    {:error, :too_large, conn}
+  end
+
+  defp decode({:error, :timeout}, _decoder, _opts) do
+    raise Plug.TimeoutError
+  end
+
+  # add better error message for debugging body reader errors
+  defp decode({:error, err}, _decoder, _opts) do
+    raise __MODULE__.BadRequestError,
+      message: "Body reader error: #{inspect(err)}",
+      plug_status: 400
+  end
+
+  defmodule BadRequestError do
+    @moduledoc false
+    defexception [:message, :plug_status]
+  end
+end

--- a/lib/logflare_web/controllers/plugs/json_parser.ex
+++ b/lib/logflare_web/controllers/plugs/json_parser.ex
@@ -1,5 +1,9 @@
 defmodule LogflareWeb.JsonParser do
-  @moduledoc false
+  @moduledoc """
+  Implementation is taken from https://github.com/elixir-plug/plug/blob/v1.15.3/lib/plug/parsers/json.ex#L1
+
+  Only changes are related to the error handling for BadRequestError.
+  """
   require Logger
   @behaviour Plug.Parsers
 

--- a/lib/logflare_web/controllers/plugs/ndjson_parser.ex
+++ b/lib/logflare_web/controllers/plugs/ndjson_parser.ex
@@ -1,4 +1,4 @@
-defmodule Plug.Parsers.NDJSON do
+defmodule LogflareWeb.NdjsonParser do
   @moduledoc """
   Parse Cloudflare Log Push request bodies.
   """

--- a/lib/logflare_web/controllers/plugs/syslog_parser.ex
+++ b/lib/logflare_web/controllers/plugs/syslog_parser.ex
@@ -1,4 +1,4 @@
-defmodule Plug.Parsers.SYSLOG do
+defmodule LogflareWeb.SyslogParser do
   @moduledoc """
   Parse syslog request bodies.
   """

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -7,6 +7,10 @@ defmodule LogflareWeb.Router do
   import Phoenix.LiveView.Router
 
   alias LogflareWeb.LayoutView
+  alias LogflareWeb.BertParser
+  alias LogflareWeb.JsonParser
+  alias LogflareWeb.SyslogParser
+  alias LogflareWeb.NdjsonParser
 
   # TODO: move plug calls in SourceController and RuleController into here
 
@@ -54,7 +58,7 @@ defmodule LogflareWeb.Router do
     plug(LogflareWeb.Plugs.MaybeContentTypeToJson)
 
     plug(Plug.Parsers,
-      parsers: [:json, :bert, :syslog, :ndjson],
+      parsers: [JsonParser, BertParser, SyslogParser, NdjsonParser],
       json_decoder: Jason,
       body_reader: {PlugCaisson, :read_body, []},
       length: 12_000_000

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -87,6 +87,21 @@ defmodule LogflareWeb.LogControllerTest do
       assert %{"message"=> [msg]}  =  json_response(conn, 406)
       assert msg =~ "not supported by"
     end
+
+    test ":create ingestion error handling for BadRequestError in Plug.Parsers", %{
+      conn: conn,
+      source: source
+    } do
+      assert_raise LogflareWeb.JsonParser.BadRequestError, fn ->
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("content-encoding", "br")
+        |> post(
+          Routes.log_path(conn, :create, source: source.token),
+          Jason.encode!(%{"batch" => @valid_batch})
+        )
+      end
+    end
   end
 
   describe "v1 pipeline with legacy user.api_key" do

--- a/test/logflare_web/plugs/bert_parser_test.exs
+++ b/test/logflare_web/plugs/bert_parser_test.exs
@@ -1,9 +1,9 @@
-defmodule Plugs.Parsers.BERTTest do
+defmodule LogflareWeb.BertParserTest do
   @moduledoc false
   use LogflareWeb.ConnCase
-  alias Plug.Parsers.BERT
+  alias LogflareWeb.BertParser
 
-  describe "Plugs.Parsers.BERT" do
+  describe "LogflareWeb.BertParser" do
     test "decodes a typical log batch post request", %{conn: conn} do
       data = %{
         "batch" => [
@@ -90,7 +90,7 @@ defmodule Plugs.Parsers.BERTTest do
           111, 117, 114, 99, 101, 95, 110, 97, 109, 101, 109, 0, 0, 0, 10, 100, 97, 115, 104, 98,
           111, 97, 114, 100, 49, 106>>
 
-      assert BERT.decode({:ok, body, conn}) == {:ok, data, conn}
+      assert BertParser.decode({:ok, body, conn}) == {:ok, data, conn}
     end
   end
 end

--- a/test/logflare_web/plugs/ndjson_parser_test.exs
+++ b/test/logflare_web/plugs/ndjson_parser_test.exs
@@ -1,17 +1,15 @@
-defmodule Plugs.Parsers.NDJSONTest do
+defmodule LogflareWeb.NdjsonParserTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
-  alias Plug.Parsers.NDJSON
+  alias LogflareWeb.NdjsonParser
   alias Logflare.TestUtils
 
-  describe "Plugs.Parsers.NDJSON" do
-    test "decodes a non-gzipped ndjson log batch post request", %{conn: conn} do
-      body = TestUtils.cloudflare_log_push_body(decoded: false) |> :zlib.gunzip()
+  test "decodes a non-gzipped ndjson log batch post request", %{conn: conn} do
+    body = TestUtils.cloudflare_log_push_body(decoded: false) |> :zlib.gunzip()
 
-      data = TestUtils.cloudflare_log_push_body(decoded: true)
+    data = TestUtils.cloudflare_log_push_body(decoded: true)
 
-      assert NDJSON.decode({:ok, body, conn}) == {:ok, data, conn}
-    end
+    assert NdjsonParser.decode({:ok, body, conn}) == {:ok, data, conn}
   end
 end


### PR DESCRIPTION
This PR adds in a JsonParser. 

It replaces the built in `Plug.Parsers.JSON` module, and adjusts the error handling for when attempting to decode the body, so that errors from the body reader is surfaced correctly in error messages instead of being discarded.

Also does some minor changes in module naming to make it clear that they are not built in modules.