### PR TITLE
fix: egress middleware metadata default

### DIFF
--- a/lib/logflare/backends/adaptor/webhook_adaptor/egress_middleware.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor/egress_middleware.ex
@@ -26,7 +26,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor.EgressMiddleware do
         headers_length: headers_len,
         request_length: body_len + headers_len
       },
-      Keyword.get(options, :metadata, %{})
+      Keyword.get(options, :metadata) || %{}
     )
 
     with {:ok, env} <- Tesla.run(env, next) do

--- a/test/logflare/backends/webhook_adaptor_test.exs
+++ b/test/logflare/backends/webhook_adaptor_test.exs
@@ -7,6 +7,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends.Backend
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Backends.SourceSup
+  alias Logflare.Backends.Adaptor.WebhookAdaptor.EgressMiddleware
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
   setup do
@@ -135,6 +136,11 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
                url: "http://example.com",
                http: "http2"
              })
+  end
+
+  test "EgressMiddleware" do
+    assert {:ok, _} = EgressMiddleware.call(%Tesla.Env{}, [], [])
+    assert {:ok, _} = EgressMiddleware.call(%Tesla.Env{}, [], metadata: nil)
   end
 
   @tag :benchmark


### PR DESCRIPTION
Fixes egress middleware telemetry raise bug when metadata value is not set.