### PR TITLE
feat: webhook adaptor batching & benchmarks

### DIFF
--- a/test/logflare/backends/webhook_adaptor_test.exs
+++ b/test/logflare/backends/webhook_adaptor_test.exs
@@ -6,32 +6,36 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
-  setup do
-    user = insert(:user)
-    source = insert(:source, user: user)
+  describe "ingestion tests" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
 
-    backend =
-      insert(:backend, type: :webhook, sources: [source], config: %{url: "https://example.com"})
+      backend =
+        insert(:backend, type: :webhook, sources: [source], config: %{url: "https://example.com"})
 
-    pid = start_supervised!({@subject, {source, backend}})
-    :timer.sleep(500)
-    [pid: pid, backend: backend, source: source]
-  end
+      pid = start_supervised!({@subject, {source, backend}})
+      :timer.sleep(500)
+      [pid: pid, backend: backend, source: source]
+    end
 
-  test "ingest/2", %{pid: pid, source: source, backend: backend} do
-    this = self()
-    ref = make_ref()
+    test "ingest/2", %{pid: pid, source: source, backend: backend} do
+      this = self()
+      ref = make_ref()
 
-    @subject.Client
-    |> expect(:send, fn _ ->
-      send(this, ref)
-      %Tesla.Env{}
-    end)
+      @subject.Client
+      |> expect(:send, fn req ->
+        body = req[:body]
+        assert is_list(body)
+        send(this, ref)
+        %Tesla.Env{}
+      end)
 
-    le = build(:log_event, source: source)
+      le = build(:log_event, source: source)
 
-    assert :ok == @subject.ingest(pid, [le], source_id: source.id, backend_id: backend.id)
-    assert_receive ^ref, 2000
+      assert :ok == @subject.ingest(pid, [le], source_id: source.id, backend_id: backend.id)
+      assert_receive ^ref, 2000
+    end
   end
 
   test "cast_and_validate_config/1" do
@@ -50,6 +54,83 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
         ] do
       assert %Ecto.Changeset{valid?: false} = Adaptor.cast_and_validate_config(@subject, invalid),
              "invalid: #{inspect(invalid)}"
+    end
+  end
+
+  @tag :benchmark
+  describe "benchmark" do
+    setup do
+      start_supervised!(BencheeAsync.Reporter)
+
+      @subject.Client
+      |> stub(:send, fn batch ->
+        body = batch[:body]
+        n = Enum.count(body)
+        BencheeAsync.Reporter.record(n)
+        # simulate latency
+        :timer.sleep(100)
+        %Tesla.Env{}
+      end)
+
+      user = insert(:user)
+      source = insert(:source, user_id: user.id)
+
+      backend =
+        insert(:backend, type: :webhook, sources: [source], config: %{url: "https://example.com"})
+
+      pid = start_supervised!({@subject, {source, backend}})
+
+      [backend: backend, pid: pid, source: source]
+    end
+
+    test "defaults", %{pid: pid, backend: backend, source: source} do
+      le = build(:log_event, source: source)
+      batch_1 = [le]
+
+      batch_10 =
+        for _i <- 1..10 do
+          le
+        end
+
+      batch_100 =
+        for _i <- 1..100 do
+          le
+        end
+
+      batch_250 =
+        for _i <- 1..250 do
+          le
+        end
+
+      batch_500 =
+        for _i <- 1..500 do
+          le
+        end
+
+      BencheeAsync.run(
+        %{
+          "batch-1" => fn ->
+            @subject.ingest(pid, batch_1, source_id: source.id, backend_id: backend.id)
+          end,
+          "batch-10" => fn ->
+            @subject.ingest(pid, batch_10, source_id: source.id, backend_id: backend.id)
+          end,
+          "batch-100" => fn ->
+            @subject.ingest(pid, batch_100, source_id: source.id, backend_id: backend.id)
+          end,
+          "batch-250" => fn ->
+            @subject.ingest(pid, batch_250, source_id: source.id, backend_id: backend.id)
+          end,
+          "batch-500" => fn ->
+            @subject.ingest(pid, batch_500, source_id: source.id, backend_id: backend.id)
+          end
+        },
+        time: 3,
+        warmup: 1,
+        print: [configuration: false],
+        # use extended_statistics to view units of work done
+        formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
+      )
     end
   end
 end


### PR DESCRIPTION
This PR adds in batching for the webhook adaptor, and benchmarks for ingestion
```
Name                ips        average  deviation         median         99th %
batch-1         2052.29        0.49 ms   ±251.86%      0.0153 ms        6.13 ms
batch-10         944.49        1.06 ms   ±172.39%      0.0500 ms        6.90 ms
batch-100        653.64        1.53 ms   ±135.53%       0.152 ms        8.05 ms
batch-250        534.37        1.87 ms   ±121.37%        0.56 ms        8.19 ms
batch-500        524.73        1.91 ms   ±120.30%        0.58 ms        8.57 ms

Comparison: 
batch-1         2052.29
batch-10         944.49 - 2.17x slower +0.57 ms
batch-100        653.64 - 3.14x slower +1.04 ms
batch-250        534.37 - 3.84x slower +1.38 ms
batch-500        524.73 - 3.91x slower +1.42 ms

Extended statistics: 

Name              minimum        maximum    sample size                     mode
batch-1        0.00008 ms        7.64 ms        74.75 K               0.00013 ms
batch-10       0.00008 ms        7.44 ms        98.25 K               0.00013 ms
batch-100      0.00008 ms        8.60 ms        98.50 K0.00029 ms, 0.00025 ms, 0
batch-250      0.00008 ms        8.91 ms        98.75 K0.00029 ms, 0.00025 ms, 0
batch-500      0.00008 ms        9.83 ms        98.50 K               0.00488 ms
```
sample size is the value to look at. This is with simulated 100ms latency (non-realistic).