### PR TITLE
feat: retention days api refactoring

### DIFF
--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -147,7 +147,6 @@ defmodule Logflare.Sources do
         user.bigquery_dataset_id,
         user.bigquery_project_id
       )
-      |> dbg()
     end
 
     {:ok, updated}

--- a/lib/logflare/users/users.ex
+++ b/lib/logflare/users/users.ex
@@ -88,8 +88,8 @@ defmodule Logflare.Users do
     user
     |> Repo.preload([:sources, :billing_account, :team])
     |> maybe_put_bigquery_defaults()
-    |> then(fn u ->
-      %{u | sources: Enum.map(u.sources, &Sources.put_retention_days/1)}
+    |> Map.update!(:sources, fn sources ->
+      Enum.map(sources, &Sources.put_retention_days/1)
     end)
   end
 
@@ -107,8 +107,8 @@ defmodule Logflare.Users do
 
   def preload_sources(user) do
     Repo.preload(user, :sources)
-    |> then(fn u ->
-      %{u | sources: Enum.map(u.sources, &Sources.put_retention_days/1)}
+    |> Map.update!(:sources, fn sources ->
+      Enum.map(sources, &Sources.put_retention_days/1)
     end)
   end
 

--- a/lib/logflare/users/users.ex
+++ b/lib/logflare/users/users.ex
@@ -88,6 +88,9 @@ defmodule Logflare.Users do
     user
     |> Repo.preload([:sources, :billing_account, :team])
     |> maybe_put_bigquery_defaults()
+    |> then(fn u ->
+      %{u | sources: Enum.map(u.sources, &Sources.put_retention_days/1)}
+    end)
   end
 
   def preload_team(user) do
@@ -104,6 +107,9 @@ defmodule Logflare.Users do
 
   def preload_sources(user) do
     Repo.preload(user, :sources)
+    |> then(fn u ->
+      %{u | sources: Enum.map(u.sources, &Sources.put_retention_days/1)}
+    end)
   end
 
   def preload_endpoints(user) do

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -439,22 +439,9 @@ defmodule LogflareWeb.SourceController do
     end
   end
 
-  def update(%{assigns: %{source: old_source, user: user}} = conn, %{"source" => source_params}) do
-    changeset = Source.update_by_user_changeset(old_source, source_params)
-
-    case Repo.update(changeset) do
+  def update(%{assigns: %{source: old_source}} = conn, %{"source" => source_params}) do
+    case Sources.update_source_by_user(old_source, source_params) do
       {:ok, source} ->
-        ttl = source.bigquery_table_ttl
-
-        if ttl do
-          BigQuery.patch_table_ttl(
-            source.token,
-            source.bigquery_table_ttl * 86_400_000,
-            user.bigquery_dataset_id,
-            user.bigquery_project_id
-          )
-        end
-
         :ok = Supervisor.ensure_started(source)
 
         conn

--- a/lib/logflare_web/templates/source/dashboard.html.heex
+++ b/lib/logflare_web/templates/source/dashboard.html.heex
@@ -135,7 +135,7 @@
                 </span>
               </div>
             </div>
-            <%= render(LogflareWeb.SharedView, "dashboard_source_metadata.html", conn: @conn, source: source, source_ttl_days: source_ttl_to_days(source, @plan), pipeline_counts: @pipeline_counts) %>
+            <%= render(LogflareWeb.SharedView, "dashboard_source_metadata.html", conn: @conn, source: source, source_ttl_days: source.retention_days, pipeline_counts: @pipeline_counts) %>
           </li>
         <% end %>
       </ul>

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -246,8 +246,8 @@
   <p>Set how long to keep data in your backend.</p>
   <%= form_for @changeset, Routes.source_path(@conn, :update, @source), fn e -> %>
   <div class="form-group">
-    <%= text_input e, :bigquery_table_ttl, placeholder: "3", class: "form-control form-control-margin" %>
-    <%= error_tag e, :bigquery_table_ttl %>
+    <%= text_input e, :retention_days, placeholder: "3", class: "form-control form-control-margin" %>
+    <%= error_tag e, :retention_days %>
     <small class="form-text text-muted">
       Days to keep data.
     </small>

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -1,9 +1,6 @@
 defmodule LogflareWeb.SourceView do
   import LogflareWeb.Helpers.Forms
   alias LogflareWeb.Router.Helpers, as: Routes
-  alias Logflare.Billing.Plan
-  alias Logflare.Source
-  alias Logflare.Google.BigQuery.GenUtils
   use LogflareWeb, :view
 
   def log_url(route) do
@@ -19,23 +16,5 @@ defmodule LogflareWeb.SourceView do
         url
     end
     |> URI.to_string()
-  end
-
-  @doc """
-  Formats a source TTL to the specified unit
-  """
-  @spec source_ttl_to_days(Source.t(), Plan.t()) :: integer()
-  def source_ttl_to_days(%Source{bigquery_table_ttl: ttl}, _plan)
-      when ttl >= 0 and ttl != nil do
-    round(ttl)
-  end
-
-  # fallback to plan value or default init value
-  # use min to avoid misrepresenting what user should see, in cases where actual is more than plan.
-  def source_ttl_to_days(_source, %Plan{limit_source_ttl: ttl}) do
-    min(
-      round(GenUtils.default_table_ttl_days()),
-      round(ttl / :timer.hours(24))
-    )
   end
 end

--- a/test/logflare/backends/adaptor/datadog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/datadog_adaptor_test.exs
@@ -13,6 +13,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
   setup do
     start_supervised!(AllLogsLogged)
+    insert(:plan)
     :ok
   end
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -6,6 +6,11 @@ defmodule Logflare.Backends.BufferProducerTest do
 
   import ExUnit.CaptureLog
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   test "pulls events from IngestEventQueue" do
     user = insert(:user)
     source = insert(:source, user: user)

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -11,6 +11,7 @@ defmodule Logflare.DynamicPipelineTest do
   import ExUnit.CaptureLog
 
   setup do
+    insert(:plan)
     user = insert(:user)
     source = insert(:source, user: user)
 

--- a/test/logflare/backends/elastic_adaptor_test.exs
+++ b/test/logflare/backends/elastic_adaptor_test.exs
@@ -12,6 +12,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
   doctest @subject
 
   setup do
+    insert(:plan)
     start_supervised!(AllLogsLogged)
     :ok
   end

--- a/test/logflare/backends/ingest_events_queue_test.exs
+++ b/test/logflare/backends/ingest_events_queue_test.exs
@@ -8,6 +8,11 @@ defmodule Logflare.Backends.IngestEventQueueTest do
   alias Logflare.Backends
   alias Logflare.Backends.IngestEventQueue
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   test "get_table_size/1 returns nil for non-existing tables" do
     assert nil == IngestEventQueue.get_table_size({1, 2, 4})
   end

--- a/test/logflare/backends/webhook_adaptor_test.exs
+++ b/test/logflare/backends/webhook_adaptor_test.exs
@@ -11,13 +11,13 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
   setup do
+    insert(:plan)
     start_supervised!(AllLogsLogged)
     :ok
   end
 
   describe "ingestion tests" do
     setup do
-      insert(:plan)
       user = insert(:user)
       source = insert(:source, user: user)
 

--- a/test/logflare/cluster_pubsub_test.exs
+++ b/test/logflare/cluster_pubsub_test.exs
@@ -63,6 +63,7 @@ defmodule Logflare.ClusterPubSubTest do
 
   describe "ChannelTopics" do
     setup do
+      insert(:plan)
       [source: insert(:source, user: insert(:user))]
     end
 

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -6,6 +6,11 @@ defmodule Logflare.EndpointsTest do
   alias Logflare.Endpoints.Query
   alias Logflare.Backends.Adaptor.PostgresAdaptor
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   test "list_endpoints_by" do
     %{id: id, name: name} = insert(:endpoint)
     assert [%{id: ^id}] = Endpoints.list_endpoints_by(name: name)
@@ -120,7 +125,6 @@ defmodule Logflare.EndpointsTest do
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
       end)
 
-      insert(:plan)
       user = insert(:user)
       insert(:source, user: user, name: "c")
       endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
@@ -133,7 +137,6 @@ defmodule Logflare.EndpointsTest do
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
       end)
 
