### PR TITLE
chore: add Goth fetch duration to metrics monitoring

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -70,6 +70,10 @@ defmodule Logflare.Telemetry do
     ]
 
     application_metrics = [
+      summary("logflare.goth.fetch.stop.duration",
+        tags: [:partition],
+        unit: {:native, :millisecond}
+      ),
       summary("logflare.logs.processor.ingest.stop.duration",
         tags: [:processor],
         unit: {:native, :millisecond}


### PR DESCRIPTION
This PR adds Goth.fetch telemetry metrics to the livedashboard.