### PR TITLE
perf: add back fullsweep_after to Task.Supervisor

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -51,7 +51,9 @@ defmodule Logflare.Application do
          name: Logflare.V1SourceRegistry,
          keys: :unique,
          partitions: max(round(System.schedulers_online() / 8), 1)},
-        {PartitionSupervisor, child_spec: Task.Supervisor, name: Logflare.TaskSupervisors},
+        {PartitionSupervisor,
+         child_spec: {Task.Supervisor, [spawn_opt: [fullsweep_after: 1_000]]},
+         name: Logflare.TaskSupervisors},
         {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
         {DynamicSupervisor,
          strategy: :one_for_one,
@@ -75,7 +77,9 @@ defmodule Logflare.Application do
       conditional_children() ++
       [
         Logflare.ErlSysMon,
-        {PartitionSupervisor, child_spec: Task.Supervisor, name: Logflare.TaskSupervisors},
+        {PartitionSupervisor,
+         child_spec: {Task.Supervisor, [spawn_opt: [fullsweep_after: 1_000]]},
+         name: Logflare.TaskSupervisors},
         {Cluster.Supervisor, [topologies, [name: Logflare.ClusterSupervisor]]},
         Logflare.Repo,
         Logflare.Vault,


### PR DESCRIPTION
Added back spawn_opt for Task.Supervisor, prevents garbage buildup.
Was removed in https://github.com/Logflare/logflare/commit/40db716e82cb3bc4041709f2aec8de6fe811cd53#diff-14a0c2e2cb2fe12cfea0794ab7c068ea2f25fa332f3fb7e0351e9d63b0266adfL81