### PR TITLE
feat: Buffer limiter v2

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -454,25 +454,20 @@ defmodule Logflare.Backends do
   @doc """
   Syncronously set the local buffer cache on the PubSub rates cache.
   Does not set the buffer len globally.
-  Does not perform clustter broadcasting.
+  Does not perform cluster broadcasting.
   Does not perform local broadcasting.
 
   if len arg is set to an integer, it will default setting the buffer len in the local node cache only
   """
-  def set_buffer_len(%Source{} = source, %Backend{} = backend, len) when is_integer(len) do
-    PubSubRates.Cache.cache_buffers(source.token, backend.token, %{Node.self() => %{len: len}})
+  def set_local_buffer_len(source, backend, node \\ Node.self(), len)
+
+  def set_local_buffer_len(%Source{} = source, %Backend{} = backend, node, len)
+      when is_integer(len) do
+    PubSubRates.Cache.cache_buffers(source.token, backend.token, %{node => %{len: len}})
   end
 
-  def set_buffer_len(%Source{} = source, %Backend{} = backend, %{} = lens) do
-    PubSubRates.Cache.cache_buffers(source.token, backend.token, lens)
-  end
-
-  def set_buffer_len(%Source{} = source, nil, len) when is_integer(len) do
-    PubSubRates.Cache.cache_buffers(source.token, nil, %{Node.self() => %{len: len}})
-  end
-
-  def set_buffer_len(%Source{} = source, nil, %{} = lens) do
-    PubSubRates.Cache.cache_buffers(source.token, nil, lens)
+  def set_local_buffer_len(%Source{} = source, nil, node, len) when is_integer(len) do
+    PubSubRates.Cache.cache_buffers(source.token, nil, %{node => %{len: len}})
   end
 
   @doc """

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -21,6 +21,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
+  @max_buffer_len 5_000
   @doc """
   Lists `Backend`s for a given source.
   """
@@ -433,6 +434,20 @@ defmodule Logflare.Backends do
     with :ok <- stop_source_sup(source),
          :ok <- start_source_sup(source) do
       :ok
+    end
+  end
+
+  @doc """
+  Checks if a local buffer is full.
+  """
+  def local_buffer_full?(%Source{} = source) do
+    case PubSubRates.Cache.get_buffers(source.token, nil) do
+      {:ok, buffers} when buffers != nil ->
+        buffer = Map.get(buffers, Node.self(), 0)
+        buffer >= @max_buffer_len
+
+      _ ->
+        false
     end
   end
 

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -10,7 +10,7 @@ defmodule Logflare.Backends.BufferProducer do
   alias Logflare.PubSubRates
   require Logger
 
-  @default_broadcast_interval 5_000
+  @default_broadcast_interval 2_000
 
   def start_link(opts) when is_list(opts) do
     GenStage.start_link(__MODULE__, opts)

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -10,7 +10,7 @@ defmodule Logflare.Backends.BufferProducer do
   alias Logflare.PubSubRates
   require Logger
 
-  @default_broadcast_interval 2_000
+  @default_broadcast_interval 500
 
   def start_link(opts) when is_list(opts) do
     GenStage.start_link(__MODULE__, opts)
@@ -29,7 +29,7 @@ defmodule Logflare.Backends.BufferProducer do
       })
 
     loop(state.broadcast_interval)
-    {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 10_000)}
+    {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 50_000)}
   end
 
   def format_discarded(discarded, state) do
@@ -68,19 +68,21 @@ defmodule Logflare.Backends.BufferProducer do
     pid = self()
 
     Task.start_link(fn ->
-      len = GenStage.estimate_buffered_count(pid)
-      local_buffer = %{Node.self() => %{len: len}}
+      # broadcasts cluster buffer length to local channels
+      cluster_buffer_len = PubSubRates.Cache.get_cluster_buffers(state.source_token)
 
-      cluster_buffer = PubSubRates.Cache.get_cluster_buffers(state.source_token)
-
-      # maybe broadcast
       payload = %{
-        buffer: cluster_buffer,
+        buffer: cluster_buffer_len,
         source_token: state.source_token,
         backend_token: state.backend_token
       }
 
-      # cluster broadcast
+      Source.ChannelTopics.broadcast_buffer(payload)
+
+      # broadcasts local buffer map to entire cluster, local included
+      len = GenStage.estimate_buffered_count(pid)
+      local_buffer = %{Node.self() => %{len: len}}
+
       cluster_broadcast_payload =
         if state.backend_token do
           {:buffers, state.source_token, state.backend_token, local_buffer}
@@ -93,9 +95,6 @@ defmodule Logflare.Backends.BufferProducer do
         "buffers",
         cluster_broadcast_payload
       )
-
-      # channel broadcast
-      Source.ChannelTopics.broadcast_buffer(payload)
     end)
   end
 

--- a/lib/logflare/pubsub_rates/buffers.ex
+++ b/lib/logflare/pubsub_rates/buffers.ex
@@ -1,7 +1,8 @@
 defmodule Logflare.PubSubRates.Buffers do
   @moduledoc false
-  alias Logflare.PubSubRates.Cache
   alias Logflare.PubSubRates
+  alias Logflare.Sources
+  alias Logflare.Backends
 
   require Logger
 
@@ -17,12 +18,23 @@ defmodule Logflare.PubSubRates.Buffers do
   end
 
   def handle_info({:buffers, source_token, buffers}, state) do
-    Cache.cache_buffers(source_token, nil, buffers)
+    source = Sources.Cache.get_by_id(source_token)
+
+    if source do
+      Backends.set_buffer_len(source, nil, buffers)
+    end
+
     {:noreply, state}
   end
 
   def handle_info({:buffers, source_token, backend_token, buffers}, state) do
-    Cache.cache_buffers(source_token, backend_token, buffers)
+    source = Sources.Cache.get_by_id(source_token)
+    backend = Backends.Cache.get_backend_by(token: backend_token)
+
+    if source do
+      Backends.set_buffer_len(source, backend, buffers)
+    end
+
     {:noreply, state}
   end
 end

--- a/lib/logflare/pubsub_rates/buffers.ex
+++ b/lib/logflare/pubsub_rates/buffers.ex
@@ -1,8 +1,9 @@
 defmodule Logflare.PubSubRates.Buffers do
-  @moduledoc false
+  @moduledoc """
+  Subscribes to all incoming cluster messages of each node's buffer.
+  """
+  alias Logflare.PubSubRates.Cache
   alias Logflare.PubSubRates
-  alias Logflare.Sources
-  alias Logflare.Backends
 
   require Logger
 
@@ -17,24 +18,13 @@ defmodule Logflare.PubSubRates.Buffers do
     {:ok, state}
   end
 
-  def handle_info({:buffers, source_token, buffers}, state) do
-    source = Sources.Cache.get_by_id(source_token)
-
-    if source do
-      Backends.set_buffer_len(source, nil, buffers)
-    end
-
+  def handle_info({:buffers, source_token, buffers}, state) when is_map(buffers) do
+    Cache.cache_buffers(source_token, nil, buffers)
     {:noreply, state}
   end
 
-  def handle_info({:buffers, source_token, backend_token, buffers}, state) do
-    source = Sources.Cache.get_by_id(source_token)
-    backend = Backends.Cache.get_backend_by(token: backend_token)
-
-    if source do
-      Backends.set_buffer_len(source, backend, buffers)
-    end
-
+  def handle_info({:buffers, source_token, backend_token, buffers}, state) when is_map(buffers) do
+    Cache.cache_buffers(source_token, backend_token, buffers)
     {:noreply, state}
   end
 end

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -46,7 +46,7 @@ defmodule Logflare.PubSubRates.Cache do
   @spec cache_buffers(atom(), String.t(), node_buffers()) :: {:ok, true}
   def cache_buffers(source_token, backend_token, buffers) when is_atom(source_token) do
     resolved =
-      case get_buffer(source_token, backend_token) do
+      case get_buffers(source_token, backend_token) do
         {:ok, val} when val != nil -> Map.merge(val, buffers)
         _ -> buffers
       end
@@ -56,7 +56,11 @@ defmodule Logflare.PubSubRates.Cache do
     )
   end
 
-  defp get_buffer(source_token, backend_token) do
+  @doc """
+  Returns a node mapping of buffer lengths across the cluster.
+  """
+  @spec get_buffers(atom(), String.t() | nil) :: map()
+  def get_buffers(source_token, backend_token) do
     Cachex.get(__MODULE__, {source_token, backend_token, "buffers"})
   end
 
@@ -66,7 +70,7 @@ defmodule Logflare.PubSubRates.Cache do
   @spec get_cluster_buffers(atom(), String.t()) :: non_neg_integer()
   @spec get_cluster_buffers(atom()) :: non_neg_integer()
   def get_cluster_buffers(source_token, backend_token \\ nil) when is_atom(source_token) do
-    case get_buffer(source_token, backend_token) do
+    case get_buffers(source_token, backend_token) do
       {:ok, node_buffers} when node_buffers != nil -> merge_buffers(node_buffers)
       _ -> 0
     end

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -40,7 +40,8 @@ defmodule Logflare.PubSubRates.Cache do
   end
 
   @doc """
