### PR TITLE
chore: fix flaky test relating to metadata expansion

### DIFF
--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -147,8 +147,10 @@ defmodule Logflare.LogEventTest do
     property "nested keys are reachable" do
       check all metadata <-
                   map_of(
-                    string(@alphas, min_length: 1),
-                    map_of(string(@alphas, min_length: 1), string(:printable),
+                    string(@alphas, min_length: 2),
+                    map_of(
+                      string(@alphas, min_length: 1),
+                      string(:printable, min_length: 1, max_length: 20),
                       min_length: 1,
                       max_length: 20
                     ),


### PR DESCRIPTION
Fixes flaky tests where the key was `m` and expanding to `metadata`