### PR TITLE
chore: add prod instance template generation

### DIFF
--- a/cloudbuild/prod/deploy.yaml
+++ b/cloudbuild/prod/deploy.yaml
@@ -1,0 +1,34 @@
+steps:
+
+  # deploy canaries
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - beta
+      - compute
+      - instance-groups
+      - managed
+      - rolling-action
+      - start-update
+      - ${_INSTANCE_GROUP}
+      - --project=logflare-232118
+      - --zone=europe-west3-c
+      - --type=proactive
+      - --max-surge=1
+      - --max-unavailable=0
+      - --min-ready=300
+      - --minimal-action=replace
+      - --most-disruptive-allowed-action=replace
+      - --replacement-method=substitute
+      - --version=template=projects/logflare-232118/global/instanceTemplates/${_TEMPLATE_NAME}
+
+substitutions:
+  _CLUSTER: canary
+  _COOKIE: default-${_CLUSTER}
+  _INSTANCE_GROUP: instance-group-prod-${_CLUSTER}
+  _IMAGE_TAG: $SHORT_SHA
+  _TEMPLATE_NAME: logflare-prod-${_NORMALIZED_IMAGE_TAG}-${_CLUSTER}
+  _CONTAINER_IMAGE: gcr.io/logflare-232118/logflare_app:${_IMAGE_TAG}
+timeout: 1800s
+options:
+  dynamicSubstitutions: true
+  substitutionOption: "ALLOW_LOOSE"

--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -28,31 +28,10 @@ steps:
       - --shielded-integrity-monitoring
       - --labels=container-vm=cos-stable-109-17800-66-54
 
-  # deploy canaries
-  - name: gcr.io/cloud-builders/gcloud
-    args:
-      - beta
-      - compute
-      - instance-groups
-      - managed
-      - rolling-action
-      - start-update
-      - ${_INSTANCE_GROUP}
-      - --project=logflare-232118
-      - --zone=europe-west3-c
-      - --type=proactive
-      - --max-surge=1
-      - --max-unavailable=0
-      - --min-ready=300
-      - --minimal-action=replace
-      - --most-disruptive-allowed-action=replace
-      - --replacement-method=substitute
-      - --version=template=projects/logflare-232118/global/instanceTemplates/${_TEMPLATE_NAME}
 
 substitutions:
   _CLUSTER: canary
   _COOKIE: default-${_CLUSTER}
-  _INSTANCE_GROUP: instance-group-prod-${_CLUSTER}
   _IMAGE_TAG: $SHORT_SHA
   _TEMPLATE_NAME: logflare-prod-${_NORMALIZED_IMAGE_TAG}-${_CLUSTER}
   _CONTAINER_IMAGE: gcr.io/logflare-232118/logflare_app:${_IMAGE_TAG}


### PR DESCRIPTION
Adds instance template generation for prod clusters.

Also separates out instance group deployment to a separate file