### PR TITLE
fix: timezone preference query string replacement on change

### DIFF
--- a/lib/logflare_web/live/search_live/templates/logs_search.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.heex
@@ -50,7 +50,7 @@
           </a>
         </li>
         <li>
-          <%= live_modal_show_link(component: Search.UserPreferencesComponent, modal_id: :user_preferences, title: "Preferences", return_to: @uri.path <> "?querystring=c:count(*) c:group_by(t::minute)")  do %>
+          <%= live_modal_show_link(component: Search.UserPreferencesComponent, modal_id: :user_preferences, title: "Preferences", return_to: @uri.path <> "?" <> (@uri.query || ""))  do %>
             <i class="fas fa-globe"></i>
             <span class="hide-on-mobile">
               timezone

--- a/lib/logflare_web/live/search_live/user_prefs_component.ex
+++ b/lib/logflare_web/live/search_live/user_prefs_component.ex
@@ -88,7 +88,14 @@ defmodule LogflareWeb.Search.UserPreferencesComponent do
           socket
           |> put_flash(:error, "Something went wrong")
       end
-      |> push_navigate(to: socket.assigns.return_to <> "&tz=#{tz}")
+      |> then(fn socket ->
+        uri = URI.parse(socket.assigns.return_to)
+        query = URI.decode_query(uri.query) |> Map.merge(%{"tz" => tz})
+        updated_uri = %{uri | query: URI.encode_query(query)} |> URI.to_string() |> dbg()
+
+        socket
+        |> push_navigate(to: updated_uri)
+      end)
 
     {:noreply, socket}
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -50,7 +50,8 @@ defmodule Logflare.Factory do
   def team_user_factory do
     %TeamUser{
       name: "some name #{TestUtils.random_string()}",
-      team: build(:team)
+      team: build(:team),
+      provider: "google"
     }
   end
 


### PR DESCRIPTION
This PR fixes a bug where the querystring gets replaced by a hardcoded value when the user changes their preferred timezone