### PR TITLE
perf: load balance on scheduler utilization

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -15,6 +15,9 @@
 +sbwtdcpu none
 +sbwtdio none
 
+## load balance on scheduler utilization
++sub true
+
 ## Reduce scheduler wake up threshold
 +swt low
 +swtdcpu low

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -19,9 +19,9 @@
 +sub true
 
 ## Reduce scheduler wake up threshold
-+swt low
-+swtdcpu low
-+swtdio low
++swt very_low
++swtdcpu very_low
++swtdio very_low
 
 
 ## Set distribution buffer limit - default is 1024


### PR DESCRIPTION
https://www.erlang.org/docs/25/man/erl#+sub

load compation leads to spikey scheduler utilization, and given the type of continuous load that we have, does not really make much sense.

This also reduces the scheduler wake up threshold further