### PR TITLE
feat: ETS-backed BufferCounter

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -134,6 +134,7 @@ defmodule Logflare.Application do
         # init Counters before Supervisof as Supervisor calls Counters through table create
         Sources.Counters,
         Sources.RateCounters,
+        Sources.BufferCounters,
         PubSubRates.Rates,
         PubSubRates.Buffers,
         PubSubRates.Inserts,

--- a/lib/logflare/logs/logs.ex
+++ b/lib/logflare/logs/logs.ex
@@ -35,7 +35,7 @@ defmodule Logflare.Logs do
   @spec ingest(Logflare.LogEvent.t()) :: Logflare.LogEvent.t() | {:error, term}
   def ingest(%LE{source: %Source{} = source} = le) do
     with {:ok, _} <- Supervisor.ensure_started(source.token),
-         {:ok, _} <- BufferCounter.push(le),
+         :ok <- BufferCounter.push(le),
          :ok <- RecentLogsServer.push(le),
          # tests fail when we match on these for some reason
          _ok <- Sources.Counters.increment(source.token),

--- a/lib/logflare/source/bigquery/buffer_counter.ex
+++ b/lib/logflare/source/bigquery/buffer_counter.ex
@@ -8,35 +8,35 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   alias Logflare.Source.RecentLogsServer, as: RLS
   alias Logflare.Source
   alias Logflare.PubSubRates
+  alias Logflare.Source.BigQuery.Pipeline
 
   require Logger
 
+  @table :buffer_counters
   @broadcast_every 5_000
   @max_buffer_len 5_000
   @pool_size Application.compile_env(:logflare, Logflare.PubSub)[:pool_size]
 
-  def start_link(%RLS{source_id: source_uuid}) when is_atom(source_uuid) do
+  def start_link(%RLS{} = rls) do
+    start_link(source_token: rls.source_id)
+  end
+
+  def start_link(opts) do
+    source_token = Keyword.get(opts, :source_token)
+
     GenServer.start_link(
       __MODULE__,
-      %{
-        source_uuid: source_uuid
-      },
-      name: Source.Supervisor.via(__MODULE__, source_uuid)
+      opts,
+      name: Source.Supervisor.via(__MODULE__, source_token)
     )
   end
 
-  def init(args) do
-    ref = :counters.new(5, [:write_concurrency])
-    {:ok, _} = Registry.register(Logflare.CounterRegistry, {__MODULE__, args.source_uuid}, ref)
-
-    state = %{
-      source_uuid: args.source_uuid,
-      len_max: :counters.put(ref, len_max_idx(), @max_buffer_len),
-      counter_ref: ref
-    }
-
+  def init([source_token: source_token] = opts) do
+    ensure_ets_key(source_token)
     Process.flag(:trap_exit, true)
+    loop()
     check_buffer()
+    state = Enum.into(opts, %{})
     {:ok, state}
   end
 
@@ -45,32 +45,34 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   """
 
   @spec push(LE.t()) :: {:ok, map()} | {:error, :buffer_full}
-  def push(%LE{source: %Source{token: source_uuid} = source} = le) do
+  def push(%LE{source: %Source{token: source_token} = source} = le) do
     batch = [
       %Broadway.Message{
         data: le,
-        acknowledger: {Source.BigQuery.BufferProducer, source_uuid, nil}
+        acknowledger: {Source.BigQuery.BufferProducer, source_token, nil}
       }
     ]
 
-    push_batch(%{source: source, batch: batch, count: 1})
+    push_batch(source, batch)
   end
 
   @doc """
   Takes a `batch` of `Broadway.Message`s, pushes them into a Broadway pipeline and increments the `BufferCounter` count.
   """
 
-  @spec push_batch(%{source: Source.t(), batch: [Broadway.Message.t(), ...], count: integer()}) ::
-          {:ok, map()} | {:error, :buffer_full}
-  def push_batch(%{source: %Source{token: source_uuid}, batch: batch, count: count})
-      when is_list(batch) and is_atom(source_uuid) do
-    with {:ok, ref} <- lookup_counter(source_uuid),
-         {:ok, resp} <- push_by(ref, count) do
-      source_uuid
-      |> Source.BigQuery.Pipeline.name()
+  @spec push_batch(Source.t(), [Broadway.Message.t(), ...]) :: :ok | {:error, :buffer_full}
+  def push_batch(%Source{token: source_token}, batch)
+      when is_list(batch) and is_atom(source_token) do
+    count = Enum.count(batch)
+    # increment counter by x amount
+    ensure_ets_key(source_token)
+
+    with {:ok, _new_len} <- push_by(source_token, count),
+         _ <- :ets.update_counter(@table, source_token, {2, count}) do
+      Pipeline.name(source_token)
       |> Broadway.push_messages(batch)
 
-      {:ok, resp}
+      :ok
     end
   end
 
@@ -78,104 +80,62 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   Decrements the actual buffer count. If we've got a successfull `ack` from Broadway it means
   we don't have the log event anymore.
   """
