### PR TITLE
fix: source routing without sink, closes ANL-719

### DIFF
--- a/lib/logflare/sources/source_routing.ex
+++ b/lib/logflare/sources/source_routing.ex
@@ -52,6 +52,10 @@ defmodule Logflare.Logs.SourceRouting do
     end
   end
 
+  defp do_routing(%Rule{sink: nil}, _le) do
+    {:error, :no_sink}
+  end
+
   @spec route_with_lql_rules?(LE.t(), Rule.t()) :: boolean()
   def route_with_lql_rules?(%LE{body: le_body}, %Rule{lql_filters: lql_filters})
       when lql_filters != [] do

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -95,7 +95,7 @@ defmodule Logflare.LogsTest do
                                            _dataset_id,
                                            _table_name,
                                            [body: body] ->
-        #  use default config adapter
+         #  use default config adapter
         assert conn.adapter == nil
         schema = body.schema
         assert %_{name: "key", type: "STRING"} = TestUtils.get_bq_field_schema(schema, "key")
@@ -155,6 +155,20 @@ defmodule Logflare.LogsTest do
 
       batch = [
         %{"event_message" => "not routed"},
+        %{"event_message" => "testing 123"}
+      ]
+
+      assert :ok = Logs.ingest_logs(batch, source)
+    end
+
+    test "rule without sink", %{user: user, source: source, source_b: target} do
+      insert(:rule, lql_string: "testing", sink: nil, source_id: source.id)
+      source = source |> Repo.preload(:rules, force: true)
+
+      Logs
+      |> expect(:broadcast, 1, fn le -> le end)
+
+      batch = [
         %{"event_message" => "testing 123"}
       ]
 

--- a/test/logflare/logs/logs_test.exs
+++ b/test/logflare/logs/logs_test.exs
@@ -95,7 +95,7 @@ defmodule Logflare.LogsTest do
                                            _dataset_id,
                                            _table_name,
                                            [body: body] ->
-         #  use default config adapter
+        #  use default config adapter
         assert conn.adapter == nil
         schema = body.schema
         assert %_{name: "key", type: "STRING"} = TestUtils.get_bq_field_schema(schema, "key")


### PR DESCRIPTION
this fixes a routing bug where backend rules without source sinks result in ingestion errors, causing subsequent payload to get dropped.