### PR TITLE
feat: logflare endpoints support large sql queries

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,7 @@ config :logflare, Logflare.Source.BigQuery.Schema, updates_per_minute: 6
 config :logflare, LogflareWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,
   http: [
+    http_1_options: [max_request_line_length: 100_000],
     http_options: [log_protocol_errors: false],
     thousand_island_options: [
       # https://cloud.google.com/load-balancing/docs/https/#timeouts_and_retries

--- a/docs/docs.logflare.com/docs/concepts/endpoints.md
+++ b/docs/docs.logflare.com/docs/concepts/endpoints.md
@@ -78,6 +78,11 @@ The Endpoint consumer can pass in the following query parameter to query across 
 ?sql=select err from errors where regexp_contains(err, "my_error")
 ```
 
+
+Should large SQL queries need to be executed, the SQL query string can be placed in the GET JSON body. Logflare will read the body and use the `sql` field in the body payload. This will only occur if **no `?sql=` query parameter is present in the request's query parameters**. This behaviour does not extend to other declared parameters (such as `@my_param`), and only applies to the special `sql` query parameter for sandboxed endpoints.
+
+
+
 ## HTTP Response
 
 The result of the query will be returned on the `result` key of the response payload.

--- a/lib/logflare/alerting/supervisor.ex
+++ b/lib/logflare/alerting/supervisor.ex
@@ -31,7 +31,7 @@ defmodule Logflare.Alerting.Supervisor do
           Logger.info("Started alerts scheduler on #{inspect(Node.self())}, pid: #{inspect(pid)}")
           :syn.join(:alerting, :scheduler, pid)
 
-        {:error, {:already_started, pid}} ->m
+        {:error, {:already_started, pid}} ->
           Logger.debug("Alerts scheduler already started on #{inspect(node(pid))}")
       end
     else

--- a/lib/logflare/alerting/supervisor.ex
+++ b/lib/logflare/alerting/supervisor.ex
@@ -31,7 +31,7 @@ defmodule Logflare.Alerting.Supervisor do
           Logger.info("Started alerts scheduler on #{inspect(Node.self())}, pid: #{inspect(pid)}")
           :syn.join(:alerting, :scheduler, pid)
 
-        {:error, {:already_started, pid}} ->
+        {:error, {:already_started, pid}} ->m
           Logger.debug("Alerts scheduler already started on #{inspect(node(pid))}")
       end
     else

--- a/lib/logflare_web/controllers/endpoints_controller.ex
+++ b/lib/logflare_web/controllers/endpoints_controller.ex
@@ -9,6 +9,12 @@ defmodule LogflareWeb.EndpointsController do
   alias LogflareWeb.OpenApi.ServerError
   alias LogflareWeb.OpenApiSchemas.EndpointQuery
 
+  @plug_parsers_init Plug.Parsers.init(
+                       parsers: [JsonParser],
+                       json_decoder: Jason,
+                       body_reader: {PlugCaisson, :read_body, []}
+                     )
+
   action_fallback(LogflareWeb.Api.FallbackController)
   tags(["Public"])
 
@@ -66,18 +72,11 @@ defmodule LogflareWeb.EndpointsController do
          _opts
        )
        when is_map_key(qp, "sql") == false do
-    args =
-      Plug.Parsers.init(
-        parsers: [JsonParser],
-        json_decoder: Jason,
-        body_reader: {PlugCaisson, :read_body, []}
-      )
-
     conn
     # Plug.Parsers only supports POST/PUT/PATCH
     |> Map.put(:method, "POST")
     |> Map.put(:body_params, %Plug.Conn.Unfetched{})
-    |> Plug.Parsers.call(args)
+    |> Plug.Parsers.call(@plug_parsers_init)
     |> Map.put(:method, "GET")
   end
 

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -109,6 +109,45 @@ defmodule LogflareWeb.EndpointsControllerTest do
     end
   end
 
+  describe "sandboxed query" do
+    setup do
+      _plan = insert(:plan, name: "Free")
+      user = insert(:user)
+      source = build(:source, user: user)
+      {:ok, user: user, source: source}
+    end
+
+    test "params in GET body", %{conn: conn, user: user} do
+      pid = self()
+
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> stub(:bigquery_jobs_query, fn _conn, _proj_id, opts ->
+        send(pid, {:sql, opts[:body].query})
+
+        {:ok, TestUtils.gen_bq_response()}
+      end)
+
+      endpoint =
+        insert(:endpoint,
+          user: user,
+          enable_auth: true,
+          sandboxable: true,
+          query: "with a as (select 1 as b) select b from a"
+        )
+
+      conn =
+        conn
+        |> put_req_header("x-api-key", user.api_key)
+        |> put_req_header("content-type", "application/json")
+        |> get("/api/endpoints/query/#{endpoint.name}", Jason.encode!(%{sql: "select 2"}))
+
+      assert [%{"event_message" => "some event message"}] = json_response(conn, 200)["result"]
+      assert conn.halted == false
+      assert_received {:sql, sql}
+      assert String.downcase(sql) =~ "select 2"
+    end
+  end
+
   describe "single tenant endpoint query" do
     setup :set_mimic_global
 


### PR DESCRIPTION
This PR adds in GET body read support as fallback for very large sql queries. It also increases the max request line length for http1 requests by 10x from the default.