### PR TITLE
fix: alerts for slack

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -185,7 +185,14 @@ defmodule Logflare.Alerting do
         end
 
         if alert_query.slack_hook_url do
-          SlackAdaptor.send_message(alert_query.slack_hook_url, results)
+          {:ok, res} = SlackAdaptor.send_message(alert_query, results)
+
+          if res.status != 200 do
+            Logger.warning(
+              "SlackAdaptor send_message failed with #{res.status} : #{inspect(res.body)}",
+              error_string: inspect(res)
+            )
+          end
         end
 
         :ok

--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -41,7 +41,7 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
 
     iex> %{blocks: [block]} = to_body([%{"some" => "key"}])
     iex> get_in(block, [:text, :text])
-    ["•some: key"]
+    "• some: key"
 
   """
   @spec to_body([map()]) :: map()
@@ -62,20 +62,20 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
   ### Example
   The text will be prefixed with a bullet point, with a colon separating the key-value pair.
     iex> to_markdown(%{"test"=> "test"})
-    "•test: test"
+    "• test: test"
 
   Keys within the map will be placed in an indentedrow below, sorted by key alphabetically.
   Indentation uses 4 spaces.
     iex> to_markdown(%{a: "test", b: "test"})
-    "•a: test\r    b: test"
+    "• a: test\r    b: test"
 
-  Muliple objects will be converted into lists of strings
+  Muliple objects will be converted into multi-line strings
     iex> to_markdown([%{one: "test"}, %{two: "test"}])
-    ["•one: test", "•two: test"]
+    "• one: test\r• two: test"
 
   """
   @spec to_markdown([map()] | map()) :: [String.t()] | String.t()
-  def to_markdown(rows) when is_list(rows), do: Enum.map(rows, &to_markdown/1) |> Enum.join("\n")
+  def to_markdown(rows) when is_list(rows), do: Enum.map(rows, &to_markdown/1) |> Enum.join("\r")
 
   def to_markdown(%{} = row) do
     bullet = "• "

--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -15,10 +15,8 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
       payload
       |> to_body()
       |> Map.update!(:blocks, fn blocks ->
-        count = Enum.count(payload)
-
         rows_text =
-          case count do
+          case Enum.count(payload) do
             0 -> ""
             1 -> ", 1 row"
             n -> ", #{n} rows"

--- a/lib/logflare/backends/adaptor/slack_adaptor/client.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor/client.ex
@@ -6,7 +6,7 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor.Client do
 
   plug Tesla.Middleware.Retry,
     delay: 500,
-    max_retries: 10,
+    max_retries: 3,
     max_delay: 4_000,
     should_retry: fn
       {:ok, %{status: status}} when status in 400..599 -> true
@@ -17,6 +17,6 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor.Client do
   plug Tesla.Middleware.JSON
 
   def send(url, %{blocks: _} = body) when is_binary(url) do
-    request(method: "post", url: url, body: body)
+    post(url, body)
   end
 end

--- a/lib/logflare_web/live/alerts/actions/show.html.heex
+++ b/lib/logflare_web/live/alerts/actions/show.html.heex
@@ -48,7 +48,7 @@
               </button>
             </div>
           <% else %>
-            <a href={"https://slack.com/oauth/v2/authorize?client_id=#{Application.get_env(:ueberauth, Ueberauth.Strategy.SlackV2.OAuth)[:client_id]}&scope=incoming-webhook&install_redirect=update-to-granular-scopes&redirect_uri=#{url(~p"/auth/slack/callback")}&state=#{Jason.encode!(%{"action" => "save_hook_url", "alert_query" => @alert})}"}>
+            <a href={"https://slack.com/oauth/v2/authorize?client_id=#{Application.get_env(:ueberauth, Ueberauth.Strategy.SlackV2.OAuth)[:client_id]}&scope=incoming-webhook&install_redirect=update-to-granular-scopes&redirect_uri=#{url(~p"/auth/slack/callback")}&state=#{Jason.encode!(%{"action" => "save_hook_url", "alert_query_id" => @alert.id})}"}>
               <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           <% end %>

--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -161,10 +161,10 @@ defmodule Logflare.AlertingTest do
       end)
 
       Logflare.Backends.Adaptor.WebhookAdaptor.Client
-      |> expect(:send, fn _url, %{"result" => _} = _body -> :ok end)
+      |> expect(:send, fn _url, %{"result" => _} = _body -> {:ok, %Tesla.Env{}} end)
 
       Logflare.Backends.Adaptor.SlackAdaptor.Client
-      |> expect(:send, fn _url, %{blocks: _} = _records -> :ok end)
+      |> expect(:send, fn _url, %{blocks: _} = _records -> {:ok, %Tesla.Env{}} end)
 
       assert :ok = Alerting.run_alert(alert_query)
     end

--- a/test/logflare_web/live_views/alerts_live_test.exs
+++ b/test/logflare_web/live_views/alerts_live_test.exs
@@ -161,10 +161,10 @@ defmodule LogflareWeb.AlertsLiveTest do
       |> stub(:fetch, fn _mod -> {:ok, %Goth.Token{token: "auth-token"}} end)
 
       WebhookAdaptor.Client
-      |> stub(:send, fn _, _ -> %Tesla.Env{} end)
+      |> stub(:send, fn _, _ -> {:ok, %Tesla.Env{}} end)
 
       SlackAdaptor.Client
-      |> stub(:send, fn _, _ -> %Tesla.Env{} end)
+      |> stub(:send, fn _, _ -> {:ok, %Tesla.Env{}} end)
 
       :ok
     end


### PR DESCRIPTION
Fixes for Alerts
- fixes for sending slack alerts
- fixes for oauth2 callback for slack alert webhook integration
- adds alert name to the outbound message