-  @spec ack(atom(), binary()) :: {:ok, %{len: integer}}
-  def ack(source_uuid, log_event_id) when is_binary(log_event_id) do
-    {:ok, ref} = lookup_counter(source_uuid)
-
-    ack_by(ref, 1)
+  @spec ack(atom(), binary()) :: :ok
+  def ack(source_token, log_event_id) when is_binary(log_event_id) do
+    :ets.update_counter(@table, source_token, {2, -1})
+    :ok
   end
 
-  @spec ack_batch(atom(), [Broadway.Message.t()]) :: {:ok, map()}
-  def ack_batch(source_uuid, log_events) when is_list(log_events) do
+  @spec ack_batch(atom(), [Broadway.Message.t()]) :: :ok
+  def ack_batch(source_token, log_events) when is_list(log_events) do
+    ensure_ets_key(source_token)
     count = Enum.count(log_events)
-
-    {:ok, ref} = lookup_counter(source_uuid)
-
-    ack_by(ref, count)
+    :ets.update_counter(@table, source_token, {2, -count})
+    :ok
   end
 
-  @spec push_by(:counters.counters_ref(), integer) ::
-          {:error, :buffer_full} | {:ok, %{len: integer}}
-  def push_by(ref, count) do
-    len = :counters.get(ref, len_idx())
-    max_len = :counters.get(ref, len_max_idx())
+  @spec push_by(atom(), integer) ::
+          {:error, :buffer_full} | {:ok, integer()}
+  def push_by(source_token, count) do
+    len = len(source_token)
 
-    if len < max_len do
-      :ok = :counters.add(ref, len_idx(), count)
-      :ok = :counters.add(ref, pushed_idx(), count)
-
-      {:ok, %{len: len + count}}
+    if len + count <= @max_buffer_len do
+      {:ok, len + count}
     else
-      :ok = :counters.add(ref, discarded_idx(), count)
       {:error, :buffer_full}
     end
   end
 
-  @spec ack_by(:counters.counters_ref(), integer) :: {:ok, %{len: integer}}
-  def ack_by(ref, count) do
-    :ok = :counters.sub(ref, len_idx(), count)
-    len = :counters.get(ref, len_idx())
-
-    {:ok, %{len: len}}
+  @spec set_len(atom(), non_neg_integer()) :: :ok
+  def set_len(source_token, num) do
+    :ets.update_element(@table, source_token, {2, num})
+    :ok
   end
 
   @doc """
   Gets the current length of the buffer.
   """
-
   @spec len(Source.t()) :: integer
-  def len(%Source{token: source_uuid}) when is_atom(source_uuid) do
-    {:ok, ref} = lookup_counter(source_uuid)
+  def len(%Source{token: source_token}), do: len(source_token)
 
-    :counters.get(ref, len_idx())
+  def len(source_token) when is_atom(source_token) do
+    :ets.lookup_element(@table, source_token, 2, 0)
   end
 
-  @doc """
-  Gets all the buffer counters for a source.
-  """
+  def handle_info(:loop, state) do
+    pipeline_name = Pipeline.name(state.source_token)
 
-  @spec get_counts(atom) :: map()
-  def get_counts(source_uuid) do
-    {:ok, ref} = lookup_counter(source_uuid)
+    producer = Broadway.producer_names(pipeline_name) |> List.first()
+    count = GenStage.estimate_buffered_count(producer)
+    set_len(state.source_token, count)
+    loop()
 
-    %{
-      source_id: source_uuid,
-      pushed: :counters.get(ref, pushed_idx()),
-      acknowledged: :counters.get(ref, ackd_idx()),
-      len: :counters.get(ref, len_idx()),
-      len_max: :counters.get(ref, len_max_idx()),
-      discarded: :counters.get(ref, discarded_idx())
-    }
-  end
-
-  @doc """
-  Sets the max length of a buffer. For tests.
-  """
-
-  @spec set_len_max(atom(), integer()) :: {:ok, map()}
-  def set_len_max(source_uuid, max) when is_atom(source_uuid) do
-    {:ok, ref} = lookup_counter(source_uuid)
-    :ok = :counters.put(ref, len_max_idx(), max)
-    max = :counters.get(ref, len_max_idx())
-
-    {:ok, %{len_max: max}}
-  end
-
-  @doc """
-  Looks up the counter reference from the Registry.
-  """
-
-  @spec lookup_counter(atom) :: {:ok, any} | {:error, :buffer_counter_not_found}
-  def lookup_counter(source_uuid) when is_atom(source_uuid) do
-    case Registry.lookup(Logflare.CounterRegistry, {__MODULE__, source_uuid}) do
-      [{_pid, counter_ref}] -> {:ok, counter_ref}
-      _error -> {:error, :buffer_counter_not_found}
-    end
+    {:noreply, state}
   end
 
   def handle_info(:check_buffer, state) do
