### PR TITLE
fix: correctly clean up source backends

### DIFF
--- a/lib/logflare/backends/source_backend.ex
+++ b/lib/logflare/backends/source_backend.ex
@@ -1,0 +1,17 @@
+defmodule Logflare.Backends.SourcesBackend do
+  @moduledoc false
+  use TypedEctoSchema
+
+  import Ecto.Changeset
+
+  alias Logflare.Backends.Adaptor
+  alias Logflare.Backends.Backend
+  alias Logflare.Source
+  alias Logflare.User
+  alias Logflare.Rule
+
+  typed_schema "sources_backends" do
+    belongs_to(:source, Source)
+    belongs_to(:backend, Backend)
+  end
+end

--- a/lib/logflare/backends/source_backend.ex
+++ b/lib/logflare/backends/source_backend.ex
@@ -2,13 +2,8 @@ defmodule Logflare.Backends.SourcesBackend do
   @moduledoc false
   use TypedEctoSchema
 
-  import Ecto.Changeset
-
-  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Backend
   alias Logflare.Source
-  alias Logflare.User
-  alias Logflare.Rule
 
   typed_schema "sources_backends" do
     belongs_to(:source, Source)

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -150,7 +150,7 @@ defmodule Logflare.Backends.SourceSup do
     found_id =
       Supervisor.which_children(via)
       |> Enum.find_value(
-        fn {{_mod, _source_id, bid}, _pid, _type, _mod} ->
+        fn {{_mod, _source_id, bid}, _pid, _type, _sup} ->
           bid == backend_id
         end,
         &elem(&1, 0)

--- a/lib/logflare/backends/source_sup_worker.ex
+++ b/lib/logflare/backends/source_sup_worker.ex
@@ -1,0 +1,62 @@
+defmodule Logflare.Backends.SourceSupWorker do
+  @moduledoc """
+  Worker that performs periodic cleanup ensure that SourceSup procs are correctly pulled down when deleted.
+  """
+  use GenServer
+  alias Logflare.Sources
+  alias Logflare.Backends
+  alias Logflare.Rules
+  alias Logflare.Backends.SourceSup
+  require Logger
+
+  @default_interval 30_000
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(opts) do
+    source = opts[:source]
+    state = %{source_id: source.id, interval: Keyword.get(opts, :interval, @default_interval)}
+    Process.send_after(self(), :check, state.interval)
+    {:ok, state}
+  end
+
+  def handle_info(:check, state) do
+    source = Sources.get(state.source_id)
+    backends = Backends.list_backends(source)
+    rules = Rules.list_rules(source)
+
+    # start rules source-backends
+    for rule <- rules, rule.backend_id do
+      SourceSup.start_rule_child(rule)
+    end
+
+    # start attached source-backends
+    for backend <- backends do
+      SourceSup.start_backend_child(source, backend)
+    end
+
+    via = Backends.via_source(source, Backends.SourceSup)
+
+    # stop stale rule source-backends
+    attached_backend_ids = for backend <- backends, do: backend.id
+
+    backend_ids =
+      Enum.map(rules, & &1.backend_id)
+      |> Enum.filter(& &1)
+      |> Enum.concat(attached_backend_ids)
+      |> Enum.uniq()
+
+    for {{_mod, _source_id, backend_id}, _, _, _} <- Supervisor.which_children(via),
+        backend_id not in backend_ids,
+        backend_id do
+      # backend = Backends.Cache.get_backend(backend_id)
+
+      SourceSup.stop_backend_child(source, backend_id)
+    end
+
+    Process.send_after(self(), :check, state.interval)
+    {:noreply, state}
+  end
+end

--- a/lib/logflare/backends/source_sup_worker.ex
+++ b/lib/logflare/backends/source_sup_worker.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Backends.SourceSupWorker do
   end
 
   def handle_info(:check, state) do
-    source = Sources.get(state.source_id)
+    source = Sources.Cache.get_by_id(state.source_id)
     backends = Backends.list_backends(source)
     rules = Rules.list_rules(source)
 

--- a/lib/logflare/backends/source_sup_worker.ex
+++ b/lib/logflare/backends/source_sup_worker.ex
@@ -51,7 +51,6 @@ defmodule Logflare.Backends.SourceSupWorker do
     for {{_mod, _source_id, backend_id}, _, _, _} <- Supervisor.which_children(via),
         backend_id not in backend_ids,
         backend_id do
-      # backend = Backends.Cache.get_backend(backend_id)
 
       SourceSup.stop_backend_child(source, backend_id)
     end

--- a/lib/logflare/backends/source_sup_worker.ex
+++ b/lib/logflare/backends/source_sup_worker.ex
@@ -51,7 +51,6 @@ defmodule Logflare.Backends.SourceSupWorker do
     for {{_mod, _source_id, backend_id}, _, _, _} <- Supervisor.which_children(via),
         backend_id not in backend_ids,
         backend_id do
-
       SourceSup.stop_backend_child(source, backend_id)
     end
 


### PR DESCRIPTION
This fix correctly cleans up source-backend procs in the SourceSup tree by adding a periodic cleanup with SourceSupWorker (yea not a very inspired name...).
This will help the issue where procs are still alive even though they are deleted on db.