### PR TITLE
perf: refactor TeamUsers.list_team_users_by_and_preload

### DIFF
--- a/lib/logflare/team_users.ex
+++ b/lib/logflare/team_users.ex
@@ -26,11 +26,10 @@ defmodule Logflare.TeamUsers do
     query =
       from t in TeamUser,
         where: ^kv,
-        select: t
+        select: t,
+        preload: [:team]
 
-    for team_user <- Repo.all(query) do
-      Repo.preload(team_user, :team)
-    end
+    Repo.all(query)
   end
 
   def list_team_users_by(kv) do

--- a/test/logflare/team_users_test.exs
+++ b/test/logflare/team_users_test.exs
@@ -1,0 +1,12 @@
+defmodule Logflare.TeamUsersTest do
+  @moduledoc false
+  use Logflare.DataCase
+  alias Logflare.TeamUsers
+
+  test "list_team_users_by_and_preload/1" do
+     insert_list(2, :team_user, email: "some email")
+     insert(:team_user, email: "other email")
+     assert [%{team: %_{}}] = TeamUsers.list_team_users_by_and_preload(email: "other email")
+  end
+
+end


### PR DESCRIPTION
This PR adds in some performance enhancements for `TeamUsers.list_team_users_by_and_preload/1`, which gets called on each dashboard load. It is likely the cause of the transaction spikes on each dashboard page load, as each team user results in another repo call, and scales linearly.

To be merged after feature freeze.