### PR TITLE
feat: rules management api initial implementation, backends metadata column

### DIFF
--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'priv/repo/migrations/**'
+      - "priv/repo/migrations/**"
 
 permissions:
   contents: read
@@ -16,19 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13
+        image: bitnami/postgresql:13.15.0
         ports:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: logflare_test
+          POSTGRESQL_WAL_LEVEL: logical
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -d logflare_test -U postgres -p 5432"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 10
     env:
       MIX_ENV: test
       SHELL: /bin/bash

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -48,13 +48,9 @@ defmodule Logflare.Backends do
 
       {:metadata, %{} = metadata}, q ->
         normalized =
-          for {k, v} <- metadata, into: %{} do
-            if v in ["true", "false"] do
-              {k, String.to_existing_atom(v)}
-            else
-              {k, v}
-            end
-          end
+          Enum.into(metadata, %{}, fn {k, v} ->
+            {k, if(v in ["true", "false"], do: String.to_existing_atom(v), else: v)}
+          end)
 
         where(q, [b], b.metadata == ^normalized)
 

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -39,6 +39,32 @@ defmodule Logflare.Backends do
     |> Enum.map(fn b -> typecast_config_string_map_to_atom_map(b) end)
   end
 
+  @spec list_backends(keyword()) :: [Backend.t()]
+  def list_backends(filters) when is_list(filters) do
+    filters
+    |> Enum.reduce(from(b in Backend), fn
+      {:user_id, id}, q ->
+        where(q, [b], b.user_id == ^id)
+
+      {:metadata, %{} = metadata}, q ->
+        normalized =
+          for {k, v} <- metadata, into: %{} do
+            if v in ["true", "false"] do
+              {k, String.to_existing_atom(v)}
+            else
+              {k, v}
+            end
+          end
+
+        where(q, [b], b.metadata == ^normalized)
+
+      _, q ->
+        q
+    end)
+    |> Repo.all()
+    |> Enum.map(fn sb -> typecast_config_string_map_to_atom_map(sb) end)
+  end
+
   @doc """
   Lists `Backend`s by user
   """

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -29,6 +29,7 @@ defmodule Logflare.Backends.Backend do
     belongs_to(:user, User)
     has_many(:rules, Rule)
     field(:register_for_ingest, :boolean, virtual: true, default: true)
+    field :metadata, :map
     timestamps()
   end
 
@@ -36,7 +37,7 @@ defmodule Logflare.Backends.Backend do
 
   def changeset(backend, attrs) do
     backend
-    |> cast(attrs, [:type, :config, :user_id, :name, :description])
+    |> cast(attrs, [:type, :config, :user_id, :name, :description, :metadata])
     |> validate_required([:user_id, :type, :config, :name])
     |> validate_inclusion(:type, Map.keys(@adaptor_mapping))
   end
@@ -56,7 +57,8 @@ defmodule Logflare.Backends.Backend do
           :description,
           :type,
           :id,
-          :config
+          :config,
+          :metadata
         ])
         |> Map.update(:config, %{}, fn
           config when type == :postgres ->

--- a/lib/logflare/sources/rule.ex
+++ b/lib/logflare/sources/rule.ex
@@ -6,8 +6,18 @@ defmodule Logflare.Rule do
   alias Logflare.Lql.Parser
   import Ecto.Changeset
 
+  @derive {Jason.Encoder,
+           only: [
+             :token,
+             :id,
+             :source_id,
+             :lql_string,
+             :backend_id
+           ]}
+
   typed_schema "rules" do
     field :sink, Ecto.UUID.Atom
+    field(:token, Ecto.UUID, autogenerate: true)
     field :lql_filters, Ecto.Term, default: []
     field :lql_string, :string
     belongs_to :source, Source

--- a/lib/logflare/sources/rules.ex
+++ b/lib/logflare/sources/rules.ex
@@ -62,6 +62,18 @@ defmodule Logflare.Rules do
   @spec get_rule(non_neg_integer()) :: Rule.t() | nil
   def get_rule(id), do: Repo.get(Rule, id)
 
+  def fetch_rule_by(kw) do
+    {user_id, kw} = Keyword.pop(kw, :user_id)
+
+    from(r in Rule, join: s in Source, on: s.user_id == ^user_id)
+    |> where([r], ^kw)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      rule -> {:ok, rule}
+    end
+  end
+
   @spec create_rule(map(), Source.t()) :: {:ok, Rule.t()} | {:error, Ecto.Changeset.t() | binary}
   def create_rule(params, %Source{} = source) when is_map(params) do
     bq_schema =

--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -19,8 +19,7 @@ defmodule LogflareWeb.Api.BackendController do
   )
 
   def index(%{assigns: %{user: user}} = conn, params) do
