### PR TITLE
feat: buffer producer broadcasting refactor

### DIFF
--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -5,12 +5,9 @@ defmodule Logflare.Backends.BufferProducer do
   Meant for push through Broadway.push_messages/2
   """
   use GenStage
-  alias Logflare.Source
   alias Logflare.Sources
-  alias Logflare.PubSubRates
+  alias Logflare.Backends.BufferProducer
   require Logger
-
-  @default_broadcast_interval 500
 
   def start_link(opts) when is_list(opts) do
     GenStage.start_link(__MODULE__, opts)
@@ -19,29 +16,45 @@ defmodule Logflare.Backends.BufferProducer do
   def init(opts) do
     state =
       Enum.into(opts, %{
-        buffer_module: nil,
-        buffer_pid: nil,
         demand: 0,
         # TODO: broadcast by id instead.
         source_token: nil,
         backend_token: nil,
-        broadcast_interval: @default_broadcast_interval
+        producer_pid: self(),
+        # discard logging backoff
+        last_discard_log_dt: nil
       })
 
-    loop(state.broadcast_interval)
+    {:ok, _pid} = BufferProducer.Worker.start_link(state)
+
+    # loop(state.active_broadcast_interval)
     {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 50_000)}
   end
 
   def format_discarded(discarded, state) do
     source = Sources.Cache.get_by_id(state.source_token)
 
-    Logger.warning(
-      "GenStage producer for #{source.name} (#{source.token}) has discarded #{discarded} events from buffer",
-      source_token: source.token,
-      source_id: source.token,
-      backend_token: state.backend_token
-    )
+    # backoff logic to prevent torrent of discards
+    # defaults to at most 1 log per 5 second per producer
+    should_log? =
+      cond do
+        state.last_discard_log_dt == nil -> true
+        DateTime.diff(DateTime.utc_now(), state.last_discard_log_dt) > 5 -> true
+        true -> false
+      end
 
+    if should_log? do
+      Logger.warning(
+        "GenStage producer for #{source.name} (#{source.token}) has discarded #{discarded} events from buffer",
+        source_token: source.token,
+        source_id: source.token,
+        backend_token: state.backend_token
+      )
+
+      send(self(), {:update_state, %{state | last_discard_log_dt: DateTime.utc_now()}})
+    end
+
+    # don't do the default log
     false
   end
 
@@ -50,52 +63,12 @@ defmodule Logflare.Backends.BufferProducer do
     {:noreply, items, state}
   end
 
-  def handle_info(:broadcast, state) do
-    do_async_broadcast(state)
-    loop(state.broadcast_interval)
-    {:noreply, [], state}
-  end
-
   def handle_info({:update_state, new_state}, _state) do
     {:noreply, [], new_state}
   end
 
   def handle_info({:add_to_buffer, items}, state) do
     {:noreply, items, state}
-  end
-
-  defp do_async_broadcast(state) do
-    pid = self()
-
-    Task.start_link(fn ->
-      # broadcasts cluster buffer length to local channels
-      cluster_buffer_len = PubSubRates.Cache.get_cluster_buffers(state.source_token)
-
-      payload = %{
-        buffer: cluster_buffer_len,
-        source_token: state.source_token,
-        backend_token: state.backend_token
-      }
-
-      Source.ChannelTopics.local_broadcast_buffer(payload)
-
-      # broadcasts local buffer map to entire cluster, local included
-      len = GenStage.estimate_buffered_count(pid)
-      local_buffer = %{Node.self() => %{len: len}}
-
-      cluster_broadcast_payload =
-        if state.backend_token do
-          {:buffers, state.source_token, state.backend_token, local_buffer}
-        else
-          {:buffers, state.source_token, local_buffer}
-        end
-
-      Phoenix.PubSub.broadcast(
-        Logflare.PubSub,
-        "buffers",
-        cluster_broadcast_payload
-      )
-    end)
   end
 
   def handle_demand(demand, state) do
@@ -109,9 +82,5 @@ defmodule Logflare.Backends.BufferProducer do
        ) do
     total_demand = prev_demand + new_demand
     {[], %{state | demand: total_demand}}
-  end
-
-  defp loop(interval) do
-    Process.send_after(self(), :broadcast, interval)
   end
 end

--- a/lib/logflare/backends/buffer_producer/worker.ex
+++ b/lib/logflare/backends/buffer_producer/worker.ex
@@ -1,0 +1,102 @@
+defmodule Logflare.Backends.BufferProducer.Worker do
+  @moduledoc """
+  A generic broadway producer that doesn't actually produce anything.
+
+  Meant for push through Broadway.push_messages/2
+  """
+  use GenStage
+  alias Logflare.Source
+  alias Logflare.PubSubRates
+  require Logger
+
+  @active_broadcast_interval 1000
+  @idle_broadcast_interval 5000
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(state) do
+    state =
+      Map.merge(
+        %{
+          last_len: 0,
+          active_broadcast_interval: @active_broadcast_interval,
+          idle_broadcast_interval: @idle_broadcast_interval
+        },
+        state
+      )
+
+    Process.send_after(self(), :check_len, state.active_broadcast_interval)
+    Process.send_after(self(), :periodic_broadcast, state.idle_broadcast_interval)
+    {:ok, state}
+  end
+
+  def handle_info(:check_len, state) do
+    state = maybe_global_broadcast_producer_buffer_len(state)
+    {:noreply, state}
+  end
+
+  def handle_info(:periodic_broadcast, state) do
+    local_broadcast_cluster_length(state)
+    Process.send_after(self(), :periodic_broadcast, state.idle_broadcast_interval)
+    {:noreply, state}
+  end
+
+  defp maybe_global_broadcast_producer_buffer_len(state) do
+    len = GenStage.estimate_buffered_count(state.producer_pid)
+    Logger.debug("BufferProducer.Worker - #{state.source_token} - #{len} buffer len")
+
+    {should_broadcast?, state} =
+      if state.last_len == 0 and len == 0 do
+        Logger.debug("BufferProducer.Worker - #{state.source_token} - Idle buffer len checking")
+        Process.send_after(self(), :check_len, state.idle_broadcast_interval)
+        {false, state}
+      else
+        Logger.debug("BufferProducer.Worker - #{state.source_token} - Active buffer len checking")
+        Process.send_after(self(), :check_len, state.active_broadcast_interval)
+        {true, %{state | last_len: len}}
+      end
+
+    # broadcast length
+    if should_broadcast? do
+      local_buffer = %{Node.self() => %{len: len}}
+
+      cluster_broadcast_payload =
+        if state.backend_token do
+          # cache local length
+          PubSubRates.Cache.cache_buffers(state.source_token, state.backend_token, local_buffer)
+
+          {:buffers, state.source_token, state.backend_token, local_buffer}
+        else
+          PubSubRates.Cache.cache_buffers(state.source_token, nil, local_buffer)
+          {:buffers, state.source_token, local_buffer}
+        end
+
+      Logger.debug(
+        "BufferProducer.Worker - #{state.source_token} - Broadcasting buffer len globally"
+      )
+
+      Phoenix.PubSub.broadcast(
+        Logflare.PubSub,
+        "buffers",
+        cluster_broadcast_payload
+      )
+    end
+
+    state
+  end
+
+  defp local_broadcast_cluster_length(state) do
+    # broadcasts cluster buffer length to local channels
+    cluster_buffer_len = PubSubRates.Cache.get_cluster_buffers(state.source_token)
+
+    payload = %{
+      buffer: cluster_buffer_len,
+      source_token: state.source_token,
+      backend_token: state.backend_token
+    }
+
+    Source.ChannelTopics.local_broadcast_buffer(payload)
+  end
+end

--- a/lib/logflare/pubsub_rates/buffers.ex
+++ b/lib/logflare/pubsub_rates/buffers.ex
@@ -16,10 +16,7 @@ defmodule Logflare.PubSubRates.Buffers do
   def init(_state) do
     PubSubRates.subscribe(:buffers)
 
-    {:ok,
-     %{
-       current_node: Node.self()
-     }}
+    {:ok, %{}}
   end
 
   def handle_info({:buffers, source_token, buffers}, state) when is_map(buffers) do

--- a/lib/logflare/pubsub_rates/buffers.ex
+++ b/lib/logflare/pubsub_rates/buffers.ex
@@ -13,18 +13,28 @@ defmodule Logflare.PubSubRates.Buffers do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
-  def init(state) do
+  def init(_state) do
     PubSubRates.subscribe(:buffers)
-    {:ok, state}
+
+    {:ok,
+     %{
+       current_node: Node.self()
+     }}
   end
 
   def handle_info({:buffers, source_token, buffers}, state) when is_map(buffers) do
-    Cache.cache_buffers(source_token, nil, buffers)
+    if not is_map_key(buffers, Node.self()) do
+      Cache.cache_buffers(source_token, nil, buffers)
+    end
+
     {:noreply, state}
   end
 
   def handle_info({:buffers, source_token, backend_token, buffers}, state) when is_map(buffers) do
-    Cache.cache_buffers(source_token, backend_token, buffers)
+    if not is_map_key(buffers, Node.self()) do
+      Cache.cache_buffers(source_token, backend_token, buffers)
+    end
+
     {:noreply, state}
   end
 end

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -12,12 +12,14 @@ defmodule Logflare.Backends.BufferProducerTest do
     %{token: source_token} = source = insert(:source, user: user)
 
     pid =
-      start_supervised!({BufferProducer, broadcast_interval: 100, source_token: source.token})
+      start_supervised!(
+        {BufferProducer,
+         active_broadcast_interval: 100, idle_broadcast_interval: 100, source_token: source.token}
+      )
 
     :timer.sleep(300)
-    assert_receive {:buffers, ^source_token, _payload}
     send(pid, {:add_to_buffer, [:something]})
-    :timer.sleep(300)
+    assert_receive {:buffers, ^source_token, _payload}
     assert PubSubRates.Cache.get_cluster_buffers(source_token) == 1
   end
 
@@ -27,15 +29,20 @@ defmodule Logflare.Backends.BufferProducerTest do
     %{token: source_token} = source = insert(:source, user: user)
     %{token: backend_token} = backend = insert(:backend, user: user)
 
-    start_supervised!(
-      {BufferProducer,
-       broadcast_interval: 100, backend_token: backend.token, source_token: source.token}
-    )
+    pid =
+      start_supervised!(
+        {BufferProducer,
+         idle_broadcast_interval: 100,
+         active_broadcast_interval: 100,
+         backend_token: backend.token,
+         source_token: source.token}
+      )
 
+    send(pid, {:add_to_buffer, [:something]})
     :timer.sleep(200)
     assert_receive {:buffers, ^source_token, ^backend_token, _payload}
 
-    assert PubSubRates.Cache.get_cluster_buffers(source.token, backend.token) == 0
+    assert PubSubRates.Cache.get_cluster_buffers(source.token, backend.token) == 1
   end
 
   test "BufferProducer when discarding will display source name" do
@@ -45,7 +52,10 @@ defmodule Logflare.Backends.BufferProducerTest do
     pid =
       start_supervised!(
         {BufferProducer,
-         broadcast_interval: 100, backend_token: nil, source_token: source.token, buffer_size: 10}
+         active_broadcast_interval: 100,
+         backend_token: nil,
+         source_token: source.token,
+         buffer_size: 10}
       )
 
     items = for _ <- 1..100, do: "test"
@@ -54,9 +64,58 @@ defmodule Logflare.Backends.BufferProducerTest do
       capture_log(fn ->
         send(pid, {:add_to_buffer, items})
         :timer.sleep(100)
+        send(pid, {:add_to_buffer, items})
+        :timer.sleep(100)
       end)
 
     assert captured =~ source.name
     assert captured =~ Atom.to_string(source.token)
+    # log only once
+    assert count_substrings(captured, source.name) == 1
+  end
+
+  def count_substrings(string, substring) do
+    regex = Regex.compile!(substring)
+
+    Regex.scan(regex, string)
+    |> length()
+  end
+
+  test "BufferProducer idle broadcast interval" do
+    PubSubRates.subscribe(:buffers)
+    user = insert(:user)
+    %{token: source_token} = source = insert(:source, user: user)
+
+    pid =
+      start_supervised!(
+        {BufferProducer,
+         idle_broadcast_interval: 500,
+         active_broadcast_interval: 100,
+         backend_token: nil,
+         source_token: source.token,
+         buffer_size: 1000}
+      )
+
+    items = for _ <- 1..100, do: "test"
+
+    send(pid, {:add_to_buffer, items})
+    :timer.sleep(600)
+    assert_receive {:buffers, ^source_token, _payload}
+    assert PubSubRates.Cache.get_cluster_buffers(source.token, nil) != 0
+    {:message_queue_len, msg_queue_len} = Process.info(self(), :message_queue_len)
+
+    GenStage.stream([{pid, max_demand: 100}])
+    |> Enum.take(5)
+
+    :timer.sleep(400)
+    test_pid = self()
+
+    TestUtils.retry_assert(fn ->
+      {:message_queue_len, new_msg_queue_len} = Process.info(test_pid, :message_queue_len)
+      assert new_msg_queue_len <= msg_queue_len + 3
+    end)
+
+    node = Node.self()
+    assert_receive {:buffers, ^source_token, %{^node => %{len: 0}}}
   end
 end

--- a/test/profiling/buffer_producer.exs
+++ b/test/profiling/buffer_producer.exs
@@ -1,0 +1,15 @@
+alias Logflare.Sources
+
+Mimic.copy(Broadway)
+
+Mimic.stub(Broadway, :push_messages, fn _, _ -> :ok end)
+
+arg1 = System.argv() |> Enum.at(0)
+source = Sources.get(:"f74e843a-e09d-42e1-b2bc-1915e75b53c5")
+Logflare.Backends.BufferProducer.start_link(backend_token: nil, source_token: source.token)
+
+:timer.sleep(60_000)
+
+# Current: 2024-06-02 bef
+# CNT    ACC (ms)    OWN (ms)
+# 37976   60007.640     195.062


### PR DESCRIPTION
This PR adds in the following optimizations for the BufferProducer:

- direct in process caching, instead of local broadcast -> handle_info -> cache
- discard warning log 5 sec backoff, to prevent bursts of warning logs 
- periodic 2.5s cluster length local broadcast
- active/idle interval switching for global (minus local node) broadcasting of buffer length, and accounting for first/last zeros, to reduce cross cluster chatter.

- also adds a profiling script, with stats from before changes were implemented.