### PR TITLE
perf: optimize batcher throughput via :concurrency and :batch_size

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -31,7 +31,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         default: [concurrency: 1]
       ],
       batchers: [
-        bq: [concurrency: System.schedulers_online(), batch_size: 350, batch_timeout: 1_500]
+        bq: [concurrency: System.schedulers_online(), batch_size: 250, batch_timeout: 1_500]
       ],
       context: rls
     )

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -20,8 +20,6 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   alias Logflare.Sources
   alias Logflare.Users
 
-  @batcher_multiple 0.5
-
   def start_link(%RLS{source: source, plan: _plan} = rls) do
     Broadway.start_link(__MODULE__,
       name: name(source.token),

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -23,8 +23,6 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   @batcher_multiple 0.5
 
   def start_link(%RLS{source: source, plan: _plan} = rls) do
-    max_batchers = (System.schedulers_online() * @batcher_multiple) |> Kernel.ceil()
-
     Broadway.start_link(__MODULE__,
       name: name(source.token),
       producer: [
@@ -35,7 +33,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         default: [concurrency: 1]
       ],
       batchers: [
-        bq: [concurrency: max_batchers, batch_size: 250, batch_timeout: 1_500]
+        bq: [concurrency: System.schedulers_online(), batch_size: 350, batch_timeout: 1_500]
       ],
       context: rls
     )


### PR DESCRIPTION
This PR doubles the batcher process counts to match scheduler counts. Additionally, it bumps the batch_size up by 100.

In local testing, this effectively almost triples the effective throughput of a source, to a point where my local machine can't even fill the buffer fast enough using loadfest.

Before:
<img width="848" alt="Screenshot 2024-02-05 at 1 18 26 PM" src="https://github.com/Logflare/logflare/assets/22714384/d456b412-7b77-46bc-a3f3-64fd7f30de6d">

After:
<img width="844" alt="Screenshot 2024-02-05 at 1 15 11 PM" src="https://github.com/Logflare/logflare/assets/22714384/0088b4a7-1ba5-4967-bbdd-925ea400bf71">

Bigquery insert error increase are negligible in relation to the batch size increase. Turning batch size all the way up to 500 (as per the max recommended in [BQ docs](https://cloud.google.com/bigquery/quotas#streaming_inserts) results in much higher error rate, likely due to timeouts).

Based on [broadway docs](https://hexdocs.pm/broadway/Broadway.html#module-batcher-concurrency), it would fill up processes in a fifo-like manner, minimizing process use where possible. This will then result in less used batcher processes getting hibernated. The risk of memory bloat for this change is thus quite low for low rate sources.

Further increases in the batcher concurrency or batch size did not yield any meaningful throughput change.