### PR TITLE
chore: refactor telemetry execution

### DIFF
--- a/lib/logflare/cache_buster.ex
+++ b/lib/logflare/cache_buster.ex
@@ -20,25 +20,16 @@ defmodule Logflare.CacheBuster do
   end
 
   def handle_info(%Transaction{changes: changes}, state) do
-    for %{relation: {schema, table}} = record <- changes,
-        :ok =
-          :telemetry.execute([:logflare, :context_cache, :handle_record], %{count: 1}, %{
-            schema: schema,
-            table: table
-          }),
+    :telemetry.execute([:logflare, :context_cache, :handle_record], %{count: length(changes)})
+
+    for record <- changes,
         record = handle_record(record),
         record != :noop do
-      :telemetry.execute(
-        [:logflare, :context_cache, :busted],
-        %{count: 1},
-        %{
-          schema: schema,
-          table: table
-        }
-      )
-
       record
     end
+    |> tap(fn records ->
+      :telemetry.execute([:logflare, :context_cache, :busted], %{count: length(records)})
+    end)
     |> ContextCache.bust_keys()
 
     {:noreply, state}


### PR DESCRIPTION
This PR does some minor refactor to `:telemetry.execute/3` calls, which are syncronous.

Due to number of messages and changes that cache buster receives, this might adversely affect CacheBuster performance.

I also have half a mind of removing the direct `:telemetry.execute/3` calls within the Logflare.Logs module, as it might be adversely affecting ingestion performance, as it is one of the main additions to the Logflare.Logs module since 1.4.x.

However, as we do not have any heavy syncronous handlers attached to telemetry handling, it should not have much significant impact unless someone has a phx live dashboard openede.