### PR TITLE
fix: add fallback for Jason.EncodError

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -238,7 +238,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
 
         # check content length
         message, {count, len} ->
-          payload = Jason.encode!(message.data.body)
+          {:ok, payload} =
+            with {:error, %Jason.EncodeError{}} <- Jason.encode(message.data.body) do
+              {:ok, inspect(message.data.body)}
+            end
+
           length = IO.iodata_length(payload)
 
           if len - length <= 0 do


### PR DESCRIPTION
This adds a fallback for non-valid utf8 strings, to allow for rough payload size estimation.
This adds a test that ensures that checks that this batcher crashes from this bug does not prevent acks to the BufferCounter