### PR TITLE
 grpc-encoding `identity` should be handled, x-source-id removal 

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -334,7 +334,7 @@ if System.get_env("LOGFLARE_OTEL_ENDPOINT") do
     otlp_endpoint: System.get_env("LOGFLARE_OTEL_ENDPOINT"),
     otlp_compression: :gzip,
     otlp_headers: [
-      {"x-source-id", System.get_env("LOGFLARE_OTEL_SOURCE_UUID")},
+      {"x-source", System.get_env("LOGFLARE_OTEL_SOURCE_UUID")},
       {"x-api-key", System.get_env("LOGFLARE_OTEL_ACCESS_TOKEN")}
     ]
 end

--- a/lib/logflare_grpc/identity_compressor.ex
+++ b/lib/logflare_grpc/identity_compressor.ex
@@ -1,0 +1,15 @@
+defmodule LogflareGrpc.IdentityCompressor do
+  @behaviour GRPC.Compressor
+
+  def name do
+    "identity"
+  end
+
+  def compress(data) do
+    data
+  end
+
+  def decompress(data) do
+    data
+  end
+end

--- a/lib/logflare_grpc/trace/server.ex
+++ b/lib/logflare_grpc/trace/server.ex
@@ -15,7 +15,7 @@ defmodule LogflareGrpc.Trace.Server do
 
   use GRPC.Server,
     service: Opentelemetry.Proto.Collector.Trace.V1.TraceService.Service,
-    compressors: [GRPC.Compressor.Gzip],
+    compressors: [GRPC.Compressor.Gzip, LogflareGrpc.IdentityCompressor],
     http_transcode: true
 
   require Logger


### PR DESCRIPTION
`identity` is set by some opentelemetry SDKs, it should be handled as a passthrough

This PR also fixes a traces exporting bug where `x-source-id` has since been removed.