### PR TITLE
fix: remove move ensure source sup started from routing logic

### DIFF
--- a/lib/logflare/logs/processor.ex
+++ b/lib/logflare/logs/processor.ex
@@ -52,8 +52,7 @@ defmodule Logflare.Logs.Processor do
   end
 
   defp store(%Logflare.Source{v2_pipeline: true} = source, batch) do
-    if not Backends.source_sup_started?(source), do: Backends.start_source_sup(source)
-
+    Backends.ensure_source_sup_started(source)
     Backends.ingest_logs(batch, source)
   end
 

--- a/lib/logflare/sources/source_routing.ex
+++ b/lib/logflare/sources/source_routing.ex
@@ -29,7 +29,6 @@ defmodule Logflare.Logs.SourceRouting do
     # route to a backend
     backend = Backends.Cache.get_backend(backend_id)
     le = %{le | via_rule: rule}
-    Backends.ensure_source_sup_started(source)
     if SourceSup.rule_child_started?(rule) == false, do: SourceSup.start_rule_child(rule)
 
     # ingest to a specific backend
@@ -43,7 +42,6 @@ defmodule Logflare.Logs.SourceRouting do
     le = %{le | source: sink_source, via_rule: rule}
 
     if source.v2_pipeline do
-      # TODO: ensure source started
       Backends.ensure_source_sup_started(sink)
       Backends.ingest_logs([le], sink_source)
     else


### PR DESCRIPTION
backend rule routing logic should not need the source (that it is ingesting in) to be started, otherwise the ingestion would have already failed. 