### PR TITLE
perf: increase max pending buffer length

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -21,7 +21,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len 7_500
+  @max_pending_buffer_len 15_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length.

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -12,7 +12,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   end
 
   test "if buffer is full of pending, return 429", %{conn: conn, source: source} do
-    for _ <- 1..8_000 do
+    for _ <- 1..20_000 do
       le = build(:log_event)
       IngestEventQueue.add_to_table({source, nil}, [le])
     end


### PR DESCRIPTION
increases the pending buffer length, to account for previous wheel behaviour