### PR TITLE
perf: tweak pipeline provisioning to be more conservative

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -116,7 +116,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
         1
 
       # gradual decrease
-      Enum.all?(lens_no_startup_values, &(&1 < 0.1 * max_len)) and state.pipeline_count > 1 and
+      Enum.all?(lens_no_startup_values, &(&1 < 0.05 * max_len)) and state.pipeline_count > 1 and
           (sec_since_last_decr > 30 or state.last_count_decrease == nil) ->
         state.pipeline_count - 1
 

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -97,7 +97,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
     last_decr = state.last_count_decrease || NaiveDateTime.utc_now()
     sec_since_last_decr = NaiveDateTime.diff(NaiveDateTime.utc_now(), last_decr)
 
-    any_almost_full? = Enum.any?(lens_no_startup_values, &(&1 > 0.75 * max_len))
+    any_almost_full? = Enum.any?(lens_no_startup_values, &(&1 > 0.5 * max_len))
 
     cond do
       # max out pipelines, overflow risk

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -51,6 +51,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
         min_pipelines: 0,
         max_pipelines: System.schedulers_online(),
         initial_count: 1,
+        resolve_interval: 2_500,
         resolve_count: fn state ->
           source = Sources.refresh_source_metrics_for_ingest(source)
 

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -104,9 +104,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       startup_size > 0 ->
         state.pipeline_count + ceil(startup_size / 5_000)
 
-      any_almost_full? and avg_rate > 10_000 ->
-        state.pipeline_count + 3
-
       any_almost_full? and avg_rate > 5_000 ->
         state.pipeline_count + 2
 

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -77,7 +77,27 @@ defmodule Logflare.Utils do
     iex> chunk_size = 2
     iex> chunked_round_robin(batch, targets, chunk_size, fn chunk, target -> {target, Enum.sum(chunk)} end )
     [x: 3, y: 4]
+
+
+    iex> batch = [1, 1, 2, 2, 3, 3, 4, 4]
+    iex> targets = [:x]
+    iex> chunk_size = 2
+    iex> chunked_round_robin(batch, targets, chunk_size, fn chunk, target -> {target, Enum.sum(chunk)} end )
+    [x: 20]
   """
+  def chunked_round_robin(batch, [target], chunk_size, func) do
+    result = func.(batch, target)
+
+    next_chunk_rr(
+      [],
+      chunk_size,
+      [],
+      [target],
+      func,
+      [result]
+    )
+  end
+
   def chunked_round_robin(batch, targets, chunk_size, func) do
     next_chunk_rr(batch, chunk_size, targets, targets, func, [])
   end


### PR DESCRIPTION
This tweaks the pipeline count resolution logic and interval, making it more conservative in pipeline creation, while also reducing the interval check.

also adds in a perf improvment when there is only one target pipeline to round robin to.