### PR TITLE
perf: reduce tasks spawning

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -24,7 +24,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len_per_queue 10_000
+  @max_pending_buffer_len_per_queue 5_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length of an individual queue

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -24,7 +24,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len_per_queue 5_000
+  @max_pending_buffer_len_per_queue 10_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length of an individual queue

--- a/lib/logflare/source/data.ex
+++ b/lib/logflare/source/data.ex
@@ -5,12 +5,6 @@ defmodule Logflare.Source.Data do
   alias Logflare.Source.RateCounterServer
   alias Logflare.Source.BigQuery.Schema
   alias Logflare.Backends
-  alias Logflare.Sources
-
-  def get_logs(source_id) when is_atom(source_id) do
-    source = Sources.Cache.get_by_id(source_id)
-    Backends.list_recent_logs(source)
-  end
 
   @spec get_log_count(atom, String.t()) :: non_neg_integer()
   def get_log_count(token, _bigquery_project_id) do

--- a/lib/logflare/source/email_notification_server.ex
+++ b/lib/logflare/source/email_notification_server.ex
@@ -9,7 +9,6 @@ defmodule Logflare.Source.EmailNotificationServer do
   alias Logflare.AccountEmail
   alias Logflare.Mailer
   alias Logflare.Backends
-  alias Logflare.Utils.Tasks
 
   def start_link(args) do
     source = Keyword.get(args, :source)
@@ -41,9 +40,7 @@ defmodule Logflare.Source.EmailNotificationServer do
       user = Users.Cache.get_by(id: source.user_id)
 
       if source.notifications.user_email_notifications do
-        Tasks.start_child(fn ->
-          AccountEmail.source_notification(user, rate, source) |> Mailer.deliver()
-        end)
+        AccountEmail.source_notification(user, rate, source) |> Mailer.deliver()
       end
 
       stranger_emails = source.notifications.other_email_notifications
@@ -52,10 +49,8 @@ defmodule Logflare.Source.EmailNotificationServer do
         other_emails = String.split(stranger_emails, ",")
 
         for email <- other_emails do
-          Tasks.start_child(fn ->
-            AccountEmail.source_notification_for_others(String.trim(email), rate, source)
-            |> Mailer.deliver()
-          end)
+          AccountEmail.source_notification_for_others(String.trim(email), rate, source)
+          |> Mailer.deliver()
         end
       end
 
@@ -64,9 +59,7 @@ defmodule Logflare.Source.EmailNotificationServer do
           team_user = TeamUsers.Cache.get_team_user(x)
 
           if team_user do
-            Tasks.start_child(fn ->
-              AccountEmail.source_notification(team_user, rate, source) |> Mailer.deliver()
-            end)
+            AccountEmail.source_notification(team_user, rate, source) |> Mailer.deliver()
           end
         end)
       end

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -89,7 +89,7 @@ defmodule Logflare.Source.RecentLogsServer do
      }}
   end
 
-  def handle_info(:touch, %{source_id: source_id, source_token: source_token} = state) do
+  def handle_info(:touch, %{source_id: source_id} = state) do
     source =
       source_id
       |> Sources.Cache.get_by_id()

--- a/lib/logflare/source/recent_logs_server.ex
+++ b/lib/logflare/source/recent_logs_server.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Source.RecentLogsServer do
 
   require Logger
 
-  @touch_timer :timer.minutes(15)
+  @touch_timer :timer.minutes(45)
   @broadcast_every 1_800
 
   ## Server

--- a/lib/logflare/source/slack_hook_server/slack_hook_server.ex
+++ b/lib/logflare/source/slack_hook_server/slack_hook_server.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Source.SlackHookServer do
   end
 
   def test_post(source) do
-    recent_events = Backends.list_recent_logs(source)
+    recent_events = Backends.list_recent_logs_local(source)
 
     __MODULE__.Client.new()
     |> __MODULE__.Client.post(source, source.metrics.rate, recent_events)
@@ -43,10 +43,12 @@ defmodule Logflare.Source.SlackHookServer do
     case rate > 0 do
       true ->
         if source.slack_hook_url do
-          recent_events = Backends.list_recent_logs(source)
+          recent_events = Backends.list_recent_logs_local(source)
 
-          __MODULE__.Client.new()
-          |> __MODULE__.Client.post(source, rate, recent_events)
+          if length(recent_events) > 0 do
+            __MODULE__.Client.new()
+            |> __MODULE__.Client.post(source, rate, recent_events)
+          end
         end
 
         check_rate(state.notifications_every)

--- a/lib/logflare/source/webhook_notification_server/webhook_notification_server.ex
+++ b/lib/logflare/source/webhook_notification_server/webhook_notification_server.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Source.WebhookNotificationServer do
   end
 
   def test_post(source) do
-    recent_events = Backends.list_recent_logs(source)
+    recent_events = Backends.list_recent_logs_local(source)
     uri = source.webhook_notification_url
 
     post(uri, source, 0, recent_events)
@@ -42,7 +42,7 @@ defmodule Logflare.Source.WebhookNotificationServer do
     case rate > 0 do
       true ->
         if uri = source.webhook_notification_url do
-          recent_events = Backends.list_recent_logs(source)
+          recent_events = Backends.list_recent_logs_local(source)
 
           post(uri, source, rate, recent_events)
         end


### PR DESCRIPTION
This PR reduces the number of tasks getting spawned unecessarily. Much of these removed are non-critical areas.
Due to SourceSup being initialized across cluster and the number of nodes in cluster, the amount of cross-cluster tasks spawning increases as our cluster size and volume increases. Keeping the comparison local will minimize the number of tasks spawned.

Critical areas preserved for future optimizations are those used in Endpoints.