### PR TITLE
feat: GenStage custom logging for producer

### DIFF
--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -8,6 +8,7 @@ defmodule Logflare.Backends.BufferProducer do
   alias Logflare.Source
   alias Logflare.Sources
   alias Logflare.PubSubRates
+  require Logger
 
   @default_broadcast_interval 5_000
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -4,6 +4,8 @@ defmodule Logflare.Backends.BufferProducerTest do
   alias Logflare.PubSubRates
   alias Logflare.Backends.BufferProducer
 
+  import ExUnit.CaptureLog
+
   test "BufferProducer broadcasts every n ms" do
     PubSubRates.subscribe(:buffers)
 
@@ -29,5 +31,27 @@ defmodule Logflare.Backends.BufferProducerTest do
     assert_receive {:buffers, :"some-token", "some-backend", _payload}
 
     assert PubSubRates.Cache.get_cluster_buffers(:"some-token", "some-backend") == 0
+  end
+
+  test "BufferProducer when discarding will display source name" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+
+    pid =
+      start_supervised!(
+        {BufferProducer,
+         broadcast_interval: 100, backend_token: nil, source_token: source.token, buffer_size: 10}
+      )
+
+    items = for _ <- 1..100, do: "test"
+
+    captured =
+      capture_log(fn ->
+        send(pid, {:add_to_buffer, items})
+        :timer.sleep(100)
+      end)
+
+    assert captured =~ source.name
+    assert captured =~ Atom.to_string(source.token)
   end
 end


### PR DESCRIPTION
Add GenStage custom logging for BufferProducer for discards, to identify the sources/backends