### PR TITLE
perf+fix: remove expensive  table traversal for pending counts, fix buffer limiter

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -24,16 +24,13 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len 100_000
+  @max_pending_buffer_len_per_queue 50_000
 
   @doc """
-  Retrieves the hardcoded max pending buffer length.
+  Retrieves the hardcoded max pending buffer length of an individual queue
   """
-  @spec max_buffer_len() :: non_neg_integer()
-  def max_buffer_len(), do: @max_pending_buffer_len
-
-  @spec max_ingest_queue_len() :: non_neg_integer()
-  def max_ingest_queue_len(), do: 10_000
+  @spec max_buffer_queue_len() :: non_neg_integer()
+  def max_buffer_queue_len(), do: @max_pending_buffer_len_per_queue
 
   @doc """
   Lists `Backend`s for a given source.
@@ -474,7 +471,16 @@ defmodule Logflare.Backends do
     do: cached_local_pending_buffer_full?(id)
 
   def cached_local_pending_buffer_full?(source_id) when is_integer(source_id) do
-    cached_local_pending_buffer_len(source_id) > @max_pending_buffer_len
+    PubSubRates.Cache.get_local_buffer(source_id, nil)
+    |> Map.get(:queues, [])
+    |> case do
+      [] ->
+        false
+
+      queues ->
+        queues
+        |> Enum.all?(fn {_key, v} -> v > @max_pending_buffer_len_per_queue end)
+    end
   end
 
   @doc """
@@ -485,12 +491,27 @@ defmodule Logflare.Backends do
           nil | integer()
         ) ::
           integer()
+  @deprecated "call `Logflare.Backends.cache_local_buffer_lens/2` instead."
   def get_and_cache_local_pending_buffer_len(source_id, backend_id \\ nil)
       when is_integer(source_id) do
-    len = IngestEventQueue.count_pending({source_id, backend_id})
+    len = IngestEventQueue.total_pending({source_id, backend_id})
     payload = %{Node.self() => %{len: len}}
     PubSubRates.Cache.cache_buffers(source_id, backend_id, payload)
     len
+  end
+
+  @doc """
+  Caches total buffer len. Includes ingested events that are awaiting cleanup.
+  """
+  def cache_local_buffer_lens(source_id, backend_id \\ nil) do
+    queues = IngestEventQueue.list_counts({source_id, backend_id})
+
+    len = for({_k, v} <- queues, do: v) |> Enum.sum()
+
+    stats = %{len: len, queues: queues}
+    payload = %{Node.self() => stats}
+    PubSubRates.Cache.cache_buffers(source_id, backend_id, payload)
+    {:ok, stats}
   end
 
   @doc """
@@ -499,10 +520,6 @@ defmodule Logflare.Backends do
   @spec cached_local_pending_buffer_len(Source.t(), Backend.t() | nil) :: non_neg_integer()
   def cached_local_pending_buffer_len(source_id, backend_id \\ nil) when is_integer(source_id) do
     PubSubRates.Cache.get_local_buffer(source_id, backend_id)
-    |> case do
-      %{len: len} -> len
-      other -> other
-    end
   end
 
   @doc """

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -24,7 +24,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len_per_queue 5_000
+  @max_pending_buffer_len_per_queue 10_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length of an individual queue

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -24,7 +24,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len_per_queue 50_000
+  @max_pending_buffer_len_per_queue 5_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length of an individual queue

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -55,7 +55,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
         resolve_count: fn state ->
           source = Sources.refresh_source_metrics_for_ingest(source)
 
-          lens = IngestEventQueue.list_pending_counts({source.id, backend.id})
+          lens = IngestEventQueue.list_counts({source.id, backend.id})
 
           handle_resolve_count(state, lens, source.metrics.avg)
         end
