### PR TITLE
fix: remove Endpoint not up error logging, switch to error tuple

### DIFF
--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -77,7 +77,7 @@ defmodule Logflare.Backends.BufferProducer do
         backend_token: state.backend_token
       }
 
-      Source.ChannelTopics.broadcast_buffer(payload)
+      Source.ChannelTopics.local_broadcast_buffer(payload)
 
       # broadcasts local buffer map to entire cluster, local included
       len = GenStage.estimate_buffered_count(pid)

--- a/lib/logflare/source/rate_counter_server.ex
+++ b/lib/logflare/source/rate_counter_server.ex
@@ -261,7 +261,7 @@ defmodule Logflare.Source.RateCounterServer do
       PubSubRates.Cache.get_cluster_rates(state.source_id)
       |> Map.put(:source_token, state.source_id)
 
-    Source.ChannelTopics.broadcast_rates(cluster_rates)
+    Source.ChannelTopics.local_broadcast_rates(cluster_rates)
   end
 
   @spec get_insert_count(atom) :: {:ok, non_neg_integer()}

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -223,7 +223,7 @@ defmodule Logflare.Source.RecentLogsServer do
 
     if current_cluster_inserts > last_cluster_inserts do
       payload = %{log_count: current_cluster_inserts, source_token: state.source_token}
-      Source.ChannelTopics.broadcast_log_count(payload)
+      Source.ChannelTopics.local_broadcast_log_count(payload)
     end
 
     {:ok, current_cluster_inserts, current_inserts}

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -386,10 +386,9 @@ defmodule Logflare.BackendsTest do
       backend = insert(:backend, user: user)
       [source1, source2] = insert_pair(:source, user: user, rules: [])
 
-      rules =
-        for _ <- 1..250 do
-          insert(:rule, source: source2, backend: backend, lql_string: "message")
-        end
+      for _ <- 1..250 do
+        insert(:rule, source: source2, backend: backend, lql_string: "message")
+      end
 
       source2 = Sources.preload_defaults(source2)
 

--- a/test/logflare/cluster_pubsub_test.exs
+++ b/test/logflare/cluster_pubsub_test.exs
@@ -54,9 +54,9 @@ defmodule Logflare.ClusterPubSubTest do
 
     test "broadcast to dashboard", %{source: %{token: source_token}} do
       ChannelTopics.subscribe_dashboard(source_token)
-      ChannelTopics.broadcast_log_count(%{log_count: 1111, source_token: source_token})
-      ChannelTopics.broadcast_rates(%{last_rate: 2222, source_token: source_token})
-      ChannelTopics.broadcast_buffer(%{buffer: 3333, source_token: source_token})
+      ChannelTopics.local_broadcast_log_count(%{log_count: 1111, source_token: source_token})
+      ChannelTopics.local_broadcast_rates(%{last_rate: 2222, source_token: source_token})
+      ChannelTopics.local_broadcast_buffer(%{buffer: 3333, source_token: source_token})
 
       :timer.sleep(500)
       assert_received %_{event: "log_count", payload: %{log_count: "1,111"}}

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -6,14 +6,15 @@ defmodule LogflareWeb.HealthCheckControllerTest do
   alias Logflare.SingleTenant
   alias Logflare.Source
 
+  setup do
+    Logflare.Google.BigQuery
+    |> stub(:init_table!, fn _, _, _, _, _, _ -> :ok end)
+
+    :ok
+  end
+
   test "normal node health check", %{conn: conn} do
     start_supervised!(Source.Supervisor)
-
-    assert %{"status" => "coming_up"} =
-             conn
-             |> get("/health")
-             |> json_response(503)
-
     :timer.sleep(1000)
 
     conn = get(conn, "/health")


### PR DESCRIPTION
Fix for error logging on node startup where SourceSup performs buffer broadcasting.
Error logs itself are unnecessary as if the endpoint goes down, the whole cluster will go down and requests will not get served in any case.