### PR TITLE
fix: finch :protocol deprecation warning

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -205,7 +205,7 @@ defmodule Logflare.Application do
 
     [
       # Finch connection pools, using http2
-      {Finch, name: Logflare.FinchGoth, pools: %{default: [protocol: :http2, count: 1]}},
+      {Finch, name: Logflare.FinchGoth, pools: %{default: [protocols: [:http2], count: 1]}},
       {Finch,
        name: Logflare.FinchDefault,
        pools: %{
@@ -213,37 +213,37 @@ defmodule Logflare.Application do
          :default => [protocols: [:http1, :http2], count: 1, size: base * 2],
          #  explicitly set http2 for other pools for multiplexing
          "https://bigquery.googleapis.com" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: max(base * 2, 20),
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.datadoghq.com" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: min_count,
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.us3.datadoghq.com" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: min_count,
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.us5.datadoghq.com" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: min_count,
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.datadoghq.eu" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: min_count,
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.ap1.datadoghq.com" => [
-           protocol: :http2,
+           protocols: [:http2],
            count: min_count,
            start_pool_metrics?: true
          ]
        }},
-      {Finch, name: Logflare.FinchDefaultHttp1, pools: %{default: [protocol: :http1, size: 50]}}
+      {Finch, name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}}
     ]
   end
 

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -243,7 +243,8 @@ defmodule Logflare.Application do
            start_pool_metrics?: true
          ]
        }},
-      {Finch, name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}}
+      {Finch,
+       name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}}
     ]
   end
 


### PR DESCRIPTION
This fixes `:protocol` option warnings for our finch pools.