### PR TITLE
fix: Use DynamicSupervisor to prevent race conditions in process startup

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -54,6 +54,12 @@ defmodule Logflare.Application do
         LogflareWeb.Endpoint,
         {Task.Supervisor, name: Logflare.TaskSupervisor},
         {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
+        {DynamicSupervisor,
+         strategy: :one_for_one,
+         restart: :transient,
+         max_restarts: 10,
+         max_seconds: 60,
+         name: Logflare.Source.V1SourceDynSup},
 
         # v2 ingestion pipelines
         {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Backends.SourcesSup},
@@ -138,6 +144,12 @@ defmodule Logflare.Application do
         PubSubRates.Buffers,
         PubSubRates.Inserts,
         Logflare.Source.Supervisor,
+        {DynamicSupervisor,
+         strategy: :one_for_one,
+         restart: :transient,
+         max_restarts: 10,
+         max_seconds: 60,
+         name: Logflare.Source.V1SourceDynSup},
 
         # If we get a log event and the Source.Supervisor is not up it will 500
         LogflareWeb.Endpoint,

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -1,0 +1,69 @@
+defmodule Logflare.Source.V1SourceSup do
+  @moduledoc """
+  Manages the individual table for the source. Limits things in the table to 1000. Manages TTL for
+  things in the table. Handles loading the table from the disk if found on startup.
+  """
+
+  alias Logflare.Source.BigQuery.Schema
+  alias Logflare.Source.BigQuery.Pipeline
+  alias Logflare.Source.BigQuery.BufferCounter
+
+  alias Logflare.Source.RecentLogsServer
+  alias Logflare.Source.EmailNotificationServer
+  alias Logflare.Source.TextNotificationServer
+  alias Logflare.Source.WebhookNotificationServer
+  alias Logflare.Source.SlackHookServer
+  alias Logflare.Source.BillingWriter
+
+  alias Logflare.Source.RateCounterServer, as: RCS
+  alias Logflare.Source
+  alias Logflare.Users
+  alias Logflare.Billing
+  alias Logflare.Logs.SearchQueryExecutor
+
+  require Logger
+  use Supervisor
+
+  def start_link(%RecentLogsServer{source_id: source_token} = rls) do
+    Supervisor.start_link(__MODULE__, rls, name: Source.Supervisor.via(__MODULE__, source_token))
+  end
+
+  @impl true
+  def init(%RecentLogsServer{source: source} = rls) do
+    Process.flag(:trap_exit, true)
+    Logger.metadata(source_id: rls.source_id, source_token: rls.source_id)
+
+    user =
+      source.user_id
+      |> Users.get()
+      |> Users.maybe_put_bigquery_defaults()
+      |> Users.preload_billing_account()
+
+    plan = Billing.get_plan_by_user(user)
+
+    rls = %RecentLogsServer{
+      rls
+      | bigquery_project_id: user.bigquery_project_id,
+        bigquery_dataset_id: user.bigquery_dataset_id,
+        user: user,
+        plan: plan,
+        notifications_every: source.notifications_every
+    }
+
+    children = [
+      {BufferCounter, rls},
+      {Pipeline, rls},
+      {RecentLogsServer, rls},
+      {Schema, rls},
+      {RCS, rls},
+      {EmailNotificationServer, rls},
+      {TextNotificationServer, rls},
+      {WebhookNotificationServer, rls},
+      {SlackHookServer, rls},
+      {SearchQueryExecutor, rls},
+      {BillingWriter, rls}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10)
+  end
+end

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.LogsTest do
   alias Logflare.Lql
   # v1 pipeline
   alias Logflare.Source.RecentLogsServer
+  alias Logflare.Source.V1SourceSup
   alias Logflare.Sources.Counters
   alias Logflare.Sources.RateCounters
   alias Logflare.SystemMetrics.AllLogsLogged
@@ -23,8 +24,8 @@ defmodule Logflare.LogsTest do
     rls = %RecentLogsServer{source: source, source_id: source.token}
     rls_b = %RecentLogsServer{source: source_b, source_id: source_b.token}
 
-    start_supervised!({RecentLogsServer, rls}, id: :source)
-    start_supervised!({RecentLogsServer, rls_b}, id: :source_b)
+    start_supervised!({V1SourceSup, rls}, id: :source)
+    start_supervised!({V1SourceSup, rls_b}, id: :source_b)
 
     :timer.sleep(250)
     [source: source, source_b: source_b, user: user]

--- a/test/logflare/source/bigquery/buffer_test.exs
+++ b/test/logflare/source/bigquery/buffer_test.exs
@@ -7,6 +7,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
   alias Logflare.Sources.RateCounters
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.LogEvent
+  alias Logflare.Source.V1SourceSup
 
   setup do
     Goth
@@ -20,7 +21,7 @@ defmodule Logflare.Source.BigQuery.BufferTest do
 
     source = insert(:source, user: user)
     rls = %RecentLogsServer{source: source, source_id: source.token}
-    start_supervised!({RecentLogsServer, rls}, id: :source)
+    start_supervised!({V1SourceSup, rls}, id: :source)
 
     [source: source]
   end

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -13,7 +13,12 @@ defmodule Logflare.SourcesTest do
   alias Logflare.Sources.Counters
   alias Logflare.SourceSchemas
   alias Logflare.Source.RateCounterServer
-      alias Logflare.Users
+  alias Logflare.Sources.Counters
+  alias Logflare.Sources.RateCounters
+  alias Logflare.SystemMetrics.AllLogsLogged
+  alias Logflare.Source.BigQuery.BufferCounter
+  alias Logflare.Source.V1SourceSup
+  alias Logflare.Users
 
   describe "create_source/2" do
     setup do
@@ -173,30 +178,45 @@ defmodule Logflare.SourcesTest do
 
   describe "Source.Supervisor" do
     alias Logflare.Source.RecentLogsServer, as: RLS
+
     setup do
       stub(Goth, :fetch, fn _mod -> {:ok, %Goth.Token{token: "auth-token"}} end)
 
-      start_supervised!(Sources.Counters)
+      Logflare.Google.BigQuery
+      |> stub(:init_table!, fn _, _, _, _, _, _ -> :ok end)
+
+      start_supervised!(AllLogsLogged)
+      start_supervised!(Counters)
+      start_supervised!(RateCounters)
 
       RateCounterServer
       |> stub(:get_data_from_ets, fn _ -> %RateCounterServer{} end)
       |> stub(:broadcast, fn _ -> :ok end)
 
       insert(:plan)
+
+      on_exit(fn ->
+        DynamicSupervisor.stop(Logflare.Source.V1SourceDynSup)
+      end)
+
       {:ok, user: insert(:user)}
     end
+
     test "bootup starts RLS for each recently logged source", %{user: user} do
       source_stale = insert(:source, user: user)
-      [source| _ ] = for _ <- 1..24 do
-        insert(:source, user: user, log_events_updated_at: DateTime.utc_now())
-      end
+
+      [source | _] =
+        for _ <- 1..24 do
+          insert(:source, user: user, log_events_updated_at: DateTime.utc_now())
+        end
+
       start_supervised!(Source.Supervisor)
       assert Source.Supervisor.booting?()
       :timer.sleep(1500)
       refute Source.Supervisor.booting?()
-      assert {:ok, pid} = Source.Supervisor.lookup(RLS, source.token)
+      assert {:ok, pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
       assert is_pid(pid)
-      assert  {:error, :no_proc} = Source.Supervisor.lookup(RLS, source_stale.token)
+      assert {:error, :no_proc} = Source.Supervisor.lookup(V1SourceSup, source_stale.token)
     end
 
     test "start_source/1, lookup/2, delete_source/1", %{user: user} do
@@ -206,46 +226,87 @@ defmodule Logflare.SourcesTest do
       |> stub(:get_bq_inserts, fn _ -> {:ok, 0} end)
       |> stub(:create, fn _ -> {:ok, :some_table} end)
 
-
       Logflare.Google.BigQuery
       |> expect(:delete_table, fn _token -> :ok end)
-      |> expect(:init_table!, fn _, _ , _, _, _, _ -> :ok end)
+      |> expect(:init_table!, fn _, _, _, _, _, _ -> :ok end)
 
       %{token: token} = insert(:source, user: user)
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
       :timer.sleep(500)
-      assert {:ok, _pid} = Source.Supervisor.lookup(RLS, token)
+      assert {:ok, _pid} = Source.Supervisor.lookup(V1SourceSup, token)
       :timer.sleep(1_000)
       assert {:ok, ^token} = Source.Supervisor.delete_source(token)
-      :timer.sleep(500)
-      assert {:error, :no_proc} = Source.Supervisor.lookup(RLS, token)
+      :timer.sleep(1000)
+      assert {:error, :no_proc} = Source.Supervisor.lookup(V1SourceSup, token)
     end
 
-
     test "reset_source/1", %{user: user} do
-      Counters
-      |> stub(:delete, fn _token -> :ok end)
-      |> stub(:get_inserts, fn _ -> {:ok, 0} end)
-      |> stub(:get_bq_inserts, fn _ -> {:ok, 0} end)
-      |> stub(:create, fn _ -> {:ok, :some_table} end)
-
-
-
-      Logflare.Google.BigQuery
-      |> stub(:init_table!, fn _, _ , _, _, _, _ -> :ok end)
-
       %{token: token} = insert(:source, user: user)
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
       :timer.sleep(500)
-      assert {:ok, pid} = Source.Supervisor.lookup(RLS, token)
+      assert {:ok, pid} = Source.Supervisor.lookup(V1SourceSup, token)
       assert {:ok, ^token} = Source.Supervisor.reset_source(token)
       :timer.sleep(1500)
-      assert {:ok, new_pid} = Source.Supervisor.lookup(RLS, token)
+      assert {:ok, new_pid} = Source.Supervisor.lookup(V1SourceSup, token)
       assert new_pid != pid
+    end
+
+    test "able to start supervision tree" do
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+
+      start_supervised!(Source.Supervisor)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      :timer.sleep(1000)
+      assert {:ok, _pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
+      assert BufferCounter.len(source) == 0
+    end
+
+    test "able to reset supervision tree" do
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+
+      start_supervised!(Source.Supervisor)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      :timer.sleep(1000)
+      assert {:ok, pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
+      assert {:ok, _} = Source.Supervisor.reset_source(source.token)
+      assert {:ok, _} = Source.Supervisor.reset_source(source.token)
+      :timer.sleep(3000)
+      assert {:ok, new_pid} = Source.Supervisor.lookup(RLS, source.token)
+      assert pid != new_pid
+      assert BufferCounter.len(source) == 0
+    end
+
+    test "concurrent start attempts" do
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+      start_supervised!(Source.Supervisor)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      :timer.sleep(3000)
+      assert {:ok, _pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
+      assert BufferCounter.len(source) == 0
+    end
+
+    test "terminating Source.Supervisor does not bring everything down" do
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+      pid = start_supervised!(Source.Supervisor)
+      assert {:ok, :started} = Source.Supervisor.ensure_started(source.token)
+      :timer.sleep(3000)
+      assert {:ok, prev_pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
+      Process.exit(pid, :kill)
+      assert {:ok, pid} = Source.Supervisor.lookup(V1SourceSup, source.token)
+      assert prev_pid == pid
     end
   end
 
@@ -257,6 +318,7 @@ defmodule Logflare.SourcesTest do
         rescue
           _e -> :ok
         end
+
         try do
           :ets.delete(:table_counters)
         rescue
@@ -264,6 +326,7 @@ defmodule Logflare.SourcesTest do
         end
       end)
     end
+
     test "ingest_ets_tables_started?/0" do
       assert false == Sources.ingest_ets_tables_started?()
       start_supervised!(Logflare.Sources.RateCounters)

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -196,7 +196,10 @@ defmodule Logflare.SourcesTest do
       insert(:plan)
 
       on_exit(fn ->
-        DynamicSupervisor.stop(Logflare.Source.V1SourceDynSup)
+
+        for {_id, child, _, _} <- DynamicSupervisor.which_children(Logflare.Source.V1SourceDynSup) do
+          DynamicSupervisor.terminate_child(Logflare.Source.V1SourceDynSup, child)
+        end
       end)
 
       {:ok, user: insert(:user)}

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -7,6 +7,7 @@ defmodule LogflareWeb.LogControllerTest do
   alias Logflare.Sources.RateCounters
   alias Logflare.SingleTenant
   alias Logflare.Users
+  alias Logflare.Source.V1SourceSup
   alias Logflare.Sources
 
   @valid %{"some" => "valid log entry", "event_message" => "hi!"}
@@ -225,7 +226,7 @@ defmodule LogflareWeb.LogControllerTest do
       rls = %RecentLogsServer{source: source, source_id: source.token}
       start_supervised!(Counters)
       start_supervised!(RateCounters)
-      start_supervised!({RecentLogsServer, rls})
+      start_supervised!({V1SourceSup, rls})
       :timer.sleep(500)
 
       Logflare.Logs
@@ -260,7 +261,7 @@ defmodule LogflareWeb.LogControllerTest do
     rls = %RecentLogsServer{source: source, source_id: source.token}
     start_supervised!(Counters)
     start_supervised!(RateCounters)
-    start_supervised!({RecentLogsServer, rls})
+    start_supervised!({V1SourceSup, rls})
     :timer.sleep(500)
 
     Logflare.Logs


### PR DESCRIPTION
This PR refactors the supervision trees out of the RLS, and uses a DynamicSupervisor + Supervisor to ensure that all processes are started up correctly without conflicts.

The `{:error, :buffer_counter_not_found}` error is a result of the RLS starting up only partially. The supervision trees, both initially within `init/1` and `handle_continue/2` were not starting up correctly due to name registration race conditions. On startup, the supervisor thinks that the processes are closed because the RLS genserver terminates first. However, all linked processes will still be in the shutdown phase while a new GenServer gets spun up. When the RLS calls `Supervisor.start_link/2`, it will error out because Registry still have the names registered as alive. However, when attempting to find the RLS trees' processes, it will be dead.

Notably, this bug only happens to high volume sources, because of the shutdown draining that occurs during tree termination. 

This bug has been simulated on test cluster, by resetting a cache 8 times in quick succession with less than 1 sec time between each reset. It has also been simulated on dev environment with loadfest payloads of 250 batch size or higher.

This PR changes the startup process control flow to DynamicSupervisor and places all processes under one Supervisor. We sacrifice startup latency for consistency in this case. 

Resetting a source multiple times can also result in many `:create` messages in the Source.Supervisor's mailbox, and due to startup blocking time, it may result in slow. However, with the DynamicSupervisor change, the Supervisor will automatically recover as each new child is seen as a new instance and has the restart count for `:max_restarts` reset. This is opposed to the current setup where the RLS will no longer get restarted upon receiving multiple shutdown exit signals.