### PR TITLE
fix: disable otel trace exporting by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -132,6 +132,6 @@ config :logflare, Logflare.AlertsScheduler, init_task: {Logflare.Alerting, :init
 
 config :opentelemetry,
   span_processor: :batch,
-  traces_exporter: :otlp
+  traces_exporter: :none
 
 import_config "#{Mix.env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -285,6 +285,9 @@ config :libcluster,
     if(System.get_env("LIBCLUSTER_TOPOLOGY") == "postgres", do: postgres_topology, else: [])
 
 if System.get_env("LOGFLARE_OTEL_ENDPOINT") do
+  config :opentelemetry,
+    traces_exporter: :otlp
+
   config :opentelemetry_exporter,
     otlp_protocol: :grpc,
     otlp_endpoint: System.get_env("LOGFLARE_OTEL_ENDPOINT"),


### PR DESCRIPTION
This disables trace exporting by default, and becomes enabled only when an endpoint is provided.