### PR TITLE
fix: multi-line styling fixes

### DIFF
--- a/lib/logflare_web/live/search_live/templates/logs_list.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_list.html.heex
@@ -16,8 +16,7 @@
                 format_timestamp(timestamp) <> " UTC"
               end %>
             <li id={"log-event_#{log.id || log.body["timestamp"]}"} class="tw-group">
-              <mark class="log-datestamp" data-timestamp={timestamp}>
-                <%= formatted_timestamp %></mark>&nbsp;<%= message %>
+              <span class="tw-whitespace-pre-wrap"><mark class="log-datestamp" data-timestamp={timestamp}><%= formatted_timestamp %></mark>&nbsp;<%= message %></span>
               <span class="tw-inline-block tw-text-[0.65rem] tw-align-text-bottom tw-inline-flex tw-flex-row tw-gap-2">
                 <%= live_modal_show_link(component: LogflareWeb.Search.LogEventViewerComponent, modal_id: :log_event_viewer, title: "Log Event", phx_value_log_event_id: log.id, phx_value_log_event_timestamp: log.body["timestamp"]) do %>
                   <span>view</span>

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -27,7 +27,7 @@
     <%= @logs |> Enum.with_index |> Enum.map(fn {log, inx} -> %>
     <li>
       <span class="tw-whitespace-pre-wrap"><mark class="log-datestamp" data-timestamp="<%= log.body["timestamp"] %>"><%= log.body["timestamp"] %></mark> <%= log.body["event_message"] %></span>
-      <a class="metadata-link" data-toggle="collapse" href="#metadata-<%= inx %>" aria-expanded="false">
+      <a class="metadata-link" data-toggle="collapse" href="#metadata-<%= inx %>" aria-expanded="false" class=" tw-text-[0.65rem]"">
         event body
       </a>
       <div class="collapse metadata" id="metadata-<%= inx %>">

--- a/lib/logflare_web/templates/source/show.html.eex
+++ b/lib/logflare_web/templates/source/show.html.eex
@@ -26,10 +26,7 @@
   <ul id="logs-list" class="list-unstyled console-text-list" hidden>
     <%= @logs |> Enum.with_index |> Enum.map(fn {log, inx} -> %>
     <li>
-      <mark class="log-datestamp" data-timestamp="<%= log.body["timestamp"] %>">
-        <%= log.body["timestamp"] %>
-      </mark>
-      <%= log.body["event_message"] %>
+      <span class="tw-whitespace-pre-wrap"><mark class="log-datestamp" data-timestamp="<%= log.body["timestamp"] %>"><%= log.body["timestamp"] %></mark> <%= log.body["event_message"] %></span>
       <a class="metadata-link" data-toggle="collapse" href="#metadata-<%= inx %>" aria-expanded="false">
         event body
       </a>


### PR DESCRIPTION
Customer has feedbacked about handling long multi-line strings. Small styling tweak to make it more readable.
<img width="705" alt="Screenshot 2024-05-08 at 6 37 58 PM" src="https://github.com/Logflare/logflare/assets/22714384/d5b4b82c-add3-4e62-8de5-18163fc9b205">
<img width="1161" alt="Screenshot 2024-05-08 at 6 34 49 PM" src="https://github.com/Logflare/logflare/assets/22714384/197242cc-bf0e-43ad-914f-39c071df2242">
