### PR TITLE
perf: completely disable opentelemetry sdk unless config is given

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -131,6 +131,7 @@ config :grpc, start_server: true
 config :logflare, Logflare.AlertsScheduler, init_task: {Logflare.Alerting, :init_alert_jobs, []}
 
 config :opentelemetry,
+  sdk_disabled: true,
   span_processor: :batch,
   traces_exporter: :none
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -292,6 +292,7 @@ if System.get_env("LOGFLARE_OTEL_ENDPOINT") do
   config :logflare, opentelemetry_enabled?: true
 
   config :opentelemetry,
+    sdk_disabled: false,
     traces_exporter: :otlp,
     sampler:
       {:parent_based,


### PR DESCRIPTION
fully disable opentelemetry, apparently telemetry signals are still collected unless `sdk_disabled` is set