### PR TITLE
feat: add/remove of source backends, secrets redaction

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -87,7 +87,6 @@ defmodule Logflare.Backends do
 
   @doc """
   Updates the backends of a source wholly. Does not work on partial data, all backends must be provided.
-
   """
   @spec update_source_backends(Source.t(), [Backend.t()]) ::
           {:ok, Source.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -85,6 +85,10 @@ defmodule Logflare.Backends do
     end
   end
 
+  @doc """
+  Updates the backends of a source wholly. Does not work on partial data, all backends must be provided.
+
+  """
   @spec update_source_backends(Source.t(), [Backend.t()]) ::
           {:ok, Source.t()} | {:error, Ecto.Changeset.t()}
   def update_source_backends(%Source{} = source, backends) do

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -49,7 +49,9 @@ defmodule Logflare.Backends.Backend do
         ])
         |> Map.update(:config, %{}, fn
           config when type == :postgres ->
-            Map.put(config, :url, "redacted")
+            url = Map.get(config, :url) || Map.get(config, "url")
+            updated = String.replace(url, ~r/(.+):.+\@/, "\\g{1}:REDACTED@")
+            Map.put(config, :url, updated)
 
           cfg ->
             cfg

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -11,16 +11,6 @@ defmodule Logflare.Backends.Backend do
 
   @adaptor_types [:bigquery, :webhook, :postgres]
 
-  @derive {Jason.Encoder,
-           only: [
-             :name,
-             :token,
-             :description,
-             :type,
-             :id,
-             :config
-           ]}
-
   typed_schema "backends" do
     field(:name, :string)
     field(:description, :string)
@@ -42,4 +32,30 @@ defmodule Logflare.Backends.Backend do
 
   @spec child_spec(Source.t(), Backend.t()) :: map()
   defdelegate child_spec(source, backend), to: Adaptor
+
+  # secrets redacting for json encoding
+  defimpl Jason.Encoder, for: __MODULE__ do
+    def encode(value, opts) do
+      type = value.type
+
+      values =
+        Map.take(value, [
+          :name,
+          :token,
+          :description,
+          :type,
+          :id,
+          :config
+        ])
+        |> Map.update(:config, %{}, fn
+          config when type == :postgres ->
+            Map.put(config, :url, "redacted")
+
+          cfg ->
+            cfg
+        end)
+
+      Jason.Encode.map(values, opts)
+    end
+  end
 end

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -89,6 +89,20 @@ defmodule Logflare.Sources do
   end
 
   @doc """
+  Retrieves a source by keyword, with `{:error, :not_found}` if not found.
+  """
+  @spec fetch_source_by(keyword()) :: {:ok, Source.t()} | {:error, :not_found}
+  def fetch_source_by(kw) do
+    source = get_by(kw)
+
+    if source do
+      {:ok, source}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  @doc """
   deprecated, use get_source_by_token/1 instead
   """
   @spec get(atom | integer) :: Source.t() | nil
@@ -218,7 +232,7 @@ defmodule Logflare.Sources do
 
   def preload_defaults(source) do
     source
-    |> Repo.preload([:user, :rules])
+    |> Repo.preload([:user, :rules, :backends])
     |> refresh_source_metrics()
     |> put_bq_table_id()
   end

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -25,7 +25,8 @@ defmodule Logflare.Source do
              :has_rejected_events,
              :metrics,
              :notifications,
-             :custom_event_message_keys
+             :custom_event_message_keys,
+             :backends
            ]}
   defp env_dataset_id_append,
     do: Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -3,6 +3,7 @@ defmodule LogflareWeb.Api.SourceController do
   use OpenApiSpex.ControllerSpecs
 
   alias Logflare.Sources
+  alias Logflare.Backends
   alias LogflareWeb.OpenApi.Accepted
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
@@ -35,7 +36,7 @@ defmodule LogflareWeb.Api.SourceController do
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
     with source when not is_nil(source) <- Sources.get_by(token: token, user_id: user.id),
-         [source] <- Sources.preload_for_dashboard([source]) do
+         source <- Sources.preload_defaults(source) do
       json(conn, source)
     end
   end
@@ -51,6 +52,8 @@ defmodule LogflareWeb.Api.SourceController do
 
   def create(%{assigns: %{user: user}} = conn, params) do
     with {:ok, source} <- Sources.create_source(params, user) do
+      source = Sources.preload_defaults(source)
+
       conn
       |> put_status(201)
       |> json(source)
@@ -70,6 +73,8 @@ defmodule LogflareWeb.Api.SourceController do
   def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
     with source when not is_nil(source) <- Sources.get_by(token: token, user_id: user.id),
          {:ok, source} <- Sources.update_source_by_user(source, params) do
