### PR TITLE
perf: split finch pools for ingest

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -208,6 +208,24 @@ defmodule Logflare.Application do
       # Finch connection pools, using http2
       {Finch, name: Logflare.FinchGoth, pools: %{default: [protocols: [:http2], count: 1]}},
       {Finch,
+       name: Logflare.FinchIngest,
+       pools: %{
+         "https://bigquery.googleapis.com" => [
+           protocols: [:http2],
+           count: max(ceil(base / 2), 10),
+           start_pool_metrics?: true
+         ]
+       }},
+      {Finch,
+       name: Logflare.FinchQuery,
+       pools: %{
+         "https://bigquery.googleapis.com" => [
+           protocols: [:http2],
+           count: max(base, 20),
+           start_pool_metrics?: true
+         ]
+       }},
+      {Finch,
        name: Logflare.FinchDefault,
        pools: %{
          # default pool uses finch defaults
@@ -215,7 +233,7 @@ defmodule Logflare.Application do
          #  explicitly set http2 for other pools for multiplexing
          "https://bigquery.googleapis.com" => [
            protocols: [:http2],
-           count: max(base * 2, 20),
+           count: max(base, 10),
            start_pool_metrics?: true
          ],
          "https://http-intake.logs.datadoghq.com" => [

--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -106,13 +106,13 @@ defmodule Logflare.Google.BigQuery.GenUtils do
   # copy over runtime adapter building from Tesla.client/2
   # https://github.com/elixir-tesla/tesla/blob/v1.7.0/lib/tesla/builder.ex#L206
   defp build_tesla_adapter_call(:ingest) do
-    Tesla.client([], {Tesla.Adapter.Finch, name: Logflare.FinchDefault, receive_timeout: 5_000}).adapter
+    Tesla.client([], {Tesla.Adapter.Finch, name: Logflare.FinchIngest, receive_timeout: 5_000}).adapter
   end
 
   defp build_tesla_adapter_call(:query) do
     Tesla.client(
       [],
-      {Tesla.Adapter.Finch, name: Logflare.FinchDefault, receive_timeout: 60_000}
+      {Tesla.Adapter.Finch, name: Logflare.FinchQuery, receive_timeout: 60_000}
     ).adapter
   end
 

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -20,7 +20,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
 
       GoogleApi.BigQuery.V2.Api.Jobs
       |> stub(:bigquery_jobs_query, fn conn, _proj_id, _opts ->
-        assert {Tesla.Adapter.Finch, :call, [[name: Logflare.FinchDefault, receive_timeout: _]]} =
+        assert {Tesla.Adapter.Finch, :call, [[name: Logflare.FinchQuery, receive_timeout: _]]} =
                  conn.adapter
 
         {:ok, TestUtils.gen_bq_response()}

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -511,7 +511,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
     test "run a query", %{conn: conn, source: source} do
       stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn conn, _proj_id, opts ->
         # use separate connection pool
-        assert {Tesla.Adapter.Finch, :call, [[name: Logflare.FinchDefault, receive_timeout: _]]} =
+        assert {Tesla.Adapter.Finch, :call, [[name: Logflare.FinchQuery, receive_timeout: _]]} =
                  conn.adapter
 
         query = opts[:body].query |> String.downcase()


### PR DESCRIPTION
This reverts to a previous optimization, splitting out the finch pools used for ingest/query into separate trees, so that we can better isolate issue relating to either.

This is so that we can pin down this issue, has not popped up recently.
![image](https://github.com/user-attachments/assets/28d5a757-d013-4d03-8c6d-dc54f5e63f36)
