### PR TITLE
fix: correctly return HTTP response codes for PUT/PATCH operations

### DIFF
--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -63,7 +63,7 @@ defmodule LogflareWeb.Api.BackendController do
     request_body: BackendApiSchema.params(),
     responses: %{
       204 => Accepted.response(),
-      201 => Created.response(BackendApiSchema),
+      200 => Accepted.response(BackendApiSchema),
       404 => NotFound.response()
     }
   )
@@ -74,7 +74,7 @@ defmodule LogflareWeb.Api.BackendController do
       conn
       |> case do
         %{method: "PATCH"} -> put_status(conn, 204)
-        %{method: "PUT"} -> put_status(conn, 201)
+        %{method: "PUT"} -> put_status(conn, 200)
       end
       |> json(updated)
     end

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -10,7 +10,7 @@ defmodule LogflareWeb.Api.EndpointController do
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
 
-  alias LogflareWeb.OpenApiSchemas.Endpoint
+  alias LogflareWeb.OpenApiSchemas.EndpointApiSchema
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -18,7 +18,7 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:index,
     summary: "List endpoints",
-    responses: %{200 => List.response(Endpoint)}
+    responses: %{200 => List.response(EndpointApiSchema)}
   )
 
   def index(%{assigns: %{user: user}} = conn, _) do
@@ -28,9 +28,9 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:show,
     summary: "Fetch endpoint",
-    parameters: [token: [in: :path, description: "Endpoint Token", type: :string]],
+    parameters: [token: [in: :path, description: "Endpoint UUID Token", type: :string]],
     responses: %{
-      200 => Endpoint.response(),
+      200 => EndpointApiSchema.response(),
       404 => NotFound.response()
     }
   )
@@ -43,9 +43,9 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:create,
     summary: "Create endpoint",
-    request_body: Endpoint.params(),
+    request_body: EndpointApiSchema.params(),
     responses: %{
-      201 => Created.response(Endpoint),
+      201 => Created.response(EndpointApiSchema),
       404 => NotFound.response()
     }
   )
@@ -60,11 +60,11 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:update,
     summary: "Update endpoint",
-    parameters: [token: [in: :path, description: "Endpoint Token", type: :string]],
-    request_body: Endpoint.params(),
+    parameters: [token: [in: :path, description: "Endpoint UUID Token", type: :string]],
+    request_body: EndpointApiSchema.params(),
     responses: %{
       204 => Accepted.response(),
-      201 => Created.response(Endpoint),
+      200 => Accepted.response(EndpointApiSchema),
       404 => NotFound.response()
     }
   )
@@ -74,7 +74,7 @@ defmodule LogflareWeb.Api.EndpointController do
          {:ok, query} <- Endpoints.update_query(query, params) do
       conn
       |> case do
-        %{method: "PUT"} -> put_status(conn, 201)
+        %{method: "PUT"} -> put_status(conn, 200)
         %{method: "PATCH"} -> put_status(conn, 204)
       end
       |> json(query)
@@ -85,7 +85,7 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:delete,
     summary: "Delete endpoint",
-    parameters: [token: [in: :path, description: "Endpoint Token", type: :string]],
+    parameters: [token: [in: :path, description: "Endpoint UUID Token", type: :string]],
     responses: %{
       204 => Accepted.response(),
       404 => NotFound.response()

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -123,7 +123,7 @@ defmodule LogflareWeb.Api.RuleController do
     request_body: RuleApiSchema.params(),
     responses: %{
       204 => Accepted.response(),
-      201 => Created.response(RuleApiSchema),
+      200 => Accepted.response(RuleApiSchema),
       404 => NotFound.response()
     }
   )

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -67,7 +67,7 @@ defmodule LogflareWeb.Api.SourceController do
     request_body: Source.params(),
     responses: %{
       204 => Accepted.response(),
-      201 => Created.response(Source),
+      200 => Accepted.response(),
       404 => NotFound.response()
     }
   )
@@ -80,7 +80,7 @@ defmodule LogflareWeb.Api.SourceController do
       conn
       |> case do
         %{method: "PATCH"} -> put_status(conn, 204)
-        %{method: "PUT"} -> put_status(conn, 201)
+        %{method: "PUT"} -> put_status(conn, 200)
       end
       |> json(source)
     end

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -48,6 +48,7 @@ defmodule LogflareWeb.OpenApi do
     OpenApiSpex.schema(%{})
 
     def response(), do: {"Accepted Response", "text/plain", __MODULE__}
+    def response(module), do: {"Accepted Response", "application/json", module}
   end
 
   defmodule NotFound do

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -58,7 +58,7 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:result, :errors]
   end
 
-  defmodule Endpoint do
+  defmodule EndpointApiSchema do
     @properties %{
       token: %Schema{type: :string},
       name: %Schema{type: :string},

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -104,7 +104,24 @@ defmodule LogflareWeb.Api.SourceControllerTest do
   end
 
   describe "update/2" do
-    test "updates an existing source from a user", %{
+    test "PUT updates an existing source from a user", %{
+      conn: conn,
+      user: user,
+      sources: [source | _]
+    } do
+      name = TestUtils.random_string()
+
+      response =
+        conn
+        |> add_access_token(user, "private")
+        |> put("/api/sources/#{source.token}", %{name: name})
+        |> json_response(200)
+
+      assert response["id"] == source.id
+      assert response["name"] == name
+    end
+
+    test "PATCH updates an existing source from a user", %{
       conn: conn,
       user: user,
       sources: [source | _]


### PR DESCRIPTION
This PR fixes http response codes for PUT operations for Sources, Endpoints, Backends