### PR TITLE
feat: GenSingleton

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -82,7 +82,7 @@ config :phoenix, :json_library, Jason
 config :postgrex, :json_library, Jason
 
 config :syn,
-  scopes: [:endpoints, :context_cache, :alerting],
+  scopes: [:core, :endpoints, :alerting],
   event_handler: Logflare.SynEventHandler
 
 oauth_common = [

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -397,7 +397,6 @@ defmodule Logflare.Backends do
         [{pid, _}] -> {:ok, pid}
         _ -> {:error, :not_started}
       end
-
     end
   end
 

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -6,6 +6,7 @@ defmodule Logflare.Backends do
   alias Logflare.Backends.SourceRegistry
   alias Logflare.Backends.SourcesSup
   alias Logflare.Backends.SourceSup
+  alias Logflare.Backends.RecentEventsTouch
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.LogEvent
   alias Logflare.Repo
@@ -369,6 +370,10 @@ defmodule Logflare.Backends do
   def via_source(source_id, mod, id), do: via_source(source_id, {mod, id})
 
   def via_source(%Source{id: id}, process_id), do: via_source(id, process_id)
+
+  def via_source(id, RecentEventsTouch) when is_number(id) do
+    {:via, :syn, {:core, RecentEventsTouch}}
+  end
 
   def via_source(id, process_id) when is_number(id) do
     {:via, Registry, {SourceRegistry, {id, process_id}}}

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -388,11 +388,16 @@ defmodule Logflare.Backends do
   end
 
   def lookup(module, %Source{} = source) do
-    {:via, _registry, {registry, via_id}} = via_source(source, module)
+    {:via, registry_mod, {registry, via_id}} = via_result = via_source(source, module)
 
-    case Registry.lookup(registry, via_id) do
-      [{pid, _}] -> {:ok, pid}
-      _ -> {:error, :not_started}
+    if registry_mod == :syn do
+      {:ok, GenServer.whereis(via_result)}
+    else
+      case Registry.lookup(registry, via_id) do
+        [{pid, _}] -> {:ok, pid}
+        _ -> {:error, :not_started}
+      end
+
     end
   end
 

--- a/lib/logflare/backends/recent_events_touch.ex
+++ b/lib/logflare/backends/recent_events_touch.ex
@@ -5,7 +5,7 @@ defmodule Logflare.Backends.RecentEventsTouch do
   Source.log_events_updated_at is used for determining sources to warm on node startup.
   """
   use TypedStruct
-  use GenServer
+  use GenServer, restart: :transient
 
   alias Logflare.Sources
   alias Logflare.Backends
@@ -16,9 +16,16 @@ defmodule Logflare.Backends.RecentEventsTouch do
   ## Server
   def start_link(args) do
     GenServer.start_link(__MODULE__, args,
-      name: Backends.via_source(args[:source], __MODULE__),
-      hibernate_after: 5_000
+      name: name(args[:source]),
+      hibernate_after: 5_000,
+      spawn_opt: [
+        fullsweep_after: 100
+      ]
     )
+  end
+
+  def name(source) do
+    Backends.via_source(source, __MODULE__)
   end
 
   ## Client

--- a/lib/logflare/backends/recent_inserts_broadcaster.ex
+++ b/lib/logflare/backends/recent_inserts_broadcaster.ex
@@ -12,7 +12,7 @@ defmodule Logflare.Backends.RecentInsertsBroadcaster do
 
   require Logger
 
-  @broadcast_every 2_500
+  @broadcast_every if Application.compile_env(:logflare, :env) == :test, do: 100, else: 5_000
 
   ## Server
   def start_link(args) do

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -8,6 +8,7 @@ defmodule Logflare.Backends.SourceSup do
   alias Logflare.Source
   alias Logflare.Users
   alias Logflare.Billing
+  alias Logflare.GenSingleton
   alias Logflare.Source.RateCounterServer
   alias Logflare.Source.EmailNotificationServer
   alias Logflare.Source.TextNotificationServer
@@ -50,7 +51,8 @@ defmodule Logflare.Backends.SourceSup do
     children =
       [
         {RateCounterServer, [source: source]},
-        {RecentEventsTouch, [source: source]},
+        {GenSingleton,
+         name: RecentEventsTouch.name(source), child_spec: {RecentEventsTouch, source: source}},
         {RecentInsertsBroadcaster, [source: source]},
         {EmailNotificationServer, [source: source]},
         {TextNotificationServer, [source: source, plan: plan]},

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -51,8 +51,7 @@ defmodule Logflare.Backends.SourceSup do
     children =
       [
         {RateCounterServer, [source: source]},
-        {GenSingleton,
-         name: RecentEventsTouch.name(source), child_spec: {RecentEventsTouch, source: source}},
+        {GenSingleton, child_spec: {RecentEventsTouch, source: source}},
         {RecentInsertsBroadcaster, [source: source]},
         {EmailNotificationServer, [source: source]},
         {TextNotificationServer, [source: source, plan: plan]},

--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -55,7 +55,7 @@ defmodule Logflare.ContextCache.Supervisor do
   Returns the publisher :via name used for syn registry.
   """
   def publisher_name do
-    {:via, :syn, {:context_cache, Logflare.PgPublisher}}
+    {:via, :syn, {:core, Logflare.PgPublisher}}
     # {:global, Logflare.PgPublisher}
   end
 

--- a/lib/logflare/gen_singleton.ex
+++ b/lib/logflare/gen_singleton.ex
@@ -1,0 +1,92 @@
+defmodule Logflare.GenSingleton do
+  @moduledoc """
+  A generic singleton GenServer that will be unique cluster-wide.
+  Checks if there the server is started, if not, will be started under the supervision tree as a transient GenServer.
+  """
+  use GenServer
+
+  @default_check 5_000
+
+  require Logger
+  @type state :: any()
+
+  @spec start_link(args :: any()) :: {:ok, pid} | {:error, any}
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, [])
+  end
+
+  def count_children(pid) do
+    GenServer.call(pid, :count_children)
+  end
+
+  @impl true
+  def init(args) do
+    interval = args[:interval] || @default_check
+    {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one)
+
+    Process.send_after(self(), :check, interval)
+
+    name =
+      if args[:name] do
+        args[:name]
+      else
+        case args[:child_spec] do
+          {_mod, args} when is_list(args) -> Keyword.get(args, :name)
+          %{start: {_mod, _func, args}} when is_list(args) -> Keyword.get(args, :name)
+          mod when is_atom(mod) -> args[:name] || mod
+        end
+      end
+      |> dbg()
+
+    {:ok, %{pid: pid, name: name, interval: interval, child_spec: args[:child_spec]},
+     {:continue, :maybe_start_child}}
+  end
+
+  @impl true
+  def handle_continue(:maybe_start_child, state) do
+    try_start_child(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    try_start_child(state)
+    # Reschedule the next check
+    Process.send_after(self(), :check, state.interval)
+    {:noreply, state}
+  end
+
+  defp try_start_child(state) do
+    with nil <- GenServer.whereis(state.name) |> dbg(),
+         {:ok, _pid} <- Supervisor.start_child(state.pid, state.child_spec) |> dbg() do
+      :ok
+    else
+      {:error, {:already_started, pid}} ->
+        Logger.debug(
+          "GenSingleton | process #{inspect(pid)} is already started on server: #{inspect(node(pid))}"
+        )
+
+        pid
+
+      pid when is_pid(pid) ->
+        Logger.debug(
+          "GenSingleton | process #{inspect(pid)} is already started on server: #{inspect(node(pid))}"
+        )
+
+        pid
+
+      other ->
+        other
+    end
+  end
+
+  @impl true
+  def handle_call(:count_children, _from, state) do
+    {:reply, Supervisor.count_children(state.pid).active, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :ok
+  end
+end

--- a/lib/logflare/gen_singleton.ex
+++ b/lib/logflare/gen_singleton.ex
@@ -20,9 +20,11 @@ defmodule Logflare.GenSingleton do
   end
 
   def get_pid(sup_pid) do
-      Supervisor.which_children(sup_pid)
-      |> Enum.find_value(fn {_id, pid, _type, [GenSingleton.Watcher]} -> pid
-    _ -> false end)
-  |> GenSingleton.Watcher.get_pid()
+    Supervisor.which_children(sup_pid)
+    |> Enum.find_value(fn
+      {_id, pid, _type, [GenSingleton.Watcher]} -> pid
+      _ -> false
+    end)
+    |> GenSingleton.Watcher.get_pid()
   end
 end

--- a/lib/logflare/gen_singleton.ex
+++ b/lib/logflare/gen_singleton.ex
@@ -1,6 +1,10 @@
 defmodule Logflare.GenSingleton do
   @moduledoc """
   A generic singleton GenServer that will be unique cluster-wide, started under the supervision tree.
+
+  Creates a monitoring process that will start the corresponding child spec under the parent supervisor.
+
+  If Watcher terminates abnormally, parent supervisor will restart all processes.
   """
 
   use Supervisor

--- a/lib/logflare/gen_singleton.ex
+++ b/lib/logflare/gen_singleton.ex
@@ -36,7 +36,6 @@ defmodule Logflare.GenSingleton do
           mod when is_atom(mod) -> args[:name] || mod
         end
       end
-      |> dbg()
 
     {:ok, %{pid: pid, name: name, interval: interval, child_spec: args[:child_spec]},
      {:continue, :maybe_start_child}}
@@ -57,8 +56,8 @@ defmodule Logflare.GenSingleton do
   end
 
   defp try_start_child(state) do
-    with nil <- GenServer.whereis(state.name) |> dbg(),
-         {:ok, _pid} <- Supervisor.start_child(state.pid, state.child_spec) |> dbg() do
+    with nil <- GenServer.whereis(state.name),
+         {:ok, _pid} <- Supervisor.start_child(state.pid, state.child_spec) do
       :ok
     else
       {:error, {:already_started, pid}} ->

--- a/lib/logflare/gen_singleton.ex
+++ b/lib/logflare/gen_singleton.ex
@@ -1,99 +1,28 @@
 defmodule Logflare.GenSingleton do
   @moduledoc """
-  A generic singleton GenServer that will be unique cluster-wide.
-  Checks if there the server is started, if not, will be started under the supervision tree as a transient GenServer.
+  A generic singleton GenServer that will be unique cluster-wide, started under the supervision tree.
   """
-  use GenServer
 
-  require Logger
-  @type state :: any()
-
-  @spec start_link(args :: any()) :: {:ok, pid} | {:error, any}
+  use Supervisor
+  alias Logflare.GenSingleton
 
   def start_link(args) do
-    GenServer.start_link(__MODULE__, {self(), args}, [])
+    Supervisor.start_link(__MODULE__, args, [])
   end
 
-  def get_pid(pid) do
-    GenServer.call(pid, :get_pid)
+  def init(args) do
+    children = [
+      {GenSingleton.Watcher, args}
+    ]
+
+    # reset state
+    Supervisor.init(children, strategy: :rest_for_one)
   end
 
-  @impl true
-  def init({sup_pid, args}) do
-    {:ok,
-     %{
-       sup_pid: sup_pid,
-       child_spec: args[:child_spec],
-       monitor_ref: nil,
-       monitor_pid: nil
-     }, {:continue, :maybe_start_child}}
-  end
-
-  @impl true
-  def handle_continue(:maybe_start_child, state) do
-    state = try_start_child(state)
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info(:maybe_start_child, state) do
-    state = try_start_child(state)
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) when ref == state.monitor_ref do
-    Logger.debug(
-      "GenSingleton | monitor_pid DOWN received for #{inspect(state.monitor_pid)}, scheduling check..."
-    )
-
-    # delay check, but not all at the same time
-    delay =
-      if Application.get_env(:logflare, :env) == :test,
-        do: 100,
-        else: 3_000 + Enum.random(0..2_500)
-
-    Process.send_after(self(), :maybe_start_child, delay)
-    {:noreply, state}
-  end
-
-  defp try_start_child(state) do
-    pid =
-      case Supervisor.start_child(state.sup_pid, state.child_spec) do
-        {:error, {:already_started, pid}} ->
-          Logger.debug(
-            "GenSingleton | process #{inspect(pid)} is already started on server: #{inspect(node(pid))}"
-          )
-
-          pid
-
-        {:ok, pid} when is_pid(pid) ->
-          Logger.debug(
-            "GenSingleton | process #{inspect(pid)} was started on server: #{inspect(node(pid))}"
-          )
-
-          pid
-
-        other ->
-          Logger.warning("GenSingleton unknown case | failed to start child: #{inspect(other)}")
-          nil
-      end
-
-    if pid do
-      monitor_ref = Process.monitor(pid)
-      %{state | monitor_ref: monitor_ref, monitor_pid: pid}
-    else
-      state
-    end
-  end
-
-  @impl true
-  def handle_call(:get_pid, _from, state) do
-    {:reply, state.monitor_pid, state}
-  end
-
-  @impl true
-  def terminate(_reason, _state) do
-    :ok
+  def get_pid(sup_pid) do
+      Supervisor.which_children(sup_pid)
+      |> Enum.find_value(fn {_id, pid, _type, [GenSingleton.Watcher]} -> pid
+    _ -> false end)
+  |> GenSingleton.Watcher.get_pid()
   end
 end

--- a/lib/logflare/gen_singleton/watcher.ex
+++ b/lib/logflare/gen_singleton/watcher.ex
@@ -1,0 +1,100 @@
+defmodule Logflare.GenSingleton.Watcher do
+  @moduledoc """
+  A generic singleton GenServer that will be unique cluster-wide.
+  Checks if there the server is started, if not, will be started under the supervision tree as a transient GenServer.
+  """
+
+  use GenServer
+
+  require Logger
+  @type state :: any()
+
+  @spec start_link(args :: any()) :: {:ok, pid} | {:error, any}
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, {self(), args}, [])
+  end
+
+  def get_pid(pid) do
+    GenServer.call(pid, :get_pid)
+  end
+
+  @impl true
+  def init({sup_pid, args}) do
+    {:ok,
+     %{
+       sup_pid: sup_pid,
+       child_spec: args[:child_spec],
+       monitor_ref: nil,
+       monitor_pid: nil
+     }, {:continue, :maybe_start_child}}
+  end
+
+  @impl true
+  def handle_continue(:maybe_start_child, state) do
+    state = try_start_child(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:maybe_start_child, state) do
+    state = try_start_child(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) when ref == state.monitor_ref do
+    Logger.debug(
+      "GenSingleton | monitor_pid DOWN received for #{inspect(state.monitor_pid)}, scheduling check..."
+    )
+
+    # delay check, but not all at the same time
+    delay =
+      if Application.get_env(:logflare, :env) == :test,
+        do: 100,
+        else: 3_000 + Enum.random(0..2_500)
+
+    Process.send_after(self(), :maybe_start_child, delay)
+    {:noreply, state}
+  end
+
+  defp try_start_child(state) do
+    pid =
+      case Supervisor.start_child(state.sup_pid, state.child_spec) do
+        {:error, {:already_started, pid}} ->
+          Logger.debug(
+            "GenSingleton | process #{inspect(pid)} is already started on server: #{inspect(node(pid))}"
+          )
+
+          pid
+
+        {:ok, pid} when is_pid(pid) ->
+          Logger.debug(
+            "GenSingleton | process #{inspect(pid)} was started on server: #{inspect(node(pid))}"
+          )
+
+          pid
+
+        other ->
+          Logger.warning("GenSingleton unknown case | failed to start child: #{inspect(other)}")
+          nil
+      end
+
+    if pid do
+      monitor_ref = Process.monitor(pid)
+      %{state | monitor_ref: monitor_ref, monitor_pid: pid}
+    else
+      state
+    end
+  end
+
+  @impl true
+  def handle_call(:get_pid, _from, state) do
+    {:reply, state.monitor_pid, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :ok
+  end
+end

--- a/lib/logflare/gen_singleton/watcher.ex
+++ b/lib/logflare/gen_singleton/watcher.ex
@@ -2,6 +2,7 @@ defmodule Logflare.GenSingleton.Watcher do
   @moduledoc """
   A generic singleton GenServer that will be unique cluster-wide.
   Checks if there the server is started, if not, will be started under the supervision tree as a transient GenServer.
+  Monitors the global process and restarts it if it terminates.
   """
 
   use GenServer
@@ -15,6 +16,10 @@ defmodule Logflare.GenSingleton.Watcher do
     GenServer.start_link(__MODULE__, {self(), args}, [])
   end
 
+  @doc """
+  Get the pid of the global singleton process. it will return the same pid for all nodes in cluster.
+  """
+  @spec get_pid(pid()) :: pid() | nil
   def get_pid(pid) do
     GenServer.call(pid, :get_pid)
   end

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -42,8 +42,7 @@ defmodule Logflare.Source.V1SourceSup do
     children = [
       {RCS, [source: source]},
       default_bigquery_spec,
-      {GenSingleton,
-       name: RecentEventsTouch.name(source), child_spec: {RecentEventsTouch, source: source}},
+      {GenSingleton, child_spec: {RecentEventsTouch, source: source}},
       {RecentInsertsBroadcaster, [source: source]},
       {EmailNotificationServer, [source: source]},
       {TextNotificationServer, [source: source, plan: plan]},

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Source.V1SourceSup do
   alias Logflare.Source.WebhookNotificationServer
   alias Logflare.Source.SlackHookServer
   alias Logflare.Source.BillingWriter
-
+  alias Logflare.GenSingleton
   alias Logflare.Source.RateCounterServer, as: RCS
   alias Logflare.Users
   alias Logflare.Backends
@@ -42,7 +42,8 @@ defmodule Logflare.Source.V1SourceSup do
     children = [
       {RCS, [source: source]},
       default_bigquery_spec,
-      {RecentEventsTouch, [source: source]},
+      {GenSingleton,
+       name: RecentEventsTouch.name(source), child_spec: {RecentEventsTouch, source: source}},
       {RecentInsertsBroadcaster, [source: source]},
       {EmailNotificationServer, [source: source]},
       {TextNotificationServer, [source: source, plan: plan]},

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -227,9 +227,10 @@ defmodule Logflare.BackendsTest do
     setup do
       insert(:plan)
       user = insert(:user)
-      source = insert(:source, user_id: user.id, log_events_updated_at: NaiveDateTime.utc_now())
+      timestamp = NaiveDateTime.utc_now()
+      source = insert(:source, user_id: user.id, log_events_updated_at: timestamp)
       {:ok, _tid} = IngestEventQueue.upsert_tid({source.id, nil, nil})
-      {:ok, source: source}
+      {:ok, source: source, timestamp: timestamp}
     end
 
     test "RecentEventsTouch updates source.log_events_updated_at", %{
@@ -245,9 +246,10 @@ defmodule Logflare.BackendsTest do
     end
 
     test "RecentEventsTouch does not update source.log_events_updated_at if already updated", %{
-      source: source
+      source: source,
+      timestamp: timestamp
     } do
-      le = build(:log_event, ingested_at: NaiveDateTime.utc_now())
+      le = build(:log_event, ingested_at: timestamp)
       IngestEventQueue.add_to_table({source.id, nil, nil}, [le])
       start_supervised!({RecentEventsTouch, source: source, touch_every: 100})
       :timer.sleep(800)

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -235,7 +235,7 @@ defmodule Logflare.BackendsTest do
     test "RecentEventsTouch updates source.log_events_updated_at", %{
       source: source
     } do
-      le = build(:log_event, ingested_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(2))
+      le = build(:log_event, ingested_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(200))
       IngestEventQueue.add_to_table({source.id, nil, nil}, [le])
       start_supervised!({RecentEventsTouch, source: source, touch_every: 100})
       :timer.sleep(800)

--- a/test/logflare/gen_singleton_test.exs
+++ b/test/logflare/gen_singleton_test.exs
@@ -30,14 +30,14 @@ defmodule Logflare.GenSingletonTest do
         )
 
       assert GenServer.whereis(__MODULE__.TestGenserver)
-      assert pid = GenSingleton.get_pid(pid1)
+      assert GenSingleton.get_pid(pid1)
       assert GenSingleton.get_pid(pid1) == GenSingleton.get_pid(pid2)
 
       Process.exit(pid1, :kill)
       refute Process.alive?(pid1)
       :timer.sleep(200)
-      assert pid == GenSingleton.get_pid(pid2)
-      assert GenServer.whereis(__MODULE__.TestGenserver)
+      assert pid = GenSingleton.get_pid(pid2)
+      assert GenServer.whereis(__MODULE__.TestGenserver) == pid
     end
   end
 end

--- a/test/logflare/gen_singleton_test.exs
+++ b/test/logflare/gen_singleton_test.exs
@@ -1,0 +1,47 @@
+defmodule Logflare.GenSingletonTest do
+  use ExUnit.Case
+  alias Logflare.GenSingleton
+
+  defmodule TestGenserver do
+    use GenServer, restart: :temporary
+
+    def start_link(args) do
+      GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    end
+
+    @impl GenServer
+    def init(args) do
+      {:ok, args}
+    end
+  end
+
+  describe "start_link/1" do
+    test "starts the GenServer with valid arguments" do
+      refute GenServer.whereis(__MODULE__.TestGenserver)
+
+      pid1 =
+        start_supervised!({GenSingleton, interval: 300, child_spec: __MODULE__.TestGenserver},
+          id: :first,
+          restart: :temporary
+        )
+
+      :timer.sleep(400)
+
+      pid2 =
+        start_supervised!({GenSingleton, interval: 100, child_spec: __MODULE__.TestGenserver},
+          id: :second,
+          restart: :temporary
+        )
+
+      assert GenServer.whereis(__MODULE__.TestGenserver)
+
+      assert GenSingleton.count_children(pid1) == 1
+      assert GenSingleton.count_children(pid2) == 0
+
+      Process.exit(pid1, :kill)
+      refute Process.alive?(pid1)
+      :timer.sleep(200)
+      assert GenSingleton.count_children(pid2) == 1
+    end
+  end
+end

--- a/test/logflare/gen_singleton_test.exs
+++ b/test/logflare/gen_singleton_test.exs
@@ -20,28 +20,24 @@ defmodule Logflare.GenSingletonTest do
       refute GenServer.whereis(__MODULE__.TestGenserver)
 
       pid1 =
-        start_supervised!({GenSingleton, interval: 300, child_spec: __MODULE__.TestGenserver},
-          id: :first,
-          restart: :temporary
+        start_supervised!({GenSingleton, child_spec: __MODULE__.TestGenserver},
+          id: :first
         )
 
-      :timer.sleep(400)
-
       pid2 =
-        start_supervised!({GenSingleton, interval: 100, child_spec: __MODULE__.TestGenserver},
-          id: :second,
-          restart: :temporary
+        start_supervised!({GenSingleton, child_spec: __MODULE__.TestGenserver},
+          id: :second
         )
 
       assert GenServer.whereis(__MODULE__.TestGenserver)
-
-      assert GenSingleton.count_children(pid1) == 1
-      assert GenSingleton.count_children(pid2) == 0
+      assert pid = GenSingleton.get_pid(pid1)
+      assert GenSingleton.get_pid(pid1) == GenSingleton.get_pid(pid2)
 
       Process.exit(pid1, :kill)
       refute Process.alive?(pid1)
       :timer.sleep(200)
-      assert GenSingleton.count_children(pid2) == 1
+      assert pid == GenSingleton.get_pid(pid2)
+      assert GenServer.whereis(__MODULE__.TestGenserver)
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -66,7 +66,8 @@ defmodule Logflare.Factory do
       },
       notifications: %{
         user_schema_update_notifications: true
-      }
+      },
+      log_events_updated_at: NaiveDateTime.utc_now()
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -66,8 +66,7 @@ defmodule Logflare.Factory do
       },
       notifications: %{
         user_schema_update_notifications: true
-      },
-      log_events_updated_at: NaiveDateTime.utc_now()
+      }
     }
   end
 


### PR DESCRIPTION
Generic cluster-wide singleton GenServer, to allow for logic reuse. This has been added to the RecentEventsTouch server to allow for a single genserver cluster-wide to perform the record updated, instead of every node in the cluster performing the update.

This module should only be used for non-critical functions or functions that are not time-sensitive, as it uses a naive interval checking logic.

It is generic enough to be applicable to both syn and global.

importantly, this reduces the total transactions occuring across the cluster, thereby also reducing cainophile messages broadcasted.