### PR TITLE
chore: add mailmap to unify emails in log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+Chase Granberry <chase@logflare.app> <chase@logflare.app>
+Chase Granberry <chase@logflare.app> <chase@pagemodified.com>
+Chase Granberry <chase@logflare.app> <chasegranberry@Chases-MacBook-Pro.local>
+
+TzeYiing <ty@tzeyiing.com> <Ziinc@users.noreply.github.com>
+
+Łukasz Niemier <lukasz@niemier.pl> <lukasz@niemier.pl>
+
+Filipe Cabaço <filipe@supabase.io> <filipe@supabase.io>
+
+ontofractal <v@ontofractal.com> <ontofractal@protonmail.com>
+ontofractal <v@ontofractal.com> <ontofractal@users.noreply.github.com>
+
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> <27856297+dependabot-preview[bot]@users.noreply.github.com>


### PR DESCRIPTION
The idea here is to make `git blame` a little bit tidier and to unify emails in `git shortlog`.