### PR TITLE
perf: move schema updates to GenServer.cast

### DIFF
--- a/lib/logflare/source/bigquery/schema.ex
+++ b/lib/logflare/source/bigquery/schema.ex
@@ -56,8 +56,6 @@ defmodule Logflare.Source.BigQuery.Schema do
 
     case SourceSchemas.get_source_schema_by(source_id: source.id) do
       nil ->
-        # persist()
-
         Logger.info("Nil schema: #{state.source_token}")
 
         {:noreply, %{state | next_update: next_update()}}
@@ -66,8 +64,6 @@ defmodule Logflare.Source.BigQuery.Schema do
         schema = BigQuery.SchemaUtils.deep_sort_by_fields_name(source_schema.bigquery_schema)
         type_map = BigQuery.SchemaUtils.to_typemap(schema)
         field_count = count_fields(type_map)
-
-        # persist()
 
         {:noreply,
          %{
@@ -89,15 +85,14 @@ defmodule Logflare.Source.BigQuery.Schema do
   end
 
   def get_state(source_token) when is_atom(source_token) do
-    with {:ok, pid} <- Source.Supervisor.lookup(__MODULE__, source_token) do
-      GenServer.call(pid, :get)
-    end
+    Source.Supervisor.via(__MODULE__, source_token)
+    |> GenServer.call(:get)
   end
 
+  @spec update(atom(), LogEvent.t()) :: :ok
   def update(source_token, %LogEvent{} = log_event) when is_atom(source_token) do
-    with {:ok, pid} <- Source.Supervisor.lookup(__MODULE__, source_token) do
-      GenServer.call(pid, {:update, log_event}, @timeout)
-    end
+    Source.Supervisor.via(__MODULE__, source_token)
+    |> GenServer.cast({:update, log_event})
   end
 
   # For tests
@@ -107,28 +102,16 @@ defmodule Logflare.Source.BigQuery.Schema do
     end
   end
 
-  # @spec update_cluster(atom(), map(), map(), non_neg_integer()) :: atom
-  # def update_cluster(source_token, schema, type_map, field_count) when is_atom(source_token) do
-  #  GenServer.abcast(
-  #    Node.list(),
-  #    pid(source_token),
-  #    {:update, schema, type_map, field_count}
-  #  )
-  # end
+  def handle_call(:get, _from, state), do: {:reply, state, state}
 
-  def handle_call(:get, _from, state) do
-    {:reply, state, state}
-  end
-
-  def handle_call(
+  def handle_cast(
         {:update, %LogEvent{}},
-        _from,
         %{field_count: fc, field_count_limit: limit} = state
       )
       when fc > limit,
       do: {:reply, :ok, state}
 
-  def handle_call({:update, %LogEvent{body: body, id: event_id}}, _from, state) do
+  def handle_cast({:update, %LogEvent{body: body, id: event_id}}, state) do
     LogflareLogger.context(source_id: state.source_token, log_event_id: event_id)
 
     schema = try_schema_update(body, state.schema)
@@ -145,15 +128,13 @@ defmodule Logflare.Source.BigQuery.Schema do
           type_map = BigQuery.SchemaUtils.to_typemap(schema)
           field_count = count_fields(type_map)
 
-          # update_cluster(state.source_token, schema, type_map, field_count)
-
           Logger.info("Source schema updated from log_event!")
 
           persist()
 
           notify_maybe(state.source_token, schema, state.schema)
 
-          {:reply, {:ok, :updated},
+          {:noreply,
            %{
              state
              | schema: schema,
@@ -179,13 +160,11 @@ defmodule Logflare.Source.BigQuery.Schema do
                       type_map = BigQuery.SchemaUtils.to_typemap(schema)
                       field_count = count_fields(type_map)
 
-                      # update_cluster(state.source_token, schema, type_map, field_count)
-
                       Logger.info("Source schema updated from BigQuery!")
 
                       persist()
 
-                      {:reply, {:ok, :updated},
+                      {:noreply,
                        %{
                          state
                          | schema: schema,
@@ -199,7 +178,7 @@ defmodule Logflare.Source.BigQuery.Schema do
                         tesla_response: BigQuery.GenUtils.get_tesla_error_message(response)
                       )
 
-                      {:reply, :error, %{state | next_update: next_update()}}
+                      {:noreply, %{state | next_update: next_update()}}
                   end
 
                 {:error, response} ->
@@ -207,7 +186,7 @@ defmodule Logflare.Source.BigQuery.Schema do
                     tesla_response: BigQuery.GenUtils.get_tesla_error_message(response)
                   )
 
-                  {:reply, :error, %{state | next_update: next_update()}}
+                  {:noreply, %{state | next_update: next_update()}}
               end
 
             message ->
@@ -215,42 +194,12 @@ defmodule Logflare.Source.BigQuery.Schema do
                 tesla_response: message
               )
 
-              {:reply, :error, %{state | next_update: next_update()}}
+              {:noreply, %{state | next_update: next_update()}}
           end
       end
     else
-      {:reply, {:ok, :noop}, state}
+      {:noreply, state}
     end
-  end
-
-  def handle_call({:update, schema}, _from, state) do
-    sorted = BigQuery.SchemaUtils.deep_sort_by_fields_name(schema)
-    type_map = BigQuery.SchemaUtils.to_typemap(sorted)
-    field_count = count_fields(type_map)
-
-    persist()
-
-    {:reply, :ok,
-     %{
-       state
-       | schema: sorted,
-         type_map: type_map,
-         field_count: field_count,
-         next_update: next_update()
-     }}
-  end
-
-  def handle_cast({:update, schema, type_map, field_count}, state) do
-    send(self(), :persist)
-
-    {:noreply,
-     %{
-       state
-       | schema: schema,
-         type_map: type_map,
-         field_count: field_count,
-         next_update: next_update()
-     }}
   end
 
   def handle_info(:persist, state) do
@@ -261,8 +210,6 @@ defmodule Logflare.Source.BigQuery.Schema do
       bigquery_schema: state.schema,
       schema_flat_map: flat_map
     })
-
-    # persist()
 
     {:noreply, state}
   end

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -64,12 +64,12 @@ defmodule Logflare.Source.BigQuery.SchemaTest do
 
     # trigger an update
     le = build(:log_event, source: source, metadata: %{"test" => 123})
-    assert {:ok, :updated} = Schema.update(source.token, le)
+    assert :ok = Schema.update(source.token, le)
     %{next_update: updated_ts} = Schema.get_state(source.token)
     assert updated_ts != initial_ts
     # try to update again with different le
     le = build(:log_event, source: source, metadata: %{"change" => 123})
-    assert {:ok, :noop} = Schema.update(source.token, le)
+    assert :ok = Schema.update(source.token, le)
     %{next_update: unchanged_ts} = Schema.get_state(source.token)
     assert unchanged_ts == updated_ts
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,6 +96,14 @@ defmodule Logflare.Factory do
     {source, params} = Map.pop(attrs, :source, build(:source))
 
     params =
+      for {k, v} <- params, into: %{} do
+        case k do
+          k when is_atom(k) -> {Atom.to_string(k), v}
+          _ -> {k, v}
+        end
+      end
+
+    params =
       Map.merge(
         params,
         %{


### PR DESCRIPTION
makes Schema update requests async, and removes a lot of dead or unnecessary code.