### PR TITLE
fix: init PubSubRates early

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -114,7 +114,6 @@ defmodule Logflare.Application do
         Logs.LogEvents.Cache,
         PubSubRates,
 
-
         # Follow Postgresql replication log and bust all our context caches
         {
           Cainophile.Adapters.Postgres,

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -101,7 +101,6 @@ defmodule Logflare.Application do
         {Cluster.Supervisor, [topologies, [name: Logflare.ClusterSupervisor]]},
         Logflare.Repo,
         {Phoenix.PubSub, name: Logflare.PubSub, pool_size: pool_size},
-        # supervisor(LogflareTelemetry.Supervisor, []),
         # Context Caches
         TeamUsers.Cache,
         ContextCache,
@@ -113,6 +112,8 @@ defmodule Logflare.Application do
         SourceSchemas.Cache,
         Auth.Cache,
         Logs.LogEvents.Cache,
+        PubSubRates,
+
 
         # Follow Postgresql replication log and bust all our context caches
         {
@@ -130,7 +131,6 @@ defmodule Logflare.Application do
           publications: publications
         },
         Logflare.CacheBuster,
-
         # Sources
         # v1 ingest pipline
         {Registry,
@@ -142,7 +142,6 @@ defmodule Logflare.Application do
         # Backends needs to be before Source.Supervisor
         Logflare.Backends,
         Logflare.Source.Supervisor,
-        PubSubRates,
         {DynamicSupervisor,
          strategy: :one_for_one,
          restart: :transient,

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -99,7 +99,7 @@ defmodule Logflare.PubSubRates.Cache do
       {:error, :no_cache} ->
         default
 
-        {:error, _} = err ->
+      {:error, _} = err ->
         Logger.error("Error when getting pubsub cluster rates: #{inspect(err)}")
 
         %{

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -96,8 +96,11 @@ defmodule Logflare.PubSubRates.Cache do
       {:ok, rates} ->
         Map.get(rates, node, default)
 
-      {:error, _} = err ->
-        Logger.error("Error when getting pubsub clustr rates: #{inspect(err)}")
+      {:error, :no_cache} ->
+        default
+
+        {:error, _} = err ->
+        Logger.error("Error when getting pubsub cluster rates: #{inspect(err)}")
 
         %{
           average_rate: -1,


### PR DESCRIPTION
![image](https://github.com/Logflare/logflare/assets/22714384/77fefcb6-f707-4d3a-adde-5971d134aeb0)
This will init the PubSubRates cache early, so that when stuff start getting ingested, it will not log an error (due to schema sampling)