### PR TITLE
fix: event message formatting for datadog adaptor

### DIFF
--- a/lib/logflare/backends/adaptor/datadog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/datadog_adaptor.ex
@@ -74,10 +74,12 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptor do
     formatted_ts =
       DateTime.from_unix!(le.body["timestamp"], :microsecond) |> DateTime.to_iso8601()
 
+    formatted_message = "#{formatted_ts} #{le.body["message"] || le.body["event_message"] || ""}"
+
     %Logflare.LogEvent{
       le
       | body: %{
-          "message" => formatted_ts <> " " <> (le.body["message"] || le.body["event_message"]),
+          "message" => formatted_message,
           "ddsource" => "Supabase",
           "service" => le.source.service_name || le.source.name,
           "data" => le.body

--- a/test/logflare/backends/adaptor/datadog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/datadog_adaptor_test.exs
@@ -66,6 +66,22 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
       assert_receive ^ref, 2000
     end
 
+    test "bug: nil event_message is still handled correctly ", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn _req ->
+        send(this, ref)
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      le = build(:log_event, source: source, message: nil, event_message: nil)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive ^ref, 2000
+    end
+
     test "service field is set to source.service_name", %{source: source} do
       this = self()
       ref = make_ref()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -137,7 +137,8 @@ defmodule Logflare.Factory do
         params,
         %{
           "message" =>
-            params["message"] || params["event_message"] || params[:message] || "test-msg",
+            params["message"] || params["event_message"] ||
+              Map.get(params, "event_message", "test-msg"),
           "timestamp" =>
             params["timestamp"] || params[:timestamp] || DateTime.utc_now() |> to_string,
           "metadata" => params["metadata"] || params[:metadata] || %{}


### PR DESCRIPTION
This PR fixes a formatting error for datadog adaptor
![image](https://github.com/user-attachments/assets/8e209617-15f7-4a7c-8354-2b3747433da8)
