### PR TITLE
fix: default postgres backend

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -256,7 +256,6 @@ defmodule Logflare.Application do
       SingleTenant.create_default_plan()
       SingleTenant.create_default_user()
       SingleTenant.create_access_tokens()
-      SingleTenant.upsert_default_backend()
     end
 
     if SingleTenant.supabase_mode?() do

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -48,6 +48,9 @@ defmodule Logflare.Backends do
       {:user_id, id}, q ->
         where(q, [b], b.user_id == ^id)
 
+      {:type, type}, q when is_atom(type) ->
+        where(q, [b], b.type == ^type)
+
       {:metadata, %{} = metadata}, q ->
         normalized =
           Enum.into(metadata, %{}, fn {k, v} ->

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -6,7 +6,6 @@ defmodule Logflare.Backends.SourceSup do
   alias Logflare.Backends.SourceSupWorker
   alias Logflare.Backends
   alias Logflare.Source
-  alias Logflare.User
   alias Logflare.Users
   alias Logflare.Billing
   alias Logflare.Source.RecentLogsServer

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -38,26 +38,10 @@ defmodule Logflare.Backends.SourceSup do
 
     plan = Billing.Cache.get_plan_by_user(user)
 
-    {project_id, dataset_id} =
-      if user.bigquery_project_id do
-        {user.bigquery_project_id, user.bigquery_dataset_id}
-      else
-        project_id = User.bq_project_id()
-        dataset_id = User.generate_bq_dataset_id(source.user_id)
-        {project_id, dataset_id}
-      end
+    default_backend = Backends.get_default_backend(user)
 
     specs =
-      [
-        %Backend{
-          type: :bigquery,
-          config: %{
-            project_id: project_id,
-            dataset_id: dataset_id
-          }
-        }
-        | ingest_backends
-      ]
+      [default_backend | ingest_backends]
       |> Enum.concat(rules_backends)
       |> Enum.map(&Backend.child_spec(source, &1))
       |> Enum.uniq()

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -11,6 +11,7 @@ defmodule Logflare.Endpoints do
   alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.SingleTenant
   alias Logflare.Alerting
+  alias Logflare.Backends
 
   import Ecto.Query
   @typep run_query_return :: {:ok, %{rows: [map()]}} | {:error, String.t()}
@@ -158,7 +159,8 @@ defmodule Logflare.Endpoints do
          {:ok, transformed_query} <-
            Logflare.Sql.transform(endpoint_query.language, transform_input, user_id) do
       {endpoint, query_string} =
-        if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend?() do
+        if SingleTenant.supabase_mode?() and SingleTenant.postgres_backend?() and
+             endpoint_query.language != :pg_sql do
           # translate the query
           schema_prefix = Keyword.get(SingleTenant.postgres_backend_adapter_opts(), :schema)
 
@@ -168,6 +170,7 @@ defmodule Logflare.Endpoints do
         else
           {endpoint_query, transformed_query}
         end
+        |> dbg()
 
       exec_query_on_backend(endpoint, query_string, declared_params, params)
     end
@@ -223,17 +226,12 @@ defmodule Logflare.Endpoints do
        ) do
     # find compatible source backend
     # TODO: move this to Backends module
-    backend =
-      Backends.list_backends_by_user_id(endpoint_query.user_id)
-      |> Enum.filter(fn sb -> sb.type == :postgres end)
-      |> List.first()
-      |> then(fn
-        nil ->
-          raise "No matching source backend found for Postgres query execution"
+    user = Users.Cache.get(endpoint_query.user_id)
+    backend = Backends.get_default_backend(user)
 
-        other ->
-          other
-      end)
+    if backend.type != :postgres do
+      raise "No matching source backend found for Postgres query execution"
+    end
 
     # convert params to PG params style
     positions =

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -31,10 +31,10 @@ defmodule Logflare.SingleTenant do
     name: "Enterprise",
     period: "year",
     price: 20_000,
-    limit_sources: 100,
-    limit_rate_limit: 5_000,
+    limit_sources: 500,
+    limit_rate_limit: 500_000,
     limit_alert_freq: 1_000,
-    limit_source_rate_limit: 100,
+    limit_source_rate_limit: 100_000,
     limit_saved_search_limit: 1,
     limit_team_users_limit: 2,
     limit_source_fields_limit: 500,
@@ -116,41 +116,8 @@ defmodule Logflare.SingleTenant do
   TODO: add support for bigquery v2 adaptor
   """
   def get_default_backend do
-    user = get_default_user()
-
-    Backends.list_backends_by_user_id(user.id)
-    |> Enum.filter(fn backend -> backend.type == :postgres end)
-    |> List.first()
-  end
-
-  @doc """
-  Updates or inserts the default backend based on env var.
-  """
-  def upsert_default_backend do
-    user = get_default_user()
-    existing_backend = get_default_backend()
-
-    cond do
-      postgres_backend?() and !!existing_backend ->
-        opts = postgres_backend_adapter_opts()
-
-        Backends.update_backend(existing_backend, %{
-          config: Map.new(opts)
-        })
-
-      postgres_backend?() ->
-        opts = postgres_backend_adapter_opts()
-
-        Backends.create_backend(%{
-          name: "Default postgres backend",
-          type: :postgres,
-          config: Map.new(opts),
-          user_id: user.id
-        })
-
-      true ->
-        :noop
-    end
+    get_default_user()
+    |> Backends.get_default_backend()
   end
 
   @doc """
