### PR TITLE
perf: dynamic BufferProducer scheduling

### DIFF
--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -61,7 +61,8 @@ defmodule Logflare.Backends.BufferProducer do
   @impl GenStage
   def handle_info(:scheduled_resolve, state) do
     {items, state} = resolve_demand(state)
-    schedule(state)
+    scale? = if Application.get_env(:logflare, :env) == :test, do: false, else: true
+    schedule(state, scale?)
     {:noreply, items, state}
   end
 
@@ -81,7 +82,7 @@ defmodule Logflare.Backends.BufferProducer do
     {:noreply, items, state}
   end
 
-  defp schedule(state, scale? \\ true) do
+  defp schedule(state, scale?) do
     metrics = Sources.get_source_metrics_for_ingest(state.source_token)
     # dynamically schedule based on metrics interval
     interval =

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Backends.BufferProducer do
   alias Logflare.Sources
   alias Logflare.Backends.IngestEventQueue.DemandWorker
   require Logger
-  @default_interval 500
+  @default_interval 1_000
 
   def start_link(opts) when is_list(opts) do
     GenStage.start_link(__MODULE__, opts)
@@ -26,7 +26,7 @@ defmodule Logflare.Backends.BufferProducer do
       interval: Keyword.get(opts, :interval, @default_interval)
     }
 
-    schedule(state.interval)
+    schedule(state)
     {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 10_000)}
   end
 
@@ -61,7 +61,7 @@ defmodule Logflare.Backends.BufferProducer do
   @impl GenStage
   def handle_info(:scheduled_resolve, state) do
     {items, state} = resolve_demand(state)
-    schedule(state.interval)
+    schedule(state)
     {:noreply, items, state}
   end
 
@@ -81,7 +81,30 @@ defmodule Logflare.Backends.BufferProducer do
     {:noreply, items, state}
   end
 
-  defp schedule(interval) do
+  defp schedule(state) do
+    metrics = Sources.get_source_metrics_for_ingest(state.source_token)
+    # dynamically schedule based on metrics interval
+    interval =
+      cond do
+        metrics.avg < 100 ->
+          round(state.interval * 5)
+
+        metrics.avg < 1000 ->
+          round(state.interval * 4)
+
+        metrics.avg < 2000 ->
+          round(state.interval * 3)
+
+        metrics.avg < 3000 ->
+          round(state.interval * 2)
+
+        metrics.avg < 4000 ->
+          round(state.interval * 1.5)
+
+        true ->
+          state.interval
+      end
+
     Process.send_after(self(), :scheduled_resolve, interval)
   end
 
@@ -90,9 +113,18 @@ defmodule Logflare.Backends.BufferProducer do
          new_demand \\ 0
        ) do
     total_demand = prev_demand + new_demand
+    to_fetch = max(total_demand, 1_000)
 
     {:ok, events} = DemandWorker.fetch({state.source_id, state.backend_id}, total_demand)
+    event_count = Enum.count(events)
 
-    {events, %{state | demand: total_demand - Enum.count(events)}}
+    new_demand =
+      if total_demand < event_count do
+        0
+      else
+        total_demand - event_count
+      end
+
+    {events, %{state | demand: new_demand}}
   end
 end

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -87,23 +87,24 @@ defmodule Logflare.Backends.BufferProducer do
     interval =
       cond do
         metrics.avg < 100 ->
-          round(state.interval * 5)
+          state.interval * 5
 
         metrics.avg < 1000 ->
-          round(state.interval * 4)
+          state.interval * 4
 
         metrics.avg < 2000 ->
-          round(state.interval * 3)
+          state.interval * 3
 
         metrics.avg < 3000 ->
-          round(state.interval * 2)
+          state.interval * 2
 
         metrics.avg < 4000 ->
-          round(state.interval * 1.5)
+          state.interval * 1.5
 
         true ->
           state.interval
       end