-      insert(:plan)
       user = insert(:user)
 
       insert(:endpoint,
@@ -151,7 +154,6 @@ defmodule Logflare.EndpointsTest do
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
       end)
 
-      insert(:plan)
       user = insert(:user)
       insert(:source, user: user, name: "c")
       query_string = "select current_datetime() as testing"
@@ -165,7 +167,6 @@ defmodule Logflare.EndpointsTest do
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
       end)
 
-      insert(:plan)
       user = insert(:user)
       endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
       _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
@@ -186,7 +187,6 @@ defmodule Logflare.EndpointsTest do
           {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
         end)
 
-        insert(:plan)
         user = insert(:user)
         endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
         cache_pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
@@ -212,8 +212,6 @@ defmodule Logflare.EndpointsTest do
 
   describe "running queries in postgres backends" do
     setup do
-      insert(:plan)
-
       cfg = Application.get_env(:logflare, Logflare.Repo)
 
       url = "postgresql://#{cfg[:username]}:#{cfg[:password]}@#{cfg[:hostname]}/#{cfg[:database]}"
@@ -295,7 +293,6 @@ defmodule Logflare.EndpointsTest do
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
       end)
 
-      insert(:plan)
       user = insert(:user)
 
       endpoint =

--- a/test/logflare/logs/rejected_logs_test.exs
+++ b/test/logflare/logs/rejected_logs_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.Logs.RejectedLogEventsTest do
   alias Logflare.{Sources, Users, LogEvent}
 
   setup do
