### PR TITLE
perf: revert busy wait

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -15,10 +15,9 @@
 -env ERL_MAX_ETS_TABLES 250000
 
 ## Set busy-wait. Options are: none|very_short|short|medium|long|very_long
-## Longer is better to maximize CPU saturation
-+sbwt long
-+sbwtdcpu long
-+sbwtdio long
++sbwt none
++sbwtdcpu none
++sbwtdio none
 
 ## use utilization load balancing
 +sub true


### PR DESCRIPTION
Reverting busy-wait, seems like this will cause an issue with load balancer as gcp load balancer calculates max loading based cpu utilization, causing load to be taken on and off nodes in a non-consistent way, since scheduler utilization (and thusly cpu utilization) jumps a lot when large amounts of load is taken on and off (despite gcp load balancer already having high utilization threshold).
I suspect that this also results in load balancer level pushback on requests resulting in higher latency on our load test cluster.
<img width="945" alt="Screenshot 2025-04-16 at 7 45 25 PM" src="https://github.com/user-attachments/assets/1814f103-36cc-4591-bf00-b3325a2635d8" />