-    metadata = Map.get(params, "metadata")
-    backends = Backends.list_backends(user_id: user.id, metadata: metadata)
+    backends = Backends.list_backends(user_id: user.id, metadata: params["metadata"])
     json(conn, backends)
   end
 

--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -18,8 +18,9 @@ defmodule LogflareWeb.Api.BackendController do
     responses: %{200 => List.response(BackendApiSchema)}
   )
 
-  def index(%{assigns: %{user: user}} = conn, _) do
-    backends = Backends.list_backends_by_user_id(user.id)
+  def index(%{assigns: %{user: user}} = conn, params) do
+    metadata = Map.get(params, "metadata")
+    backends = Backends.list_backends(user_id: user.id, metadata: metadata)
     json(conn, backends)
   end
 

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -1,0 +1,119 @@
+defmodule LogflareWeb.Api.RuleController do
+  use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Logflare.Backends
+  alias Logflare.Sources
+  alias Logflare.Rules
+  alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.Created
+  alias LogflareWeb.OpenApi.List
+  alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApiSchemas.RuleApiSchema
+
+  action_fallback(LogflareWeb.Api.FallbackController)
+
+  tags(["management"])
+
+  operation(:index,
+    summary: "List rules",
+    responses: %{200 => List.response(RuleApiSchema)}
+  )
+
+  def index(%{assigns: %{user: user}} = conn, filters)
+      when is_map_key(filters, "backend_id") or is_map_key(filters, "backend_token") do
+    kw =
+      case filters do
+        %{"backend_id" => bid} -> [id: bid]
+        %{"backend_token" => token} -> [token: token]
+      end
+
+    with {:ok, backend} <- Backends.fetch_backend_by([{:user_id, user.id} | kw]) do
+      rules = Rules.list_rules(backend)
+      json(conn, rules)
+    end
+  end
+
+  operation(:show,
+    summary: "Fetch rule",
+    parameters: [token: [in: :path, description: "Rule UUID", type: :string]],
+    responses: %{
+      200 => RuleApiSchema.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, backend} <- Rules.fetch_rule_by(token: token, user_id: user.id) do
+      json(conn, backend)
+    end
+  end
+
+  operation(:create,
+    summary: "Create rule",
+    request_body: RuleApiSchema.params(),
+    responses: %{
+      201 => Created.response(RuleApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def create(%{assigns: %{user: user}} = conn, params) do
+    with {:ok, _} <- verify_backend_owner(params, user),
+         {:ok, _} <- verify_source_owner(params, user),
+         {:ok, rule} <- Rules.create_rule(params) do
+      conn
+      |> put_status(201)
+      |> json(rule)
+    end
+  end
+
+  defp verify_backend_owner(%{"backend_id" => id}, user) do
+    Backends.fetch_backend_by(id: id, user_id: user.id)
+  end
+
+  defp verify_source_owner(%{"source_id" => id}, user) do
+    Sources.fetch_source_by(id: id, user_id: user.id)
+  end
+
+  operation(:update,
+    summary: "Update rule",
+    parameters: [token: [in: :path, description: "Rule UUID", type: :string]],
+    request_body: RuleApiSchema.params(),
+    responses: %{
+      204 => Accepted.response(),
+      201 => Created.response(RuleApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
+    with {:ok, rule} <- Rules.fetch_rule_by(token: token, user_id: user.id),
+         {:ok, updated} <- Rules.update_rule(rule, params) do
+      conn
+      |> case do
+        %{method: "PATCH"} -> put_status(conn, 204)
+        %{method: "PUT"} -> put_status(conn, 200)
+      end
+      |> json(updated)
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete rule",
+    parameters: [token: [in: :path, description: "Rule UUID", type: :string]],
+    responses: %{
+      204 => Accepted.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, rule} <- Rules.fetch_rule_by(token: token, user_id: user.id),
+         {:ok, _} <- Rules.delete_rule(rule) do
+      conn
+      |> Plug.Conn.send_resp(204, [])
+      |> Plug.Conn.halt()
+    end
+  end
+end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -123,6 +123,20 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]
   end
 
+  defmodule RuleApiSchema do
+    @properties %{
+      id: %Schema{type: :integer},
+      token: %Schema{type: :string},
+      lql_string: %Schema{type: :string},
+      backend_id: %Schema{type: :integer},
+      source_id: %Schema{type: :integer},
+      inserted_at: %Schema{type: :string, format: :"date-time"},
+      updated_at: %Schema{type: :string, format: :"date-time"}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+  end
+
   defmodule BackendApiSchema do
     @properties %{
       name: %Schema{type: :string},

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -143,6 +143,7 @@ defmodule LogflareWeb.OpenApiSchemas do
       id: %Schema{type: :integer},
       token: %Schema{type: :string},
       config: %Schema{type: :object},
+      metadata: %Schema{type: :object},
       inserted_at: %Schema{type: :string, format: :"date-time"},
       updated_at: %Schema{type: :string, format: :"date-time"}
     }

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -395,6 +395,11 @@ defmodule LogflareWeb.Router do
       delete "/backends/:backend_token", Api.SourceController, :remove_backend
     end
 
+    resources("/rules", Api.RuleController,
+      param: "token",
+      only: [:index, :show, :create, :update, :delete]
+    )
+
     resources("/endpoints", Api.EndpointController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]

--- a/priv/repo/migrations/20240725033149_add_token_to_rules.exs
+++ b/priv/repo/migrations/20240725033149_add_token_to_rules.exs
@@ -1,0 +1,18 @@
+defmodule Logflare.Repo.Migrations.AddTokenToRules do
+  use Ecto.Migration
+
+  def up do
+    alter table(:rules) do
+      add :token, :uuid, default: fragment("gen_random_uuid()")
+    end
+    execute "UPDATE rules SET token=gen_random_uuid() WHERE token is null"
+    create unique_index(:rules, [:token])
+  end
+
+  def down do
+    drop index(:rules, [:token])
+    alter table(:rules) do
+      remove(:token, :uuid)
+    end
+  end
+end

--- a/priv/repo/migrations/20240725083359_add_metadata_column_to_backends_table.exs
+++ b/priv/repo/migrations/20240725083359_add_metadata_column_to_backends_table.exs
@@ -1,0 +1,10 @@
+defmodule Logflare.Repo.Migrations.AddMetadataColumnToBackendsTable do
+  use Ecto.Migration
+
+  def change do
+
+    alter table(:backends) do
+      add :metadata, :map
+    end
+  end
+end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -28,6 +28,15 @@ defmodule Logflare.BackendsTest do
       [source: insert(:source, user_id: user.id), user: user]
     end
 
+    test "list_backends/1 with metadata" do
+      backend = insert(:backend, metadata: %{some: "data", value: true, other: false})
+
+      assert [result] =
+               Backends.list_backends(metadata: %{some: "data", value: "true", other: false})
+
+      assert result.id == backend.id
+    end
+
     test "create backend", %{user: user} do
       assert {:ok, %Backend{}} =
                Backends.create_backend(%{

--- a/test/logflare_web/controllers/api/rule_controller_test.exs
+++ b/test/logflare_web/controllers/api/rule_controller_test.exs
@@ -1,0 +1,133 @@
+defmodule LogflareWeb.Api.RuleControllerTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  setup %{conn: conn} do
+    insert(:plan, name: "Free")
+    user = insert(:user)
+    conn = add_access_token(conn, user, "private")
+    source = insert(:source, user: user)
+    backend = insert(:backend, user: user)
+    {:ok, conn: conn, user: user, backend: backend, source: source}
+  end
+
+  test "list rules", %{conn: conn, source: source, backend: backend, user: user} do
+    insert(:rule, backend: insert(:backend, user: user), source: source)
+    rule = insert(:rule, backend: backend, source: source)
+
+    assert [result] =
+             conn
+             |> get(~p"/api/rules?#{%{backend_token: backend.token}}")
+             |> json_response(200)
+
+    assert result["id"] == rule.id
+    assert result["token"] == rule.token
+  end
+
+  test "show rules", %{conn: conn, source: source, backend: backend} do
+    rule = insert(:rule, backend: backend, source: source)
+    insert_pair(:rule, backend: backend, source: source)
+
+    assert result =
+             conn
+             |> get(~p"/api/rules/#{rule.token}")
+             |> json_response(200)
+
+    assert result["id"] == rule.id
+    assert result["token"] == rule.token
+    assert result["lql_string"] == rule.lql_string
+  end
+
+  describe "with rules" do
+    test "create rule", %{conn: conn, backend: backend, source: source} do
+      assert %{"token" => rule_token} =
+               conn
+               |> post(~p"/api/rules", %{
+                 source_id: source.id,
+                 backend_id: backend.id,
+                 lql_string: "test"
+               })
+               |> json_response(201)
+
+      assert rule_token
+
+      assert conn
+             |> get(~p"/api/rules/#{rule_token}")
+             |> json_response(200)
+    end
+
+    test "create rule with bad user", %{conn: conn, backend: backend, source: source} do
+      user = insert(:user)
+
+      assert %{"error" => _} =
+               conn
+               |> add_access_token(user, "private")
+               |> post(~p"/api/rules", %{
+                 source_id: source.id,
+                 backend_id: backend.id,
+                 lql_string: "test"
+               })
+               |> json_response(404)
+    end
+
+    test "update rule", %{conn: conn, backend: backend, source: source} do
+      rule = insert(:rule, lql_string: "initial", source: source, backend: backend)
+
+      assert %{"token" => rule_token} =
+               conn
+               |> put(~p"/api/rules/#{rule.token}", %{
+                 lql_string: "adjusted"
+               })
+               |> json_response(200)
+
+      assert %{"lql_string" => "adjusted"} =
+               conn
+               |> get(~p"/api/rules/#{rule_token}")
+               |> json_response(200)
+    end
+
+    test "update rule with bad user", %{conn: conn, backend: backend, source: source} do
+      user = insert(:user)
+      rule = insert(:rule, lql_string: "initial", source: source, backend: backend)
+
+      assert %{"error" => _} =
+               conn
+               |> add_access_token(user, "private")
+               |> put(~p"/api/rules/#{rule.token}", %{
+                 lql_string: "adjusted"
+               })
+               |> json_response(404)
+
+      assert %{"lql_string" => "initial"} =
+               conn
+               |> get(~p"/api/rules/#{rule.token}")
+               |> json_response(200)
+    end
+
+    test "delete rule", %{conn: conn, backend: backend, source: source} do
+      rule = insert(:rule, backend: backend, source: source)
+
+      assert conn
+             |> delete(~p"/api/rules/#{rule.token}")
+             |> response(204)
+
+      assert conn
+             |> get(~p"/api/rules/#{rule.token}")
+             |> json_response(404)
+    end
+
+    test "delete rule with bad user", %{conn: conn, backend: backend, source: source} do
+      user = insert(:user)
+      rule = insert(:rule, backend: backend, source: source)
+
+      assert conn
+             |> add_access_token(user, "private")
+             |> delete(~p"/api/rules/#{rule.token}")
+             |> response(404)
+
+      assert conn
+             |> get(~p"/api/rules/#{rule.token}")
+             |> json_response(200)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,7 +96,7 @@ defmodule Logflare.Factory do
   end
 
   def rule_factory(attrs) do
-    lql = Map.get(attrs, "lql_string", "testing")
+    lql = Map.get(attrs, :lql_string) || Map.get(attrs, "lql_string", "testing")
     {:ok, lql_filters} = Lql.Parser.parse(lql, TestUtils.default_bq_schema())
 
     %Rule{
@@ -105,7 +105,8 @@ defmodule Logflare.Factory do
       sink: attrs[:sink],
       source_id: attrs[:source_id],
       source: attrs[:source],
-      backend: attrs[:backend]
+      backend: attrs[:backend],
+      backend_id: attrs[:backend_id]
     }
   end
 


### PR DESCRIPTION
management api adjustments for log drains:
1. addition of `/api/rules` for managing rules
2. addition of metadata column for `/api/backends` as well as filtering options for managing backends programmatically