### PR TITLE
fix: slack hooks adaptor alerts and recent alerts uses message with CTA.

### DIFF
--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -27,7 +27,13 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
 
     body =
       payload
-      |> to_body(context: context)
+      |> to_body(
+        button_link: %{
+          markdown_text: context,
+          url: view_url,
+          text: "Manage"
+        }
+      )
 
     Client.send(hook_url, body)
   end
@@ -55,8 +61,8 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
     %{
       blocks:
         build_context_blocks(context) ++
-          build_rich_text_blocks(results) ++
-          build_button_link_blocks(button_link)
+          build_button_link_blocks(button_link) ++
+          build_rich_text_blocks(results)
     }
   end
 
@@ -66,6 +72,10 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
     [
       %{
         type: "section",
+        text: %{
+          type: "mrkdwn",
+          text: button_link.markdown_text
+        },
         accessory: %{
           type: "button",
           text: %{type: "plain_text", text: button_link.text},

--- a/lib/logflare/source/slack_hook_server/client.ex
+++ b/lib/logflare/source/slack_hook_server/client.ex
@@ -109,12 +109,10 @@ defmodule Logflare.Source.SlackHookServer.Client do
     source_link =
       LogflareWeb.Endpoint.static_url() <> Routes.source_path(Endpoint, :show, source.id)
 
-    main_message = "*Recent Events* - #{rate} new event(s) for your source `#{source.name}`"
-
     SlackAdaptor.to_body(event_bodies,
-      context: main_message,
       button_link: %{
-        text: "See all events",
+        markdown_text: "*#{rate} new event(s)* for `#{source.name}`",
+        text: "View events",
         url: source_link
       }
     )

--- a/test/logflare/backends/slack_adaptor_test.exs
+++ b/test/logflare/backends/slack_adaptor_test.exs
@@ -83,7 +83,7 @@ defmodule Logflare.Backends.SlackAdaptorTest do
                %{
                  type: "section",
                  text: %{
-                   type: "text",
+                   type: "mrkdwn",
                    text: "some markdown text"
                  },
                  accessory: %{type: "button", text: %{text: "some text"}}
@@ -106,7 +106,11 @@ defmodule Logflare.Backends.SlackAdaptorTest do
 
     assert %{
              blocks: [
-               %{type: "context", elements: [%{text: "*Recent Events*" <> _}]},
+               %{
+                 type: "section",
+                 text: %{text: "*5 new event(s)*" <> _},
+                 accessory: %{type: "button", text: %{text: "View events"}}
+               },
                %{
                  type: "rich_text",
                  elements: [
@@ -114,8 +118,7 @@ defmodule Logflare.Backends.SlackAdaptorTest do
                      elements: [%{text: text}, %{text: " "}, %{text: msg}]
                    }
                  ]
-               },
-               %{type: "section", accessory: %{type: "button", text: %{text: "See all events"}}}
+               }
              ]
            } = SlackHookServer.Client.slack_post_body(source, 5, [le])
 

--- a/test/logflare/backends/slack_adaptor_test.exs
+++ b/test/logflare/backends/slack_adaptor_test.exs
@@ -80,10 +80,24 @@ defmodule Logflare.Backends.SlackAdaptorTest do
 
     assert %{
              blocks: [
-               _,
-               %{type: "section", accessory: %{type: "button", text: %{text: "some text"}}}
+               %{
+                 type: "section",
+                 text: %{
+                   type: "text",
+                   text: "some markdown text"
+                 },
+                 accessory: %{type: "button", text: %{text: "some text"}}
+               },
+               _
              ]
-           } = to_body([%{}], button_link: %{text: "some text", url: "some url"})
+           } =
+             to_body([%{}],
+               button_link: %{
+                 markdown_text: "some markdown text",
+                 text: "some text",
+                 url: "some url"
+               }
+             )
   end
 
   test "SlackHookServer compat" do


### PR DESCRIPTION
Fixes slack button link block generation, which affects recent events notifications to slack

<img width="638" alt="Screenshot 2024-04-12 at 8 52 21 PM" src="https://github.com/Logflare/logflare/assets/22714384/23cdf7a6-f584-431b-85bc-7426ad8be94e">
