### PR TITLE
fix: should be able to delete a partner provisioned user

### DIFF
--- a/priv/repo/migrations/20240327073534_add_cascade_delete_for_partner_users.exs
+++ b/priv/repo/migrations/20240327073534_add_cascade_delete_for_partner_users.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddCascadeDeleteForPartnerUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:partner_users) do
+      modify :user_id, references(:users, on_delete: :delete_all), from: references(:users)
+    end
+  end
+end


### PR DESCRIPTION
Should be able to delete a partner provisioned user 