### PR TITLE
fix: stale backend config in webhook adaptor

### DIFF
--- a/lib/logflare/backends/adaptor.ex
+++ b/lib/logflare/backends/adaptor.ex
@@ -34,8 +34,25 @@ defmodule Logflare.Backends.Adaptor do
     mapping[type]
   end
 
+  @spec get_backend_config(Backend.t()) :: map()
+  def get_backend_config(%Backend{config: config} = backend) do
+    adaptor = get_adaptor(backend)
+
+    if function_exported?(adaptor, :transform_config, 1) do
+      adaptor.transform_config(config)
+    else
+      config
+    end
+  end
+
   @callback start_link(source_backend()) ::
               {:ok, pid()} | :ignore | {:error, term()}
+
+  @doc """
+  Optional callback to transform a stored backend config before usage.
+  Example use cases: when an adaptor extends another adaptor by customizing the end configuration.
+  """
+  @callback transform_config(map()) :: map()
 
   @doc """
   Optional callback to manipulate log events before queueing.
@@ -67,5 +84,5 @@ defmodule Logflare.Backends.Adaptor do
     |> mod.validate_config()
   end
 
-  @optional_callbacks pre_ingest: 3
+  @optional_callbacks pre_ingest: 3, transform_config: 1
 end

--- a/lib/logflare/backends/adaptor/datadog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/datadog_adaptor.ex
@@ -35,17 +35,18 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptor do
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend}) do
-    backend = %{
-      backend
-      | config: %{
-          url: Map.get(@api_url_mapping, backend.config.region),
-          headers: %{"dd-api-key" => backend.config.api_key},
-          http: "http2",
-          gzip: true
-        }
-    }
-
+    backend = %{backend | config: transform_config(backend.config)}
     WebhookAdaptor.start_link({source, backend})
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def transform_config(config) do
+    %{
+      url: Map.get(@api_url_mapping, config.region),
+      headers: %{"dd-api-key" => config.api_key},
+      http: "http2",
+      gzip: true
+    }
   end
 
   @impl Logflare.Backends.Adaptor

--- a/lib/logflare/backends/adaptor/elastic_adaptor.ex
+++ b/lib/logflare/backends/adaptor/elastic_adaptor.ex
@@ -32,23 +32,24 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptor do
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend}) do
-    basic_auth = get_basic_auth(backend.config)
-
-    backend = %{
-      backend
-      | config: %{
-          url: backend.config.url,
-          http: "http1",
-          headers:
-            if basic_auth do
-              %{"Authorization" => "Basic #{basic_auth}"}
-            else
-              %{}
-            end
-        }
-    }
-
+    backend = %{backend | config: transform_config(backend.config)}
     WebhookAdaptor.start_link({source, backend})
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def transform_config(config) do
+    basic_auth = get_basic_auth(config)
+
+    %{
+      url: config.url,
+      http: "http1",
+      headers:
+        if basic_auth do
+          %{"Authorization" => "Basic #{basic_auth}"}
+        else
+          %{}
+        end
+    }
   end
 
   defp get_basic_auth(%{username: username, password: password})

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -4,6 +4,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   use TypedStruct
 
   alias Logflare.Backends
+  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.WebhookAdaptor.EgressMiddleware
 
   @behaviour Logflare.Backends.Adaptor
@@ -148,8 +149,11 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
          when backend_id != nil do
       Backends.Cache.get_backend(backend_id)
       |> then(fn
-        %_{config: config} -> config
-        _ -> startup_config
+        %_{} = backend ->
+          Adaptor.get_backend_config(backend)
+
+        _ ->
+          startup_config
       end)
     end
 


### PR DESCRIPTION
This PR fixes stale backend configs once a backend is created and updated. 