### PR TITLE
fix: don't flood logs on bad user urls

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,7 +40,11 @@ config :logflare, Logflare.PubSub, pool_size: 10
 config :logger,
   handle_otp_reports: true,
   handle_sasl_reports: false,
-  level: :info
+  level: :info,
+  compile_time_purge_matching: [
+    # to prevent pool connection attempts for bad user urls from flooding logs
+    [application: :finch, mfa: "Finch.HTTP2.Pool.disconnected/3", level_lower_than: :critical]
+  ]
 
 config :logger_json, :backend,
   metadata: :all,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -44,7 +44,7 @@ config :logflare, LogflareWeb.Endpoint,
 
 config :logger, :console,
   format: "\n[$level] [$metadata] $message\n",
-  metadata: [:request_id],
+  metadata: [:application, :mfa, :file, :line, :request_id],
   level: :debug
 
 config :phoenix, :stacktrace_depth, 20

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -41,7 +41,9 @@ config :logger,
   sync_threshold: 10_000,
   discard_threshold: 10_000,
   compile_time_purge_matching: [
-    [level_lower_than: :info]
+    [level_lower_than: :info],
+    # to prevent pool connection attempts for bad user urls from flooding logs
+    [application: :finch, mfa: "Finch.HTTP2.Pool.disconnected/3", level_lower_than: :critical]
   ]
 
 config :logflare_logger_backend,


### PR DESCRIPTION
This fixes bug where bad user input urls will flood logs from finch
<img width="623" alt="Screenshot 2024-08-21 at 2 49 31 AM" src="https://github.com/user-attachments/assets/2ac4604f-d0aa-4042-8fae-e76b604f76bb">

We should technically stop attempting requests and disable the backend if this occurs too much...