### PR TITLE
perf: tweak chunk size for adding to table

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -140,7 +140,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       Logflare.Utils.chunked_round_robin(
         batch,
         procs,
-        100,
+        10,
         fn chunk, target ->
           add_to_table(target, chunk)
         end


### PR DESCRIPTION
Reduces chunk size to ensure that events are more spread out across queues.
![image](https://github.com/user-attachments/assets/06885caa-bbf7-48ae-8ef3-fa538cb6db66)