-    if Source.RateCounterServer.should_broadcast?(state.source_uuid) do
-      broadcast_buffer(state.source_uuid)
+    if Source.RateCounterServer.should_broadcast?(state.source_token) do
+      broadcast_buffer(state.source_token)
     end
 
     check_buffer()
@@ -184,30 +144,31 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   end
 
   def terminate(reason, state) do
-    # Do Shutdown Stuff
-    Logger.info("Going Down - #{inspect(reason)} - #{__MODULE__}", %{source_id: state.source_uuid})
+    Logger.info("Going Down - #{inspect(reason)} - #{__MODULE__}", %{
+      source_id: state.source_token,
+      source_Token: state.source_token
+    })
 
     reason
   end
 
-  defp broadcast_buffer(source_uuid) when is_atom(source_uuid) do
-    {:ok, ref} = lookup_counter(source_uuid)
-    len = :counters.get(ref, len_idx())
+  defp broadcast_buffer(source_token) when is_atom(source_token) do
+    len = len(source_token)
     local_buffer = %{Node.self() => %{len: len}}
 
-    shard = :erlang.phash2(source_uuid, @pool_size)
+    shard = :erlang.phash2(source_token, @pool_size)
 
     Phoenix.PubSub.broadcast(
       Logflare.PubSub,
       "buffers:shard-#{shard}",
-      {:buffers, source_uuid, local_buffer}
+      {:buffers, source_token, local_buffer}
     )
 
-    cluster_buffer = PubSubRates.Cache.get_cluster_buffers(source_uuid)
+    cluster_buffer = PubSubRates.Cache.get_cluster_buffers(source_token)
 
     payload = %{
       buffer: cluster_buffer,
-      source_token: source_uuid
+      source_token: source_token
     }
 
     Source.ChannelTopics.broadcast_buffer(payload)
@@ -217,9 +178,11 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
     Process.send_after(self(), :check_buffer, @broadcast_every)
   end
 
-  defp pushed_idx(), do: 1
-  defp ackd_idx(), do: 2
-  defp len_idx(), do: 3
-  defp len_max_idx(), do: 4
-  defp discarded_idx(), do: 5
+  defp loop do
+    Process.send_after(self(), :loop, 1_000)
+  end
+
+  defp ensure_ets_key(source_token) do
+    :ets.insert_new(@table, {source_token, 0})
+  end
 end

--- a/lib/logflare/source/bigquery/buffer_counter.ex
+++ b/lib/logflare/source/bigquery/buffer_counter.ex
@@ -99,7 +99,8 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   def push_by(source_token, count) do
     len = len(source_token)
 
-    if len + count <= @max_buffer_len do
+    # allow bursting
+    if len <= @max_buffer_len do
       {:ok, len + count}
     else
       {:error, :buffer_full}

--- a/lib/logflare/source/supervisor.ex
+++ b/lib/logflare/source/supervisor.ex
@@ -255,7 +255,10 @@ defmodule Logflare.Source.Supervisor do
   def ensure_started(source_token) do
     case lookup(RLS, source_token) do
       {:error, _} ->
-        Logger.info("Source process not found, starting...", source_id: source_token)
+        Logger.info("Source process not found, starting...",
+          source_id: source_token,
+          source_token: source_token
+        )
 
         start_source(source_token)
 

--- a/lib/logflare/sources/buffer_counters.ex
+++ b/lib/logflare/sources/buffer_counters.ex
@@ -20,6 +20,7 @@ defmodule Logflare.Sources.BufferCounters do
       :ordered_set,
       :public,
       :named_table,
+      decentralized_counters: true,
       read_concurrency: true,
       write_concurrency: true
     ])