+      |> round()
 
     Process.send_after(self(), :scheduled_resolve, interval)
   end

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -114,9 +114,9 @@ defmodule Logflare.Backends.BufferProducer do
          new_demand \\ 0
        ) do
     total_demand = prev_demand + new_demand
-    to_fetch = max(total_demand, 1_000)
+    to_fetch = max(total_demand, 500)
 
-    {:ok, events} = DemandWorker.fetch({state.source_id, state.backend_id}, total_demand)
+    {:ok, events} = DemandWorker.fetch({state.source_id, state.backend_id}, to_fetch)
     event_count = Enum.count(events)
 
     new_demand =

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -114,7 +114,13 @@ defmodule Logflare.Backends.BufferProducer do
          new_demand \\ 0
        ) do
     total_demand = prev_demand + new_demand
-    to_fetch = max(total_demand, 500)
+
+    to_fetch =
+      if new_demand == 0 do
+        max(total_demand, 500)
+      else
+        total_demand
+      end
 
     {:ok, events} = DemandWorker.fetch({state.source_id, state.backend_id}, to_fetch)
     event_count = Enum.count(events)

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -26,7 +26,7 @@ defmodule Logflare.Backends.BufferProducer do
       interval: Keyword.get(opts, :interval, @default_interval)
     }
 
-    schedule(state)
+    schedule(state, false)
     {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 10_000)}
   end
 
@@ -81,11 +81,14 @@ defmodule Logflare.Backends.BufferProducer do
     {:noreply, items, state}
   end
 
-  defp schedule(state) do
+  defp schedule(state, scale? \\ true) do
     metrics = Sources.get_source_metrics_for_ingest(state.source_token)
     # dynamically schedule based on metrics interval
     interval =
       cond do
+        scale? == false ->
+          state.interval
+
         metrics.avg < 100 ->
           state.interval * 5
 

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -35,7 +35,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
       purge_ratio: Keyword.get(opts, :purge_ratio, @default_purge_ratio)
     }
 
-    schedule(state)
+    schedule(state, false)
     {:ok, state}
   end
 
@@ -77,11 +77,14 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   end
 
   # schedule work based on rps
-  defp schedule(state) do
+  defp schedule(state, scale? \\ true) do
     metrics = Sources.get_source_metrics_for_ingest(state.source_token)
     # dynamically schedule based on metrics interval
     interval =
       cond do
+        scale? == false ->
+          state.interval
+
         metrics.avg < 100 ->
           state.interval * 10
 

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -41,8 +41,9 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
   def handle_info(:work, state) do
     do_drop(state)
+    scale? = if Application.get_env(:logflare, :env) == :test, do: false, else: true
 
-    schedule(state)
+    schedule(state, scale?)
 
     {:noreply, state}
   end

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -78,7 +78,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   end
 
   # schedule work based on rps
-  defp schedule(state, scale? \\ true) do
+  defp schedule(state, scale?) do
     metrics = Sources.get_source_metrics_for_ingest(state.source_token)
     # dynamically schedule based on metrics interval
     interval =

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -33,9 +33,11 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       end)
 
       assert {:ok, 1} = Backends.ingest_logs([log_event], source)
+
       TestUtils.retry_assert(fn ->
         assert_receive :streamed, 2500
       end)
+
       :timer.sleep(1000)
     end
 
@@ -60,6 +62,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       TestUtils.retry_assert(fn ->
         assert_receive :ok, 2500
       end)
+
       :timer.sleep(1000)
     end
   end
@@ -160,9 +163,11 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert Backends.local_pending_buffer_len(source, nil) == 1
       assert Backends.local_pending_buffer_len(source, backend) == 1
       :timer.sleep(2000)
+
       TestUtils.retry_assert(fn ->
         assert_receive ^ref
       end)
+
       assert Backends.local_pending_buffer_len(source, nil) == 0
       assert Backends.local_pending_buffer_len(source, backend) == 0
     end

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -33,7 +33,9 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       end)
 
       assert {:ok, 1} = Backends.ingest_logs([log_event], source)
