### PR TITLE
perf: BufferLimiter optimization, use PubSubRates.Cache instead

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -416,7 +416,7 @@ defmodule Logflare.Backends do
   Checks if a local buffer is full.
   """
   def local_pending_buffer_full?(%Source{} = source) do
-    local_pending_buffer_len(source) > @max_pending_buffer_len
+    get_and_cache_local_pending_buffer_len(source) > @max_pending_buffer_len
   end
 
   @doc """
@@ -430,9 +430,12 @@ defmodule Logflare.Backends do
   @doc """
   Get local pending buffer len of a source/backend combination, and caches it at the same time.
   """
-  @spec local_pending_buffer_len(Source.t() | integer(), Backend.t() | nil | integer()) ::
+  @spec get_and_cache_local_pending_buffer_len(
+          Source.t() | integer(),
+          Backend.t() | nil | integer()
+        ) ::
           integer()
-  def local_pending_buffer_len(source, backend \\ nil) do
+  def get_and_cache_local_pending_buffer_len(source, backend \\ nil) do
     len =
       case IngestEventQueue.count_pending({source, backend}) do
         len when is_integer(len) -> len

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -10,6 +10,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   alias Logflare.Users
   alias Logflare.Sources
   alias Logflare.Billing
+  alias Logflare.Backends
   use Supervisor
   require Logger
 

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -51,7 +51,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
         initial_count: 1,
         resolve_count: fn state ->
           source = Sources.refresh_source_metrics_for_ingest(source)
-          len = Backends.local_pending_buffer_len(source, backend)
+          len = Backends.get_and_cache_local_pending_buffer_len(source, backend)
           handle_resolve_count(state, len, source.metrics.avg)
         end
       },

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -11,6 +11,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   use GenServer
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.Sources
+  alias Logflare.Backends
   require Logger
   @default_interval 1_000
   @default_remainder 100
@@ -53,10 +54,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
     sid_bid = {state.source_id, state.backend_id}
     # clear out ingested events
     pending_size =
-      case IngestEventQueue.count_pending(sid_bid) do
-        value when is_integer(value) -> value
-        _ -> 0
-      end
+      Backends.get_and_cache_local_pending_buffer_len(state.source_id, state.backend_id)
 
     if pending_size > state.remainder do
       # drop all ingested

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -13,6 +13,10 @@ defmodule Logflare.PubSubRates.Cache do
     %{id: __MODULE__, start: {Cachex, :start_link, [@cache, [stats: stats]]}}
   end
 
+  def clear() do
+    Cachex.clear(__MODULE__)
+  end
+
   def cache_rates(source_id, rates) when is_atom(source_id) do
     {:ok, val} = Cachex.get(__MODULE__, {source_id, "rates"})
 
@@ -61,6 +65,15 @@ defmodule Logflare.PubSubRates.Cache do
   @spec get_buffers(non_neg_integer(), non_neg_integer() | nil) :: map()
   def get_buffers(source_id, backend_id) do
     Cachex.get(__MODULE__, {source_id, backend_id, "buffers"})
+  end
+
+  @spec get_local_buffer(non_neg_integer(), non_neg_integer() | nil) :: map()
+  def get_local_buffer(source_id, backend_id) do
+    Cachex.get(__MODULE__, {source_id, backend_id, "buffers"})
+    |> case do
+      {:ok, val} when val != nil -> Map.get(val, Node.self(), 0)
+      _ -> 0
+    end
   end
 
   @doc """

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -8,7 +8,7 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
   def init(_opts), do: nil
 
   def call(%{assigns: %{source: source}} = conn, _opts \\ []) do
-    if Backends.local_pending_buffer_full?(source) do
+    if Backends.cached_local_pending_buffer_full?(source) do
       conn
       |> send_resp(429, "Buffer full: Too many requests")
       |> halt()

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -160,16 +160,16 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
       assert {:ok, _} = Backends.ingest_logs([log_event], source)
 
-      assert Backends.local_pending_buffer_len(source, nil) == 1
-      assert Backends.local_pending_buffer_len(source, backend) == 1
+      assert Backends.get_and_cache_local_pending_buffer_len(source, nil) == 1
+      assert Backends.get_and_cache_local_pending_buffer_len(source, backend) == 1
       :timer.sleep(2000)
 
       TestUtils.retry_assert(fn ->
         assert_receive ^ref
       end)
 
-      assert Backends.local_pending_buffer_len(source, nil) == 0
-      assert Backends.local_pending_buffer_len(source, backend) == 0
+      assert Backends.get_and_cache_local_pending_buffer_len(source, nil) == 0
+      assert Backends.get_and_cache_local_pending_buffer_len(source, backend) == 0
     end
   end
 

--- a/test/logflare/backends/ingest_events_queue_test.exs
+++ b/test/logflare/backends/ingest_events_queue_test.exs
@@ -129,8 +129,8 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     IngestEventQueue.add_to_table({source, backend}, [le])
     IngestEventQueue.add_to_table({source, nil}, [le])
     :timer.sleep(300)
-    assert Backends.local_pending_buffer_len(source) == 1
-    assert Backends.local_pending_buffer_len(source, backend) == 1
+    assert Backends.get_and_cache_local_pending_buffer_len(source) == 1
+    assert Backends.get_and_cache_local_pending_buffer_len(source, backend) == 1
     assert PubSubRates.Cache.get_cluster_buffers(source.id, backend.id) == 1
     assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 1
   end
@@ -147,7 +147,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert {:ok, [_]} = DemandWorker.fetch({source, backend}, 5)
     assert IngestEventQueue.get_table_size({source, backend}) == 1
     assert IngestEventQueue.count_pending({source, backend}) == 0
-    assert Backends.local_pending_buffer_len(source, backend) == 0
+    assert Backends.get_and_cache_local_pending_buffer_len(source, backend) == 0
   end
 
   test "QueueJanitor cleans up :ingested events" do

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -3,6 +3,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   use LogflareWeb.ConnCase
   alias LogflareWeb.Plugs.BufferLimiter
   alias Logflare.Backends.IngestEventQueue
+  alias Logflare.Backends
 
   setup do
     conn = build_conn(:post, "/api/logs", %{"message" => "some text"})
@@ -16,6 +17,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       le = build(:log_event)
       IngestEventQueue.add_to_table({source, nil}, [le])
     end
+
+    # get and cache the value
+    Backends.get_and_cache_local_pending_buffer_len(source, nil)
 
     conn =
       conn
@@ -32,6 +36,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       IngestEventQueue.add_to_table({source, nil}, [le])
       IngestEventQueue.mark_ingested({source, nil}, [le])
     end
+
+    # get and cache the value
+    Backends.get_and_cache_local_pending_buffer_len(source, nil)
 
     conn =
       conn

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -53,6 +53,7 @@ defmodule LogflareWeb.ConnCase do
 
         on_exit(fn ->
           Logflare.Backends.IngestEventQueue.delete_all_mappings()
+          Logflare.PubSubRates.Cache.clear()
         end)
 
         :ok

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -35,6 +35,7 @@ defmodule Logflare.DataCase do
 
         on_exit(fn ->
           Logflare.Backends.IngestEventQueue.delete_all_mappings()
+          Logflare.PubSubRates.Cache.clear()
         end)
 
         :ok


### PR DESCRIPTION
This PR improves the BufferLimiter plug by over ~5899x ips (in worst case 50k queue sizes), by using the PubSubRates cache. 