### PR TITLE
perf: set busy wait to long from none

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -15,9 +15,10 @@
 -env ERL_MAX_ETS_TABLES 250000
 
 ## Set busy-wait. Options are: none|very_short|short|medium|long|very_long
-+sbwt none
-+sbwtdcpu none
-+sbwtdio none
+## Longer is better to maximize CPU saturation
++sbwt long
++sbwtdcpu long
++sbwtdio long
 
 ## load balance on scheduler utilization
 +sub true


### PR DESCRIPTION
This PR increases busy-wait for the scheduler. When we initially reduced it to `none`, it was with the understanding that we wanted to reduce system cpu % to cater for scaling down our instance sizes. 
Since we want to now saturate CPU usage fully on our now cheaper instances, this should be optimal since the workloads are constant and we want to maximize throughput. It is unlikely that we will need to reduce instance size more, unless we really can't saturate the instance even at 32 cores.