### PR TITLE
fix: health check for ETS ingestion tables

### DIFF
--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -407,4 +407,12 @@ defmodule Logflare.Sources do
     |> Enum.map(&put_schema_field_count/1)
     |> Enum.sort_by(&{!&1.favorite, &1.name})
   end
+
+  @doc "Checks if all ETS tables used for source ingestion are started"
+  def ingest_ets_tables_started?() do
+    case {:ets.whereis(:rate_counters), :ets.whereis(:table_counters)} do
+      {a, b} when is_reference(a) and is_reference(b) -> true
+      _ -> false
+    end
+  end
 end

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -248,4 +248,27 @@ defmodule Logflare.SourcesTest do
       assert new_pid != pid
     end
   end
+
+  describe "Ingestion ETS tables" do
+    setup do
+      on_exit(fn ->
+        try do
+          :ets.delete(:rate_counters)
+        rescue
+          _e -> :ok
+        end
+        try do
+          :ets.delete(:table_counters)
+        rescue
+          _e -> :ok
+        end
+      end)
+    end
+    test "ingest_ets_tables_started?/0" do
+      assert false == Sources.ingest_ets_tables_started?()
+      start_supervised!(Logflare.Sources.RateCounters)
+      start_supervised!(Logflare.Sources.Counters)
+      assert true == Sources.ingest_ets_tables_started?()
+    end
+  end
 end


### PR DESCRIPTION
Health check for ETS tables is now needed, due to race conditions in startup time. 