### PR TITLE
fix: alerts duplication bug, LOGFLARE_ALERTS_MIN_CLUSTER_SIZE

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=5
+      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=4
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring

--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER}
+      - --container-env=LOGFLARE_GRPC_PORT=4001,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=5
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,8 @@ config :logflare,
   # normal instances can be more than 90 seconds
   sigterm_shutdown_grace_period_ms: 15_000
 
+config :logflare, Logflare.Alerting, min_cluster_size: 1, enabled: true
+
 config :logflare, Logflare.Google, dataset_id_append: "_default"
 
 # Configures the endpoint

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,6 +28,18 @@ config :logflare,
        |> filter_nil_kv_pairs.()
 
 config :logflare,
+       Logflare.Alerting,
+       [
+         min_cluster_size:
+           if(System.get_env("LOGFLARE_ALERTS_MIN_CLUSTER_SIZE") != nil,
+             do: String.to_integer(System.get_env("LOGFLARE_ALERTS_MIN_CLUSTER_SIZE")),
+             else: nil
+           ),
+         enabled: System.get_env("LOGFLARE_ALERTS_ENABLED", "true") == "true"
+       ]
+       |> filter_nil_kv_pairs.()
+
+config :logflare,
        LogflareWeb.Endpoint,
        filter_nil_kv_pairs.(
          http: filter_nil_kv_pairs.(port: System.get_env("PHX_HTTP_PORT")),

--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -30,6 +30,8 @@ All browser authentication will be disabled when in single-tenant mode.
 | `LOGFLARE_NODE_HOST`               | string, defaults to `127.0.0.1`                                  | Sets node host on startup, which affects the node name `logflare@<host>`                                                                                         |
 | `LOGFLARE_LOGGER_METADATA_CLUSTER` | string, defaults to `nil`                                        | Sets global logging metadata for the cluster name. Useful for filtering logs by cluster name.                                                                    |
 | `LOGFLARE_PUBSUB_POOL_SIZE`        | Integer, defaults to `10`                                        | Sets the number of `Phoenix.PubSub.PG2` partitions to be created. Should be configured to the number of cores of your server for optimal multi-node performance. |
+| `LOGFLARE_ALERTS_ENABLED`          | Boolean, defaults to `true`                                      | Flag for enabling and disabling query alerts.                                                                                                                    |
+| `LOGFLARE_ALERTS_MIN_CLUSTER_SIZE` | Integer, defaults to `1`                                         | Sets the required cluster size for Query Alerts to be run. If cluster size is below the provided value, query alerts will not run.                               |
 
 ### BigQuery Backend Configuration
 

--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -178,17 +178,20 @@ defmodule Logflare.Alerting do
   def run_alert(%AlertQuery{} = alert_query, :scheduled) do
     # perform pre-run checks
     cfg = Application.get_env(:logflare, Logflare.Alerting)
+
     cond do
       cfg[:enabled] == false ->
         {:error, :not_enabled}
+
       cfg[:min_cluster_size] > Cluster.Utils.actual_cluster_size() ->
         {:error, :below_min_cluster_size}
+
       true ->
         run_alert(alert_query)
-      end
-
+    end
   end
-    def run_alert(%AlertQuery{} = alert_query) do
+
+  def run_alert(%AlertQuery{} = alert_query) do
     alert_query = alert_query |> Repo.preload([:user])
 
     case execute_alert_query(alert_query) do

--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -12,6 +12,7 @@ defmodule Logflare.Alerting do
   alias Logflare.Alerting.AlertQuery
   alias Logflare.User
   alias Logflare.Endpoints
+  alias Logflare.Cluster
 
   @doc """
   Returns the list of alert_queries.
@@ -144,7 +145,7 @@ defmodule Logflare.Alerting do
       id: alert_query.id,
       schedule: alert_query.cron,
       extended_syntax: false,
-      task: {__MODULE__, :run_alert, [alert_query]}
+      task: {__MODULE__, :run_alert, [alert_query, :scheduled]}
     })
 
     {:ok, get_alert_job(alert_query)}
@@ -172,8 +173,22 @@ defmodule Logflare.Alerting do
 
   Send notifications if necessary configurations are set. If no results are returned from the query execution, no alert is sent.
   """
+  @spec run_alert(AlertQuery.t(), :scheduled) :: :ok
   @spec run_alert(AlertQuery.t()) :: :ok
-  def run_alert(%AlertQuery{} = alert_query) do
+  def run_alert(%AlertQuery{} = alert_query, :scheduled) do
+    # perform pre-run checks
+    cfg = Application.get_env(:logflare, Logflare.Alerting)
+    cond do
+      cfg[:enabled] == false ->
+        {:error, :not_enabled}
+      cfg[:min_cluster_size] > Cluster.Utils.actual_cluster_size() ->
+        {:error, :below_min_cluster_size}
+      true ->
+        run_alert(alert_query)
+      end
+
+  end
+    def run_alert(%AlertQuery{} = alert_query) do
     alert_query = alert_query |> Repo.preload([:user])
 
     case execute_alert_query(alert_query) do


### PR DESCRIPTION
This adds in two env vars, `LOGFLARE_ALERTS_MIN_CLUSTER_SIZE` and `LOGFLARE_ALERTS_ENABLED`.

If current cluster size is below the min, then alerts will not send. Alerts can also be disabled cluster-wide as well.