### PR TITLE
fix: bq pipeline max length

### DIFF
--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -106,7 +106,7 @@ defmodule Logflare.Google.BigQuery.GenUtils do
   # copy over runtime adapter building from Tesla.client/2
   # https://github.com/elixir-tesla/tesla/blob/v1.7.0/lib/tesla/builder.ex#L206
   defp build_tesla_adapter_call(:ingest) do
-    Tesla.client([], {Tesla.Adapter.Finch, name: Logflare.FinchIngest, receive_timeout: 15_000}).adapter
+    Tesla.client([], {Tesla.Adapter.Finch, name: Logflare.FinchIngest, receive_timeout: 5_000}).adapter
   end
 
   defp build_tesla_adapter_call(:query) do


### PR DESCRIPTION
This PR adds in a custom batch_size splitter for handling large log events, and a timeout reduction for ingest to ensure that we catch rate limiting issues earlier.