### PR TITLE
fix: max buffer size for producer

### DIFF
--- a/lib/logflare/source/bigquery/buffer_producer.ex
+++ b/lib/logflare/source/bigquery/buffer_producer.ex
@@ -12,7 +12,7 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
      %{
        demand: 0,
        source_id: source_id
-     }, buffer_size: 50_000}
+     }, buffer_size: 10_000}
   end
 
   @impl true


### PR DESCRIPTION
This reduces the max buffer size to double the hardcoded BufferCounter limit. This accommodates for bursting beyond the limit, but not to the point where the memory usage goes out of hand.