### PR TITLE
fix: set jobs to run locally for quantum run strategy

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -159,7 +159,7 @@ defmodule Logflare.Alerting do
   end
 
   def create_alert_job_struct(alert_query) do
-    AlertsScheduler.new_job()
+    AlertsScheduler.new_job(run_strategy: Quantum.RunStrategy.Local)
     |> Quantum.Job.set_task({__MODULE__, :run_alert, [alert_query, :scheduled]})
     |> Quantum.Job.set_schedule(Crontab.CronExpression.Parser.parse!(alert_query.cron))
     |> Quantum.Job.set_name(make_ref())

--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -249,6 +249,7 @@ defmodule Logflare.AlertingTest do
 
       assert {:ok,
               %Quantum.Job{
+                run_strategy: %Quantum.RunStrategy.Local{},
                 task: {Logflare.Alerting, :run_alert, [%AlertQuery{id: ^alert_id}, :scheduled]}
               }} = Alerting.upsert_alert_job(alert)
 


### PR DESCRIPTION
This PR sets the run strategy for newly created quantum jobs