### PR TITLE
perf: reduce bootup recent update window

### DIFF
--- a/lib/logflare/source/supervisor.ex
+++ b/lib/logflare/source/supervisor.ex
@@ -42,7 +42,7 @@ defmodule Logflare.Source.Supervisor do
     # Starting sources only when we've seen an event in the last 6 hours
     # Plugs.EnsureSourceStarted makes sure if a source isn't started, it gets started for ingest and the UI
 
-    milli = :timer.hours(6)
+    milli = :timer.hours(1)
     from_datetime = DateTime.utc_now() |> DateTime.add(-milli, :millisecond)
 
     query =
@@ -50,7 +50,7 @@ defmodule Logflare.Source.Supervisor do
         order_by: s.log_events_updated_at,
         where: s.log_events_updated_at > ^from_datetime,
         select: s,
-        limit: 10_000
+        limit: 5_000
       )
 
     Repo.all(query)

--- a/lib/logflare/source/supervisor.ex
+++ b/lib/logflare/source/supervisor.ex
@@ -41,14 +41,10 @@ defmodule Logflare.Source.Supervisor do
     # Starting sources by latest events first
     # Starting sources only when we've seen an event in the last 6 hours
     # Plugs.EnsureSourceStarted makes sure if a source isn't started, it gets started for ingest and the UI
-
-    milli = :timer.hours(1)
-    from_datetime = DateTime.utc_now() |> DateTime.add(-milli, :millisecond)
-
     query =
       from(s in Source,
         order_by: s.log_events_updated_at,
-        where: s.log_events_updated_at > ^from_datetime,
+        where: s.log_events_updated_at > ago(1, "hour"),
         select: s,
         limit: 5_000
       )


### PR DESCRIPTION
- tweaks the busy sources bootup window to reduce time-to-healthy