### PR TITLE
fix: BQ errors propagated to ui and api queries

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -299,11 +299,16 @@ defmodule Logflare.Endpoints do
   defp env_project_id, do: Application.get_env(:logflare, Logflare.Google)[:project_id]
   defp env, do: Application.get_env(:logflare, :env)
 
-  defp process_bq_error(error, user_id) when is_atom(error) do
+  @doc """
+  Formats a bigquery json decoded error.
+  User id should be provided for handling BQ table name replacements to source names.
+  """
+  @spec process_bq_error(map(), integer()) :: map()
+  def process_bq_error(error, user_id) when is_atom(error) do
     %{"message" => process_bq_message(error, user_id)}
   end
 
-  defp process_bq_error(error, user_id) when is_map(error) do
+  def process_bq_error(error, user_id) when is_map(error) do
     error = %{error | "message" => process_bq_message(error["message"], user_id)}
 
     if is_list(error["errors"]) do
@@ -316,9 +321,9 @@ defmodule Logflare.Endpoints do
     end
   end
 
-  defp process_bq_message(message, _user_id) when is_atom(message), do: message
+  def process_bq_message(message, _user_id) when is_atom(message), do: message
 
-  defp process_bq_message(message, user_id) when is_binary(message) do
+  def process_bq_message(message, user_id) when is_binary(message) do
     regex =
       ~r/#{env_project_id()}\.#{user_id}_#{env()}\.(?<uuid>[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12})/
 

--- a/lib/logflare_web/controllers/api/fallback_controller.ex
+++ b/lib/logflare_web/controllers/api/fallback_controller.ex
@@ -26,6 +26,12 @@ defmodule LogflareWeb.Api.FallbackController do
     |> json(%{error: "Not Found"})
   end
 
+  def call(conn, {:error, %{} = err_map}) do
+    conn
+    |> put_status(400)
+    |> json(%{error: err_map})
+  end
+
   def call(conn, {:error, msg}) when is_atom(msg) do
     call(conn, {:error, Atom.to_string(msg)})
   end

--- a/lib/logflare_web/live/alert_component.ex
+++ b/lib/logflare_web/live/alert_component.ex
@@ -9,8 +9,8 @@ defmodule LogflareWeb.AlertComponent do
   def render(assigns) do
     ~H"""
     <div class="message">
-      <div class={"inner-message alert alert-#{@alert_class}"} role="alert">
-        <span><%= render_slot(@inner_block) %></span>
+      <div class={"inner-message alert alert-#{@alert_class} tw-min-w-[350px]"} role="alert">
+        <p><%= render_slot(@inner_block) %></p>
         <a href="#" phx-click="close" phx-target={@myself} phx-value-flash_key={@key}>
           <button type="button" class="close">
             &times;

--- a/lib/logflare_web/live/alerts/actions/show.html.heex
+++ b/lib/logflare_web/live/alerts/actions/show.html.heex
@@ -29,6 +29,7 @@
   </div>
 
   <div>
+    <button class="btn btn-secondary" phx-click="run-query">Run query</button>
     <button class="btn btn-secondary" phx-click="manual-trigger">Manual trigger</button>
   </div>
 

--- a/lib/logflare_web/live/alerts/components/run_query_result.html.heex
+++ b/lib/logflare_web/live/alerts/components/run_query_result.html.heex
@@ -1,7 +1,12 @@
-<div :if={@query_result_rows}>
+<div :if={@query_result_rows != nil}>
   <h5 class="tw-text-white">Results</h5>
+  <button class="btn btn-secondary" phx-click="clear-results">Clear results</button>
+</div>
+<div :if={@query_result_rows}>
+  <code class="tw-whitespace-pre tw-block tw-text-white tw-bg-zinc-800 tw-rounded tw-p-2 tw-text-xs"><%= Jason.encode!(@query_result_rows) |> Jason.Formatter.pretty_print() %></code>
+</div>
 
-  <code class="tw-whitespace-pre tw-block tw-text-white tw-bg-zinc-800 tw-rounded tw-p-2 tw-text-xs">
-    <%= Jason.encode!(@query_result_rows) |> Jason.Formatter.pretty_print() %>
-  </code>
+<div :if={@query_result_rows == []}>
+  <h5 class="tw-text-white">Results</h5>
+  <span>No rows returned from query</span>
 </div>

--- a/lib/logflare_web/templates/layout/flash.html.eex
+++ b/lib/logflare_web/templates/layout/flash.html.eex
@@ -1,7 +1,7 @@
 <%= if @flash.info do %>
   <div class="message" >
     <div class="inner-message alert alert-info" role="alert">
-      <span><%= @flash.info %></span>
+      <span class="tw-block tw-whitespace-pre-wrap"><%= @flash.info %></span>
       <a href="#" >
         <button type="button" class="close" data-dismiss="alert" >
           &times;
@@ -13,7 +13,7 @@
 <%= if @flash.error do %>
   <div class="message" >
     <div class="inner-message alert alert-warning" role="alert">
-      <span><%= @flash.error %></span>
+      <span class="tw-block tw-whitespace-pre-wrap"><%= @flash.error %></span>
       <a href="#" >
         <button type="button" class="close" data-dismiss="alert" > &times;</button>
       </a>

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -125,6 +125,22 @@ defmodule Logflare.TestUtils do
   def gen_email, do: "#{random_string()}@#{random_string()}.com"
 
   @doc """
+  Generates a mock BigQuery error
+  ```elixir
+  GoogleApi.BigQuery.V2.Api.Jobs
+  |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+    {:ok, TestUtils.gen_bq_error("some-error")}
+  end)
+  ```
+  """
+  def gen_bq_error(err) do
+    %Tesla.Env{
+      status: 400,
+      body: Jason.encode!(%{error: %{message: err}})
+    }
+  end
+
+  @doc """
   Generates a mock BigQuery response.
   This is a successful bq response retrieved manually
   """


### PR DESCRIPTION
Propagates BQ errors to UI and management API.

- 400 err with the error message when calling `/api/query`
- Adds a `Run Query` button with results shown
- Flash is added when query is run with BQ errors, instead of silent failure.

https://github.com/Logflare/logflare/assets/22714384/531c7bf3-3be5-4490-aa05-e3ca44b185c6

