### PR TITLE
perf: add schema sampling based on local ingestion rates on high ingestion volume

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
+++ b/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
@@ -101,6 +101,12 @@ metadata: {
 }
 ```
 
+:::note
+On high ingestion volume, Logflare will sample incoming events instead of checking each event. The sample rate decreases as the ingestion rate increases. Ingestion rates are compared only on an individual local server that is performing the ingestion.
+
+From 1000-5000 events per second, sample rate is 0.1. Above 5000 events per second, sample rate is 0.01.
+:::
+
 ### Key Transformation
 
 When logging object, your object keys will be transformed automatically to comply with the respective backend in use. For example, BigQuery column requirements require that names only contain letters (a-z, A-Z), numbers (0-9), or underscores (\_), and it must start with a letter or underscore. This will be automatically handled for you when ingesting data.

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -76,6 +76,35 @@ defmodule Logflare.PubSubRates.Cache do
     Cachex.get(__MODULE__, {source_id, "rates"})
   end
 
+  def get_local_rates(source_id) when is_atom(source_id) do
+    node = Node.self()
+
+    default = %{
+      average_rate: 0,
+      last_rate: 0,
+      max_rate: 0,
+      limiter_metrics: %{average: 0, duration: @default_bucket_width, sum: 0}
+    }
+
+    case get_rates(source_id) do
+      {:ok, nil} ->
+        default
+
+      {:ok, rates} ->
+        Map.get(rates, node, default)
+
+      {:error, _} = err ->
+        Logger.error("Error when getting pubsub clustr rates: #{inspect(err)}")
+
+        %{
+          average_rate: -1,
+          last_rate: -1,
+          max_rate: -1,
+          limiter_metrics: %{average: 100_000, duration: @default_bucket_width, sum: 6_000_000}
+        }
+    end
+  end
+
   def get_cluster_rates(source_id) when is_atom(source_id) do
     case get_rates(source_id) do
       {:ok, nil} ->


### PR DESCRIPTION
Adds in ingestion sampling based on local ingestion rates. This greatly reduces memory usage of the Schema module and prevents message queue buildup. In local testing, reduced memory usage by ~50% and reduced message queue buildup from over >11k messages to 0 messages.