### PR TITLE
fix: don't handle 3 element tuples of previous format

### DIFF
--- a/lib/logflare/pubsub_rates/buffers.ex
+++ b/lib/logflare/pubsub_rates/buffers.ex
@@ -13,14 +13,22 @@ defmodule Logflare.PubSubRates.Buffers do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
+  @impl GenServer
   def init(_state) do
     PubSubRates.subscribe(:buffers)
     {:ok, %{}}
   end
 
+  @impl GenServer
   def handle_info({:buffers, source_id, backend_id, buffers}, state)
       when is_integer(source_id) and is_map(buffers) do
     Cache.cache_buffers(source_id, backend_id, buffers)
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info({:buffers, _, _}, state) do
+    # don't handle old format of 3-elem tuple.
     {:noreply, state}
   end
 end

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -58,9 +58,9 @@ defmodule Logflare.PubSubRates.Cache do
   @doc """
   Returns a node mapping of buffer lengths across the cluster.
   """
-  @spec get_buffers(atom(), String.t() | nil) :: map()
-  def get_buffers(source_token, backend_token) do
-    Cachex.get(__MODULE__, {source_token, backend_token, "buffers"})
+  @spec get_buffers(non_neg_integer(), non_neg_integer() | nil) :: map()
+  def get_buffers(source_id, backend_id) do
+    Cachex.get(__MODULE__, {source_id, backend_id, "buffers"})
   end
 
   @doc """

--- a/test/logflare/cluster_pubsub_test.exs
+++ b/test/logflare/cluster_pubsub_test.exs
@@ -45,6 +45,20 @@ defmodule Logflare.ClusterPubSubTest do
         assert_received {:buffers, ^source_id, nil, %{data: "some val"}}
       end)
     end
+
+    test "buffers 3-elem tuple is no op", %{source: source} do
+      Phoenix.PubSub.broadcast(
+        Logflare.PubSub,
+        "buffers",
+        {:buffers, source.token, %{Node.self() => %{len: 5}}}
+      )
+
+      :timer.sleep(100)
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 0
+      PubSubRates.global_broadcast_rate({:buffers, source.id, nil, %{Node.self() => %{len: 5}}})
+      :timer.sleep(100)
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 5
+    end
   end
 
   describe "ChannelTopics" do


### PR DESCRIPTION
This fixes an error when previous version nodes are broadcasting 3-elem buffer msg tuples for PubSubRates