-      assert_receive :streamed, 2500
+      TestUtils.retry_assert(fn ->
+        assert_receive :streamed, 2500
+      end)
       :timer.sleep(1000)
     end
 
@@ -55,7 +57,9 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
       assert {:ok, 1} = Backends.ingest_logs([log_event], source)
 
-      assert_receive :ok, 2500
+      TestUtils.retry_assert(fn ->
+        assert_receive :ok, 2500
+      end)
       :timer.sleep(1000)
     end
   end
@@ -156,7 +160,9 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert Backends.local_pending_buffer_len(source, nil) == 1
       assert Backends.local_pending_buffer_len(source, backend) == 1
       :timer.sleep(2000)
-      assert_receive ^ref
+      TestUtils.retry_assert(fn ->
+        assert_receive ^ref
+      end)
       assert Backends.local_pending_buffer_len(source, nil) == 0
       assert Backends.local_pending_buffer_len(source, backend) == 0
     end

--- a/test/logflare/backends/ingest_events_queue_test.exs
+++ b/test/logflare/backends/ingest_events_queue_test.exs
@@ -161,10 +161,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert IngestEventQueue.get_table_size({source, backend}) == 1
 
     start_supervised!(
-      {QueueJanitor, source: source, backend: backend, interval: 100, remainder: 0}
+      {QueueJanitor, source: source, backend: backend, interval: 50, remainder: 0}
     )
 
-    :timer.sleep(500)
+    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source, backend}) == 0
     assert IngestEventQueue.count_pending({source, backend}) == 0
   end
@@ -179,10 +179,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert IngestEventQueue.get_table_size({source, backend}) == 105
 
     start_supervised!(
-      {QueueJanitor, source: source, backend: backend, interval: 100, max: 100, purge_ratio: 1.0}
+      {QueueJanitor, source: source, backend: backend, interval: 50, max: 100, purge_ratio: 1.0}
     )
 
-    :timer.sleep(500)
+    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source, backend}) == 0
   end
 
@@ -196,10 +196,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert IngestEventQueue.get_table_size({source, backend}) == 100
 
     start_supervised!(
-      {QueueJanitor, source: source, backend: backend, interval: 100, max: 90, purge_ratio: 0.5}
+      {QueueJanitor, source: source, backend: backend, interval: 50, max: 90, purge_ratio: 0.5}
     )
 
-    :timer.sleep(500)
+    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source, backend}) == 50
   end
 

--- a/test/logflare/backends/ingest_events_queue_test.exs
+++ b/test/logflare/backends/ingest_events_queue_test.exs
@@ -344,7 +344,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
           # "truncate/3 with match_object/3, insert/2, and match_delete/3" => fn {input, _} ->
           #   IngestEventQueue.truncate_no_traversal(sb, :all, 100)
           # end,
-          "mark with :ets.select/3 and traversal" => fn {input, to_drop} ->
+          "mark with :ets.select/3 and traversal" => fn {_input, _to_drop} ->
             IngestEventQueue.truncate(sb, :all, 100)
           end
         },

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -299,7 +299,9 @@ defmodule Logflare.BackendsTest do
                  source
                )
 
-      assert_receive ^ref, 2_000
+      TestUtils.retry_assert(fn ->
+        assert_receive ^ref, 2_000
+      end)
       :timer.sleep(1000)
     end
   end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -302,6 +302,7 @@ defmodule Logflare.BackendsTest do
       TestUtils.retry_assert(fn ->
         assert_receive ^ref, 2_000
       end)
+
       :timer.sleep(1000)
     end
   end


### PR DESCRIPTION
This PR adds in dynamic BufferProducer emit scheduling.
It also adds in a minimum of 1k events to be pulled from the demand worker,

also fixes a float rounding issue in the QueueJanitor scheduling