### PR TITLE
fix: cut down broadway context size

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -17,7 +17,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
     context = %{
       source_token: source_backend.source.token,
       bigquery_project_id: source_backend.source.user.bigquery_project_id,
-      bigquery_dataset_id: source_backend.source.user.bigquery_dataset_id,
+      bigquery_dataset_id: source_backend.source.user.bigquery_dataset_id
     }
 
     _ = Enum.map(events, &Pipeline.process_data(&1.data))

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @moduledoc false
 
   alias Logflare.Source.BigQuery.Pipeline
-  alias Logflare.Source.RecentLogsServer, as: RLS
 
   @behaviour Logflare.Backends.Adaptor
 
@@ -15,16 +14,15 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   def ingest(pid, events) do
     source_backend = Agent.get(pid, fn state -> state end)
 
-    rls = %RLS{
-      source_id: source_backend.source.token,
+    context = %{
+      source_token: source_backend.source.token,
       bigquery_project_id: source_backend.source.user.bigquery_project_id,
       bigquery_dataset_id: source_backend.source.user.bigquery_dataset_id,
-      source: source_backend.source
     }
 
     _ = Enum.map(events, &Pipeline.process_data(&1.data))
 
-    Pipeline.stream_batch(rls, events)
+    Pipeline.stream_batch(context, events)
   end
 
   @impl Logflare.Backends.Adaptor

--- a/lib/logflare/google/bigquery/bigquery.ex
+++ b/lib/logflare/google/bigquery/bigquery.ex
@@ -24,7 +24,6 @@ defmodule Logflare.Google.BigQuery do
   alias Logflare.Billing.Plan
   alias Logflare.TeamUsers
   alias Logflare.Source.BigQuery.SchemaBuilder
-  alias Logflare.Source.RecentLogsServer, as: RLS
 
   @type ok_err_tup :: {:ok, term} | {:error, term}
 

--- a/lib/logflare/google/bigquery/bigquery.ex
+++ b/lib/logflare/google/bigquery/bigquery.ex
@@ -181,17 +181,25 @@ defmodule Logflare.Google.BigQuery do
     |> GenUtils.maybe_parse_google_api_result()
   end
 
+  # TODO: kept for backward compat with RLS, to remove once all rls.source_id references are removed
+  def stream_batch!(%{source_id: token} = config, batch) do
+    config
+    |> Map.take([:bigquery_project_id, :bigquery_dataset_id])
+    |> Map.put(:source_token, token)
+    |> stream_batch!(batch)
+  end
+
   def stream_batch!(
-        %RLS{
+        %{
           bigquery_project_id: project_id,
           bigquery_dataset_id: dataset_id,
-          source_id: source_id
+          source_token: source_token
         },
         batch
       )
-      when is_atom(source_id) do
+      when is_atom(source_token) do
     conn = GenUtils.get_conn(:ingest)
-    table_name = GenUtils.format_table_name(source_id)
+    table_name = GenUtils.format_table_name(source_token)
 
     body = %Model.TableDataInsertAllRequest{
       ignoreUnknownValues: true,

--- a/lib/logflare/source/bigquery/buffer_producer.ex
+++ b/lib/logflare/source/bigquery/buffer_producer.ex
@@ -7,11 +7,13 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
   alias Logflare.Source.BigQuery.BufferCounter
 
   @impl true
-  def init(%{source_id: source_id}) when is_atom(source_id) do
+  def init(%{source_id: token}), do: init(%{source_token: token})
+
+  def init(%{source_token: source_token}) when is_atom(source_token) do
     {:producer,
      %{
        demand: 0,
-       source_id: source_id
+       source_token: source_token
      }, buffer_size: 10_000}
   end
 
@@ -31,14 +33,14 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
   end
 
   @spec ack(atom(), [Broadway.Message.t()], [Broadway.Message.t()]) :: :ok
-  def ack(source_id, successful, unsuccessful) when is_atom(source_id) do
-    BufferCounter.ack_batch(source_id, successful ++ unsuccessful)
+  def ack(source_token, successful, unsuccessful) when is_atom(source_token) do
+    BufferCounter.ack_batch(source_token, successful ++ unsuccessful)
 
     :ok
   end
 
   defp handle_receive_messages(
-         %{source_id: _source_id, receive_timer: nil, demand: demand} = state
+         %{source_token: _source_token, receive_timer: nil, demand: demand} = state
        )
        when demand > 0 do
     # would normall pop log events from a buffer here

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -29,7 +29,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         [
           name: name(source.token),
           producer: [
-            module: {BufferProducer, rls},
+            module: {BufferProducer, %{source_token: rls.source_id}},
             hibernate_after: 30_000
           ],
           processors: [

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -42,7 +42,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
               batch_timeout: 1_500
             ]
           ],
-          context: rls
+          context: %{
+            bigquery_project_id: rls.bigquery_project_id,
+            bigquery_dataset_id: rls.bigquery_dataset_id,
+            source_token: rls.source_id
+          }
         ],
         opts
       )
@@ -54,20 +58,20 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   end
 
   @spec handle_message(any, Broadway.Message.t(), any) :: Broadway.Message.t()
-  def handle_message(_processor_name, message, rls) do
-    Logger.metadata(source_id: rls.source_id, source_token: rls.source_id)
+  def handle_message(_processor_name, message, context) do
+    Logger.metadata(source_id: context.source_token, source_token: context.source_token)
 
     message
     |> Message.update_data(&process_data/1)
     |> Message.put_batcher(:bq)
   end
 
-  def handle_batch(:bq, messages, batch_info, %RLS{source: source} = context) do
+  def handle_batch(:bq, messages, batch_info, %{source_token: token} = context) do
     :telemetry.execute(
       [:logflare, :ingest, :pipeline, :handle_batch],
       %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
       %{
-        source_token: source.token
+        source_token: token
       }
     )
 
@@ -100,8 +104,8 @@ defmodule Logflare.Source.BigQuery.Pipeline do
     }
   end
 
-  def stream_batch(%RLS{source_id: source_id} = context, messages) do
-    Logger.metadata(source_id: source_id)
+  def stream_batch(%{source_token: source_token} = context, messages) do
+    Logger.metadata(source_id: source_token, source_token: source_token)
 
     rows = le_messages_to_bq_rows(messages)
 
@@ -119,11 +123,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
         case GenUtils.get_tesla_error_message(response) do
           "Access Denied: BigQuery BigQuery: Streaming insert is not allowed in the free tier" =
               message ->
-            disconnect_backend_and_email(source_id, message)
+            disconnect_backend_and_email(source_token, message)
 
           "The project" <> _tail = message ->
             # "The project web-wtc-1537199112807 has not enabled BigQuery."
-            disconnect_backend_and_email(source_id, message)
+            disconnect_backend_and_email(source_token, message)
 
           # Don't disconnect here because sometimes the GCP API doesn't find projects
           #


### PR DESCRIPTION
This reduces the broadway pipeline context to the bare minimum needed for ingestion.

With the other memory fixes, this has dropped the per-processor/batcher/producer process memory from 14-15MB to 3.5-7.5MB