### PR TITLE
fix: BillingWriter should not receive user and plan args

### DIFF
--- a/test/logflare/source/billing_writer_test.exs
+++ b/test/logflare/source/billing_writer_test.exs
@@ -12,11 +12,10 @@ defmodule Logflare.Source.BillingWriterTest do
 
     user = insert(:user)
     source = insert(:source, user: user)
-    _billing_account = insert(:billing_account, user: user)
-    user = user |> Logflare.Repo.preload(:billing_account)
-    plan = insert(:plan, type: "metered")
+    plan = insert(:plan, type: "metered", name: "Metered")
+    insert(:billing_account, user: user, stripe_plan_id: plan.stripe_id)
 
-    pid = start_supervised!({BillingWriter, source: source, user: user, plan: plan})
+    pid = start_supervised!({BillingWriter, source: source})
 
     # Stripe mocks
     Stripe.SubscriptionItem.Usage


### PR DESCRIPTION
BillingWriter is failing for v2 pipeline as no `:user` and `:plan` args are passed anymore