### PR TITLE
perf: increase fullsweep_after for BigQuery pipeline

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -37,7 +37,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
           # top-level will apply to all children
           hibernate_after: 5_000,
           spawn_opt: [
-            fullsweep_after: 0
+            fullsweep_after: 10
           ],
           producer: [
             module:


### PR DESCRIPTION
Increase fullsweep_after to reduce scheduler time, should reduce `:long_gc` warnings...