### PR TITLE
feat: add labels for BQ jobs for billing association

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -300,7 +300,10 @@ defmodule Logflare.Alerting do
              [],
              parameterMode: "NAMED",
              maxResults: 1000,
-             location: alert_query.user.bigquery_dataset_location
+             location: alert_query.user.bigquery_dataset_location,
+             labels: %{
+               "alert_id" => alert_query.id
+             }
            ) do
       {:ok, rows}
     else

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -31,7 +31,7 @@ defmodule Logflare.BqRepo do
   def query_with_sql_and_params(%User{} = user, project_id, sql, params, opts \\ [])
       when not is_nil(project_id) and is_binary(sql) and is_list(params) and is_list(opts) do
     override = Map.new(opts)
-
+    {labels, override} = Map.pop(override, :labels, %{})
     %Plan{name: plan} = Billing.Cache.get_plan_by_user(user)
 
     query_request = %QueryRequest{
@@ -42,11 +42,15 @@ defmodule Logflare.BqRepo do
       queryParameters: params,
       dryRun: false,
       timeoutMs: @query_request_timeout,
-      labels: %{
-        "managed_by" => "logflare",
-        "logflare_plan" => GenUtils.format_key(plan),
-        "logflare_account" => GenUtils.format_key(user.id)
-      }
+      labels:
+        Map.merge(
+          %{
+            "managed_by" => "logflare",
+            "logflare_plan" => GenUtils.format_key(plan),
+            "logflare_account" => GenUtils.format_key(user.id)
+          },
+          labels
+        )
     }
 
     query_request = Map.merge(query_request, override)

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -288,7 +288,10 @@ defmodule Logflare.Endpoints do
            bq_params,
            parameterMode: "NAMED",
            maxResults: endpoint_query.max_limit,
-           location: endpoint_query.user.bigquery_dataset_location
+           location: endpoint_query.user.bigquery_dataset_location,
+           labels: %{
+             "endpoint_id" => endpoint_query.id
+           }
          ) do
       {:ok, result} ->
         {:ok, result}


### PR DESCRIPTION
For billing. Uses id instead of uuid for consistency with user id labelling.