### PR TITLE
fix: duplicate logflare alerts being triggered by increasing alerts cluster size threshold

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=50051,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=7
+      - --container-env=LOGFLARE_GRPC_PORT=50051,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=15
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring


### PR DESCRIPTION
Fixes for duplicate logflare alerts getting triggered