### PR TITLE
perf: increase max ets tables allocation

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -10,6 +10,10 @@
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
 
+## Increase max ets tables allocation
+## https://www.erlang.org/doc/apps/stdlib/ets.html#module-table-traversal
+-env ERL_MAX_ETS_TABLES 250000
+
 ## Set busy-wait. Options are: none|very_short|short|medium|long|very_long
 +sbwt none
 +sbwtdcpu none


### PR DESCRIPTION
<img width="987" alt="Screenshot 2024-12-16 at 11 36 23 AM" src="https://github.com/user-attachments/assets/3a3b2cb4-da33-4a94-9d9b-546c7bc1e821" />


    
    > If large amounts of named tables are used and `ERL_MAX_ETS_TABLES`
    hasn't been increased, the performance of named table lookup will degrade.
    > 
    
    https://www.erlang.org/doc/apps/stdlib/ets.html#module-table-traversal