@@ -242,10 +209,6 @@ defmodule Logflare.SingleTenant do
         for name <- @source_names do
           # creating a source will automatically start the source's RLS process
           {:ok, source} = Sources.create_source(%{name: name}, user)
-
-          if backend do
-            {:ok, _backend} = Backends.update_source_backends(source, [backend])
-          end
 
           source
         end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -202,8 +202,6 @@ defmodule Logflare.SingleTenant do
     user = get_default_user()
     count = Sources.count_sources_by_user(user)
 
-    backend = get_default_backend()
-
     if count == 0 do
       sources =
         for name <- @source_names do

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -12,7 +12,6 @@ defmodule Logflare.Source.V1SourceSup do
 
   alias Logflare.Source.RateCounterServer, as: RCS
   alias Logflare.Users
-  alias Logflare.User
   alias Logflare.Backends
   alias Logflare.Backends.Backend
   alias Logflare.Billing

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -39,22 +39,7 @@ defmodule Logflare.Source.V1SourceSup do
 
     plan = Billing.Cache.get_plan_by_user(user)
 
-    {project_id, dataset_id} =
-      if user.bigquery_project_id do
-        {user.bigquery_project_id, user.bigquery_dataset_id}
-      else
-        project_id = User.bq_project_id()
-        dataset_id = User.generate_bq_dataset_id(source.user_id)
-        {project_id, dataset_id}
-      end
-
-    backend = %Backend{
-      type: :bigquery,
-      config: %{
-        project_id: project_id,
-        dataset_id: dataset_id
-      }
-    }
+    backend = Backends.get_default_backend(user)
 
     default_bigquery_spec = Backend.child_spec(source, backend)
 

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -51,11 +51,7 @@ defmodule Logflare.Sources do
            |> Ecto.build_assoc(:sources)
            |> Source.update_by_user_changeset(source_params)
            |> Repo.insert() do
-      if SingleTenant.postgres_backend?() do
-        # attach the source to the postgres backend
-        backend = SingleTenant.get_default_backend()
-        Backends.update_source_backends(source, [backend])
-      else
+      if !SingleTenant.postgres_backend?() do
         create_big_query_schema_and_start_source(source)
       end
 

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -235,7 +235,6 @@ defmodule LogflareWeb.QueryLive do
         %_{type: :bigquery} -> :bq_sql
         %_{type: :postgres} -> :pg_sql
       end
-      |> dbg()
 
     case Endpoints.run_query_string(user, {type, query_string}, params: %{}) do
       {:ok, %{rows: rows}} ->

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -7,6 +7,7 @@ defmodule LogflareWeb.QueryLive do
 
   alias Logflare.Endpoints
   alias Logflare.Users
+  alias Logflare.Backends
 
   def render(assigns) do
     ~H"""
@@ -229,7 +230,14 @@ defmodule LogflareWeb.QueryLive do
   end
 
   defp run_query(socket, user, query_string) do
-    case Endpoints.run_query_string(user, {:bq_sql, query_string}, params: %{}) do
+    type =
+      case Backends.get_default_backend(user) do
+        %_{type: :bigquery} -> :bq_sql
+        %_{type: :postgres} -> :pg_sql
+      end
+      |> dbg()
+
+    case Endpoints.run_query_string(user, {type, query_string}, params: %{}) do
       {:ok, %{rows: rows}} ->
         socket
         |> put_flash(:info, "Ran query successfully")

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -22,7 +22,6 @@ defmodule Logflare.TestUtils do
     opts =
       Enum.into(opts, %{
         seed_user: false,
-        seed_backend: false,
         supabase_mode: false,
         bigquery_project_id: random_string(),
         backend_type: :bigquery,
@@ -39,10 +38,6 @@ defmodule Logflare.TestUtils do
         if unquote(opts.seed_user) do
           {:ok, _} = SingleTenant.create_default_plan()
           {:ok, _user} = SingleTenant.create_default_user()
-        end
-
-        if unquote(opts.seed_backend) do
-          {:ok, _backend} = SingleTenant.upsert_default_backend()
         end
 
         if unquote(opts.supabase_mode) do


### PR DESCRIPTION
This PR fixes a bug where the default backend created for single tenant mode was still bigquery instead of postgres.

Also fixes a bug to allow running queries directly on postgres when using the query UI.

Currently blocks local dev/cli version bump to v1.8.x