### PR TITLE
chore: refactor Webhook adaptor

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -197,9 +197,12 @@ defmodule Logflare.Alerting do
     case execute_alert_query(alert_query) do
       {:ok, [_ | _] = results} ->
         if alert_query.webhook_notification_url do
-          WebhookAdaptor.Client.send(alert_query.webhook_notification_url, %{
-            "result" => results
-          })
+          WebhookAdaptor.Client.send(
+            url: alert_query.webhook_notification_url,
+            body: %{
+              "result" => results
+            }
+          )
         end
 
         if alert_query.slack_hook_url do

--- a/test/logflare_web/live_views/alerts_live_test.exs
+++ b/test/logflare_web/live_views/alerts_live_test.exs
@@ -157,7 +157,7 @@ defmodule LogflareWeb.AlertsLiveTest do
 
     setup do
       WebhookAdaptor.Client
-      |> stub(:send, fn _, _ -> {:ok, %Tesla.Env{}} end)
+      |> stub(:send, fn _ -> {:ok, %Tesla.Env{}} end)
 
       SlackAdaptor.Client
       |> stub(:send, fn _, _ -> {:ok, %Tesla.Env{}} end)


### PR DESCRIPTION
New implementation supports passing headers values that will be sent
in HTTP requests which will allow reusing the same implementation for
different HTTP-based adaptors.
