### PR TITLE
fix: slack invalid blocks

### DIFF
--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
       end
 
     view_url = url(~p"/alerts/#{id}")
-    context = "🔊 *#{name}*#{rows_text} | [View alert](#{view_url})"
+    context = "🔊 *#{name}*#{rows_text} | #{view_url}"
 
     body =
       payload

--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
   alias __MODULE__.Client
 
   alias Logflare.Alerting.AlertQuery
-
+  @endpoint LogflareWeb.Endpoint
   @doc """
   Sends a given payload to slack.
 

--- a/lib/logflare/source/slack_hook_server/client.ex
+++ b/lib/logflare/source/slack_hook_server/client.ex
@@ -5,6 +5,7 @@ defmodule Logflare.Source.SlackHookServer.Client do
   alias Logflare.Sources
   alias LogflareWeb.Router.Helpers, as: Routes
   alias LogflareWeb.Endpoint
+  alias Logflare.Backends.Adaptor.SlackAdaptor
 
   @middleware [Tesla.Middleware.JSON]
 
@@ -82,7 +83,7 @@ defmodule Logflare.Source.SlackHookServer.Client do
     |> Map.put(:body, inspect(req_or_resp.body))
   end
 
-  defp prep_recent_events(recent_events, rate) do
+  defp take_events(recent_events, rate) do
     cond do
       0 == rate ->
         slack_no_events_message()
@@ -90,51 +91,33 @@ defmodule Logflare.Source.SlackHookServer.Client do
       rate in 1..3 ->
         recent_events
         |> Enum.take(-rate)
-        |> Enum.map_join("\r", &slack_event_message/1)
 
       true ->
         recent_events
         |> Enum.take(-3)
-        |> Enum.map_join("\r", &slack_event_message/1)
     end
   end
 
-  defp slack_post_body(source, rate, recent_events) do
-    prepped_recent_events = prep_recent_events(recent_events, rate)
+  def slack_post_body(source, rate, recent_events) do
+    event_bodies =
+      take_events(recent_events, rate)
+      |> Enum.map(fn le ->
+        {:ok, dt} = DateTime.from_unix(le.body["timestamp"], :microsecond)
+        %{DateTime.to_string(dt) => le.body["event_message"]}
+      end)
 
     source_link =
       LogflareWeb.Endpoint.static_url() <> Routes.source_path(Endpoint, :show, source.id)
 
-    main_message = "#{rate} new event(s) for your source `#{source.name}`"
+    main_message = "*Recent Events* - #{rate} new event(s) for your source `#{source.name}`"
 
-    %{
-      text: main_message,
-      blocks: [
-        %{
-          type: "section",
-          text: %{
-            type: "mrkdwn",
-            text: main_message
-          }
-        },
-        %{
-          type: "section",
-          text: %{
-            type: "mrkdwn",
-            text: "*Recent Events*\r#{prepped_recent_events}"
-          },
-          accessory: %{
-            type: "button",
-            text: %{
-              type: "plain_text",
-              text: "See all events"
-            },
-            url: source_link,
-            style: "primary"
-          }
-        }
-      ]
-    }
+    SlackAdaptor.to_body(event_bodies,
+      context: main_message,
+      button_link: %{
+        text: "See all events",
+        url: source_link
+      }
+    )
   end
 
   defp slack_event_message(event) do

--- a/lib/logflare/source/slack_hook_server/client.ex
+++ b/lib/logflare/source/slack_hook_server/client.ex
@@ -86,7 +86,7 @@ defmodule Logflare.Source.SlackHookServer.Client do
   defp take_events(recent_events, rate) do
     cond do
       0 == rate ->
-        slack_no_events_message()
+        []
 
       rate in 1..3 ->
         recent_events
@@ -118,16 +118,5 @@ defmodule Logflare.Source.SlackHookServer.Client do
         url: source_link
       }
     )
-  end
-
-  defp slack_event_message(event) do
-    time = Kernel.floor(event.body["timestamp"] / 1_000_000)
-
-    "<!date^#{time}^{date_pretty} at {time_secs}|#{event.ingested_at}>\r>#{event.body["event_message"]}"
-  end
-
-  defp slack_no_events_message() do
-    time = DateTime.to_unix(DateTime.utc_now())
-    "<!date^#{time}^{date_pretty} at {time_secs}|blah>\r>Your events will show up here!"
   end
 end

--- a/test/logflare/backends/slack_adaptor_test.exs
+++ b/test/logflare/backends/slack_adaptor_test.exs
@@ -2,5 +2,54 @@ defmodule Logflare.Backends.SlackAdaptorTest do
   @moduledoc false
   use ExUnit.Case, async: true
   import Logflare.Backends.Adaptor.SlackAdaptor
-  doctest Logflare.Backends.Adaptor.SlackAdaptor
+  doctest Logflare.Backends.Adaptor.SlackAdaptor, except: [to_rich_text_preformatted: 1]
+
+  test "to_rich_text_preformatted/1" do
+    assert [%{text: "test:"}, %{text: " "}, %{text: "test"}] =
+             to_rich_text_preformatted(%{"test" => "test"})
+
+    assert [%{text: "test:"}, %{text: "\n"}, %{text: "test\ntest"}] =
+             to_rich_text_preformatted(%{"test" => "test\ntest"})
+
+    # multi-key
+    assert [
+             %{text: "a:"},
+             %{text: " "},
+             %{text: "a"},
+             %{text: "\n"},
+             %{text: "b:"},
+             %{text: " "},
+             %{text: "b"}
+           ] = to_rich_text_preformatted(%{"a" => "a", "b" => "b"})
+
+    # url handling
+    assert [%{text: "test:"}, %{text: " "}, %{url: "http://" <> _}] =
+             to_rich_text_preformatted(%{"test" => "http://test.com"})
+
+    assert [%{text: "test:"}, %{text: " "}, %{url: "https://" <> _}] =
+             to_rich_text_preformatted(%{"test" => "https://test.com"})
+  end
+
+  test "to_body/2" do
+    assert %{
+             blocks: [
+               %{
+                 type: "context",
+                 elements: [
+                   %{
+                     text: "some context markdown"
+                   }
+                 ]
+               }
+             ]
+           } = to_body([], context: "some context markdown")
+
+    assert %{
+             blocks: [
+               %{type: "context"},
+               _,
+               _
+             ]
+           } = to_body([%{a: "b"}, %{a: "b", c: "d"}], context: "some context markdown")
+  end
 end

--- a/test/logflare/backends/slack_adaptor_test.exs
+++ b/test/logflare/backends/slack_adaptor_test.exs
@@ -1,6 +1,7 @@
 defmodule Logflare.Backends.SlackAdaptorTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use Logflare.DataCase, async: false
+  alias Logflare.Source.SlackHookServer
   import Logflare.Backends.Adaptor.SlackAdaptor
   doctest Logflare.Backends.Adaptor.SlackAdaptor, except: [to_rich_text_preformatted: 1]
 
@@ -28,6 +29,31 @@ defmodule Logflare.Backends.SlackAdaptorTest do
 
     assert [%{text: "test:"}, %{text: " "}, %{url: "https://" <> _}] =
              to_rich_text_preformatted(%{"test" => "https://test.com"})
+
+    # timestamp handling
+    unix = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+    assert [%{text: "timestamp:"}, %{text: " "}, %{text: ts}] =
+             to_rich_text_preformatted(%{"timestamp" => unix})
+
+    {:ok, microsecond} = DateTime.from_unix(unix, :microsecond)
+    assert ts == DateTime.to_string(microsecond)
+  end
+
+  test "to_rich_text_preformatted/1 with numbers" do
+    assert [%{text: "123:"}, %{text: " "}, %{text: "123"}] =
+             to_rich_text_preformatted(%{"123" => 123})
+
+    assert [%{text: "123:"}, %{text: " "}, %{text: "123.2"}] =
+             to_rich_text_preformatted(%{"123" => 123.2})
+  end
+
+  test "to_rich_text_preformatted/1 with maps" do
+    assert [%{text: "123:"}, %{text: " "}, %{text: "{\"test\":\"test\"}"}] =
+             to_rich_text_preformatted(%{"123" => %{"test" => "test"}})
+
+    assert [%{text: "123:"}, %{text: " "}, %{text: "{\"test\":\"test\"}"}] =
+             to_rich_text_preformatted(%{"123" => %{test: "test"}})
   end
 
   test "to_body/2" do
@@ -51,5 +77,35 @@ defmodule Logflare.Backends.SlackAdaptorTest do
                _
              ]
            } = to_body([%{a: "b"}, %{a: "b", c: "d"}], context: "some context markdown")
+
+    assert %{
+             blocks: [
+               _,
+               %{type: "section", accessory: %{type: "button", text: %{text: "some text"}}}
+             ]
+           } = to_body([%{}], button_link: %{text: "some text", url: "some url"})
+  end
+
+  test "SlackHookServer compat" do
+    source = insert(:source, user: build(:user))
+    le = build(:log_event, source: source)
+
+    assert %{
+             blocks: [
+               %{type: "context", elements: [%{text: "*Recent Events*" <> _}]},
+               %{
+                 type: "rich_text",
+                 elements: [
+                   %{
+                     elements: [%{text: text}, %{text: " "}, %{text: msg}]
+                   }
+                 ]
+               },
+               %{type: "section", accessory: %{type: "button", text: %{text: "See all events"}}}
+             ]
+           } = SlackHookServer.Client.slack_post_body(source, 5, [le])
+
+    refute text =~ Integer.to_string(le.body["timestamp"])
+    assert msg == le.body["event_message"]
   end
 end


### PR DESCRIPTION
This fixes the invalid_blocks errors that slack webhooks return due to invalid markdown. This affects both Legacy Recent Events Alerts and Query Alerts.
New block formatting will look something like this:
<img width="520" alt="Screenshot 2024-04-04 at 9 50 34 AM" src="https://github.com/Logflare/logflare/assets/22714384/cb1aa40c-f3f2-483a-b246-229a5a4fd978">

For each row, a new block will be used, allowing for intra-slack linking to specific events.

SlackHookServer is also adjusted to use this new block generation logic, as many events are not getting sent to slack channels due to the invalid formatting.
