### PR TITLE
chore: revert max buffer length

### DIFF
--- a/lib/logflare/source/bigquery/buffer_counter.ex
+++ b/lib/logflare/source/bigquery/buffer_counter.ex
@@ -12,7 +12,7 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   require Logger
 
   @broadcast_every 5_000
-  @max_buffer_len 40_000
+  @max_buffer_len 5_000
   @pool_size Application.compile_env(:logflare, Logflare.PubSub)[:pool_size]
 
   def start_link(%RLS{source_id: source_uuid}) when is_atom(source_uuid) do


### PR DESCRIPTION
At 40k buffer length, the ram consumed can balloon to over >1GB.  

This can put the node at risk by consuming all available memory if there is sudden high load across many sources

SS was taken from load test cluster, where sources were at or near max buffer length. 

<img width="1108" alt="Screenshot 2024-01-19 at 8 04 03 PM" src="https://github.com/Logflare/logflare/assets/22714384/fe9c3d78-6846-424f-a8a8-ad3eddc58700">
