### PR TITLE
feat: Logflare UI displays backend metadata

### DIFF
--- a/lib/logflare_web/live/backends/actions/index.html.heex
+++ b/lib/logflare_web/live/backends/actions/index.html.heex
@@ -31,6 +31,7 @@
       <div class="tw-flex tw-gap-2 tw-mt-1">
         <span class="badge badge-pill badge-secondary tw-leading-normal"><%= backend.type %></span>
         <span>drain rules: <%= Enum.count(backend.rules) %></span>
+        <span :for={{k, v} when is_binary(v) <- backend.metadata || %{}} :if={backend.metadata}><%= k %>: <%= v %></span>
       </div>
     </li>
   </ul>

--- a/lib/logflare_web/live/backends/actions/show.html.heex
+++ b/lib/logflare_web/live/backends/actions/show.html.heex
@@ -20,6 +20,10 @@
           <%= Jason.encode!(@backend.config, pretty: true) %>
         </pre>
       </li>
+      <li :if={@backend.metadata} class="list-group-item tw-flex-col tw-gap-2 ">
+        <strong>metadata:</strong>
+        <span :for={{k, v} when is_binary(v) <- @backend.metadata || %{}} :if={@backend.metadata} class="tw-block tw-ml-4"><%= k %>: <%= v %></span>
+      </li>
     </ul>
   </div>
 </section>

--- a/test/logflare_web/live/backends_live_test.exs
+++ b/test/logflare_web/live/backends_live_test.exs
@@ -22,6 +22,14 @@ defmodule LogflareWeb.BackendsLiveTest do
     assert html =~ Atom.to_string(backend.type)
   end
 
+  test "index with backend metadata", %{conn: conn, user: user, source: source} do
+    insert(:backend, sources: [source], user: user, metadata: %{some: "custom-metadata"})
+    {:ok, view, _html} = live(conn, ~p"/backends")
+
+    html = render(view)
+    assert html =~ "some: custom-metadata"
+  end
+
   test "show", %{conn: conn, user: user, source: source} do
     backend = insert(:backend, sources: [source], user: user)
     {:ok, view, _html} = live(conn, ~p"/backends/#{backend.id}")
@@ -29,6 +37,16 @@ defmodule LogflareWeb.BackendsLiveTest do
     html = render(view)
     assert html =~ backend.name
     assert html =~ "#{backend.type}"
+  end
+
+  test "show with backend metadata", %{conn: conn, user: user, source: source} do
+    backend =
+      insert(:backend, sources: [source], user: user, metadata: %{some: "custom-metadata"})
+
+    {:ok, view, _html} = live(conn, ~p"/backends/#{backend.id}")
+
+    html = render(view)
+    assert html =~ "some: custom-metadata"
   end
 
   test "edit", %{conn: conn, user: user, source: source} do


### PR DESCRIPTION
This PR adds in metadata displaying if set programmatically. Only way to set it is via API.

<img width="648" alt="Screenshot 2024-08-06 at 1 26 24 AM" src="https://github.com/user-attachments/assets/91d44563-36f6-4499-bc20-8994485bf383">
<img width="699" alt="Screenshot 2024-08-06 at 1 24 47 AM" src="https://github.com/user-attachments/assets/fab1d9ea-4318-48c2-9357-145c07723daa">

