### PR TITLE
perf: dynamic pipelines tweaks

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len 500_000
+  @max_pending_buffer_len 50_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length.

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -23,13 +23,16 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len 50_000
+  @max_pending_buffer_len 500_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length.
   """
   @spec max_buffer_len() :: non_neg_integer()
   def max_buffer_len(), do: @max_pending_buffer_len
+
+  @spec max_ingest_queue_len() :: non_neg_integer()
+  def max_ingest_queue_len(), do: 10_000
 
   @doc """
   Lists `Backend`s for a given source.

--- a/lib/logflare/backends/dynamic_pipeline.ex
+++ b/lib/logflare/backends/dynamic_pipeline.ex
@@ -7,7 +7,6 @@ defmodule Logflare.Backends.DynamicPipeline do
   - `:name` - name of the pipeline, required.
   - `:pipeline` - module of the pipeline, required.
   - `:pipeline_args` - args of the pipeline, optional.
-  - `:max_buffer_len` - soft limit that each pipeline buffer grows to before a new pipeline is added. Optional.
   - `:max_pipelines` - max pipelines that can be scaled to.
   - `:min_pipelines` - max pipelines that can be scaled to, defaults to 0.
   - `:initial_count` - the initial number of pipelines to start. Defaults to :min_pipelines value.
@@ -31,8 +30,6 @@ defmodule Logflare.Backends.DynamicPipeline do
         name: nil,
         pipeline: nil,
         pipeline_args: [],
-        # genstage default https://hexdocs.pm/gen_stage/GenStage.html#content
-        max_buffer_len: 10_000,
         max_pipelines: System.schedulers_online(),
         min_pipelines: 0,
         initial_count: args[:min_pipelines] || 0,

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -141,7 +141,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       Logflare.Utils.chunked_round_robin(
         batch,
         procs,
-        100,
+        250,
         fn chunk, target ->
           add_to_table(target, chunk)
         end

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -121,7 +121,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec add_to_table(source_backend_pid(), [LogEvent.t()]) :: :ok | {:error, :not_initialized}
   def add_to_table({sid, bid} = sid_bid, batch) when is_integer(sid) do
-    procs =
+    proc_counts =
       list_counts(sid_bid)
       |> Enum.sort_by(fn {_key, count} -> count end, :asc)
       |> Enum.filter(fn
@@ -129,7 +129,8 @@ defmodule Logflare.Backends.IngestEventQueue do
         {{_, _, nil}, _} -> false
         {{_, _, _}, _} -> true
       end)
-      |> Enum.map(fn {key, _count} -> key end)
+
+    procs = Enum.map(proc_counts, fn {key, _count} -> key end)
 
     procs_length = Enum.count(procs)
 
@@ -140,7 +141,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       Logflare.Utils.chunked_round_robin(
         batch,
         procs,
-        10,
+        100,
         fn chunk, target ->
           add_to_table(target, chunk)
         end

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   require Logger
   @default_interval 1_000
   @default_remainder 100
-  @default_max 50_000
+  @default_max Logflare.Backends.max_buffer_len()
   @default_purge_ratio 0.1
 
   def start_link(opts) do
@@ -66,7 +66,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
         IngestEventQueue.drop(sid_bid_pid, :pending, to_drop)
 
         Logger.warning(
-          "IngestEventQueue private :ets buffer exceeded max for source id=#{state.source_id}, dropping #{pending_size} events",
+          "IngestEventQueue private :ets buffer exceeded max for source id=#{state.source_id}, dropping #{to_drop} events",
           backend_id: state.backend_id
         )
       end

--- a/lib/logflare/logs/log_events_cache.ex
+++ b/lib/logflare/logs/log_events_cache.ex
@@ -4,7 +4,7 @@ defmodule Logflare.Logs.LogEvents.Cache do
   alias Logflare.Logs.LogEvents
   alias Logflare.ContextCache
   alias Logflare.LogEvent, as: LE
-  @ttl :timer.hours(24)
+  @ttl :timer.hours(1)
 
   @cache __MODULE__
 
@@ -19,7 +19,7 @@ defmodule Logflare.Logs.LogEvents.Cache do
         :start_link,
         [
           @cache,
-          [expiration: expiration(default: @ttl), limit: limit(size: 10_000), stats: stats]
+          [expiration: expiration(default: @ttl), limit: limit(size: 5_000), stats: stats]
         ]
       }
     }

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -51,7 +51,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
             transformer: {__MODULE__, :transform, []}
           ],
           processors: [
-            default: [concurrency: 4, max_demand: 100]
+            default: [concurrency: 4]
           ],
           batchers: [
             bq: [

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -51,7 +51,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
             transformer: {__MODULE__, :transform, []}
           ],
           processors: [
-            default: [concurrency: 4]
+            default: [concurrency: 4, max_demand: 100]
           ],
           batchers: [
             bq: [

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -174,7 +174,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
   test "resolve_count will increase counts" do
     check all pipeline_count <- integer(0..100),
-              queue_size <- integer(5001..10000),
+              queue_size <- integer(9001..10000),
               startup_queue_size <- integer(0..100),
               avg_rate <- integer(0..10_000),
               last <- member_of([nil, NaiveDateTime.utc_now()]) do

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -174,7 +174,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
   test "resolve_count will increase counts" do
     check all pipeline_count <- integer(0..100),
-              queue_size <- integer(501..1000),
+              queue_size <- integer(5001..10000),
               startup_queue_size <- integer(0..100),
               avg_rate <- integer(0..10_000),
               last <- member_of([nil, NaiveDateTime.utc_now()]) do
@@ -186,7 +186,14 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       }
 
       desired =
-        BigQueryAdaptor.handle_resolve_count(state, startup_queue_size, queue_size, avg_rate)
+        BigQueryAdaptor.handle_resolve_count(
+          state,
+          %{
+            {1, 2, nil} => startup_queue_size,
+            {1, 2, make_ref()} => queue_size
+          },
+          avg_rate
+        )
 
       assert desired > pipeline_count
     end
@@ -206,7 +213,14 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       }
 
       desired =
-        BigQueryAdaptor.handle_resolve_count(state, startup_queue_size, queue_size, avg_rate)
+        BigQueryAdaptor.handle_resolve_count(
+          state,
+          %{
+            {1, 2, nil} => startup_queue_size,
+            {1, 2, make_ref()} => queue_size
+          },
+          avg_rate
+        )
 
       assert desired < pipeline_count
       assert desired != 0
@@ -227,7 +241,14 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       }
 
       desired =
