### PR TITLE
fix: alert_queries should use text column types

### DIFF
--- a/priv/repo/migrations/20240219101411_alter_alert_queries_table_text_field.exs
+++ b/priv/repo/migrations/20240219101411_alter_alert_queries_table_text_field.exs
@@ -1,0 +1,10 @@
+defmodule Logflare.Repo.Migrations.AlterAlertQueriesTableTextField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:alert_queries) do
+      modify :query, :text, from: :string
+      modify :description, :text, from: :string
+    end
+  end
+end


### PR DESCRIPTION
Fixes a typing error for the `:query` and `:description` column, where queries cannot be saved if they are beyond 255 characters. 