### PR TITLE
chore: remove ssl option from libcluster postgres

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -317,7 +317,7 @@ postgres_topology = [
       password: db_password,
       username: db_username,
       port: db_port,
-      ssl: if(db_ssl, do: db_ssl_opts, else: false),
+      # ssl: if(db_ssl, do: db_ssl_opts, else: false),
       channel:
         "cluster_#{clean_for_postgres_channel.(Node.get_cookie())}_#{clean_for_postgres_channel.(vsn)}"
     ]


### PR DESCRIPTION
seems like the direct Postgrex connection did not use ssl before (?) even though the ecto repo requires it