+    insert(:plan)
     s1 = build(:source)
     s2 = build(:source)
     sources = [s1, s2]

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -5,6 +5,11 @@ defmodule Logflare.Source.BigQuery.SchemaTest do
   alias Logflare.Source.BigQuery.Schema
   alias Logflare.Google.BigQuery.SchemaUtils
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   test "next_update_ts/1" do
     next_update = Schema.next_update_ts(6) |> trunc()
     assert String.length("#{next_update}") == String.length("#{System.system_time(:millisecond)}")

--- a/test/logflare/sources/sources_cache_test.exs
+++ b/test/logflare/sources/sources_cache_test.exs
@@ -4,6 +4,7 @@ defmodule Logflare.SourcesCacheTest do
   use Logflare.DataCase
 
   setup do
+    insert(:plan)
     u1 = insert(:user)
     s01 = insert(:source, user_id: u1.id)
     s02 = insert(:source, user_id: u1.id)

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -11,6 +11,7 @@ defmodule Logflare.SqlTest do
   @env "test"
 
   setup do
+    insert(:plan)
     values = Application.get_env(:logflare, Logflare.Google)
     to_put = Keyword.put(values, :project_id, @logflare_project_id)
     Application.put_env(:logflare, Logflare.Google, to_put)

--- a/test/logflare/users/users_cache_test.exs
+++ b/test/logflare/users/users_cache_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.Users.CacheTest do
   use Logflare.DataCase
 
   setup do
+    insert(:plan)
     source = build(:source, notifications: %{})
 
     user =

--- a/test/logflare/users/users_test.exs
+++ b/test/logflare/users/users_test.exs
@@ -6,6 +6,7 @@ defmodule Logflare.UsersTest do
   alias Logflare.Users
 
   setup do
+    insert(:plan)
     user = insert(:user)
     source = insert(:source, user_id: user.id)
     source = Sources.get_by(token: source.token)

--- a/test/logflare_grpc/trace/server_test.exs
+++ b/test/logflare_grpc/trace/server_test.exs
@@ -6,6 +6,11 @@ defmodule LogflareGrpc.Trace.ServerTest do
   alias Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
   alias Opentelemetry.Proto.Collector.Trace.V1.TraceService.Stub
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   describe "export/2" do
     setup do
       user = insert(:user)

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -2,6 +2,7 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
   use LogflareWeb.ConnCase
 
   setup do
+    insert(:plan)
     endpoints = insert_list(2, :endpoint)
     user = insert(:user, endpoint_queries: endpoints)
     insert(:source, name: "logs", user: user)

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -86,8 +86,6 @@ defmodule LogflareWeb.Api.QueryControllerTest do
 
   describe "pg_sql" do
     setup do
-      insert(:plan)
-
       cfg = Application.get_env(:logflare, Logflare.Repo)
 
       url = "postgresql://#{cfg[:username]}:#{cfg[:password]}@#{cfg[:hostname]}/#{cfg[:database]}"

--- a/test/logflare_web/plugs/fetch_resource_test.exs
+++ b/test/logflare_web/plugs/fetch_resource_test.exs
@@ -6,6 +6,7 @@ defmodule LogflareWeb.Plugs.FetchResourceTest do
   alias Logflare.Endpoints.Query
 
   setup do
+    insert(:plan)
     user = insert(:user)
     endpoint = insert(:endpoint, user: user)
     source = insert(:source, user: user)

--- a/test/logflare_web/plugs/verify_api_access_test.exs
+++ b/test/logflare_web/plugs/verify_api_access_test.exs
@@ -4,6 +4,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
   alias LogflareWeb.Plugs.VerifyApiAccess
 
   setup do
+    insert(:plan)
     user = insert(:user)
     endpoint_auth = insert(:endpoint, user: user, enable_auth: true)
     endpoint_open = insert(:endpoint, user: user, enable_auth: false)


### PR DESCRIPTION
This refactors the retention days updating to use `retention_days` field to be backend agnostic.

It currently does nothing for non-BQ backends.
Might be moved to backend level in the future.

