### PR TITLE
fix: disable busy wait

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -15,6 +15,10 @@
 +sbwtdcpu none
 +sbwtdio none
 
+## Reduce scheduler wake up threshold
++swt low
++swtdio low
+
 ## Set distribution buffer limit - default is 1024
 +zdbbl 1028000
 

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -11,9 +11,9 @@
 ##-env ERL_FULLSWEEP_AFTER 10
 
 ## Set busy-wait. Options are: none|very_short|short|medium|long|very_long
-+sbwt medium
-+sbwtdcpu medium
-+sbwtdio medium
++sbwt none
++sbwtdcpu none
++sbwtdio none
 
 ## Set distribution buffer limit - default is 1024
 +zdbbl 1028000

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -17,7 +17,9 @@
 
 ## Reduce scheduler wake up threshold
 +swt low
++swtdcpu low
 +swtdio low
+
 
 ## Set distribution buffer limit - default is 1024
 +zdbbl 1028000


### PR DESCRIPTION
https://erlangforums.com/t/vm-tuning-guide/1945/4

as well as [rabbitmq advice](https://www.rabbitmq.com/runtime.html#busy-waiting)

COS is also linux based, which also has CFS since it was merged to linux kernel in 2007.
docker image is on debian, which uses CFS.

Some other discussions backing this up:
- https://stressgrid.com/blog/beam_cpu_usage/
- https://elixirforum.com/t/any-tips-on-tuning-the-beam-vm/51038/4?u=ziinc