-  Stores a node map of buffer counts on the local cache
+  Stores a node map of buffer counts on the local cache.
+  Merges a node map into the local cache.
   """
   @typep node_buffers :: %{atom() => non_neg_integer()}
   @spec cache_buffers(atom(), String.t(), node_buffers()) :: {:ok, true}

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -1,0 +1,19 @@
+defmodule LogflareWeb.Plugs.BufferLimiter do
+  @moduledoc """
+  A plug that allows or denies API action based on the API request rate rules for user/source
+  """
+  import Plug.Conn
+  alias Logflare.Backends
+
+  def init(_opts), do: nil
+
+  def call(%{assigns: %{source: source}} = conn, _opts \\ []) do
+    if Backends.local_buffer_full?(source) do
+      conn
+      |> send_resp(429, "Buffer full: Too many requests")
+      |> halt()
+    else
+      conn
+    end
+  end
+end

--- a/lib/logflare_web/live/search_live/user_prefs_component.ex
+++ b/lib/logflare_web/live/search_live/user_prefs_component.ex
@@ -91,7 +91,7 @@ defmodule LogflareWeb.Search.UserPreferencesComponent do
       |> then(fn socket ->
         uri = URI.parse(socket.assigns.return_to)
         query = URI.decode_query(uri.query) |> Map.merge(%{"tz" => tz})
-        updated_uri = %{uri | query: URI.encode_query(query)} |> URI.to_string() |> dbg()
+        updated_uri = %{uri | query: URI.encode_query(query)} |> URI.to_string()
 
         socket
         |> push_navigate(to: updated_uri)

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -83,6 +83,7 @@ defmodule LogflareWeb.Router do
     # plug LogflareWeb.Plugs.EnsureSourceStarted
     plug(LogflareWeb.Plugs.SetPlanFromCache)
     plug(LogflareWeb.Plugs.RateLimiter)
+    plug(LogflareWeb.Plugs.BufferLimiter)
   end
 
   pipeline :require_mgmt_api_auth do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -164,7 +164,6 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # switch to arizona
       {:error, {:live_redirect, %{to: to}}} =
-        redirect =
         view
         |> element("form#user-tz-form")
         |> render_submit(%{user_preferences: %{timezone: "US/Arizona"}})

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -19,7 +19,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     test "if buffer is full, return 429", %{conn: conn} do
       source = insert(:source, user: insert(:user))
-      Backends.set_buffer_len(source, nil, 20_000)
+      Backends.set_local_buffer_len(source, nil, 20_000)
 
       conn =
         conn
@@ -43,7 +43,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     test "if buffer not full, passthrough", %{conn: conn} do
       source = insert(:source, user: insert(:user))
-      Backends.set_buffer_len(source, nil, 1)
+      Backends.set_local_buffer_len(source, nil, 1)
 
       conn =
         conn

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -1,0 +1,38 @@
+defmodule LogflareWeb.Plugs.BufferLimiterTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+  alias LogflareWeb.Plugs.BufferLimiter
+  alias Logflare.PubSubRates
+
+  describe "partner impersonation" do
+    setup do
+      conn = build_conn(:post, "/api/logs", %{"message" => "some text"})
+      {:ok, conn: conn}
+    end
+
+    test "if buffer is full, return 429", %{conn: conn} do
+      source = insert(:source, user: insert(:user))
+      PubSubRates.Cache.cache_buffers(source.token, nil, %{Node.self() => 20_000})
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == true
+      assert conn.status == 429
+    end
+
+    test "if buffer not full, passthrough", %{conn: conn} do
+      source = insert(:source, user: insert(:user))
+      PubSubRates.Cache.cache_buffers(source.token, nil, %{"localhost" => 1})
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == false
+    end
+  end
+end

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -3,16 +3,23 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   use LogflareWeb.ConnCase
   alias LogflareWeb.Plugs.BufferLimiter
   alias Logflare.PubSubRates
+  alias Logflare.Backends
 
   describe "partner impersonation" do
     setup do
       conn = build_conn(:post, "/api/logs", %{"message" => "some text"})
+
+      on_exit(fn ->
+        PubSubRates.Cache
+        |> Cachex.clear()
+      end)
+
       {:ok, conn: conn}
     end
 
     test "if buffer is full, return 429", %{conn: conn} do
       source = insert(:source, user: insert(:user))
-      PubSubRates.Cache.cache_buffers(source.token, nil, %{Node.self() => 20_000})
+      Backends.set_buffer_len(source, nil, 20_000)
 
       conn =
         conn
@@ -23,9 +30,20 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       assert conn.status == 429
     end
 
+    test "check if buffer is full if no node value is found", %{conn: conn} do
+      source = insert(:source, user: insert(:user))
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == false
+    end
+
     test "if buffer not full, passthrough", %{conn: conn} do
       source = insert(:source, user: insert(:user))
-      PubSubRates.Cache.cache_buffers(source.token, nil, %{"localhost" => 1})
+      Backends.set_buffer_len(source, nil, 1)
 
       conn =
         conn


### PR DESCRIPTION
This reverts commit 70bb8d5 and reworks the buffer limiter code:
1. Max buffer length on producer is now 50k, 10x of 5k soft limit. If buffer count is at or above 5k, it will reject incoming requests. This allows for burst requests that occur within the broadcast time interval when count is still below the 5k limit. On local testing, this results in no buffer producer discards occuring on even extremely high ingest rates (>15k/s) 
2. Broadcast interval reduced to 500ms, to ensure that buffer limiter cache data is always up to date. 
3. It fixes some logic for setting of uninitialized bufer cache, which was resulting in all incoming requests getting rejected. Tests have been updated to cover this situation.


Potential improvements in the future:
- reducing and removing zero buffer length broadcasting