### PR TITLE
perf: ingestion tweaking for bigquery

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -213,7 +213,7 @@ defmodule Logflare.Application do
        pools: %{
          "https://bigquery.googleapis.com" => [
            protocols: [:http1],
-           size: max(base * 100, 150),
+           size: max(base * 125, 150),
            count: http1_count,
            start_pool_metrics?: true
          ]
@@ -223,7 +223,7 @@ defmodule Logflare.Application do
        pools: %{
          "https://bigquery.googleapis.com" => [
            protocols: [:http2],
-           count: max(base, 20),
+           count: max(base, 20) * 2,
            start_pool_metrics?: true
          ]
        }},
@@ -235,6 +235,7 @@ defmodule Logflare.Application do
          #  explicitly set http2 for other pools for multiplexing
          "https://bigquery.googleapis.com" => [
            protocols: [:http1],
+           size: 100,
            count: http1_count,
            start_pool_metrics?: true
          ],

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_pending_buffer_len_per_queue 5_000
+  @max_pending_buffer_len_per_queue 15_000
 
   @doc """
   Retrieves the hardcoded max pending buffer length of an individual queue

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -108,19 +108,19 @@ defmodule Logflare.Backends.BufferProducer do
         scale? == false ->
           state.interval
 
-        metrics.avg < 100 ->
+        metrics.avg < 10 ->
           state.interval * 5
 
-        metrics.avg < 1000 ->
+        metrics.avg < 50 ->
           state.interval * 4
 
-        metrics.avg < 2000 ->
+        metrics.avg < 100 ->
           state.interval * 3
 
-        metrics.avg < 3000 ->
+        metrics.avg < 150 ->
           state.interval * 2
 
-        metrics.avg < 4000 ->
+        metrics.avg < 250 ->
           state.interval * 1.5
 
         true ->

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -132,16 +132,14 @@ defmodule Logflare.Backends.IngestEventQueue do
 
     procs = Enum.map(proc_counts, fn {key, _count} -> key end)
 
-    procs_length = Enum.count(procs)
-
-    if procs_length == 0 do
+    if procs == [] do
       # not yet started, add to startup queue
       add_to_table({sid, bid, nil}, batch)
     else
       Logflare.Utils.chunked_round_robin(
         batch,
         procs,
-        250,
+        50,
         fn chunk, target ->
           add_to_table(target, chunk)
         end

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -15,7 +15,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   @default_interval 1_000
   @default_remainder 100
   @default_max Logflare.Backends.max_buffer_queue_len()
-  @default_purge_ratio 0.1
+  @default_purge_ratio 0.05
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
@@ -70,7 +70,10 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
         Logger.warning(
           "IngestEventQueue private :ets buffer exceeded max for source id=#{state.source_id}, dropping #{to_drop} events",
-          backend_id: state.backend_id
+          backend_id: state.backend_id,
+          source_id: state.source_token,
+          source_token: state.source_token,
+          ingest_drop_count: to_drop
         )
       end
     end

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -23,11 +23,10 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   alias Logflare.Users
   alias Logflare.PubSubRates
 
-  # each batch should at most be 5MB
   # BQ max is 10MB
   # https://cloud.google.com/bigquery/quotas#streaming_inserts
-  @max_batch_length 5_000_000
-  @max_batch_size 300
+  @max_batch_length 6_000_000
+  @max_batch_size 500
 
   def start_link(args, opts \\ []) do
     {name, args} = Keyword.pop(args, :name)
@@ -41,7 +40,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
           # top-level will apply to all children
           hibernate_after: 5_000,
           spawn_opt: [
-            fullsweep_after: 10
+            fullsweep_after: 15
           ],
           producer: [
             module:
@@ -55,11 +54,11 @@ defmodule Logflare.Source.BigQuery.Pipeline do
                [ref: {{source.id, backend.id, args[:pipeline_ref]}, source.token}]}
           ],
           processors: [
-            default: [concurrency: 4, max_demand: 100]
+            default: [concurrency: 8, max_demand: 100]
           ],
           batchers: [
             bq: [
-              concurrency: 8,
+              concurrency: 16,
               batch_size: bq_batch_size_splitter(),
               batch_timeout: 1_500,
               # must be set when using custom batch_size splitter

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -7,6 +7,7 @@ defmodule Logflare.BigQuery.PipelineTest do
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.Backends.Backend
+  alias Logflare.Backends
   use ExUnitProperties
 
   @pipeline_name :test_pipeline
@@ -114,8 +115,8 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       insert(:plan)
       user = insert(:user)
-      source = insert(:source, user_id: user.id, lock_schema: true)
-      args = [source: source, name: @pipeline_name]
+      source = insert(:source, user: user, lock_schema: true)
+      args = [source: source, backend: Backends.get_default_backend(user), name: @pipeline_name]
       le = build(:log_event, source: source)
 
       start_supervised!(
@@ -138,21 +139,26 @@ defmodule Logflare.BigQuery.PipelineTest do
           # {4, 4}, #264k, 33k/proc
           # {4, 6}, #368k, 36.8k/proc
           # 472k, 39k/proc
-          {4, 8},
+          # {4, 8},
           # 559k, 39k/proc
-          {4, 10}
-          # {4, 16},#743k,  37k/proc
-          # {6, 6}, #395k, 32.9k/proc
-          # {6, 8}, #500k, 35.7k/proc
-          # {6, 10}, #595k, 37.1k/proc
-          # {6, 12},#680k, 37k/proc
-          # {6, 14},#757.75k, 37.8k/proc
-          # {6, 16}, #813.25k, 36.96/proc
-          # {8, 8}, #522, 32k/proc
-          # {8, 16},#856k, 35k/proc
-          # {12, 8}, #525k, 26k/proc
-          # {10, 16}, #907k, 34k/proc
-          # {12, 16}, #953k, 34k/proc
+          # {4, 10},
+          # {4, 12},
+          # {4, 14},
+          # 527.75k
+          {4, 16},
+          # {6, 6},
+          # {6, 8},
+          # {6, 10},
+          # {6, 12},
+          # {6, 14},
+          # {6, 16},
+          # {8, 8},
+          # 515.25k-539.00k
+          {8, 12},
+          # 696.75k-778.75k
+          {8, 16}
+          # {12, 12}, #544.50
+          # {12, 16}, #855.75k
         ] do
       @tag :benchmark
       test "#{processors}-#{batchers}", %{args: args, batch: batch, test: name} do


### PR DESCRIPTION
- doubles processor and batcher counts for BigQuery pipeline, in a real world scenario it would likely be limited by batcher request speed, so there are diminishing returns in increasing processor counts. This will roughly 2.6x output per pipeline, so that we can burn down queues faster. see benchmark for details 
- increases http1 pools to increase overall max http throughput. Likely redundant once we move to Storage Write API
- tweak producer schedule scaling based on avg ingest rate, reducing it significantly for high rate sources. 
- Increase Ingest event queue to 15k, and reduce round robin chunking to 50. This should spread out chunks to more queues now.
- Reduce QueueJanitor purge ratio to 0.05, to account for larger ingest queue permitted.


BencheeAsync benchmark of Pipeline. only sample size is relevant
```
Name                           minimum        maximum    sample size                     mode
:"test benchmarks 8-16"       0.0410 μs     7228.54 μs       864.00 K                  1.75 μs
:"test benchmarks 12-16"       0.0830 μs     5178.04 μs       935.25 K                  1.38 μs
:"test benchmarks 8-8"       0.0840 μs    11146.08 μs       401.00 K                  1.75 μs
:"test benchmarks 4-8"        0.125 μs     9210.75 μs       326.50 K                  1.50 μs
```