### PR TITLE
fix: add guard for empty email form submissions on email login

### DIFF
--- a/lib/logflare_web/controllers/auth/email_controller.ex
+++ b/lib/logflare_web/controllers/auth/email_controller.ex
@@ -16,7 +16,7 @@ defmodule LogflareWeb.Auth.EmailController do
     render(conn, "verify_token.html")
   end
 
-  def send_link(conn, %{"email" => email}) do
+  def send_link(conn, %{"email" => email}) when is_binary(email) and email != "" do
     email = email |> String.downcase() |> String.trim()
 
     if get_session(conn, :vercel_setup) do
@@ -29,6 +29,12 @@ defmodule LogflareWeb.Auth.EmailController do
     conn
     |> put_flash(:info, "Check your email for a sign in link!")
     |> redirect(to: Routes.email_path(conn, :verify_token))
+  end
+
+  def send_link(conn, _params) do
+    conn
+    |> put_flash(:error, "Email cannot be empty")
+    |> render("email_login.html")
   end
 
   def verify_token_form(conn, %{"token" => _token} = params) do

--- a/test/logflare_web/controllers/email_controller_tests.exs
+++ b/test/logflare_web/controllers/email_controller_tests.exs
@@ -1,0 +1,31 @@
+defmodule LogflareWeb.EmailControllerTests do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  test "GET email login", %{conn: conn} do
+    conn =
+      conn
+      |> get(~p"/auth/login/email")
+
+    assert html_response(conn, 200) =~ "email"
+    assert conn.assigns.flash["error"] == nil
+  end
+
+  test "POST email login", %{conn: conn} do
+    conn =
+      conn
+      |> post(~p"/auth/login/email", %{email: "some-email@logflare.app"})
+
+    assert html_response(conn, 302)
+    assert conn.assigns.flash["error"] == nil
+  end
+
+  test "POST email login with empty email", %{conn: conn} do
+    conn =
+      conn
+      |> post(~p"/auth/login/email", %{email: ""})
+
+    assert html_response(conn, 200)
+    assert conn.assigns.flash["error"] =~ "cannot be empty"
+  end
+end


### PR DESCRIPTION
Fix for empty email login submissions when email is empty