### PR TITLE
feat: threshold-based DynamicPipeline resolving

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,1 @@
+import Logflare.Utils.Debugging

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -78,7 +78,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
 
   """
   def handle_resolve_count(state, lens, avg_rate) do
-
     startup_size =
       Enum.find_value(lens, 0, fn
         {{_sid, _bid, nil}, val} -> val

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -78,6 +78,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
 
   """
   def handle_resolve_count(state, lens, avg_rate) do
+
     startup_size =
       Enum.find_value(lens, 0, fn
         {{_sid, _bid, nil}, val} -> val

--- a/lib/logflare/backends/dynamic_pipeline.ex
+++ b/lib/logflare/backends/dynamic_pipeline.ex
@@ -323,7 +323,9 @@ defmodule Logflare.Backends.DynamicPipeline do
     end
 
     defp loop(args) do
-      Process.send_after(self(), :check, args.resolve_interval)
+      # add small randomizer to spread out resolve checks
+      randomizer = :rand.uniform(ceil(args.resolve_interval / 5))
+      Process.send_after(self(), :check, args.resolve_interval + randomizer)
     end
   end
 end

--- a/lib/logflare/utils/debugging.ex
+++ b/lib/logflare/utils/debugging.ex
@@ -3,22 +3,20 @@ defmodule Logflare.Utils.Debugging do
   alias Logflare.Backends.IngestEventQueue
 
   def list_counts(source_id) do
-    :erpc.multicall(
-      [Node.self() | Node.list()],
-      fn ->
-        {Node.self(), IngestEventQueue.list_counts({source_id, nil})}
-      end,
-      5000
-    )
+    :erpc.multicall(all_nodes(), __MODULE__, :list_counts_callback, [source_id], 5000)
+  end
+
+  def list_counts_callback(source_id) do
+    {Node.self(), IngestEventQueue.list_counts({source_id, nil})}
   end
 
   def list_pending_counts(source_id) do
-    :erpc.multicall(
-      [Node.self() | Node.list()],
-      fn ->
-        {Node.self(), IngestEventQueue.list_pending_counts({source_id, nil})}
-      end,
-      5000
-    )
+    :erpc.multicall(all_nodes(), __MODULE__, :list_pending_counts_callback, [source_id], 5000)
+  end
+
+  defp all_nodes, do: [Node.self() | Node.list()]
+
+  def list_pending_counts_callback(source_id) do
+    {Node.self(), IngestEventQueue.list_pending_counts({source_id, nil})}
   end
 end

--- a/lib/logflare/utils/debugging.ex
+++ b/lib/logflare/utils/debugging.ex
@@ -1,0 +1,24 @@
+defmodule Logflare.Utils.Debugging do
+  @moduledoc false
+  alias Logflare.Backends.IngestEventQueue
+
+  def list_counts(source_id) do
+    :erpc.multicall(
+      [Node.self() | Node.list()],
+      fn ->
+        {Node.self(), IngestEventQueue.list_counts({source_id, nil})}
+      end,
+      5000
+    )
+  end
+
+  def list_pending_counts(source_id) do
+    :erpc.multicall(
+      [Node.self() | Node.list()],
+      fn ->
+        {Node.self(), IngestEventQueue.list_pending_counts({source_id, nil})}
+      end,
+      5000
+    )
+  end
+end

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -172,112 +172,138 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
     end
   end
 
-  test "resolve_count will increase counts" do
-    check all pipeline_count <- integer(0..100),
-              queue_size <- integer(9001..10000),
-              startup_queue_size <- integer(0..100),
-              avg_rate <- integer(0..10_000),
-              last <- member_of([nil, NaiveDateTime.utc_now()]) do
-      state = %{
-        pipeline_count: pipeline_count,
-        max_pipelines: 101,
-        last_count_increase: last,
-        last_count_decrease: last
-      }
+  describe "handle_resolve_count/3" do
+    test "resolve_count will increase counts when queue size is above threshold" do
+      check all pipeline_count <- integer(0..100),
+                queue_size <- integer(505..10000),
+                avg_rate <- integer(100..10_000),
+                last <- member_of([nil, NaiveDateTime.utc_now()]) do
+        state = %{
+          pipeline_count: pipeline_count,
+          max_pipelines: 101,
+          last_count_increase: last,
+          last_count_decrease: last
+        }
 
-      desired =
-        BigQueryAdaptor.handle_resolve_count(
-          state,
-          %{
-            {1, 2, nil} => startup_queue_size,
-            {1, 2, make_ref()} => queue_size
-          },
-          avg_rate
-        )
+        desired =
+          BigQueryAdaptor.handle_resolve_count(
+            state,
+            %{
+              {1, 2, nil} => 0,
+              {1, 2, make_ref()} => queue_size
+            },
+            avg_rate
+          )
 
-      assert desired > pipeline_count
+        assert desired > pipeline_count
+      end
     end
-  end
 
-  test "resolve_count will decrease counts" do
-    check all pipeline_count <- integer(2..100),
-              queue_size <- integer(0..49),
-              startup_queue_size <- constant(0),
-              avg_rate <- integer(0..10_000),
-              since <- integer(31..100) do
-      state = %{
-        pipeline_count: pipeline_count,
-        max_pipelines: 101,
-        last_count_increase: NaiveDateTime.utc_now(),
-        last_count_decrease: NaiveDateTime.utc_now() |> NaiveDateTime.add(-since)
-      }
+    test "resolve_count will increase counts when startup queue is non-empty" do
+      check all pipeline_count <- integer(0..100),
+                queue_size <- integer(1..250),
+                startup_queue_size <- integer(5000..10000),
+                avg_rate <- integer(100..10_000),
+                last <- member_of([nil, NaiveDateTime.utc_now()]) do
+        state = %{
+          pipeline_count: pipeline_count,
+          max_pipelines: 101,
+          last_count_increase: last,
+          last_count_decrease: last
+        }
 
-      desired =
-        BigQueryAdaptor.handle_resolve_count(
-          state,
-          %{
-            {1, 2, nil} => startup_queue_size,
-            {1, 2, make_ref()} => queue_size
-          },
-          avg_rate
-        )
+        desired =
+          BigQueryAdaptor.handle_resolve_count(
+            state,
+            %{
+              {1, 2, nil} => startup_queue_size,
+              {1, 2, make_ref()} => queue_size
+            },
+            avg_rate
+          )
 
-      assert desired < pipeline_count
-      assert desired != 0
+        assert desired - pipeline_count > 5
+      end
     end
-  end
 
-  test "resolve_count scale to zero" do
-    check all pipeline_count <- constant(1),
-              queue_size <- constant(0),
-              startup_queue_size <- constant(0),
-              avg_rate <- constant(0),
-              since <- integer(360..1000) do
-      state = %{
-        pipeline_count: pipeline_count,
-        max_pipelines: 101,
-        last_count_increase: NaiveDateTime.utc_now(),
-        last_count_decrease: NaiveDateTime.utc_now() |> NaiveDateTime.add(-since)
-      }
+    test "resolve_count increases startup queue by 1 if less than 500 " do
+      check all pipeline_count <- constant(0),
+                startup_queue_size <- integer(1..444),
+                avg_rate <- integer(1..500) do
+        state = %{
+          pipeline_count: pipeline_count,
+          max_pipelines: 101,
+          last_count_increase: NaiveDateTime.utc_now(),
+          last_count_decrease: NaiveDateTime.utc_now()
+        }
 
-      desired =
-        BigQueryAdaptor.handle_resolve_count(
-          state,
-          %{
-            {1, 2, nil} => startup_queue_size,
-            {1, 2, make_ref()} => queue_size
-          },
-          avg_rate
-        )
+        desired =
+          BigQueryAdaptor.handle_resolve_count(
+            state,
+            %{
+              {1, 2, nil} => startup_queue_size
+            },
+            avg_rate
+          )
 
-      assert desired < pipeline_count
-      assert desired == 0
+        assert desired - pipeline_count == 1
+      end
     end
-  end
 
-  test "resolve_count initial incoming" do
-    check all pipeline_count <- constant(0),
-              startup_queue_size <- integer(1..500),
-              avg_rate <- integer(1..500),
-              since <- integer(0..100) do
-      state = %{
-        pipeline_count: pipeline_count,
-        max_pipelines: 101,
-        last_count_increase: NaiveDateTime.utc_now(),
-        last_count_decrease: NaiveDateTime.utc_now() |> NaiveDateTime.add(-since)
-      }
+    test "resolve_count will decrease counts" do
+      check all pipeline_count <- integer(2..100),
+                queue_size <- integer(0..49),
+                startup_queue_size <- constant(0),
+                avg_rate <- integer(0..10_000),
+                since <- integer(71..100) do
+        state = %{
+          pipeline_count: pipeline_count,
+          max_pipelines: 101,
+          last_count_increase: NaiveDateTime.utc_now(),
+          last_count_decrease: NaiveDateTime.utc_now() |> NaiveDateTime.add(-since)
+        }
 
-      desired =
-        BigQueryAdaptor.handle_resolve_count(
-          state,
-          %{
-            {1, 2, nil} => startup_queue_size
-          },
-          avg_rate
-        )
+        desired =
+          BigQueryAdaptor.handle_resolve_count(
+            state,
+            %{
+              {1, 2, nil} => startup_queue_size,
+              {1, 2, make_ref()} => queue_size
+            },
+            avg_rate
+          )
 
-      assert desired > pipeline_count
-      assert desired != 0
+        assert desired < pipeline_count
+        assert desired != 0
+      end
+    end
+
+    test "resolve_count scale to zero" do
+      check all pipeline_count <- constant(1),
+                queue_size <- constant(0),
+                startup_queue_size <- constant(0),
+                avg_rate <- constant(0),
+                since <- integer(360..1000) do
+        state = %{
+          pipeline_count: pipeline_count,
+          max_pipelines: 101,
+          last_count_increase: NaiveDateTime.utc_now(),
+          last_count_decrease: NaiveDateTime.utc_now() |> NaiveDateTime.add(-since)
+        }
+
+        desired =
+          BigQueryAdaptor.handle_resolve_count(
+            state,
+            %{
+              {1, 2, nil} => startup_queue_size,
+              {1, 2, make_ref()} => queue_size
+            },
+            avg_rate
+          )
+
+        assert desired < pipeline_count
+        assert desired == 0
+      end
     end
   end
 end


### PR DESCRIPTION
This adjusts the dynamic Broadway pipeline creation logic to be threshold based -- if any queue hits a certain threshold, it would add an additional scaled number of pipelines.

It also adjusts the gradual decrease to make it much harder for it to scale down. Scale to zero condition is unchanged.

Threshold chosen is 500 items, which seems to be the eyeballed number in prod that queues are hovering at for busy sources. Most spike to 1-2k even for very busy sources. 

This should help avoid load shedding by the QueueJanitor, as load shedding is still getting triggered due to request spikes on only one pipeline, as previous resolve logic would only create more pipelines when pipeline is at least half of max (7.5k) at point of resolving. What is likely happening is a race condition where:
- the Queue Janitor triggers load sheding
- the BufferProducer takes majority of remainder of the queue
- the queue drops to below 50%
- the resolve triggers but doesn't increase pipeline count

On staging, seems like pipelines only get spun up at saturation at over >80% cpu util, and only 4 get spun up. So definitely a red flag.

Some other changes include:
- adding small randomizer to the pipeline resolve interval
- adding some debugging utils for runtime debugging
