### PR TITLE
fix: show recent logs should not require metadata key to display event body

### DIFF
--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -30,14 +30,12 @@
         <%= log.body["timestamp"] %>
       </mark>
       <%= log.body["event_message"] %>
-      <%= if not is_nil(log.body["metadata"]) and map_size(log.body["metadata"]) > 0 do %>
-        <a class="metadata-link" data-toggle="collapse" href="#metadata-<%= inx %>" aria-expanded="false">
-          event body
-        </a>
-        <div class="collapse metadata" id="metadata-<%= inx %>">
-          <pre class="pre-metadata"><code><%= JSON.encode!(log.body, pretty: true) %></code></pre>
-        </div>
-      <% end %>
+      <a class="metadata-link" data-toggle="collapse" href="#metadata-<%= inx %>" aria-expanded="false">
+        event body
+      </a>
+      <div class="collapse metadata" id="metadata-<%= inx %>">
+        <pre class="pre-metadata"><code><%= JSON.encode!(log.body, pretty: true) %></code></pre>
+      </div>
       <%= if log.via_rule do %>
         <span
             data-toggle="tooltip" data-placement="top" title="Matching <%= log.via_rule.lql_string %> routing from <%= log.origin_source_id %>" style="color: ##5eeb8f;">

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -14,6 +14,7 @@ defmodule LogflareWeb.SourceControllerTest do
   alias Logflare.SavedSearches
   alias Logflare.Logs.RejectedLogEvents
   alias Logflare.SingleTenant
+  alias Logflare.Source.RecentLogsServer
 
   setup do
 
@@ -79,6 +80,19 @@ defmodule LogflareWeb.SourceControllerTest do
       assert html =~ "scroll down"
       # search
       assert html =~ "Search"
+    end
+
+    test "show source's recent logs", %{conn: conn, source: source} do
+      start_supervised!({RecentLogsServer, %RecentLogsServer{source_id: source.token}})
+      le = build(:log_event, source: source)
+      :ok = RecentLogsServer.push(source.token, le)
+      html =
+        conn
+        |> get(Routes.source_path(conn, :show, source))
+        |> html_response(200)
+
+      assert html =~ le.body["event_message"]
+      assert html =~ "event body"
     end
 
     test "invalid source", %{conn: conn, source: source} do


### PR DESCRIPTION
This PR fixes a bug where if no `metadata` key is set, the show recent logs page will not display the `event body` toggle, making it hard to see the received payloads