### PR TITLE
chore: reduce wait time for staging deployments

### DIFF
--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -40,9 +40,9 @@ steps:
       - --project=logflare-staging
       - --zone=us-central1-a
       - --type=proactive
-      - --max-surge=1
+      - --max-surge=2
       - --max-unavailable=0
-      - --min-ready=300
+      - --min-ready=15
       - --minimal-action=replace
       - --most-disruptive-allowed-action=replace
       - --replacement-method=substitute


### PR DESCRIPTION
makes feedback loop for staging deployments smaller, as staging does not need large wait times as db has plenty of capacity.