### PR TITLE
perf: increase broadway process concurrency

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -36,7 +36,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
             default: [concurrency: System.schedulers_online() * 2]
           ],
           batchers: [
-            bq: [concurrency: System.schedulers_online() * 2, batch_size: 250, batch_timeout: 1_500]
+            bq: [
+              concurrency: System.schedulers_online() * 2,
+              batch_size: 250,
+              batch_timeout: 1_500
+            ]
           ],
           context: rls
         ],

--- a/mix.exs
+++ b/mix.exs
@@ -200,6 +200,7 @@ defmodule Logflare.Mixfile do
 
       # benchmarking
       {:benchee, "~> 1.0", only: [:dev, :test]},
+      {:benchee_async, "~> 0.1.0", only: [:dev, :test]},
       # Filesystem fix to respect `CFLAGS` and `LDFLAGS`
       # https://github.com/falood/file_system/pull/87
       #

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -3,43 +3,233 @@ defmodule Logflare.BigQuery.PipelineTest do
   alias Logflare.Source.BigQuery.Pipeline
   alias Logflare.{LogEvent}
   alias GoogleApi.BigQuery.V2.Model.TableDataInsertAllRequestRows
+  alias Logflare.Source.RecentLogsServer, as: RLS
   use Logflare.DataCase
 
-  setup do
-    user = insert(:user)
-    source = insert(:source, user_id: user.id)
-    {:ok, source: source}
+  @pipeline_name :test_pipeline
+  describe "pipeline" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+      {:ok, source: source}
+    end
+
+    test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{
+      source: source
+    } do
+      datetime = DateTime.utc_now()
+
+      le =
+        LogEvent.make(
+          %{
+            "event_message" => "valid",
+            "top_level" => "top",
+            "project" => "my-project",
+            "metadata" => %{"a" => "nested"},
+            "timestamp" => datetime |> DateTime.to_unix(:microsecond)
+          },
+          %{source: source}
+        )
+
+      id = le.id
+
+      assert %TableDataInsertAllRequestRows{
+               insertId: ^id,
+               json: %{
+                 "event_message" => "valid",
+                 "top_level" => "top",
+                 "timestamp" => ^datetime,
+                 "metadata" => [%{"a" => "nested"}],
+                 "id" => ^id,
+                 "project" => "my-project"
+               }
+             } = Pipeline.le_to_bq_row(le)
+    end
   end
 
-  test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{
-    source: source
-  } do
-    datetime = DateTime.utc_now()
+  describe "benchmarks" do
+    setup do
+      start_supervised!(BencheeAsync.Reporter)
 
-    le =
-      LogEvent.make(
-        %{
-          "event_message" => "valid",
-          "top_level" => "top",
-          "project" => "my-project",
-          "metadata" => %{"a" => "nested"},
-          "timestamp" => datetime |> DateTime.to_unix(:microsecond)
-        },
-        %{source: source}
+      GoogleApi.BigQuery.V2.Api.Tabledata
+      |> stub(:bigquery_tabledata_insert_all, fn _conn,
+                                                 _project_id,
+                                                 _dataset_id,
+                                                 _table_name,
+                                                 _opts ->
+        BencheeAsync.Reporter.record()
+        # simulate some latency
+        # :timer.sleep(100)
+        {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      stub(Goth, :fetch, fn _mod -> {:ok, %Goth.Token{token: "auth-token"}} end)
+
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+      rls = %RLS{source_id: source.token, source: source}
+      le = build(:log_event, source: source)
+
+      batch =
+        for _i <- 1..250 do
+          %Broadway.Message{
+            data: le,
+            acknowledger: {__MODULE__, :ack_id, :ack_data}
+          }
+        end
+
+      [batch: batch, rls: rls]
+    end
+
+    @tag :benchmark
+    test "defaults", %{test: name, rls: rls, batch: batch} do
+      start_supervised!({Pipeline, [rls, name: @pipeline_name]})
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online", %{test: name, rls: rls, batch: batch} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online()]]
+         ]}
       )
 
