### PR TITLE
chore: revert FinchDefault changes, separate FinchGoth pool

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -252,10 +252,10 @@ defmodule Logflare.Application do
   defp finch_pools do
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 200]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 100]}},
-      {Finch, name: Logflare.FinchGoth, pools: %{:default => [protocol: :http2, count: 1]}}
-      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 50]}}
+      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: 200]}},
+      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: 100]}},
+      {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
+      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: 50]}}
     ]
   end
 

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -246,7 +246,7 @@ defmodule Logflare.Application do
     {body, options} = Keyword.pop!(options, :body)
 
     Finch.build(method, url, headers, body)
-    |> Finch.request(Logflare.FinchDefault, options)
+    |> Finch.request(Logflare.FinchGoth, options)
   end
 
   defp finch_pools do
@@ -254,7 +254,8 @@ defmodule Logflare.Application do
       # Finch connection pools, using http2
       {Finch, name: Logflare.FinchIngest, pools: %{:default => [protocol: :http2, count: 200]}},
       {Finch, name: Logflare.FinchQuery, pools: %{:default => [protocol: :http2, count: 100]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 150]}}
+      {Finch, name: Logflare.FinchGoth, pools: %{:default => [protocol: :http2, count: 1]}}
+      {Finch, name: Logflare.FinchDefault, pools: %{:default => [protocol: :http2, count: 50]}}
     ]
   end
 


### PR DESCRIPTION
This PR adds in a FinchGoth pool that is separate from FinchDefault.
This also drops the FinchDefault count to 50, which is the same as v1.4.4.

The goal of this is to eliminate the possibility that the FinchDefault change to `count: 150` is causing the higher disconnections from the gcp apis, and also isolates the Finch changes since v1.4.4.

As Goth only uses the pool to refresh tokens, it is not needed to have high counts.

We had only customized it as by default it will use http