### PR TITLE
fix: backends user_id parsing for team users

### DIFF
--- a/lib/logflare_web/live/backends_live.ex
+++ b/lib/logflare_web/live/backends_live.ex
@@ -117,7 +117,7 @@ defmodule LogflareWeb.BackendsLive do
     """
   end
 
-  def mount(_params, %{"user_id" => user_id} = session, socket) do
+  def mount(_params, %{"user_id" => user_id}, socket) do
     {user_id, _} =
       case user_id do
         v when is_binary(v) -> Integer.parse(v)

--- a/lib/logflare_web/live/backends_live.ex
+++ b/lib/logflare_web/live/backends_live.ex
@@ -3,6 +3,7 @@ defmodule LogflareWeb.BackendsLive do
   use LogflareWeb, :live_view
   require Logger
   alias Logflare.Backends
+  alias Logflare.Users
 
   def render(assigns) do
     ~H"""
@@ -116,9 +117,15 @@ defmodule LogflareWeb.BackendsLive do
     """
   end
 
-  def mount(_params, %{"user_id" => user_id}, socket) do
-    backends = Logflare.Backends.list_backends_by_user_id(user_id)
-    user = Logflare.Users.get(user_id)
+  def mount(_params, %{"user_id" => user_id} = session, socket) do
+    {user_id, _} =
+      case user_id do
+        v when is_binary(v) -> Integer.parse(v)
+        _ -> {user_id, nil}
+      end
+
+    backends = Backends.list_backends_by_user_id(user_id)
+    user = Users.get(user_id)
 
     socket =
       socket

--- a/test/logflare_web/live/backends_live_test.exs
+++ b/test/logflare_web/live/backends_live_test.exs
@@ -12,6 +12,13 @@ defmodule LogflareWeb.BackendsLiveTest do
     [conn: conn, source: source, user: user]
   end
 
+  test "bug: string user_id on session", %{conn: conn, user: user} do
+    conn = put_session(conn, :user_id, inspect(user.id))
+    assert {:ok, _view, _html} = live(conn, ~p"/backends")
+
+  end
+
+
   test "create/delete", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/backends")
 

--- a/test/logflare_web/live/backends_live_test.exs
+++ b/test/logflare_web/live/backends_live_test.exs
@@ -12,7 +12,7 @@ defmodule LogflareWeb.BackendsLiveTest do
     [conn: conn, source: source, user: user]
   end
 
-  test "bug: string user_id on session", %{conn: conn, user: user} do
+  test "bug: string user_id on session for team users", %{conn: conn, user: user} do
     conn = put_session(conn, :user_id, inspect(user.id))
     assert {:ok, _view, _html} = live(conn, ~p"/backends")
 


### PR DESCRIPTION
fix for situation where user_id is stored in session as string when it is a team user