### PR TITLE
fix: handle floats in timestamp events

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -123,6 +123,19 @@ defmodule Logflare.LogEvent do
             _ -> x
           end
 
+        x when is_float(x) ->
+          rounded = round(x)
+          length = rounded |> Integer.digits() |> Enum.count()
+
+          case length do
+            19 -> round(rounded / 1_000)
+            16 -> rounded
+            13 -> x * 1_000
+            10 -> x * 1_000_000
+            7 -> x * 1_000_000_000
+            _ -> rounded
+          end
+
         nil ->
           System.system_time(:microsecond)
       end

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -166,6 +166,23 @@ defmodule Logflare.LogEventTest do
       end
     end
 
+    property "timestamp unix conversions" do
+      source = build(:source, user: build(:user))
+
+      check all ts <-
+                  one_of([
+                    integer(1_713_268_565_764_892..1_713_268_565_764_999),
+                    integer(1_713_268_565_764..1_713_268_565_999),
+                    integer(1_713_268_565..1_713_268_999),
+                    float(min: 1_713_268_565.1, max: 1_713_268_999.9),
+                    float(min: 1_713_268_000_000.1, max: 1_713_268_000_999.9),
+                    float(min: 1_713_268_565_000_000.1, max: 1_713_268_565_000_999.9)
+                  ]) do
+        params = Map.put(@valid_params, "timestamp", ts)
+        LogEvent.make(params, %{source: source})
+      end
+    end
+
     defp event_with_message(pattern, %LogEvent{} = le) do
       @subject.apply_custom_event_message(%LogEvent{
         le


### PR DESCRIPTION
Vercel has started to send float timestamps suddenly.