### PR TITLE
perf: Compress LogEventCache, adjust acceptors, add batch stream tracing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,7 @@ config :logflare, LogflareWeb.Endpoint,
   http: [
     http_options: [log_protocol_errors: false],
     thousand_island_options: [
+      num_acceptors: 200,
       # https://cloud.google.com/load-balancing/docs/https/#timeouts_and_retries
       # preserves idle keepalive connections up to load balancer max of 600s
       read_timeout: 600_000,

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,7 @@ config :logflare, LogflareWeb.Endpoint,
   http: [
     http_options: [log_protocol_errors: false],
     thousand_island_options: [
-      num_acceptors: 200,
+      num_acceptors: 1000,
       # https://cloud.google.com/load-balancing/docs/https/#timeouts_and_retries
       # preserves idle keepalive connections up to load balancer max of 600s
       read_timeout: 600_000,

--- a/lib/logflare/logs/log_events_cache.ex
+++ b/lib/logflare/logs/log_events_cache.ex
@@ -25,7 +25,8 @@ defmodule Logflare.Logs.LogEvents.Cache do
                 Utils.cache_limit(15_000)
               ]
               |> Enum.filter(& &1),
-            expiration: Utils.cache_expiration_min(15)
+            expiration: Utils.cache_expiration_min(10),
+            compressed: true
           ]
         ]
       }

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -131,7 +131,17 @@ defmodule Logflare.Source.BigQuery.Pipeline do
       }
     )
 
-    stream_batch(context, messages)
+    OpenTelemetry.Tracer.with_span :bigquery_pipeline, %{
+      attributes: %{
+        source_id: context.source_id,
+        source_token: context.source_token,
+        backend_id: context.backend_id,
+        ingest_batch_size: batch_info.size,
+        ingest_batch_trigger: batch_info.trigger
+      }
+    } do
+      stream_batch(context, messages)
+    end
   end
 
   def le_messages_to_bq_rows(messages) do

--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -23,6 +23,8 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   alias Logflare.Users
   alias Logflare.PubSubRates
 
+  require OpenTelemetry.Tracer
+
   # BQ max is 10MB
   # https://cloud.google.com/bigquery/quotas#streaming_inserts
   @max_batch_length 6_000_000


### PR DESCRIPTION

Adds minor adjustments for memory. Increasing acceptors is a low hanging fruit for reducing bottleneck chance, still need to add metrics around acceptor idling for further optimizing.

https://linear.app/supabase/issue/ANL-873/minimzing-logeventcache-memory-footprint
https://linear.app/supabase/issue/ANL-883/logflare-ingestion-add-tracing-around-bq-batch-sending

fixes ANL-873 , ANL-883