### PR TITLE
fix: handle multiple union all

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -355,11 +355,10 @@ defmodule Logflare.Sql do
 
     sandboxed_cte_names = extract_cte_alises(ast)
 
-
     unknown_table_names =
       for statement <- ast,
           from <- extract_all_from(statement),
-      %{"value" => table_name} <- get_in(from, ["relation", "Table", "name"]),
+          %{"value" => table_name} <- get_in(from, ["relation", "Table", "name"]),
           table_name not in aliases,
           table_name not in sandboxed_cte_names do
         table_name
@@ -754,7 +753,6 @@ defmodule Logflare.Sql do
   end
 
   defp extract_all_from(_kv, acc), do: acc
-
 
   # returns true if the name is fully qualified and has the project id prefix.
   defp is_project_fully_qualified_name(_table_name, nil), do: false

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -44,10 +44,15 @@ defmodule Logflare.SqlTest do
       # valid CTE queries with UNION ALL
       input = """
       with cte1 as (select a from my_table),
-           cte2 as (select b from my_table)
+           cte2 as (select b from my_table),
+           edge_logs as (select b from my_table),
+           postgres_logs as (select b from my_table),
+           auth_logs as (select b from my_table)
       select a from cte1
       union all
       select b from cte2
+      union all
+      \nselect el.id as id from edge_logs as el\nunion all\nselect pgl.id as id from postgres_logs as pgl\nunion all\nselect al.id as id from auth_logs as al
       """
 
       assert {:ok, _result} = Sql.transform(:bq_sql, input, user)
@@ -140,6 +145,12 @@ defmodule Logflare.SqlTest do
               {"with cte1 as (select a from my_table), cte2 as (select b from my_table) select a from cte1",
                "select a from cte1 union all select b from cte2"},
               "with cte1 as (select a from #{table}), cte2 as (select b from #{table}) select a from cte1 union all select b from cte2"
+            },
+            # multiple union alls
+            {
+              {"with cte1 as (select a from my_table), cte2 as (select b from my_table) select a from cte1",
+               "select a from cte1 union all select b from cte2 union all select c from cte2"},
+              "with cte1 as (select a from #{table}), cte2 as (select b from #{table}) select a from cte1 union all select b from cte2 union all select c from cte2"
             },
             # handle nested CTEs
             {


### PR DESCRIPTION
Fixes https://linear.app/supabase/issue/ANL-863/logflare-endpoints-fix-union-all-for-2-expressions

Handles multiple union all in sql statements.
Moves tree traversal code from anon function to separate function definition for recursion. I should probably extract this out to a macro soon...