-    id = le.id
+      run_pipeline_benchmark(name, batch)
+    end
 
-    assert %TableDataInsertAllRequestRows{
-             insertId: ^id,
-             json: %{
-               "event_message" => "valid",
-               "top_level" => "top",
-               "timestamp" => ^datetime,
-               "metadata" => [%{"a" => "nested"}],
-               "id" => ^id,
-               "project" => "my-project"
-             }
-           } = Pipeline.le_to_bq_row(le)
+    @tag :benchmark
+    @tag :skip
+    test "schedulers_online, max_demand=250", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online(), max_demand: 250]]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online x2", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online() * 2]]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online, batchers schedulers x2", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online()]],
+           batchers: [
+             bq: [
+               concurrency: System.schedulers_online() * 2,
+               batch_size: 250,
+               batch_timeout: 1_500
+             ]
+           ]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online x2, batchers schedulers x2", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online() * 2]],
+           batchers: [
+             bq: [
+               concurrency: System.schedulers_online() * 2,
+               batch_size: 250,
+               batch_timeout: 1_500
+             ]
+           ]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online x2, batchers schedulers x3", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online() * 2]],
+           batchers: [
+             bq: [
+               concurrency: System.schedulers_online() * 3,
+               batch_size: 250,
+               batch_timeout: 1_500
+             ]
+           ]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+
+    @tag :benchmark
+    test "schedulers_online x3, batchers schedulers x3", %{rls: rls, batch: batch, test: name} do
+      start_supervised!(
+        {Pipeline,
+         [
+           rls,
+           name: @pipeline_name,
+           processors: [default: [concurrency: System.schedulers_online() * 3]],
+           batchers: [
+             bq: [
+               concurrency: System.schedulers_online() * 3,
+               batch_size: 250,
+               batch_timeout: 1_500
+             ]
+           ]
+         ]}
+      )
+
+      run_pipeline_benchmark(name, batch)
+    end
+  end
+
+  defp run_pipeline_benchmark(name, batch) do
+    BencheeAsync.run(
+      %{
+        inspect(name) => fn ->
+          Broadway.push_messages(@pipeline_name, batch)
+        end
+      },
+      time: 3,
+      warmup: 1,
+      print: [configuration: false],
+      # use extended_statistics to view units of work done
+      formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
+    )
+  end
+
+  def ack(_ack_ref, _successful, _failed) do
   end
 end


### PR DESCRIPTION
This PR focuses on optimization tuning of broadway for v1 ingest


Using BencheeAsync, the number to look at is **sample size.**

From benchmarks, the optimal config in perfect world conditions with no latency is x2 scheduler count for both processors and batchers.

Once we introduce latency in the bigquery insert, the max throughput then scales linearly with the batcher count. Hence, using `System.schedulers_online() * 3` and x4 and so on will correspondingly increase the overall max throughput.

```
Name                                                                   minimum        maximum    sample size                     mode
:"test benchmarks defaults"                                          0.0830 μs      788.21 μs         1.25 K                 0.125 μs

Name                                                                 minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online, batchers schedulers x2"       0.0420 μs     3056.92 μs         4.70 K                  0.38 μs

Name                                                                    minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online x2, batchers schedulers x3"       0.0830 μs      707.67 μs         5.88 K                 0.167 μs

Name                                                               minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online"                                0.0420 μs     4949.71 μs         4.85 K                  0.25 μs

Name                                                                    minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online x2, batchers schedulers x2"       0.0410 μs      946.54 μs         5.87 K                  0.25 μs

Name                                                                     minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online x2"                                0.0420 μs     1137.29 μs         5.84 K                  0.25 μs

Name                                                                    minimum        maximum    sample size                     mode
:"test benchmarks schedulers_online x3, batchers schedulers x3"       0.0830 μs      802.08 μs         5.59 K                 0.25 μs
```