### PR TITLE
perf: add spawn_opts and hibernate_after for better memory management

### DIFF
--- a/lib/logflare/source/bigquery/schema.ex
+++ b/lib/logflare/source/bigquery/schema.ex
@@ -22,7 +22,14 @@ defmodule Logflare.Source.BigQuery.Schema do
 
   def start_link(args) when is_list(args) do
     {name, args} = Keyword.pop(args, :name)
-    GenServer.start_link(__MODULE__, args, name: name)
+
+    GenServer.start_link(__MODULE__, args,
+      name: name,
+      spawn_opt: [
+        fullsweep_after: 20
+      ],
+      hibernate_after: 5_000
+    )
   end
 
   def init(args) do

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -90,7 +90,13 @@ defmodule Logflare.Source.RecentLogsServer do
 
   ## Server
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: Backends.via_source(args[:source], __MODULE__))
+    GenServer.start_link(__MODULE__, args,
+      name: Backends.via_source(args[:source], __MODULE__),
+      spawn_opt: [
+        fullsweep_after: 20
+      ],
+      hibernate_after: 5_000
+    )
   end
 
   ## Client


### PR DESCRIPTION
This reduces memory consumption for Schema and RecentLogsServer procs, which consume significant amounts of memory (~800-5GB) on high ingestion traffic. This ensures that GCing occurs frequently. These two modules usually on the top of the list for high memory usage on prod.