### PR TITLE
perf: increase insert count broadcast interval

### DIFF
--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -18,7 +18,7 @@ defmodule Logflare.Source.RecentLogsServer do
   require Logger
 
   @touch_timer :timer.minutes(45)
-  @broadcast_every 500
+  @broadcast_every 1_500
 
   @spec push(Source.t(), LE.t() | [LE.t()]) :: :ok
   def push(source, %LE{} = le), do: push(source, [le])


### PR DESCRIPTION
Increases broadcast count interval by x3. To reduce cross cluster messages. Should have a very minor effect on ux, and will reduce rate of flashing for sources. Having too much count flashing on the ui isn't good for ux anyway, can get distracting at times.