--- a/lib/logflare/sources/buffer_counters.ex
+++ b/lib/logflare/sources/buffer_counters.ex
@@ -1,0 +1,29 @@
+defmodule Logflare.Sources.BufferCounters do
+  @moduledoc """
+  Maintains a count of log events inside the Source.BigQuery.Pipeline Broadway pipeline.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @ets_table_name :buffer_counters
+
+  def start_link(args \\ []) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(state) do
+    Logger.info("BufferCounters table started!")
+
+    :ets.new(@ets_table_name, [
+      :ordered_set,
+      :public,
+      :named_table,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    {:ok, state}
+  end
+end

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -7,12 +7,14 @@ defmodule Logflare.LogsTest do
   alias Logflare.Source.RecentLogsServer
   alias Logflare.Sources.Counters
   alias Logflare.Sources.RateCounters
+  alias Logflare.Sources.BufferCounters
   alias Logflare.SystemMetrics.AllLogsLogged
 
   def source_and_user(_context) do
     start_supervised!(AllLogsLogged)
     start_supervised!(Counters)
     start_supervised!(RateCounters)
+    start_supervised!(BufferCounters)
 
     insert(:plan)
     user = insert(:user)

--- a/test/logflare/source/bigquery/buffer_test.exs
+++ b/test/logflare/source/bigquery/buffer_test.exs
@@ -129,6 +129,7 @@ defmodule Logflare.Source.BufferCounterTest do
           }
         end
 
+      assert :ok = BufferCounter.push_batch(source, big_batch)
       assert {:error, :buffer_full} = BufferCounter.push_batch(source, big_batch)
     end
   end

--- a/test/logflare/source/source_supervisor_test.exs
+++ b/test/logflare/source/source_supervisor_test.exs
@@ -1,21 +1,27 @@
-defmodule Logflare.Source.RecentLogsServerTest do
+defmodule Logflare.Source.SupervisorTest do
   @moduledoc false
   use Logflare.DataCase
-  alias Logflare.Source.RecentLogsServer
+  alias Logflare.Source
   alias Logflare.Sources.Counters
   alias Logflare.Sources.RateCounters
+  alias Logflare.Sources.BufferCounters
   alias Logflare.SystemMetrics.AllLogsLogged
+  alias Logflare.Source.BigQuery.BufferCounter
 
   test "able to start supervision tree" do
     start_supervised!(AllLogsLogged)
     start_supervised!(Counters)
     start_supervised!(RateCounters)
+    start_supervised!(BufferCounters)
     stub(Goth, :fetch, fn _mod -> {:ok, %Goth.Token{token: "auth-token"}} end)
     user = insert(:user)
     source = insert(:source, user_id: user.id)
-    plan = insert(:plan)
-    rls = %RecentLogsServer{source_id: source.token, source: source, plan: plan, user: user}
-    start_supervised!({RecentLogsServer, rls})
+    insert(:plan)
+
+    start_supervised!(Source.Supervisor)
+    assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+    assert Source.Supervisor.lookup(BufferCounter, source.token)
+    assert BufferCounter.len(source) == 0
     :timer.sleep(1000)
   end
 end

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -5,6 +5,7 @@ defmodule LogflareWeb.LogControllerTest do
   alias Logflare.Source.RecentLogsServer
   alias Logflare.Sources.Counters
   alias Logflare.Sources.RateCounters
+  alias Logflare.Sources.BufferCounters
   alias Logflare.SingleTenant
   alias Logflare.Users
   alias Logflare.Sources
@@ -18,6 +19,7 @@ defmodule LogflareWeb.LogControllerTest do
   ]
 
   setup do
+
     Logflare.Sources.Counters
     |> stub(:increment, fn v -> v end)
 
@@ -42,6 +44,7 @@ defmodule LogflareWeb.LogControllerTest do
 
       start_supervised!(Counters)
       start_supervised!(RateCounters)
+      start_supervised!(BufferCounters)
 
       source_backend =
         insert(:source_backend, source_id: source.id, type: :webhook, config: %{url: "some url"})
@@ -225,6 +228,7 @@ defmodule LogflareWeb.LogControllerTest do
       rls = %RecentLogsServer{source: source, source_id: source.token}
       start_supervised!(Counters)
       start_supervised!(RateCounters)
+      start_supervised!(BufferCounters)
       start_supervised!({RecentLogsServer, rls})
       :timer.sleep(500)
 
@@ -260,6 +264,7 @@ defmodule LogflareWeb.LogControllerTest do
     rls = %RecentLogsServer{source: source, source_id: source.token}
     start_supervised!(Counters)
     start_supervised!(RateCounters)
+    start_supervised!(BufferCounters)
     start_supervised!({RecentLogsServer, rls})
     :timer.sleep(500)
 


### PR DESCRIPTION
This switches the BufferCounter table to use ets instead of `:counter` module.
This makes it non-blocking as well, so that if RLS tree is slow to come up, any calls to the BufferCounter module does not result in buffer_counter_not_found error.

The GenServer essentially only ensures that the counter is in sync with what Broadway has internally, and does the buffer broadcast. In event that Broadway slows down or provides an incorrect estimate, acks/push events will still inc/decr the current counter value, so some latency retrieving the estimate count is tolerable. Once retrieved, it will reset the counter value atomically.

Many operations make the `:ets.insert_new/2` call to ensure that the key is present. This can be optimized in the future with benchmarks.

ets table options are adjusted based on this:
- https://www.erlang.org/blog/scalable-ets-counters/