-        BigQueryAdaptor.handle_resolve_count(state, startup_queue_size, queue_size, avg_rate)
+        BigQueryAdaptor.handle_resolve_count(
+          state,
+          %{
+            {1, 2, nil} => startup_queue_size,
+            {1, 2, make_ref()} => queue_size
+          },
+          avg_rate
+        )
 
       assert desired < pipeline_count
       assert desired == 0
@@ -236,7 +257,6 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
   test "resolve_count initial incoming" do
     check all pipeline_count <- constant(0),
-              queue_size <- integer(1..500),
               startup_queue_size <- integer(1..500),
               avg_rate <- integer(1..500),
               since <- integer(0..100) do
@@ -248,7 +268,13 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       }
 
       desired =
-        BigQueryAdaptor.handle_resolve_count(state, startup_queue_size, queue_size, avg_rate)
+        BigQueryAdaptor.handle_resolve_count(
+          state,
+          %{
+            {1, 2, nil} => startup_queue_size
+          },
+          avg_rate
+        )
 
       assert desired > pipeline_count
       assert desired != 0


### PR DESCRIPTION
This PR tweaks the spawning logic of dynamic pipelines. This reduces the number of concurrentl pipelines (and thus processes), and also reduces the number of concurrent small requests being made to the BQ api.

Logic now factors in a expected queue length cap (10k), where if any is 75% full, a new pipeline will be created. 
The round robin chunking logic has been bumped to 250 items, so as to emphasize filling up of queues, as opposed to the previous chunking using 10 items which spread events out across all pipelines, resulting in very small batch requests. This would match the batching size of a BQ request.

At avg 15k events per sec, only 3 pipelines are used on local dev