### PR TITLE
feat: remove Cachex from ContextCache, use direct cache busting, list value busting

### DIFF
--- a/lib/logflare/auth.ex
+++ b/lib/logflare/auth.ex
@@ -132,7 +132,7 @@ defmodule Logflare.Auth do
   Optionally validates if the access token needs to have any required scope.
   """
   @spec verify_access_token(OauthAccessToken.t() | String.t(), String.t() | [String.t()]) ::
-          {:ok, User.t()} | {:error, term()}
+          {:ok, OauthAccessToken.t(), User.t()} | {:error, term()}
   def verify_access_token(token, scopes \\ [])
 
   def verify_access_token(token, scope) when is_binary(scope) do
@@ -166,7 +166,7 @@ defmodule Logflare.Auth do
     with {:ok, access_token} <- ExOauth2Provider.authenticate_token(str_token, config),
          :ok <- check_scopes(access_token, required_scopes),
          owner <- get_resource_owner_by_id(resource_owner, access_token.resource_owner_id) do
-      {:ok, owner}
+      {:ok, access_token, owner}
     end
   end
 

--- a/lib/logflare/auth/cache.ex
+++ b/lib/logflare/auth/cache.ex
@@ -32,12 +32,12 @@ defmodule Logflare.Auth.Cache do
   end
 
   @spec verify_access_token(OauthAccessToken.t() | String.t()) ::
-          {:ok, User.t()} | {:error, term()}
+          {:ok, OauthAccessToken.t(), User.t()} | {:error, term()}
   def verify_access_token(access_token_or_api_key),
     do: apply_repo_fun(__ENV__.function, [access_token_or_api_key])
 
   @spec verify_access_token(OauthAccessToken.t() | String.t(), String.t() | [String.t()]) ::
-          {:ok, User.t()} | {:error, term()}
+          {:ok, OauthAccessToken.t(), User.t()} | {:error, term()}
   def verify_access_token(access_token_or_api_key, scopes),
     do: apply_repo_fun(__ENV__.function, [access_token_or_api_key, scopes])
 

--- a/lib/logflare/context_cache.ex
+++ b/lib/logflare/context_cache.ex
@@ -30,7 +30,6 @@ defmodule Logflare.ContextCache do
 
   require Logger
 
-
   @spec apply_fun(atom(), tuple() | atom(), [list()]) :: any()
   def apply_fun(context, {fun, _arity}, args), do: apply_fun(context, fun, args)
 

--- a/lib/logflare/context_cache.ex
+++ b/lib/logflare/context_cache.ex
@@ -81,24 +81,19 @@ defmodule Logflare.ContextCache do
       {
         # use orelse to prevent 2nd condition failing as value is not a map
         :orelse,
-        {:orelse,
+        {
+          :orelse,
           # handle lists
           {:is_list, {:element, 2, :value}},
           # handle :ok tuples when struct with id is in 2nd element pos.
-          {:andalso,
-            {:is_tuple, {:element, 2, :value}},
-              {:andalso,
-              {:==, {:element, 1, {:element, 2, :value}}, :ok},
-              {:andalso,
-              {:is_map, {:element, 2, {:element, 2, :value}}},
-                {:==, {:map_get, :id, {:element, 2, {:element, 2, :value}}}, pkey}
-              }
-            }
-          }
-
+          {:andalso, {:is_tuple, {:element, 2, :value}},
+           {:andalso, {:==, {:element, 1, {:element, 2, :value}}, :ok},
+            {:andalso, {:is_map, {:element, 2, {:element, 2, :value}}},
+             {:==, {:map_get, :id, {:element, 2, {:element, 2, :value}}}, pkey}}}}
         },
         # handle single maps
-        {:andalso, {:is_map, {:element, 2, :value}}, {:==, {:map_get, :id, {:element, 2, :value}}, pkey}}
+        {:andalso, {:is_map, {:element, 2, :value}},
+         {:==, {:map_get, :id, {:element, 2, :value}}, pkey}}
       }
 
     query =

--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -40,7 +40,6 @@ defmodule Logflare.ContextCache.Supervisor do
 
   def list_caches do
     [
-      ContextCache,
       TeamUsers.Cache,
       Partners.Cache,
       Users.Cache,

--- a/lib/logflare/system_metrics/cachex/poller.ex
+++ b/lib/logflare/system_metrics/cachex/poller.ex
@@ -10,7 +10,6 @@ defmodule Logflare.SystemMetrics.Cachex.Poller do
 
   @poll_every 30_000
   @caches [
-    Logflare.ContextCache,
     Logflare.Users.Cache,
     Logflare.Sources.Cache,
     Logflare.Billing.Cache,

--- a/lib/logflare_grpc/trace/server.ex
+++ b/lib/logflare_grpc/trace/server.ex
@@ -55,7 +55,7 @@ defmodule LogflareGrpc.Trace.Server do
   end
 
   defp verify_user(access_token_or_api_key) do
-    with {:ok, %User{} = owner} <-
+    with {:ok, _token, %User{} = owner} <-
            Auth.Cache.verify_access_token(access_token_or_api_key, ["public"]) do
       {:ok, owner}
     else

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -67,7 +67,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
     is_private_route? = "private" in scopes
 
     with {:ok, access_token_or_api_key} <- extracted,
-         {:ok, %User{id: user_id}} <-
+         {:ok, _token, %User{id: user_id}} <-
            Auth.Cache.verify_access_token(access_token_or_api_key, scopes) do
       {:ok, Users.Cache.get(user_id)}
     else

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -72,7 +72,7 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
       {:ok, Users.Cache.get(user_id)}
     else
       # don't preload for partners
-      {:ok, %Partner{}} = res -> res
+      {:ok, _token, %Partner{} = partner} -> {:ok, partner}
       {:error, :no_token} = err -> err
       {:error, _} = err -> handle_legacy_api_key(extracted, err, is_private_route?)
     end

--- a/test/logflare/auth/cache_test.exs
+++ b/test/logflare/auth/cache_test.exs
@@ -13,15 +13,15 @@ defmodule Logflare.Auth.CacheTest do
   test "verify_access_token/2 public scope is cached", %{user: user} do
     # no scope set
     {:ok, key} = Auth.create_access_token(user)
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, "public")
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, "public")
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token)
 
     # scope is set
     {:ok, key} = Auth.create_access_token(user, %{scopes: "public"})
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, "public")
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, "public")
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token)
   end
 
   test "verify_access_token/2 private scope is cached", %{user: user} do
@@ -35,14 +35,14 @@ defmodule Logflare.Auth.CacheTest do
 
     # scope is set
     {:ok, key} = Auth.create_access_token(user, %{scopes: "private"})
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token, ~w(private))
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, ~w(public))
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token, ~w(private))
   end
 
   test "verify_access_token/2 partner scope is cached", %{partner: partner} do
     key = access_token_fixture(partner)
-    assert {:ok, %Partner{}} = Auth.Cache.verify_access_token(key, ~w(partner))
-    assert {:ok, %Partner{}} = Auth.Cache.verify_access_token(key.token, ~w(partner))
+    assert {:ok, key, %Partner{}} = Auth.Cache.verify_access_token(key, ~w(partner))
+    assert {:ok, _token, %Partner{}} = Auth.Cache.verify_access_token(key.token, ~w(partner))
 
     # If scope is missing, should be unauthorized
     assert {:error, :unauthorized} = Auth.Cache.verify_access_token(key)
@@ -52,11 +52,11 @@ defmodule Logflare.Auth.CacheTest do
     {:ok, key} = Auth.create_access_token(user)
 
     Auth
-    |> expect(:verify_access_token, 2, fn _ -> {:ok, key} end)
+    |> expect(:verify_access_token, 2, fn _ -> {:ok, key, user} end)
 
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token)
     ContextCache.bust_keys([{Auth, key.id}])
-    assert {:ok, _} = Auth.Cache.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.Cache.verify_access_token(key.token)
   end
 
   defp access_token_fixture(user_or_team_or_partner) do

--- a/test/logflare/auth_test.exs
+++ b/test/logflare/auth_test.exs
@@ -36,31 +36,31 @@ defmodule Logflare.AuthTest do
 
     test "verify access tokens", %{user: user} do
       key = access_token_fixture(user)
-      assert {:ok, %User{}} = Auth.verify_access_token(key)
-      assert {:ok, _} = Auth.verify_access_token(key.token)
+      assert {:ok, key, %User{}} = Auth.verify_access_token(key)
+      assert {:ok, _token, _user} = Auth.verify_access_token(key.token)
     end
   end
 
   test "verify_access_token/2 ingest scope", %{user: user} do
     # no scope set on token, defaults to ingest to any sources
     {:ok, key} = Auth.create_access_token(user)
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(ingest))
-    assert {:ok, _} = Auth.verify_access_token(key.token, "ingest")
-    assert {:ok, _} = Auth.verify_access_token(key.token)
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(ingest source:2))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(ingest))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, "ingest")
+    assert {:ok, _, _} = Auth.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(ingest source:2))
 
     # scope is set
     {:ok, key} = Auth.create_access_token(user, %{scopes: "ingest"})
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(ingest))
-    assert {:ok, _} = Auth.verify_access_token(key.token, "ingest")
-    assert {:ok, _} = Auth.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(ingest))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, "ingest")
+    assert {:ok, _, _} = Auth.verify_access_token(key.token)
 
     # scope to a specific resource
     # source and collection are resource aliases. i.e. they refer to the same resource.
     for name <- ["source", "collection"] do
       {:ok, key} = Auth.create_access_token(user, %{scopes: "ingest:#{name}:3 ingest:#{name}:1"})
-      assert {:ok, _} = Auth.verify_access_token(key.token, ~w(ingest:#{name}:1))
-      assert {:ok, _} = Auth.verify_access_token(key.token, ~w(ingest:#{name}:3))
+      assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(ingest:#{name}:1))
+      assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(ingest:#{name}:3))
     end
   end
 
@@ -72,13 +72,13 @@ defmodule Logflare.AuthTest do
     # scope is set on token
     {:ok, key} = Auth.create_access_token(user, %{scopes: "query"})
     assert {:error, _} = Auth.verify_access_token(key.token, ~w(ingest))
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(query))
-    assert {:ok, _} = Auth.verify_access_token(key.token)
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(query))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token)
 
     # scope to a specific resource
     {:ok, key} = Auth.create_access_token(user, %{scopes: "query:endpoint:3 query:endpoint:1"})
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(query:endpoint:1))
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(query:endpoint:3))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(query:endpoint:1))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(query:endpoint:3))
   end
 
   test "check_scopes/2 private scope ", %{user: user} do
@@ -130,14 +130,14 @@ defmodule Logflare.AuthTest do
 
     # scope is set
     {:ok, key} = Auth.create_access_token(user, %{scopes: "private"})
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(public))
-    assert {:ok, _} = Auth.verify_access_token(key.token, ~w(private))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(public))
+    assert {:ok, _, _} = Auth.verify_access_token(key.token, ~w(private))
   end
 
   test "verify_access_token/2 partner scope", %{partner: partner} do
     key = access_token_fixture(partner)
-    assert {:ok, %Partner{}} = Auth.verify_access_token(key, ~w(partner))
-    assert {:ok, %Partner{}} = Auth.verify_access_token(key.token, ~w(partner))
+    assert {:ok, key, %Partner{}} = Auth.verify_access_token(key, ~w(partner))
+    assert {:ok, _token, %Partner{}} = Auth.verify_access_token(key.token, ~w(partner))
 
     # If scope is missing, should be unauthorized
     assert {:error, :unauthorized} = Auth.verify_access_token(key)

--- a/test/logflare/context_cache_test.exs
+++ b/test/logflare/context_cache_test.exs
@@ -6,6 +6,7 @@ defmodule Logflare.ContextCacheTest do
   alias Logflare.Backends
   alias Logflare.Backends.Backend
   alias Logflare.Auth
+
   describe "ContextCache" do
     setup do
       insert(:plan, name: "Free")
@@ -23,9 +24,7 @@ defmodule Logflare.ContextCacheTest do
       assert is_nil(Cachex.get!(Sources.Cache, cache_key))
     end
 
-
     test "apply_fun/3,  bust_keys/1 by :id field of value for :ok tuple", %{user: user} do
-
       {:ok, key} = Auth.create_access_token(user)
       assert {:ok, _token, _user} = Auth.Cache.verify_access_token(key.token)
       cache_key = {:verify_access_token, [key.token]}
@@ -34,8 +33,6 @@ defmodule Logflare.ContextCacheTest do
       assert {:ok, 1} = ContextCache.bust_keys([{Auth, key.id}])
       assert is_nil(Cachex.get!(Auth.Cache, cache_key))
     end
-
-
 
     test "apply_fun/3, bust_keys/1 if primary key is in list of returned structs", %{
       source: source

--- a/test/logflare/context_cache_test.exs
+++ b/test/logflare/context_cache_test.exs
@@ -5,7 +5,7 @@ defmodule Logflare.ContextCacheTest do
   alias Logflare.Source
   alias Logflare.Backends
   alias Logflare.Backends.Backend
-
+  alias Logflare.Auth
   describe "ContextCache" do
     setup do
       insert(:plan, name: "Free")
@@ -22,6 +22,20 @@ defmodule Logflare.ContextCacheTest do
       assert {:ok, 1} = ContextCache.bust_keys([{Sources, source.id}])
       assert is_nil(Cachex.get!(Sources.Cache, cache_key))
     end
+
+
+    test "apply_fun/3,  bust_keys/1 by :id field of value for :ok tuple", %{user: user} do
+
+      {:ok, key} = Auth.create_access_token(user)
+      assert {:ok, _token, _user} = Auth.Cache.verify_access_token(key.token)
+      cache_key = {:verify_access_token, [key.token]}
+      assert {:cached, {:ok, %_{}, _user}} = Cachex.get!(Auth.Cache, cache_key)
+
+      assert {:ok, 1} = ContextCache.bust_keys([{Auth, key.id}])
+      assert is_nil(Cachex.get!(Auth.Cache, cache_key))
+    end
+
+
 
     test "apply_fun/3, bust_keys/1 if primary key is in list of returned structs", %{
       source: source

--- a/test/logflare/context_cache_test.exs
+++ b/test/logflare/context_cache_test.exs
@@ -2,34 +2,37 @@ defmodule Logflare.ContextCacheTest do
   use Logflare.DataCase, async: false
   alias Logflare.ContextCache
   alias Logflare.Sources
+  alias Logflare.Source
+  alias Logflare.Backends
+  alias Logflare.Backends.Backend
 
-  describe "ContextCache functions" do
+  describe "ContextCache" do
     setup do
-      user = insert(:user)
       insert(:plan, name: "Free")
+      user = insert(:user)
       source = insert(:source, user: user)
-      args = [token: source.token]
-      source = Sources.Cache.get_by(args)
-      fun = :get_by
-      cache_key = {fun, [args]}
-      %{source: source, cache_key: cache_key}
+      %{source: source, user: user}
     end
 
-    test "cache_name/1" do
-      assert Sources.Cache == ContextCache.cache_name(Sources)
-    end
+    test "apply_fun/3,  bust_keys/1 by :id field of value", %{source: source} do
+      Sources.Cache.get_by(token: source.token)
+      cache_key = {:get_by, [[token: source.token]]}
+      assert {:cached, %Source{}} = Cachex.get!(Sources.Cache, cache_key)
 
-    test "apply_fun/3", %{cache_key: cache_key} do
-      # apply_fun was called in the setup when we called `Sources.Cache.get_by/1`
-      # here's we're making sure it did get cached correctly
-      assert {:cached, %Logflare.Source{}} = Cachex.get!(Sources.Cache, cache_key)
-    end
-
-    test "bust_keys/1", %{source: source, cache_key: cache_key} do
-      assert {:ok, :busted} = ContextCache.bust_keys([{Sources, source.id}])
+      assert {:ok, 1} = ContextCache.bust_keys([{Sources, source.id}])
       assert is_nil(Cachex.get!(Sources.Cache, cache_key))
-      match = {:entry, {{Sources, source.id}, :_}, :_, :_, :"$1"}
-      assert [] = :ets.match(ContextCache, match)
+    end
+
+    test "apply_fun/3, bust_keys/1 if primary key is in list of returned structs", %{
+      source: source
+    } do
+      backend = insert(:backend, sources: [source])
+      Backends.Cache.list_backends(source)
+      cache_key = {:list_backends, [source]}
+      assert {:cached, [%Backend{}]} = Cachex.get!(Backends.Cache, cache_key)
+
+      assert {:ok, 1} = ContextCache.bust_keys([{Backends, backend.id}])
+      assert is_nil(Cachex.get!(Backends.Cache, cache_key))
     end
   end
 

--- a/test/logflare/single_tenant_test.exs
+++ b/test/logflare/single_tenant_test.exs
@@ -296,8 +296,8 @@ defmodule Logflare.SingleTenantTest do
   defp assert_access_tokens(%_{id: user_id} = user) do
     assert length(Auth.list_valid_access_tokens(user)) == 2
     public = Application.get_env(:logflare, :public_access_token)
-    assert {:ok, %_{id: ^user_id}} = Auth.verify_access_token(public, "public")
+    assert {:ok, _token, %_{id: ^user_id}} = Auth.verify_access_token(public, "public")
     private = Application.get_env(:logflare, :private_access_token)
-    assert {:ok, %_{id: ^user_id}} = Auth.verify_access_token(private, "private")
+    assert {:ok, _token, %_{id: ^user_id}} = Auth.verify_access_token(private, "private")
   end
 end


### PR DESCRIPTION
This PR removes Cachex from the ContextCache module, which was acting as a reverse index to reference the context MFA and primary id of records.
The original approach has a few limitations:
- setting the cache limit high to 500k results in a prod memory footprint of 25-30GB at max size, however a high cache limit is needed in order to retain the mfa keys to bust. Otherwise, if they are not in the reverse index, they will not get busted and there is risk of stale data.
- setting the cache ttl to a long value results in cache reaching max limit set above, excacerbating the above problem.
- ContextCache does not actually get used as a cache, making the overhead of Cachex redundant.
- high record count results in slow traversals, and can back up the TransactionBuster which is a single local GenServer.

This new approach directly queries the relevant cache to be busted and performs the primary key checking within the matchspec, and queries across a much narrow set of records. This will speed up busting, and most importantly, eliminate the need for ContextCache Cachex processes, effectively cutting prod memory footprint by 25-30GB which should instead go towards ingest queues. 

This PR also adds in list busting, which was not handled in the previous busting iteration. If a struct in a non-empty list contains the :id field, the record will get busted.