### PR TITLE
perf: tweak gc-ing of RLS genserver

### DIFF
--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -15,7 +15,7 @@ defmodule Logflare.Source.RecentLogsServer do
   require Logger
 
   @touch_timer :timer.minutes(45)
-  @broadcast_every 2_500
+  @broadcast_every 1_800
 
   ## Server
   def start_link(args) do

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -15,14 +15,14 @@ defmodule Logflare.Source.RecentLogsServer do
   require Logger
 
   @touch_timer :timer.minutes(45)
-  @broadcast_every 1_800
+  @broadcast_every 2_500
 
   ## Server
   def start_link(args) do
     GenServer.start_link(__MODULE__, args,
       name: Backends.via_source(args[:source], __MODULE__),
       spawn_opt: [
-        fullsweep_after: 1_000
+        fullsweep_after: 100
       ],
       hibernate_after: 5_000
     )


### PR DESCRIPTION
This PR increases major GC frequency for RLS server, which stores ingestion count metrics.

Longer term solution is to move such metrics to ETS instead