### PR TITLE
perf: scale finch pools with schedulers to reduce idle memory consumption

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -262,12 +262,14 @@ defmodule Logflare.Application do
   end
 
   defp finch_pools do
+    # scales per core
+    base = System.schedulers_online()
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: 200]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: 100]}},
+      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
+      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
       {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: 50]}}
+      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
     ]
   end
 

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -264,12 +264,16 @@ defmodule Logflare.Application do
   defp finch_pools do
     # scales per core
     base = System.schedulers_online()
+
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
+      {Finch,
+       name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
+      {Finch,
+       name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
       {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
+      {Finch,
+       name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
     ]
   end
 


### PR DESCRIPTION
This scales the finch pools dynamically based on available schedulers, to reduce idle memory usage.

On dev with 10 cores, process memory dropped from ~500MB to ~130MB. The connection pools only need to scale based on ingest volume, which is correspondingly limited by the scheduler count. 

This should not result in much difference on production, however it means that the connection pools will increase when we beef up servers in the future.

This change will impact self-hosters and supabase cli users the most, as it will drop idle memory consumption for smaller/local setups.