@@ -78,7 +78,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
 
   """
   def handle_resolve_count(state, lens, avg_rate) do
-    max_len = Backends.max_ingest_queue_len()
+    max_len = Backends.max_buffer_queue_len()
 
     startup_size =
       Enum.find_value(lens, 0, fn

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -236,7 +236,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       fn objs, acc ->
         items =
           for {sid_bid_pid, _tid} <- objs,
-              count = count_pending(sid_bid_pid),
+              count = total_pending(sid_bid_pid),
               is_integer(count) do
             {sid_bid_pid, count}
           end
@@ -271,15 +271,15 @@ defmodule Logflare.Backends.IngestEventQueue do
   @doc """
   Counts pending items from a given table
   """
-  @spec count_pending(source_backend_pid()) :: integer() | {:error, :not_initialized}
-  def count_pending({_, _} = sid_bid) do
+  @spec total_pending(source_backend_pid()) :: integer() | {:error, :not_initialized}
+  def total_pending({_, _} = sid_bid) do
     # iterate over each matching source-backend queue and sum the totals
     for {_sid_bid_pid, count} <- list_pending_counts(sid_bid), reduce: 0 do
       acc -> acc + count
     end
   end
 
-  def count_pending({_sid, _bid, _pid} = sid_bid_pid) do
+  def total_pending({_sid, _bid, _pid} = sid_bid_pid) do
     ms =
       Ex2ms.fun do
         {_event_id, :pending, _event} -> true

--- a/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
+++ b/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
@@ -62,9 +62,9 @@ defmodule Logflare.Backends.IngestEventQueue.BroadcastWorker do
   end
 
   defp global_broadcast_producer_buffer_len({source_id, backend_id}) do
-    len = Backends.get_and_cache_local_pending_buffer_len(source_id, backend_id)
+    {:ok, stats} = Backends.cache_local_buffer_lens(source_id, backend_id)
 
-    local_buffer = %{Node.self() => %{len: len}}
+    local_buffer = %{Node.self() => stats}
     PubSubRates.global_broadcast_rate({"buffers", source_id, backend_id, local_buffer})
   end
 

--- a/lib/logflare/logs/browser_report.ex
+++ b/lib/logflare/logs/browser_report.ex
@@ -16,6 +16,6 @@ defmodule Logflare.Logs.BrowserReport do
   end
 
   def message(params) do
-    Jason.encode!(params)
+    Jason.encode_to_iodata!(params)
   end
 end

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -89,8 +89,8 @@ defmodule Logflare.PubSubRates.Cache do
   def get_local_buffer(source_id, backend_id) do
     Cachex.get(__MODULE__, {source_id, backend_id, "buffers"})
     |> case do
-      {:ok, val} when val != nil -> Map.get(val, Node.self(), 0)
-      _ -> 0
+      {:ok, val} when val != nil -> Map.get(val, Node.self(), %{len: 0, queues: []})
+      _ -> %{len: 0, queues: []}
     end
   end
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -27,7 +27,7 @@ defmodule Logflare.Backends.BufferProducerTest do
     GenStage.stream([{buffer_producer_pid, max_demand: 1}])
     |> Enum.take(1)
 
-    assert IngestEventQueue.count_pending(sid_bid_pid) == 0
+    assert IngestEventQueue.total_pending(sid_bid_pid) == 0
     # marked as :ingested
     assert IngestEventQueue.get_table_size(sid_bid_pid) == 1
   end
@@ -49,7 +49,7 @@ defmodule Logflare.Backends.BufferProducerTest do
     GenStage.stream([{buffer_producer_pid, max_demand: 1}])
     |> Enum.take(1)
 
-    assert IngestEventQueue.count_pending(sid_bid_pid) == 0
+    assert IngestEventQueue.total_pending(sid_bid_pid) == 0
     # marked as :ingested
     assert IngestEventQueue.get_table_size(sid_bid_pid) == 1
   end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -19,7 +19,6 @@ defmodule Logflare.BackendsTest do
   alias Logflare.Rules
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.Backends.SourceSupWorker
-  alias Logflare.LogEvent
 
   setup do
     start_supervised!(AllLogsLogged)
@@ -264,6 +263,25 @@ defmodule Logflare.BackendsTest do
       # Producer will pop from the queue
       :timer.sleep(1_500)
       assert Backends.get_and_cache_local_pending_buffer_len(source.id) == 0
+    end
+
+    test "cache_estimated_buffer_lens/1 will cache all queue information", %{
+      source: %{id: source_id} = source
+    } do
+      assert {:ok,
+              %{
+                len: 0,
+                queues: [_, _]
+              }} = Backends.cache_local_buffer_lens(source_id)
+
+      events = for _n <- 1..5, do: build(:log_event, source: source, some: "event")
+      assert {:ok, 5} = Backends.ingest_logs(events, source)
+
+      assert {:ok,
+              %{
+                len: 5,
+                queues: [_, _]
+              }} = Backends.cache_local_buffer_lens(source_id)
     end
   end
 

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -6,6 +6,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   alias Logflare.Backends
 
   setup do
+    insert(:plan)
     conn = build_conn(:post, "/api/logs", %{"message" => "some text"})
     source = insert(:source, user: insert(:user))
     table_key = {source.id, nil, self()}
@@ -24,10 +25,53 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     end
 
     # get and cache the value
-    Backends.get_and_cache_local_pending_buffer_len(source.id, nil)
+    Backends.cache_local_buffer_lens(source.id, nil)
 
     conn =
       conn
+      |> assign(:source, source)
+      |> BufferLimiter.call(%{})
+
+    assert conn.halted == true
+    assert conn.status == 429
+  end
+
+  test "bug: buffer limiting is based on all queues", %{
+    conn: conn,
+    source: source,
+    table_key: table_key
+  } do
+    other_table_key = {source.id, nil, make_ref()}
+    IngestEventQueue.upsert_tid(other_table_key)
+
+    for _ <- 1..25_100 do
+      le = build(:log_event)
+      IngestEventQueue.add_to_table(table_key, [le])
+      IngestEventQueue.add_to_table(other_table_key, [le])
+    end
+
+    # get and cache the value
+    Backends.cache_local_buffer_lens(source.id, nil)
+
+    conn =
+      conn
+      |> assign(:source, source)
+      |> BufferLimiter.call(%{})
+
+    assert conn.halted == false
+
+    for _ <- 1..25_100 do
+      le = build(:log_event)
+      IngestEventQueue.add_to_table(table_key, [le])
+      IngestEventQueue.add_to_table(other_table_key, [le])
+    end
+
+    # get and cache the value
+    Backends.cache_local_buffer_lens(source.id, nil)
+
+    conn =
+      conn
+      |> recycle()
       |> assign(:source, source)
       |> BufferLimiter.call(%{})
 
@@ -43,7 +87,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     end
 
     # get and cache the value
-    Backends.get_and_cache_local_pending_buffer_len(source.id, nil)
+    Backends.cache_local_buffer_lens(source.id, nil)
 
     conn =
       conn

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -19,7 +19,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     source: source,
     table_key: table_key
   } do
-    for _ <- 1..100_500 do
+    for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
       le = build(:log_event)
       IngestEventQueue.add_to_table(table_key, [le])
     end
@@ -44,7 +44,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     other_table_key = {source.id, nil, make_ref()}
     IngestEventQueue.upsert_tid(other_table_key)
 
-    for _ <- 1..25_100 do
+    for _ <- 1..round(Backends.max_buffer_queue_len() / 2) do
       le = build(:log_event)
       IngestEventQueue.add_to_table(table_key, [le])
       IngestEventQueue.add_to_table(other_table_key, [le])
@@ -80,7 +80,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   end
 
   test "200 if most events are ingested", %{conn: conn, source: source, table_key: table_key} do
-    for _ <- 1..8_000 do
+    for _ <- 1..(Backends.max_buffer_queue_len() - 500) do
       le = build(:log_event)
       IngestEventQueue.add_to_table(table_key, [le])
       IngestEventQueue.mark_ingested(table_key, [le])

--- a/test/profiling/buffer_limiter.exs
+++ b/test/profiling/buffer_limiter.exs
@@ -1,0 +1,72 @@
+alias Logflare.Sources
+alias Logflare.Users
+require Phoenix.ConnTest
+Mimic.copy(Broadway)
+Mimic.copy(Logflare.Backends)
+Mimic.copy(Logflare.Logs)
+Mimic.copy(Logflare.Partners)
+alias Logflare.Backends.IngestEventQueue
+
+Mimic.stub(Logflare.Backends, :ingest_logs, fn _, _ -> :ok end)
+Mimic.stub(Logflare.Logs, :ingest_logs, fn _, _ -> :ok end)
+# Mimic.stub(Broadway, :push_messages, fn _, _ -> :ok end)
+ver = System.argv() |> Enum.at(0)
+
+source = Sources.get(:"9f37d86e-e4fa-4ef2-a47e-e8d4ac1fceba")
+
+# v2_source = Sources.get(:"94d07aab-30f5-460e-8871-eb85f4674e35")
+
+# user = Users.get(v1_source.user_id)
+
+Benchee.run(
+  %{
+    "list_pending_counts" => fn _input ->
+      IngestEventQueue.list_pending_counts({source.id, nil})
+    end,
+    "cached_local_pending_buffer_len" => fn _input ->
+      Logflare.Backends.cached_local_pending_buffer_len(source.id)
+    end,
+    "get_buffers" => fn _input ->
+      Logflare.PubSubRates.Cache.get_buffers(source.id, nil)
+    end,
+    "cache_local_buffer_lens" => fn _ ->
+      Logflare.Backends.cache_local_buffer_lens(source.id)
+    end
+  },
+  before_scenario: fn prev ->
+    key1 = {source.id, nil, make_ref()}
+    key2 = {source.id, nil, make_ref()}
+    IngestEventQueue.upsert_tid(key1)
+    IngestEventQueue.upsert_tid(key2)
+
+    events =
+      for _ <- 1..10_000 do
+        Logflare.Factory.build(:log_event)
+      end
+
+    IngestEventQueue.add_to_table(key1, events)
+    IngestEventQueue.add_to_table(key2, events)
+
+    prev
+  end,
+  inputs: %{
+    "v1" => source
+    # "v2" => v2_source
+  },
+  time: 4,
+  memory_time: 0
+)
+
+# 2024-12-14 addition of cache_local_buffer_lens/1
+# ##### With input v1 #####
+# Name                                      ips        average  deviation         median         99th %
+# get_buffers                         2247.46 K        0.44 μs  ±5589.04%        0.38 μs        0.58 μs
+# cached_local_pending_buffer_len      264.75 K        3.78 μs   ±429.42%        3.50 μs        5.42 μs
+# cache_local_buffer_lens              148.17 K        6.75 μs   ±184.04%        6.25 μs       12.21 μs
+# list_pending_counts                    1.07 K      933.85 μs    ±22.27%      887.48 μs     1523.25 μs
+
+# Comparison:
+# get_buffers                         2247.46 K
+# cached_local_pending_buffer_len      264.75 K - 8.49x slower +3.33 μs
+# cache_local_buffer_lens              148.17 K - 15.17x slower +6.30 μs
+# list_pending_counts                    1.07 K - 2098.80x slower +933.41 μs

--- a/test/profiling/ingest_event_queue_trunc.exs
+++ b/test/profiling/ingest_event_queue_trunc.exs
@@ -1,0 +1,189 @@
+alias Logflare.Sources
+require Phoenix.ConnTest
+Mimic.copy(Broadway)
+Mimic.copy(Logflare.Backends)
+Mimic.copy(Logflare.Logs)
+Mimic.copy(Logflare.Partners)
+alias Logflare.Backends.IngestEventQueue
+
+Mimic.stub(Logflare.Backends, :ingest_logs, fn _, _ -> :ok end)
+Mimic.stub(Logflare.Logs, :ingest_logs, fn _, _ -> :ok end)
+# Mimic.stub(Broadway, :push_messages, fn _, _ -> :ok end)
+ver = System.argv() |> Enum.at(0)
+
+source = Sources.get(:"9f37d86e-e4fa-4ef2-a47e-e8d4ac1fceba")
+
+# v2_source = Sources.get(:"94d07aab-30f5-460e-8871-eb85f4674e35")
+
+# user = Users.get(v1_source.user_id)
+
+key1 = {source.id, nil, make_ref()}
+key2 = {source.id, nil, make_ref()}
+
+onek =
+  for _ <- 1..1_000 do
+    Logflare.Factory.build(:log_event)
+  end
+
+tenk =
+  for _ <- 1..10_000 do
+    Logflare.Factory.build(:log_event)
+  end
+
+# hundredk =
+#   for _ <- 1..100_000 do
+#     Logflare.Factory.build(:log_event)
+#   end
+
+require Ex2ms
+
+ms =
+  Ex2ms.fun do
+    {event_id, _status, _event} -> true
+  end
+
+Benchee.run(
+  %{
+    "destroy and recreate" => fn _ ->
+      :ets.delete(IngestEventQueue.get_tid(key2))
+      IngestEventQueue.upsert_tid(key2)
+    end,
+    "delete_all_objects" => fn _ ->
+      :ets.delete_all_objects(IngestEventQueue.get_tid(key2))
+    end,
+    "select_delete" => fn _ ->
+      :ets.select_delete(IngestEventQueue.get_tid(key2), ms)
+    end,
+    "truncate pending 100" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :pending, 100)
+    end,
+    "truncate pending 0" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :pending, 0)
+    end,
+    "truncate all 100" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :all, 100)
+    end,
+    "truncate all 0" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :all, 0)
+    end,
+    "truncate ingested 100" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :ingested, 100)
+    end,
+    "truncate ingested 0" => fn _ ->
+      IngestEventQueue.truncate_table(key2, :ingested, 0)
+    end
+  },
+  before_each: fn input ->
+    # IngestEventQueue.upsert_tid(key1)
+    IngestEventQueue.upsert_tid(key2)
+
+    # IngestEventQueue.add_to_table(key1, input)
+    IngestEventQueue.add_to_table(key2, input)
+    {_pending, ingested} = Enum.split(input, round(length(input) / 2))
+    IngestEventQueue.mark_ingested(key2, ingested)
+
+    input
+  end,
+  inputs: %{
+    "1k" => onek,
+    "10k" => tenk
+    # "100k" => hundredk,
+    # "v2" => v2_source
+  },
+  time: 4,
+  memory_time: 0
+)
+
+# 2024-12-16 baseline
+# ##### With input 10k #####
+# Name                            ips        average  deviation         median         99th %
+# truncate ingested 0          957.25        1.04 ms    ±11.45%        1.01 ms        1.48 ms
+# truncate all 0               814.22        1.23 ms    ±11.73%        1.17 ms        1.73 ms
+# destroy and recreate         789.53        1.27 ms    ±11.10%        1.24 ms        1.66 ms
+# delete_all_objects           750.82        1.33 ms    ±12.73%        1.33 ms        1.90 ms
+# select_delete                647.51        1.54 ms    ±11.29%        1.48 ms        2.21 ms
+# truncate ingested 100        427.72        2.34 ms    ±12.09%        2.27 ms        3.32 ms
+# truncate pending 100         383.53        2.61 ms     ±7.92%        2.58 ms        3.28 ms
+# truncate pending 0           372.31        2.69 ms     ±8.99%        2.66 ms        3.51 ms
+# truncate all 100             250.31        4.00 ms    ±15.86%        3.83 ms        5.21 ms
+
+# Comparison:
+# truncate ingested 0          957.25
+# truncate all 0               814.22 - 1.18x slower +0.184 ms
+# destroy and recreate         789.53 - 1.21x slower +0.22 ms
+# delete_all_objects           750.82 - 1.27x slower +0.29 ms
+# select_delete                647.51 - 1.48x slower +0.50 ms
+# truncate ingested 100        427.72 - 2.24x slower +1.29 ms
+# truncate pending 100         383.53 - 2.50x slower +1.56 ms
+# truncate pending 0           372.31 - 2.57x slower +1.64 ms
+# truncate all 100             250.31 - 3.82x slower +2.95 ms
+
+# ##### With input 1k #####
+# Name                            ips        average  deviation         median         99th %
+# delete_all_objects          16.79 K       59.56 μs    ±21.70%       55.21 μs      123.99 μs
+# truncate ingested 0         15.31 K       65.30 μs    ±14.51%       62.25 μs      102.75 μs
+# truncate all 0              15.26 K       65.54 μs    ±18.66%       61.67 μs      123.27 μs
+# destroy and recreate        13.77 K       72.60 μs    ±30.84%       72.38 μs      136.25 μs
+# select_delete               11.27 K       88.75 μs    ±13.58%       85.46 μs      147.53 μs
+# truncate pending 100         5.65 K      176.93 μs    ±10.37%      172.05 μs      247.83 μs
+# truncate ingested 100        5.64 K      177.32 μs     ±9.51%      172.92 μs      238.22 μs
+# truncate pending 0           4.98 K      200.96 μs     ±9.38%      197.13 μs      280.21 μs
+# truncate all 100             3.70 K      270.23 μs     ±9.08%      263.38 μs      376.23 μs
+
+# Comparison:
+# delete_all_objects          16.79 K
+# truncate ingested 0         15.31 K - 1.10x slower +5.74 μs
+# truncate all 0              15.26 K - 1.10x slower +5.98 μs
+# destroy and recreate        13.77 K - 1.22x slower +13.04 μs
+# select_delete               11.27 K - 1.49x slower +29.19 μs
+# truncate pending 100         5.65 K - 2.97x slower +117.36 μs
+# truncate ingested 100        5.64 K - 2.98x slower +117.75 μs
+# truncate pending 0           4.98 K - 3.37x slower +141.40 μs
+# truncate all 100             3.70 K - 4.54x slower +210.66 μs
+
+# 2024-12-16: after using select_delete and insert
+# ##### With input 10k #####
+# Name                            ips        average  deviation         median         99th %
+# truncate all 0               789.76        1.27 ms    ±10.88%        1.23 ms        1.64 ms
+# destroy and recreate         737.32        1.36 ms    ±10.71%        1.32 ms        1.75 ms
+# delete_all_objects           724.07        1.38 ms    ±28.37%        1.32 ms        2.08 ms
+# truncate ingested 0          677.53        1.48 ms    ±11.47%        1.43 ms        1.95 ms
+# truncate pending 0           621.05        1.61 ms     ±7.08%        1.58 ms        1.92 ms
+# select_delete                605.67        1.65 ms    ±10.60%        1.59 ms        2.14 ms
+# truncate ingested 100        587.34        1.70 ms     ±9.20%        1.66 ms        2.17 ms
+# truncate pending 100         552.29        1.81 ms     ±7.26%        1.78 ms        2.20 ms
+# truncate all 100             493.30        2.03 ms     ±9.65%        1.95 ms        2.58 ms
+
+# Comparison:
+# truncate all 0               789.76
+# destroy and recreate         737.32 - 1.07x slower +0.0901 ms
+# delete_all_objects           724.07 - 1.09x slower +0.115 ms
+# truncate ingested 0          677.53 - 1.17x slower +0.21 ms
+# truncate pending 0           621.05 - 1.27x slower +0.34 ms
+# select_delete                605.67 - 1.30x slower +0.38 ms
+# truncate ingested 100        587.34 - 1.34x slower +0.44 ms
+# truncate pending 100         552.29 - 1.43x slower +0.54 ms
+# truncate all 100             493.30 - 1.60x slower +0.76 ms
+
+# ##### With input 1k #####
+# Name                            ips        average  deviation         median         99th %
+# truncate all 0              15.79 K       63.35 μs    ±16.85%       60.38 μs      116.20 μs
+# delete_all_objects          14.06 K       71.12 μs    ±22.67%       69.13 μs      139.57 μs
+# destroy and recreate        12.81 K       78.04 μs    ±25.68%       76.33 μs      147.74 μs
+# select_delete               11.15 K       89.67 μs    ±14.57%       86.25 μs      155.82 μs
+# truncate ingested 0         10.36 K       96.50 μs     ±9.07%       94.08 μs      127.98 μs
+# truncate pending 0          10.01 K       99.91 μs    ±12.49%       96.13 μs      164.25 μs
+# truncate all 100             2.77 K      360.40 μs    ±14.55%      338.04 μs      582.32 μs
+# truncate pending 100         2.76 K      362.31 μs    ±13.17%      342.58 μs      564.19 μs
+# truncate ingested 100        2.74 K      364.55 μs    ±14.32%      342.17 μs      558.54 μs
+
+# Comparison:
+# truncate all 0              15.79 K
+# delete_all_objects          14.06 K - 1.12x slower +7.77 μs
+# destroy and recreate        12.81 K - 1.23x slower +14.70 μs
+# select_delete               11.15 K - 1.42x slower +26.32 μs
+# truncate ingested 0         10.36 K - 1.52x slower +33.15 μs
+# truncate pending 0          10.01 K - 1.58x slower +36.56 μs
+# truncate all 100             2.77 K - 5.69x slower +297.05 μs
+# truncate pending 100         2.76 K - 5.72x slower +298.96 μs
+# truncate ingested 100        2.74 K - 5.75x slower +301.20 μs


### PR DESCRIPTION
This PR:
- removes expensive table traversals in hot code paths, and instead uses table size as an estimate for the buffer pending length as it is O(1)
- fixes buffer limiter to be based on the total size of the table as an estimate, which achieves the same intended goal of protecting memory, albeit being more conservative as it includes ingested events as well. However, theoretical total max queue size is currently num of cores * 50k so it would be plenty.


Also added benchmark to verify that `list_pending_counts/1` was very expensive and should be avoided.