### PR TITLE
feat: adjust default chart grouping to hourly

### DIFF
--- a/lib/logflare/logs/lql/lql_utils.ex
+++ b/lib/logflare/logs/lql/lql_utils.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Lql.Utils do
     %ChartRule{
       aggregate: :count,
       path: "timestamp",
-      period: :minute,
+      period: :hour,
       value_type: :datetime
     }
   end

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -31,7 +31,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   @tail_search_interval 500
   @user_idle_interval :timer.minutes(5)
-  @default_qs "c:count(*) c:group_by(t::minute)"
+  @default_qs "c:count(*) c:group_by(t::hour)"
 
   def mount(
         %{"source_id" => source_id} = params,

--- a/lib/logflare_web/live/search_live/templates/logs_search.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.heex
@@ -109,7 +109,7 @@
       %{
         data: if(@search_op_log_aggregates, do: @search_op_log_aggregates.rows, else: []),
         loading: @chart_loading,
-        chart_period: get_chart_period(@lql_rules, "minute"),
+        chart_period: get_chart_period(@lql_rules, "hour"),
         user_local_timezone: @user_local_timezone,
         use_local_time: @use_local_time,
         chart_data_shape_id:


### PR DESCRIPTION
This should avoid users having the issue where the default chart grouping causes issues when doing filtering, since default query range is 48 hours.