### PR TITLE
fix: http1 finch pools for BQ ingestion, BufferProducer exit handling  

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -203,6 +203,7 @@ defmodule Logflare.Application do
   defp finch_pools do
     base = System.schedulers_online()
     min_count = max(5, ceil(base / 10))
+    http1_count = max(div(base, 10), 1)
 
     [
       # Finch connection pools, using http2
@@ -211,8 +212,9 @@ defmodule Logflare.Application do
        name: Logflare.FinchIngest,
        pools: %{
          "https://bigquery.googleapis.com" => [
-           protocols: [:http2],
-           count: max(ceil(base / 2), 10),
+           protocols: [:http1],
+           size: max(base * 10, 50),
+           count: http1_count,
            start_pool_metrics?: true
          ]
        }},

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -15,6 +15,7 @@ defmodule Logflare.Backends.BufferProducer do
 
   @impl GenStage
   def init(opts) do
+    Process.flag(:trap_exit, true)
     source = Sources.Cache.get_by_id(opts[:source_id])
 
     state = %{
@@ -81,6 +82,17 @@ defmodule Logflare.Backends.BufferProducer do
   @impl GenStage
   def handle_info({:add_to_buffer, items}, state) do
     {:noreply, items, state}
+  end
+
+  @impl GenStage
+  def handle_info({:EXIT, _caller_pid, _reason}, state) do
+    table_key = {state.source_id, state.backend_id, self()}
+    startup_table_key = {state.source_id, state.backend_id, nil}
+    IngestEventQueue.upsert_tid(table_key)
+    # move to startup queue
+    IngestEventQueue.move(table_key, startup_table_key)
+
+    {:noreply, [], state}
   end
 
   @impl GenStage

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -88,7 +88,6 @@ defmodule Logflare.Backends.BufferProducer do
   def handle_info({:EXIT, _caller_pid, _reason}, state) do
     table_key = {state.source_id, state.backend_id, self()}
     startup_table_key = {state.source_id, state.backend_id, nil}
-    IngestEventQueue.upsert_tid(table_key)
     # move to startup queue
     IngestEventQueue.move(table_key, startup_table_key)
 

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -225,6 +225,20 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   @doc """
+  Deletes the queue associated with the given source-backend-pid.
+  """
+  @spec delete_queue(source_backend_pid()) :: :ok | {:error, :not_initialized}
+  def delete_queue(sid_bid_pid) do
+    with tid when tid != nil <- get_tid(sid_bid_pid) do
+      :ets.delete(tid)
+      :ets.delete(@ets_table_mapper, sid_bid_pid)
+      :ok
+    else
+      nil -> {:error, :not_initialized}
+    end
+  end
+
+  @doc """
   Returns a list of two-element tuples.
   First element is the table key.
   Second element is the pending count.

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
       size = IngestEventQueue.get_table_size(sid_bid_pid)
 
-      if size > state.max and is_integer(size) do
+      if size > state.max and pid != nil and is_integer(size) do
         to_drop = round(state.purge_ratio * size)
         IngestEventQueue.drop(sid_bid_pid, :pending, to_drop)
 

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -74,7 +74,6 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
         )
       end
 
-      dbg(pid)
       # check if pid is alive
       if pid != nil and Process.alive?(pid) == false do
         startup_table_key = {state.source_id, state.backend_id, nil}

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
       size = IngestEventQueue.get_table_size(sid_bid_pid)
 
-      if size > state.max and pid != nil do
+      if size > state.max and ref != nil and is_integer(size) do
         to_drop = round(state.purge_ratio * size)
         IngestEventQueue.drop(sid_bid_pid, :pending, to_drop)
 
@@ -72,13 +72,6 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
           "IngestEventQueue private :ets buffer exceeded max for source id=#{state.source_id}, dropping #{to_drop} events",
           backend_id: state.backend_id
         )
-      end
-
-      # check if pid is alive
-      if pid != nil and Process.alive?(pid) == false do
-        startup_table_key = {state.source_id, state.backend_id, nil}
-        IngestEventQueue.move(sid_bid_pid, startup_table_key)
-        IngestEventQueue.delete_queue(sid_bid_pid)
       end
     end
   end

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
       size = IngestEventQueue.get_table_size(sid_bid_pid)
 
-      if size > state.max and ref != nil and is_integer(size) do
+      if size > state.max and is_integer(size) do
         to_drop = round(state.purge_ratio * size)
         IngestEventQueue.drop(sid_bid_pid, :pending, to_drop)
 

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -42,7 +42,6 @@ defmodule Logflare.ContextCache.CacheBuster do
         child_spec: __MODULE__.Worker,
         name: __MODULE__.Supervisor
       )
-      |> dbg()
 
     {:ok, %{partitions: System.schedulers_online()}}
   end

--- a/lib/logflare/system_metrics/cluster.ex
+++ b/lib/logflare/system_metrics/cluster.ex
@@ -34,11 +34,28 @@ defmodule Logflare.SystemMetrics.Cluster do
         ] do
       case Finch.get_pool_status(pool, url) do
         {:ok, metrics} ->
-          counts = for metric <- metrics, do: metric.in_flight_requests
+          counts =
+            for metric <- metrics,
+                Map.get(metric, :in_flight_requests),
+                do: metric.in_flight_requests
+
+          in_use_connections =
+            for metric <- metrics,
+                Map.get(metric, :in_use_connections),
+                do: metric.in_use_connections
+
+          available_connections =
+            for metric <- metrics,
+                Map.get(metric, :available_connections),
+                do: metric.available_connections
 
           :telemetry.execute(
             [:logflare, :system, :finch],
-            %{in_flight_requests: Enum.sum(counts)},
+            %{
+              in_flight_requests: Enum.sum(counts),
+              in_use_connections: Enum.sum(in_use_connections),
+              available_connections: Enum.sum(available_connections)
+            },
             %{url: url, pool: Atom.to_string(pool)}
           )
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -32,6 +32,28 @@ defmodule Logflare.Backends.BufferProducerTest do
     assert IngestEventQueue.get_table_size(sid_bid_pid) == 1
   end
 
+  test "moves events in IngestEventQueue to other queues on termination" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+
+    le = build(:log_event, source: source)
+
+    buffer_producer_pid =
+      start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
+
+    sid_bid_pid = {source.id, nil, buffer_producer_pid}
+    startup_table_key = {source.id, nil, nil}
+    IngestEventQueue.upsert_tid(startup_table_key)
+    :timer.sleep(100)
+    :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
+
+    Process.exit(buffer_producer_pid, :normal)
+    :timer.sleep(200)
+
+    assert IngestEventQueue.total_pending(startup_table_key) == 1
+    assert IngestEventQueue.total_pending(sid_bid_pid) == 0
+  end
+
   test "pulls events from startup queue" do
     user = insert(:user)
     source = insert(:source, user: user)

--- a/test/logflare/backends/ingest_events_queue_test.exs
+++ b/test/logflare/backends/ingest_events_queue_test.exs
@@ -273,6 +273,28 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert IngestEventQueue.total_pending(table) == 0
   end
 
+  test "QueueJanitor cleans up orphaned queues" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+    backend = insert(:backend, user: user)
+    le = build(:log_event, source: source)
+
+    sid_bid_pid = {source.id, backend.id, :c.pid(0, 255, 0)}
+    startup_table_key = {source.id, backend.id, nil}
+    IngestEventQueue.upsert_tid(startup_table_key)
+    IngestEventQueue.upsert_tid(sid_bid_pid)
+    assert :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
+
+    start_supervised!(
+      {QueueJanitor, source: source, backend: backend, interval: 50, remainder: 0}
+    )
+
+    :timer.sleep(550)
+    assert nil == IngestEventQueue.get_table_size(sid_bid_pid)
+    assert IngestEventQueue.total_pending(startup_table_key) == 1
+    assert length(IngestEventQueue.list_queues({source.id, backend.id})) == 1
+  end
+
   test "QueueJanitor purges if exceeds max" do
     user = insert(:user)
     source = insert(:source, user: user)


### PR DESCRIPTION
This PR moves the ingestion to http1, to avoid gotchas experienced in http2 finch pools.

It also implements BufferProducer exit trapping to handle graceful shutdown of events.