### PR TITLE
feat: source schema api

### DIFF
--- a/lib/logflare/source_schemas.ex
+++ b/lib/logflare/source_schemas.ex
@@ -105,7 +105,7 @@ defmodule Logflare.SourceSchemas do
 
   def format_schema(bq_schema, variant, to_merge \\ %{})
 
-  def format_schema(%SourceSchema{bigquery_schema: bq_schema} = schema, :dot, to_merge) do
+  def format_schema(%SourceSchema{bigquery_schema: bq_schema}, :dot, to_merge) do
     bq_schema
     |> SchemaUtils.bq_schema_to_flat_typemap()
     |> Enum.filter(fn

--- a/lib/logflare/source_schemas.ex
+++ b/lib/logflare/source_schemas.ex
@@ -5,6 +5,7 @@ defmodule Logflare.SourceSchemas do
 
   alias Logflare.Repo
   alias Logflare.SourceSchemas.SourceSchema
+  alias Logflare.Google.BigQuery.SchemaUtils
 
   require Logger
 
@@ -101,4 +102,61 @@ defmodule Logflare.SourceSchemas do
   def change_source_schema(%SourceSchema{} = source_schema, attrs \\ %{}) do
     SourceSchema.changeset(source_schema, attrs)
   end
+
+  def format_schema(bq_schema, variant, to_merge \\ %{})
+
+  def format_schema(%SourceSchema{bigquery_schema: bq_schema} = schema, :dot, to_merge) do
+    bq_schema
+    |> SchemaUtils.bq_schema_to_flat_typemap()
+    |> Enum.filter(fn
+      {_k, :map} -> false
+      _ -> true
+    end)
+    |> Enum.map(fn
+      {k, {:list, type}} -> {k, "#{type}[]"}
+      {k, v} -> {k, Atom.to_string(v)}
+    end)
+    |> Map.new()
+    |> Map.merge(to_merge)
+  end
+
+  def format_schema(%SourceSchema{bigquery_schema: bq_schema}, :json_schema, to_merge) do
+    bq_schema
+    |> SchemaUtils.to_typemap()
+    |> typemap_to_json_schema()
+    |> Map.merge(to_merge)
+    |> Map.put(
+      "$schema",
+      "https://json-schema.org/draft/2020-12/schema"
+    )
+  end
+
+  defp typemap_to_json_schema(map) when is_map(map) do
+    properties = Enum.map(map, &typemap_to_json_schema/1) |> Map.new()
+
+    %{
+      "properties" => properties,
+      "type" => "object"
+    }
+  end
+
+  defp typemap_to_json_schema({key, %{fields: fields, t: :map}}) do
+    {Atom.to_string(key), typemap_to_json_schema(fields)}
+  end
+
+  defp typemap_to_json_schema({key, %{t: {:list, type}}}) do
+    {Atom.to_string(key), %{"type" => "array", "items" => %{"type" => Atom.to_string(type)}}}
+  end
+
+  defp typemap_to_json_schema({key, %{t: :datetime}}),
+    do: {Atom.to_string(key), %{"type" => "number"}}
+
+  defp typemap_to_json_schema({key, %{t: :integer}}),
+    do: {Atom.to_string(key), %{"type" => "number"}}
+
+  defp typemap_to_json_schema({key, %{t: :float}}),
+    do: {Atom.to_string(key), %{"type" => "number"}}
+
+  defp typemap_to_json_schema({key, %{t: type}}),
+    do: {Atom.to_string(key), %{"type" => Atom.to_string(type)}}
 end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -123,6 +123,12 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]
   end
 
+  defmodule SourceSchema do
+    @properties %{}
+
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
   defmodule RuleApiSchema do
     @properties %{
       id: %Schema{type: :integer},

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -391,6 +391,7 @@ defmodule LogflareWeb.Router do
       param: "token",
       only: [:index, :show, :create, :update, :delete]
     ) do
+      get "/schema", Api.SourceController, :show_schema
       get "/recent", Api.SourceController, :recent
       post "/backends/:backend_token", Api.SourceController, :add_backend
       delete "/backends/:backend_token", Api.SourceController, :remove_backend

--- a/test/logflare/sources_schemas_test.exs
+++ b/test/logflare/sources_schemas_test.exs
@@ -1,0 +1,66 @@
+defmodule Logflare.SourceSchemasTest do
+  @moduledoc false
+  use Logflare.DataCase
+
+  alias Logflare.SourceSchemas
+
+  describe "format_schema/3" do
+    setup do
+      insert(:plan, name: "Free")
+      user = insert(:user)
+      source = insert(:source, user: user)
+      %{user: user, source: source}
+    end
+
+    test "dot notation with nested values", %{
+      source: source
+    } do
+      schema =
+        insert(:source_schema,
+          source: source,
+          bigquery_schema:
+            TestUtils.build_bq_schema(%{
+              "test" => %{"nested" => 123, "listical" => ["testing", "123"]}
+            })
+        )
+
+      assert %{
+               "test.nested" => "integer",
+               "timestamp" => "datetime",
+               "test.listical" => "string[]"
+             } = params = SourceSchemas.format_schema(schema, :dot)
+
+      refute Map.get(params, "test")
+    end
+
+    test "json schema ", %{
+      source: source
+    } do
+      schema =
+        insert(:source_schema,
+          source: source,
+          bigquery_schema:
+            TestUtils.build_bq_schema(%{
+              "test" => %{"nested" => 123, "listical" => ["testing", "123"]}
+            })
+        )
+
+      assert %{
+               "properties" => %{
+                 "test" => %{
+                   "type" => "object",
+                   "properties" => %{
+                     "nested" => %{
+                       "type" => "number"
+                     },
+                     "listical" => %{
+                       "type" => "array",
+                       "items" => %{"type" => "string"}
+                     }
+                   }
+                 }
+               }
+             } = SourceSchemas.format_schema(schema, :json_schema)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds in source schema APIs.
It adds in dot notation and json schema as variants.
Currently converts directly from the stored BQ schema.
Textual representation of array is done by appending `[]` to the data type.
Over time we will be moving typings to conform with json schema types, so backend-specific typing will become irrelevant and phased out with the transition of v1->v2 schema management.