### PR TITLE
fix: rule child is started on source routing at ingest time

### DIFF
--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -16,4 +16,12 @@ defmodule Logflare.Cluster.Utils do
   def actual_cluster_size(), do: Enum.count(node_list_all())
 
   def min_cluster_size, do: Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
+
+  @doc """
+  Convenience function for `:rpc.multicall/3` with default timeout set instead of `:infinity`.
+  """
+  @spec rpc_multicall(module(), atom(), [term()], non_neg_integer()) :: term()
+  def rpc_multicall(mod, func, args, timeout \\ 5_000) do
+    :rpc.multicall(node_list_all(), mod, func, args, timeout)
+  end
 end

--- a/lib/logflare/sources/rules.ex
+++ b/lib/logflare/sources/rules.ex
@@ -11,6 +11,7 @@ defmodule Logflare.Rules do
   alias Logflare.SourceSchemas
   alias Logflare.Backends.Backend
   alias Logflare.Backends.SourceSup
+  alias Logflare.Cluster
 
   @doc """
   Lists rules for a given Source or Backend
@@ -38,7 +39,7 @@ defmodule Logflare.Rules do
     |> case do
       {:ok, %Rule{backend_id: backend_id} = rule} = result when backend_id != nil ->
         # expected to fail on nodes where SourceSup is not started
-        :rpc.multicall(SourceSup, :start_rule_child, [rule])
+        Cluster.Utils.rpc_multicall(SourceSup, :start_rule_child, [rule])
 
         result
 
@@ -85,7 +86,7 @@ defmodule Logflare.Rules do
   @spec delete_rule(Rule.t()) :: {:ok, Rule.t()}
   def delete_rule(rule) do
     res = Repo.delete(rule)
-    :rpc.multicall(SourceSup, :stop_rule_child, [rule])
+    Cluster.Utils.rpc_multicall(SourceSup, :stop_rule_child, [rule])
 
     res
   end

--- a/lib/logflare/sources/rules.ex
+++ b/lib/logflare/sources/rules.ex
@@ -11,7 +11,6 @@ defmodule Logflare.Rules do
   alias Logflare.SourceSchemas
   alias Logflare.Backends.Backend
   alias Logflare.Backends.SourceSup
-  alias Logflare.Backends
 
   @doc """
   Lists rules for a given Source or Backend
@@ -38,7 +37,9 @@ defmodule Logflare.Rules do
     |> Repo.insert()
     |> case do
       {:ok, %Rule{backend_id: backend_id} = rule} = result when backend_id != nil ->
-        if Backends.source_sup_started?(rule.source_id), do: SourceSup.start_rule_child(rule)
+        # expected to fail on nodes where SourceSup is not started
+        :rpc.multicall(SourceSup, :start_rule_child, [rule])
+
         result
 
       other ->
@@ -84,7 +85,8 @@ defmodule Logflare.Rules do
   @spec delete_rule(Rule.t()) :: {:ok, Rule.t()}
   def delete_rule(rule) do
     res = Repo.delete(rule)
-    if Backends.source_sup_started?(rule.source_id), do: SourceSup.stop_rule_child(rule)
+    :rpc.multicall(SourceSup, :stop_rule_child, [rule])
+
     res
   end
 

--- a/lib/logflare/sources/source_routing.ex
+++ b/lib/logflare/sources/source_routing.ex
@@ -6,6 +6,7 @@ defmodule Logflare.Logs.SourceRouting do
   alias Logflare.LogEvent, as: LE
   alias Logflare.Logs
   alias Logflare.Backends
+  alias Logflare.Backends.SourceSup
 
   require Logger
 
@@ -28,6 +29,8 @@ defmodule Logflare.Logs.SourceRouting do
     # route to a backend
     backend = Backends.Cache.get_backend(backend_id)
     le = %{le | via_rule: rule}
+    if SourceSup.rule_child_started?(rule) == false, do: SourceSup.start_rule_child(rule)
+
     # ingest to a specific backend
     Backends.ingest_logs([le], source, backend)
   end


### PR DESCRIPTION
Fixes log drains that do not have the rule child started at ingest time, for situations such as multi-cluster setups (as we have in prod), where a rule is created on one cluster and the startup does not propagate across the cluster.

This also adds in an `:rpc.multicall/3` to ensure that usage rules are started/stopped across the cluster
