### PR TITLE
chore: add LOGFLARE_LOGGER_METADATA_CLUSTER for adding global metadata

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE}
+      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER}
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --metadata=google-monitoring-enabled=true,google-logging-enabled=true
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=4001,RELEASE_COOKIE=${_COOKIE}
+      - --container-env=LOGFLARE_GRPC_PORT=4001,RELEASE_COOKIE=${_COOKIE},LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER}
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -87,6 +87,11 @@ config :logger,
     ]
     |> Enum.filter(&(&1 != nil))
 
+config :logger,
+  metadata:
+    [cluster: System.get_env("LOGFLARE_LOGGER_METADATA_CLUSTER")]
+    |> filter_nil_kv_pairs.()
+
 log_level =
   case String.downcase(System.get_env("LOGFLARE_LOG_LEVEL") || "") do
     "warn" -> :warn

--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -19,15 +19,16 @@ All browser authentication will be disabled when in single-tenant mode.
 
 ### Common Configuration
 
-| Env Var                  | Type                                                                      | Description                                                                                                                 |
-| ------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `LOGFLARE_SINGLE_TENANT` | Boolean, defaults to `false`                                              | If enabled, a singular user will be seeded. All browser usage will default to the user.                                     |
-| `LOGFLARE_API_KEY`       | string, defaults to `nil`                                                 | If set, this API Key can be used for interacting with the Logflare API. API key will be automatically generated if not set. |
-| `LOGFLARE_SUPABASE_MODE` | Boolean, defaults to `false`                                              | A special mode for Logflare, where Supabase-specific resources will be seeded. Intended for Suapbase self-hosted usage.     |
-| `PHX_HTTP_PORT`          | Integer, defaults to `4000`                                               | Allows configuration of the HTTP server port.                                                                               |
-| `DB_SCHEMA`              | String, defaults to `nil`                                                 | Allows configuration of the database schema to scope Logflare operations.                                                   |
-| `LOGFLARE_LOG_LEVEL`     | String, defaults to `info`. <br/>Options: `error`,`warn`, `info`, `debug` | Allows runtime configuration of log level.                                                                                  |
-| `LOGFLARE_NODE_HOST`     | string, defaults to `127.0.0.1`                                           | Sets node host on startup, which affects the node name `logflare@<host>`                                                    |
+| Env Var                            | Type                                                                      | Description                                                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `LOGFLARE_SINGLE_TENANT`           | Boolean, defaults to `false`                                              | If enabled, a singular user will be seeded. All browser usage will default to the user.                                     |
+| `LOGFLARE_API_KEY`                 | string, defaults to `nil`                                                 | If set, this API Key can be used for interacting with the Logflare API. API key will be automatically generated if not set. |
+| `LOGFLARE_SUPABASE_MODE`           | Boolean, defaults to `false`                                              | A special mode for Logflare, where Supabase-specific resources will be seeded. Intended for Suapbase self-hosted usage.     |
+| `PHX_HTTP_PORT`                    | Integer, defaults to `4000`                                               | Allows configuration of the HTTP server port.                                                                               |
+| `DB_SCHEMA`                        | String, defaults to `nil`                                                 | Allows configuration of the database schema to scope Logflare operations.                                                   |
+| `LOGFLARE_LOG_LEVEL`               | String, defaults to `info`. <br/>Options: `error`,`warn`, `info`, `debug` | Allows runtime configuration of log level.                                                                                  |
+| `LOGFLARE_NODE_HOST`               | string, defaults to `127.0.0.1`                                           | Sets node host on startup, which affects the node name `logflare@<host>`                                                    |
+| `LOGFLARE_LOGGER_METADATA_CLUSTER` | string, defaults to `nil`                                                 | Sets global logging metadata for the cluster name. Useful for filtering logs by cluster name.                               |
 
 ### BigQuery Backend Configuration
 


### PR DESCRIPTION
This adds cluster names to logs to ensure ability to filter