### PR TITLE
fix: no reponse body for patch

### DIFF
--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -73,10 +73,14 @@ defmodule LogflareWeb.Api.BackendController do
          {:ok, updated} <- Backends.update_backend(backend, params) do
       conn
       |> case do
-        %{method: "PATCH"} -> put_status(conn, 204)
-        %{method: "PUT"} -> put_status(conn, 200)
+        %{method: "PATCH"} ->
+          conn
+          |> send_resp(204, "")
+
+        %{method: "PUT"} ->
+          put_status(conn, 200)
+          |> json(updated)
       end
-      |> json(updated)
     end
   end
 

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -74,10 +74,14 @@ defmodule LogflareWeb.Api.EndpointController do
          {:ok, query} <- Endpoints.update_query(query, params) do
       conn
       |> case do
-        %{method: "PUT"} -> put_status(conn, 200)
-        %{method: "PATCH"} -> put_status(conn, 204)
+        %{method: "PUT"} ->
+          put_status(conn, 200)
+          |> json(query)
+
+        %{method: "PATCH"} ->
+          conn
+          |> send_resp(204, "")
       end
-      |> json(query)
     end
   end
 

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -133,10 +133,13 @@ defmodule LogflareWeb.Api.RuleController do
          {:ok, updated} <- Rules.update_rule(rule, params) do
       conn
       |> case do
-        %{method: "PATCH"} -> put_status(conn, 204)
-        %{method: "PUT"} -> put_status(conn, 200)
+        %{method: "PATCH"} ->
+          conn |> send_resp(204, "")
+
+        %{method: "PUT"} ->
+          put_status(conn, 200)
+          |> json(updated)
       end
-      |> json(updated)
     end
   end
 

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -79,10 +79,14 @@ defmodule LogflareWeb.Api.SourceController do
 
       conn
       |> case do
-        %{method: "PATCH"} -> put_status(conn, 204)
-        %{method: "PUT"} -> put_status(conn, 200)
+        %{method: "PATCH"} ->
+          conn |> send_resp(204, "")
+
+        %{method: "PUT"} ->
+          conn
+          |> put_status(200)
+          |> json(source)
       end
-      |> json(source)
     end
   end
 

--- a/lib/logflare_web/controllers/api/team_controller.ex
+++ b/lib/logflare_web/controllers/api/team_controller.ex
@@ -76,10 +76,14 @@ defmodule LogflareWeb.Api.TeamController do
          team <- Teams.preload_fields(team, [:user, :team_users]) do
       conn
       |> case do
-        %{method: "PUT"} -> put_status(conn, 201)
-        %{method: "PATCH"} -> put_status(conn, 204)
+        %{method: "PUT"} ->
+          conn
+          |> put_status(201)
+          |> json(team)
+
+        %{method: "PATCH"} ->
+          conn |> send_resp(204, "")
       end
-      |> json(team)
     end
   end
 

--- a/test/logflare_web/controllers/api/backend_controller_test.exs
+++ b/test/logflare_web/controllers/api/backend_controller_test.exs
@@ -202,9 +202,9 @@ defmodule LogflareWeb.Api.BackendControllerTest do
         conn
         |> add_access_token(user, "private")
         |> patch("/api/backends/#{backend.token}", %{name: name})
-        |> json_response(204)
+        |> response(204)
 
-      assert response["name"] == name
+      assert response == ""
     end
 
     test "returns not found if doesn't own the resource", %{conn: conn, user: user} do

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -105,9 +105,9 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         conn
         |> add_access_token(user, ~w(private))
         |> patch("/api/endpoints/#{endpoint.token}", %{name: name})
-        |> json_response(204)
+        |> response(204)
 
-      assert response["name"] == name
+      assert response == ""
     end
 
     test "returns not found if doesn't own the enpoint query", %{

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -132,9 +132,9 @@ defmodule LogflareWeb.Api.SourceControllerTest do
         conn
         |> add_access_token(user, "private")
         |> patch("/api/sources/#{source.token}", %{name: name})
-        |> json_response(204)
+        |> response(204)
 
-      assert response["name"] == name
+      assert response == ""
     end
 
     test "returns not found if doesn't own the source", %{conn: conn, sources: [source | _]} do

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -129,9 +129,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         conn
         |> add_access_token(user, "private")
         |> patch("/api/teams/#{main_team.token}", %{name: name})
-        |> json_response(204)
+        |> response(204)
 
-      assert response["name"] == name
+      assert response == ""
     end
 
     test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do


### PR DESCRIPTION
Fixes mgmt API PATCH handling, response body should always be empty.

https://github.com/phoenixframework/phoenix/issues/1131