### PR TITLE
fix: message queue backing up for CacheBuster

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -22,7 +22,7 @@ steps:
       - --container-image=${_CONTAINER_IMAGE}
       - --container-privileged
       - --container-restart-policy=always
-      - --container-env=LOGFLARE_GRPC_PORT=50051,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=56,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=15
+      - --container-env=LOGFLARE_GRPC_PORT=50051,LOGFLARE_MIN_CLUSTER_SIZE=2,RELEASE_COOKIE=${_COOKIE},LOGFLARE_PUBSUB_POOL_SIZE=32,LOGFLARE_LOGGER_METADATA_CLUSTER=${_CLUSTER},LOGFLARE_ALERTS_MIN_CLUSTER_SIZE=20
       - --no-shielded-secure-boot
       - --shielded-vtpm
       - --shielded-integrity-monitoring

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -3,6 +3,26 @@ defmodule Logflare.ContextCache.CacheBuster do
     Monitors our Postgres replication log and busts the cache accordingly.
   """
 
+  # worker process
+  defmodule Worker do
+    use GenServer
+    alias Logflare.ContextCache
+
+    def start_link(init_args) do
+      GenServer.start_link(__MODULE__, init_args)
+    end
+
+    def init(state) do
+      {:ok, state}
+    end
+
+    def handle_cast({:to_bust, context_pkeys}, state) do
+      ContextCache.bust_keys(context_pkeys) |> dbg()
+      {:noreply, state}
+    end
+  end
+
+  # main process
   use GenServer
 
   require Logger
@@ -14,9 +34,17 @@ defmodule Logflare.ContextCache.CacheBuster do
     GenServer.start_link(__MODULE__, init_args, name: __MODULE__)
   end
 
-  def init(state) do
+  def init(_state) do
     subscribe_to_transactions()
-    {:ok, state}
+
+    {:ok, _pid} =
+      PartitionSupervisor.start_link(
+        child_spec: __MODULE__.Worker,
+        name: __MODULE__.Supervisor
+      )
+      |> dbg()
+
+    {:ok, %{partitions: System.schedulers_online()}}
   end
 
   def subscribe_to_transactions do
@@ -55,7 +83,12 @@ defmodule Logflare.ContextCache.CacheBuster do
       records ->
         :telemetry.execute([:logflare, :cache_buster, :to_bust], %{count: length(records)})
     end)
-    |> ContextCache.bust_keys()
+    |> then(fn records ->
+      GenServer.cast(
+        {:via, PartitionSupervisor, {__MODULE__.Supervisor, records}},
+        {:to_bust, records}
+      )
+    end)
 
     {:noreply, state}
   end

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -17,7 +17,7 @@ defmodule Logflare.ContextCache.CacheBuster do
     end
 
     def handle_cast({:to_bust, context_pkeys}, state) do
-      ContextCache.bust_keys(context_pkeys) |> dbg()
+      ContextCache.bust_keys(context_pkeys)
       {:noreply, state}
     end
   end

--- a/test/profiling/context_cache_bust_keys_bench.exs
+++ b/test/profiling/context_cache_bust_keys_bench.exs
@@ -1,0 +1,91 @@
+alias Logflare.Sources
+alias Logflare.Users
+import Logflare.Factory
+# Setup test data
+user = insert(:user)
+source = insert(:source, user: user)
+
+# Populate cache with test data
+for i <- 1..1000 do
+  cache_key = {:get_by, [[token: "token_#{i}"]]}
+  Cachex.put!(Sources.Cache, cache_key, {:cached, %{id: i, token: "token_#{i}"}})
+end
+
+# Add our target record
+cache_key = {:get_by, [[token: source.token]]}
+Cachex.put!(Sources.Cache, cache_key, {:cached, source})
+
+filter = {
+  :orelse,
+  {
+    :orelse,
+    {:is_list, {:element, 2, :value}},
+    {:andalso, {:is_tuple, {:element, 2, :value}},
+     {:andalso, {:==, {:element, 1, {:element, 2, :value}}, :ok},
+      {:andalso, {:is_map, {:element, 2, {:element, 2, :value}}},
+       {:==, {:map_get, :id, {:element, 2, {:element, 2, :value}}}, source.id}}}}
+  },
+  {:andalso, {:is_map, {:element, 2, :value}},
+   {:==, {:map_get, :id, {:element, 2, :value}}, source.id}}
+}
+
+query = Cachex.Query.build(where: filter, output: {:key, :value})
+
+Benchee.run(
+  %{
+    "bust_keys with ETS filter" => fn ->
+      Sources.Cache
+      |> Cachex.stream!(query)
+      |> Enum.reduce(0, fn
+        {k, {:cached, v}}, acc when is_list(v) ->
+          if Enum.any?(v, fn %{id: id} -> id == source.id end) do
+            acc + 1
+          else
+            acc
+          end
+
+        {_k, _v}, acc ->
+          acc + 1
+      end)
+    end,
+    "bust_keys with Elixir match" => fn ->
+      Sources.Cache
+      |> Cachex.stream!(Cachex.Query.build(output: {:key, :value}))
+      |> Stream.filter(fn {_k, {:cached, v}} ->
+        cond do
+          is_list(v) -> Enum.any?(v, &(&1.id == source.id))
+          is_map(v) -> Map.get(v, :id) == source.id
+          {:ok, %{id: id}} = v -> id == source.id
+          true -> false
+        end
+      end)
+      |> Enum.count()
+    end
+  },
+  before_each: fn input ->
+    Cachex.clear(Sources.Cache)
+    # Repopulate cache
+    for i <- 1..1000 do
+      cache_key = {:get_by, [[token: "token_#{i}"]]}
+      Cachex.put!(Sources.Cache, cache_key, {:cached, %{id: i, token: "token_#{i}"}})
+    end
+    Cachex.put!(Sources.Cache, cache_key, {:cached, source})
+    input
+  end,
+  time: 4,
+  memory_time: 2
+)
+
+# Name                                  ips        average  deviation         median         99th %
+# bust_keys with ETS filter         10.23 K       97.75 μs    ±36.05%       94.79 μs      137.00 μs
+# bust_keys with Elixir match        4.84 K      206.63 μs     ±7.33%      202.79 μs      272.72 μs
+
+# Comparison:
+# bust_keys with ETS filter         10.23 K
+# bust_keys with Elixir match        4.84 K - 2.11x slower +108.88 μs
+
+# Memory usage statistics:
+
+# Name                           Memory usage
+# bust_keys with ETS filter           1.48 KB
+# bust_keys with Elixir match       255.24 KB - 171.95x memory usage +253.76 KB

--- a/test/profiling/context_cache_bust_keys_bench.exs
+++ b/test/profiling/context_cache_bust_keys_bench.exs
@@ -73,8 +73,6 @@ Benchee.run(
   memory_time: 2
 )
 
-
-
 # benchmarked on 2025-03-03
 # Name                                  ips        average  deviation         median         99th %
 # bust_keys with ETS filter          7.00 K       0.143 ms     ±0.00%       0.143 ms       0.143 ms

--- a/test/profiling/context_cache_bust_keys_bench.exs
+++ b/test/profiling/context_cache_bust_keys_bench.exs
@@ -3,37 +3,26 @@ alias Logflare.Users
 import Logflare.Factory
 # Setup test data
 user = insert(:user)
-source = insert(:source, user: user)
-
-# Populate cache with test data
-for i <- 1..1000 do
-  cache_key = {:get_by, [[token: "token_#{i}"]]}
-  Cachex.put!(Sources.Cache, cache_key, {:cached, %{id: i, token: "token_#{i}"}})
-end
-
-# Add our target record
-cache_key = {:get_by, [[token: source.token]]}
-Cachex.put!(Sources.Cache, cache_key, {:cached, source})
-
-filter = {
-  :orelse,
-  {
-    :orelse,
-    {:is_list, {:element, 2, :value}},
-    {:andalso, {:is_tuple, {:element, 2, :value}},
-     {:andalso, {:==, {:element, 1, {:element, 2, :value}}, :ok},
-      {:andalso, {:is_map, {:element, 2, {:element, 2, :value}}},
-       {:==, {:map_get, :id, {:element, 2, {:element, 2, :value}}}, source.id}}}}
-  },
-  {:andalso, {:is_map, {:element, 2, :value}},
-   {:==, {:map_get, :id, {:element, 2, :value}}, source.id}}
-}
-
-query = Cachex.Query.build(where: filter, output: {:key, :value})
 
 Benchee.run(
   %{
-    "bust_keys with ETS filter" => fn ->
+    "bust_keys with ETS filter" => fn [source | _] = sources ->
+      filter = {
+        :orelse,
+        {
+          :orelse,
+          {:is_list, {:element, 2, :value}},
+          {:andalso, {:is_tuple, {:element, 2, :value}},
+           {:andalso, {:==, {:element, 1, {:element, 2, :value}}, :ok},
+            {:andalso, {:is_map, {:element, 2, {:element, 2, :value}}},
+             {:==, {:map_get, :id, {:element, 2, {:element, 2, :value}}}, source.id}}}}
+        },
+        {:andalso, {:is_map, {:element, 2, :value}},
+         {:==, {:map_get, :id, {:element, 2, :value}}, source.id}}
+      }
+
+      query = Cachex.Query.build(where: filter, output: {:key, :value})
+
       Sources.Cache
       |> Cachex.stream!(query)
       |> Enum.reduce(0, fn
@@ -48,44 +37,55 @@ Benchee.run(
           acc + 1
       end)
     end,
-    "bust_keys with Elixir match" => fn ->
+    "bust_keys with Elixir match" => fn [source | _] = sources ->
       Sources.Cache
       |> Cachex.stream!(Cachex.Query.build(output: {:key, :value}))
-      |> Stream.filter(fn {_k, {:cached, v}} ->
-        cond do
-          is_list(v) -> Enum.any?(v, &(&1.id == source.id))
-          is_map(v) -> Map.get(v, :id) == source.id
-          {:ok, %{id: id}} = v -> id == source.id
-          true -> false
-        end
+      |> Stream.filter(fn
+        {_k, {:cached, v}} when is_list(v) ->
+          Enum.any?(v, &(&1.id == source.id))
+
+        {_k, {:cached, %{id: id}}} when id == source.id ->
+          true
+
+        {_k, {:cached, {:ok, %{id: id}}}} when id == source.id ->
+          true
+
+        _ ->
+          false
       end)
       |> Enum.count()
     end
   },
-  before_each: fn input ->
+  before_each: fn _input ->
     Cachex.clear(Sources.Cache)
-    # Repopulate cache
-    for i <- 1..1000 do
-      cache_key = {:get_by, [[token: "token_#{i}"]]}
-      Cachex.put!(Sources.Cache, cache_key, {:cached, %{id: i, token: "token_#{i}"}})
-    end
-    Cachex.put!(Sources.Cache, cache_key, {:cached, source})
-    input
+    # Populate cache with test data
+    sources =
+      for i <- 1..1000 do
+        source = insert(:source, user: user)
+        cache_key = {:get_by, [[token: source.token]]}
+        Cachex.put!(Sources.Cache, cache_key, {:cached, source})
+        source
+      end
+
+    sources
   end,
   time: 4,
   memory_time: 2
 )
 
+
+
+# benchmarked on 2025-03-03
 # Name                                  ips        average  deviation         median         99th %
-# bust_keys with ETS filter         10.23 K       97.75 μs    ±36.05%       94.79 μs      137.00 μs
-# bust_keys with Elixir match        4.84 K      206.63 μs     ±7.33%      202.79 μs      272.72 μs
+# bust_keys with ETS filter          7.00 K       0.143 ms     ±0.00%       0.143 ms       0.143 ms
+# bust_keys with Elixir match        0.41 K        2.44 ms     ±0.00%        2.44 ms        2.44 ms
 
 # Comparison:
-# bust_keys with ETS filter         10.23 K
-# bust_keys with Elixir match        4.84 K - 2.11x slower +108.88 μs
+# bust_keys with ETS filter          7.00 K
+# bust_keys with Elixir match        0.41 K - 17.07x slower +2.30 ms
 
 # Memory usage statistics:
 
 # Name                           Memory usage
-# bust_keys with ETS filter           1.48 KB
-# bust_keys with Elixir match       255.24 KB - 171.95x memory usage +253.76 KB
+# bust_keys with ETS filter        0.00986 MB
+# bust_keys with Elixir match         4.94 MB - 500.72x memory usage +4.93 MB


### PR DESCRIPTION
This PR partitions the CacheBuster, to account for slow Cachex streaming.

Also added in a benchmark for good measure.

This PR also tweaks the pool_size of the prod instances.

```

# benchmarked on 2025-03-03
# Name                                  ips        average  deviation         median         99th %
# bust_keys with ETS filter          7.00 K       0.143 ms     ±0.00%       0.143 ms       0.143 ms
# bust_keys with Elixir match        0.41 K        2.44 ms     ±0.00%        2.44 ms        2.44 ms

# Comparison:
# bust_keys with ETS filter          7.00 K
# bust_keys with Elixir match        0.41 K - 17.07x slower +2.30 ms

# Memory usage statistics:

# Name                           Memory usage
# bust_keys with ETS filter        0.00986 MB
# bust_keys with Elixir match         4.94 MB - 500.72x memory usage +4.93 MB

```