### PR TITLE
test: silence Finch errors

### DIFF
--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -1,6 +1,7 @@
 defmodule Logflare.Source.BigQuery.SchemaTest do
   @moduledoc false
   use Logflare.DataCase
+
   alias Logflare.Source.BigQuery.Schema
   alias Logflare.Google.BigQuery.SchemaUtils
 


### PR DESCRIPTION
This adds Logger filter, that will silence Finch disconnection errors in tests to reduce amount of pollution in the test log.