### PR TITLE
perf: v1 pipeline - hibernate _after pipeline opt, fullsweep_after spawn_opt

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -262,12 +262,14 @@ defmodule Logflare.Application do
   end
 
   defp finch_pools do
+    # scales per core
+    base = System.schedulers_online()
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: 200]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: 100]}},
+      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
+      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
       {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: 50]}}
+      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
     ]
   end
 

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -264,12 +264,16 @@ defmodule Logflare.Application do
   defp finch_pools do
     # scales per core
     base = System.schedulers_online()
+
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
-      {Finch, name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
+      {Finch,
+       name: Logflare.FinchIngest, pools: %{default: [protocol: :http2, count: max(base * 4, 20)]}},
+      {Finch,
+       name: Logflare.FinchQuery, pools: %{default: [protocol: :http2, count: max(base * 2, 10)]}},
       {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
-      {Finch, name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
+      {Finch,
+       name: Logflare.FinchDefault, pools: %{default: [protocol: :http2, count: max(base, 5)]}}
     ]
   end
 

--- a/lib/logflare/source/bigquery/buffer_producer.ex
+++ b/lib/logflare/source/bigquery/buffer_producer.ex
@@ -27,7 +27,7 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
 
   @impl true
   def handle_info(_, state) do
-    {:noreply, [], state}
+    {:noreply, [], state, :hibernate}
   end
 
   @spec ack(atom(), [Broadway.Message.t()], [Broadway.Message.t()]) :: :ok
@@ -43,11 +43,11 @@ defmodule Logflare.Source.BigQuery.BufferProducer do
        when demand > 0 do
     # would normall pop log events from a buffer here
 
-    {:noreply, [], %{state | demand: 0}}
+    {:noreply, [], %{state | demand: 0}, :hibernate}
   end
 
   defp handle_receive_messages(state) do
-    {:noreply, [], state}
+    {:noreply, [], state, :hibernate}
   end
 
   @impl true

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -28,6 +28,8 @@ defmodule Logflare.Source.BigQuery.Pipeline do
       Keyword.merge(
         [
           name: name(source.token),
+          # top-level will apply to all children
+          hibernate_after: 5_000,
           producer: [
             module: {BufferProducer, rls},
             hibernate_after: 30_000

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -30,9 +30,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
           name: name(source.token),
           # top-level will apply to all children
           hibernate_after: 5_000,
+          spawn_opt: [
+            fullsweep_after: 0
+          ],
           producer: [
-            module: {BufferProducer, rls},
-            hibernate_after: 30_000
+            module: {BufferProducer, rls}
           ],
           processors: [
             default: [concurrency: System.schedulers_online() * 2]


### PR DESCRIPTION
This adds in more aggressive hibernation in the v1 BufferProducer, and adds in spawn_opt `fullsweep_after` for all processors and batchers, such that all binaries are discarded. Since these are long lived processes, we need to trigger GC faster, and as we don't need/store binaries across each pipeline work unit, we can set it to 0 and sacrifice some cpu for triggering GC more frequently.

On dev, these changes (mainly the spawn_opt adjustments) dropped  process memory usage by over half, from ~1.9GB to ~950GB, with local loadfest serving as load testing.

Since we're severly underutilizing our prod cpu capacity, this adjustment should balance the resource usage better.