+      source = Sources.preload_defaults(source)
+
       conn
       |> put_status(204)
       |> json(source)
@@ -91,6 +96,53 @@ defmodule LogflareWeb.Api.SourceController do
       conn
       |> Plug.Conn.send_resp(204, [])
       |> Plug.Conn.halt()
+    end
+  end
+
+  operation(:add_backend,
+    summary: "Add source backend",
+    parameters: [
+      source_token: [in: :path, description: "Source Token", type: :string],
+      backend_token: [in: :path, description: "Backend Token", type: :string]
+    ],
+    request_body: nil,
+    responses: %{
+      201 => Source.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def add_backend(conn, %{"source_token" => token, "backend_token" => backend_token}) do
+    with {:ok, backend} <- Backends.fetch_backend_by(token: backend_token),
+         {:ok, source} <- Sources.fetch_source_by(token: token),
+         source <- Sources.preload_backends(source),
+         {:ok, source} <- Backends.update_source_backends(source, [backend | source.backends]) do
+      conn
+      |> put_status(201)
+      |> json(source)
+    end
+  end
+
+  operation(:removebackend,
+    summary: "Remove source backend",
+    parameters: [
+      source_token: [in: :path, description: "Source Token", type: :string],
+      backend_token: [in: :path, description: "Backend Token", type: :string]
+    ],
+    responses: %{
+      200 => Source.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def remove_backend(conn, %{"source_token" => token, "backend_token" => backend_token}) do
+    with {:ok, source} <- Sources.fetch_source_by(token: token),
+         source <- Sources.preload_backends(source),
+         filtered <- Enum.filter(source.backends, &(&1.token != backend_token)),
+         {:ok, source} <- Backends.update_source_backends(source, filtered) do
+      conn
+      |> put_status(200)
+      |> json(source)
     end
   end
 end

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -36,7 +36,7 @@ defmodule LogflareWeb.Api.SourceController do
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
     with source when not is_nil(source) <- Sources.get_by(token: token, user_id: user.id),
-         source <- Sources.preload_defaults(source) do
+         source = Sources.preload_defaults(source) do
       json(conn, source)
     end
   end
@@ -115,7 +115,7 @@ defmodule LogflareWeb.Api.SourceController do
   def add_backend(conn, %{"source_token" => token, "backend_token" => backend_token}) do
     with {:ok, backend} <- Backends.fetch_backend_by(token: backend_token),
          {:ok, source} <- Sources.fetch_source_by(token: token),
-         source <- Sources.preload_backends(source),
+         source = Sources.preload_backends(source),
          {:ok, source} <- Backends.update_source_backends(source, [backend | source.backends]) do
       conn
       |> put_status(201)
@@ -137,8 +137,8 @@ defmodule LogflareWeb.Api.SourceController do
 
   def remove_backend(conn, %{"source_token" => token, "backend_token" => backend_token}) do
     with {:ok, source} <- Sources.fetch_source_by(token: token),
-         source <- Sources.preload_backends(source),
-         filtered <- Enum.filter(source.backends, &(&1.token != backend_token)),
+         source = Sources.preload_backends(source),
+         filtered = Enum.filter(source.backends, &(&1.token != backend_token)),
          {:ok, source} <- Backends.update_source_backends(source, filtered) do
       conn
       |> put_status(200)

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -384,7 +384,10 @@ defmodule LogflareWeb.Router do
     resources("/sources", Api.SourceController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]
-    )
+    ) do
+      post "/backends/:backend_token", Api.SourceController, :add_backend
+      delete "/backends/:backend_token", Api.SourceController, :remove_backend
+    end
 
     resources("/endpoints", Api.EndpointController,
       param: "token",

--- a/test/logflare_web/controllers/api/backend_controller_test.exs
+++ b/test/logflare_web/controllers/api/backend_controller_test.exs
@@ -74,7 +74,7 @@ defmodule LogflareWeb.Api.BackendControllerTest do
         |> post("/api/backends", %{
           name: name,
           type: "postgres",
-          config: %{url: "postgresql://localhost:5432", schema: "_my_schema"}
+          config: %{url: "postgresql://test:my-password@localhost:5432", schema: "_my_schema"}
         })
 
       assert %{
@@ -82,7 +82,7 @@ defmodule LogflareWeb.Api.BackendControllerTest do
         "token"=> _,
         "name"=> ^name,
         "config" => %{
-          "url"=>  "redacted",
+          "url"=>  "postgresql://test:REDACTED@"<> _,
           "schema"=>  "_my_schema",
         }
       } = json_response(conn, 201)

--- a/test/logflare_web/controllers/api/backend_controller_test.exs
+++ b/test/logflare_web/controllers/api/backend_controller_test.exs
@@ -14,7 +14,7 @@ defmodule LogflareWeb.Api.BackendControllerTest do
       insert(:backend)
       backend = insert(:backend, user: user)
 
-      [result] =
+      assert [result] =
         conn
         |> add_access_token(user, "private")
         |> get(~p"/api/backends")
@@ -49,7 +49,7 @@ defmodule LogflareWeb.Api.BackendControllerTest do
   end
 
   describe "create/2" do
-    test "creates a new backend for an authenticated user", %{conn: conn, user: user} do
+    test "creates a webhook backend for an authenticated user", %{conn: conn, user: user} do
       name = TestUtils.random_string()
 
       response =
@@ -64,6 +64,28 @@ defmodule LogflareWeb.Api.BackendControllerTest do
 
       assert response["name"] == name
       assert response["config"]["url"] =~ "example.com"
+    end
+
+    test "creates a postgres backend for an authenticated user", %{conn: conn, user: user} do
+      name = TestUtils.random_string()
+
+        conn = conn
+        |> add_access_token(user, "private")
+        |> post("/api/backends", %{
+          name: name,
+          type: "postgres",
+          config: %{url: "postgresql://localhost:5432", schema: "_my_schema"}
+        })
+
+      assert %{
+        "id"=> _,
+        "token"=> _,
+        "name"=> ^name,
+        "config" => %{
+          "url"=>  "redacted",
+          "schema"=>  "_my_schema",
+        }
+      } = json_response(conn, 201)
     end
 
     test "returns 422 on missing arguments", %{conn: conn, user: user} do

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -35,7 +35,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
       assert response["id"] == source.id
     end
     test "backend postgres secrets are redacted", %{conn: conn, user: user, sources: [source | _]} do
-      insert(:backend, sources: [source], user: user, type: :postgres, config: %{url: "some url"})
+      insert(:backend, sources: [source], user: user, type: :postgres, config: %{url: "postgresql://user:secret@localhost"})
       assert %{"backends"=> [backend]} =
         conn
         |> add_access_token(user, "private")
@@ -43,7 +43,7 @@ defmodule LogflareWeb.Api.SourceControllerTest do
         |> json_response(200)
 
       config = backend["config"]
-      assert config["url"] == "redacted"
+      assert config["url"] =~ "postgresql://user:REDACTED@localhost"
     end
 
     test "returns not found if doesn't own the source", %{conn: conn, sources: [source | _]} do

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -34,6 +34,17 @@ defmodule LogflareWeb.Api.SourceControllerTest do
 
       assert response["id"] == source.id
     end
+    test "backend postgres secrets are redacted", %{conn: conn, user: user, sources: [source | _]} do
+      insert(:backend, sources: [source], user: user, type: :postgres, config: %{url: "some url"})
+      assert %{"backends"=> [backend]} =
+        conn
+        |> add_access_token(user, "private")
+        |> get("/api/sources/#{source.token}")
+        |> json_response(200)
+
+      config = backend["config"]
+      assert config["url"] == "redacted"
+    end
 
     test "returns not found if doesn't own the source", %{conn: conn, sources: [source | _]} do
       invalid_user = insert(:user)
@@ -113,6 +124,27 @@ defmodule LogflareWeb.Api.SourceControllerTest do
         |> json_response(422)
 
       assert resp == %{"errors" => %{"name" => ["is invalid"]}}
+    end
+  end
+
+  describe "add_backend/2" do
+    test "attaches a backend", %{conn: conn, user: user, sources: [source | _]} do
+      backend = insert(:backend, user: user)
+      conn = conn
+      |> add_access_token(user, "private")
+      |> post("/api/sources/#{source.token}/backends/#{backend.token}")
+
+      # returns the source
+      assert %{"token"=> _, "backends"=> [_]} = json_response(conn, 201)
+    end
+    test "removes a backend", %{conn: conn, user: user, sources: [source | _]} do
+      backend = insert(:backend, user: user, sources: [source])
+      conn = conn
+      |> add_access_token(user, "private")
+      |> delete("/api/sources/#{source.token}/backends/#{backend.token}")
+
+      # returns the source
+      assert %{"token"=> _, "backends"=> []} = json_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
This PR adds in the adding/removal of source backends to management api.

It also adds in secrets redaction for postgres url when performing json encoding, to ensure that secrets within connection strings are not leaked.