### PR TITLE
fix: buffer counter boot queue

### DIFF
--- a/lib/logflare/source/bigquery/buffer_counter.ex
+++ b/lib/logflare/source/bigquery/buffer_counter.ex
@@ -140,12 +140,12 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
     :ets.lookup_element(@table, source_token, 2, 0)
   end
 
-  @typep identifier :: atom() | tuple() | pid()
+  @typep proc_name :: atom() | tuple() | pid()
 
   @doc """
   Retrieves the length of the boot queue in GenServer state.
   """
-  @spec boot_queue_len(identifier()) :: non_neg_integer()
+  @spec boot_queue_len(proc_name()) :: non_neg_integer()
   def boot_queue_len(source_token) when is_atom(source_token) do
     Source.Supervisor.via(__MODULE__, source_token)
     |> boot_queue_len()
@@ -158,7 +158,7 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   @doc """
   Adds events to the boot queue.
   """
-  @spec add_to_boot_queue(identifier(), [Broadway.Message.t()]) :: :ok
+  @spec add_to_boot_queue(proc_name(), [Broadway.Message.t()]) :: :ok
   def add_to_boot_queue(source_token, batch) when is_atom(source_token) do
     Source.Supervisor.via(__MODULE__, source_token)
     |> add_to_boot_queue(batch)
@@ -173,7 +173,7 @@ defmodule Logflare.Source.BigQuery.BufferCounter do
   @doc """
   Retrieves the entire boot queue from GenServer state.
   """
-  @spec pop_boot_queue(identifier()) :: {:ok, [Broadway.Message.t()]}
+  @spec pop_boot_queue(proc_name()) :: {:ok, [Broadway.Message.t()]}
   def pop_boot_queue(source_token) when is_atom(source_token) do
     Source.Supervisor.via(__MODULE__, source_token)
     |> pop_boot_queue()

--- a/lib/logflare/source/bigquery/buffer_producer.ex
+++ b/lib/logflare/source/bigquery/buffer_producer.ex
@@ -5,19 +5,38 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
   require Logger
 
   alias Logflare.Source.BigQuery.BufferCounter
+  alias Logflare.Source
 
   @impl true
-  def init(%{source_id: source_id}) when is_atom(source_id) do
+  def init(%{source_id: source_token}) when is_atom(source_token) do
     {:producer,
      %{
        demand: 0,
-       source_id: source_id
+       source_token: source_token
      }, buffer_size: 50_000}
   end
 
   @impl true
   def handle_demand(incoming_demand, %{demand: demand} = state) do
     handle_receive_messages(%{state | demand: demand + incoming_demand})
+  end
+
+  @impl true
+  def handle_info(:boot_queue, state) do
+    queue =
+      with {:ok, _pid} <- Source.Supervisor.lookup(BufferCounter, state.source_token),
+           {:ok, [_ | _] = queue} <- BufferCounter.pop_boot_queue(state.source_token) do
+        Logger.info("[#{__MODULE__}] Non-empty boot queue retrieved",
+          source_id: state.source_token,
+          source_token: state.source_token
+        )
+
+        queue
+      else
+        _ -> []
+      end
+
+    {:noreply, queue, state}
   end
 
   @impl true
@@ -31,14 +50,14 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
   end
 
   @spec ack(atom(), [Broadway.Message.t()], [Broadway.Message.t()]) :: :ok
-  def ack(source_id, successful, unsuccessful) when is_atom(source_id) do
-    BufferCounter.ack_batch(source_id, successful ++ unsuccessful)
+  def ack(source_token, successful, unsuccessful) when is_atom(source_token) do
+    BufferCounter.ack_batch(source_token, successful ++ unsuccessful)
 
     :ok
   end
 
   defp handle_receive_messages(
-         %{source_id: _source_id, receive_timer: nil, demand: demand} = state
+         %{source_token: _source_token, receive_timer: nil, demand: demand} = state
        )
        when demand > 0 do
     # would normall pop log events from a buffer here


### PR DESCRIPTION
This PR adds in a boot queue for the broadway Pipeline. Boot queue length is set to 1k items, with fifo discards when queue is maxed (i.e. older items are discarded)

Boot queue is popped from the BufferProducer, and once the pipeline is up, the BufferCounter switches to inserting directly into the buffer.

depends on #1947 