### PR TITLE
chore: silence postgrex errors for database errors

### DIFF
--- a/test/logflare/backends/postgres_adaptor_test.exs
+++ b/test/logflare/backends/postgres_adaptor_test.exs
@@ -138,12 +138,16 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
         schema: nil,
         username: "some-invalid",
         password: "!@#$",
+        database: "logflare_test",
         hostname: "localhost",
         port: 5432
       }
 
       backend = insert(:backend, type: :postgres, sources: [source], config: config)
-      assert {:ok, _pid} = start_supervised({AdaptorSupervisor, {source, backend}})
+
+      capture_log(fn ->
+        assert {:ok, _pid} = start_supervised({AdaptorSupervisor, {source, backend}})
+      end) =~ "invalid_password"
     end
 
     test "cannot connect to invalid ", %{source: source} do
@@ -163,7 +167,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
 
         assert {:error, :cannot_connect} =
                  PostgresAdaptor.insert_log_event(source, backend, log_event)
-      end)
+      end) =~ "invalid_password"
     end
   end
 


### PR DESCRIPTION
```

15:20:28.535 [error] :gen_statem #PID<0.1682.0> terminating
** (RuntimeError) connect raised KeyError exception: key :database not found. The exception details are hidden, as they may contain sensitive data such as database credentials. You may set :show_sensitive_data_on_connection_error to true when starting your connection if you wish to see all of the details
    (elixir 1.17.3) lib/keyword.ex:602: Keyword.fetch!/2
    (postgrex 0.17.3) lib/postgrex/protocol.ex:163: Postgrex.Protocol.connect_endpoints/6
    (db_connection 2.6.0) lib/db_connection/connection.ex:92: DBConnection.Connection.handle_event/4
    (stdlib 6.1.2) gen_statem.erl:3737: :gen_statem.loop_state_callback/11
    (stdlib 6.1.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Queue: [internal: {:connect, :init}]
Postponed: []

```
This PR fixes this test error.