### PR TITLE
perf: add fullsweep_after to SourceSup

### DIFF
--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -24,6 +24,8 @@ defmodule Logflare.Backends.SourceSup do
   end
 
   def init(source) do
+    Process.flag(:fullsweep_after, 5_000)
+
     ingest_backends =
       source
       |> Backends.Cache.list_backends()


### PR DESCRIPTION
Cannot be passed through start_link, must use `Process.flag/2` which then uses `:erlang.process_flag/2`

https://www.erlang.org/doc/apps/erts/erlang.html#process_flag/3