### PR TITLE
feat: add support for arrays for otel traces

### DIFF
--- a/lib/logflare/logs/otel_trace.ex
+++ b/lib/logflare/logs/otel_trace.ex
@@ -98,18 +98,16 @@ defmodule Logflare.Logs.OtelTrace do
 
   defp extract_key_value(%KeyValue{
          key: key,
-         value: %AnyValue{value: {:array_value, %ArrayValue{values: values}}}
+         value: value
        }) do
-    {key, Enum.map(values, &extract_key_value/1)}
+    {key, extract_value(value)}
   end
 
-  defp extract_key_value(%KeyValue{key: key, value: %{value: {_, value}}}) do
-    {key, value}
+  defp extract_value(%AnyValue{value: {:array_value, %ArrayValue{values: values}}}) do
+    Enum.map(values, &extract_value/1)
   end
 
-  defp extract_key_value(%AnyValue{value: {_type, value}}) do
-    value
-  end
-
-  defp extract_key_value(v), do: v
+  defp extract_value(%_{value: {_type, value}}), do: value
+  defp extract_value(nil), do: nil
+  defp extract_value(value), do: value
 end

--- a/test/logflare/logs/otel_trace_test.exs
+++ b/test/logflare/logs/otel_trace_test.exs
@@ -21,13 +21,6 @@ defmodule Logflare.Logs.OtelTraceTest do
       assert Enum.any?(Map.values(a), &is_boolean/1)
     end
 
-    test "array handling", %{
-      resource_spans: resource_spans,
-      source: source
-    } do
-      batch = OtelTrace.handle_batch(resource_spans, source)
-    end
-
     test "Creates params from a list with one Resource Span that contains an Event", %{
       resource_spans: resource_spans,
       source: source

--- a/test/logflare/logs/otel_trace_test.exs
+++ b/test/logflare/logs/otel_trace_test.exs
@@ -9,6 +9,25 @@ defmodule Logflare.Logs.OtelTraceTest do
       %{resource_spans: TestUtilsGrpc.random_resource_span(), source: source}
     end
 
+    test "attributes", %{
+      resource_spans: resource_spans,
+      source: source
+    } do
+      [%{"attributes" => a} | _] = OtelTrace.handle_batch(resource_spans, source)
+      assert a != %{}
+      assert Enum.any?(Map.values(a), &is_list/1)
+      assert Enum.any?(Map.values(a), &is_number/1)
+      assert Enum.any?(Map.values(a), &is_binary/1)
+      assert Enum.any?(Map.values(a), &is_boolean/1)
+    end
+
+    test "array handling", %{
+      resource_spans: resource_spans,
+      source: source
+    } do
+      batch = OtelTrace.handle_batch(resource_spans, source)
+    end
+
     test "Creates params from a list with one Resource Span that contains an Event", %{
       resource_spans: resource_spans,
       source: source

--- a/test/logflare_grpc/trace/server_test.exs
+++ b/test/logflare_grpc/trace/server_test.exs
@@ -5,6 +5,11 @@ defmodule LogflareGrpc.Trace.ServerTest do
   alias Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
   alias Opentelemetry.Proto.Collector.Trace.V1.TraceService.Stub
   alias Logflare.SystemMetrics.AllLogsLogged
+  require OpenTelemetry.Tracer
+
+  require Record
+  @fields Record.extract(:span_ctx, from_lib: "opentelemetry_api/include/opentelemetry.hrl")
+  Record.defrecordp(:span_ctx, @fields)
 
   setup do
     insert(:plan)

--- a/test/logflare_grpc/trace/server_test.exs
+++ b/test/logflare_grpc/trace/server_test.exs
@@ -5,11 +5,6 @@ defmodule LogflareGrpc.Trace.ServerTest do
   alias Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
   alias Opentelemetry.Proto.Collector.Trace.V1.TraceService.Stub
   alias Logflare.SystemMetrics.AllLogsLogged
-  require OpenTelemetry.Tracer
-
-  require Record
-  @fields Record.extract(:span_ctx, from_lib: "opentelemetry_api/include/opentelemetry.hrl")
-  Record.defrecordp(:span_ctx, @fields)
 
   setup do
     insert(:plan)

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -144,7 +144,7 @@ defmodule LogflareWeb.LogControllerTest do
         |> post(Routes.log_path(conn, :otel_traces), body)
 
       assert json_response(conn, 200) == %{"message" => "Logged!"}
-      assert_receive {^ref, [event1, event2]}, 3000
+      assert_receive {^ref, [event1, event2]}, 4000
 
       assert event1["trace_id"] == event2["trace_id"]
       assert %{"metadata" => _, "event_message" => _} = event1

--- a/test/support/test_utils_grpc.ex
+++ b/test/support/test_utils_grpc.ex
@@ -3,6 +3,7 @@ defmodule Logflare.TestUtilsGrpc do
 
   alias Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest
   alias Opentelemetry.Proto.Common.V1.AnyValue
+  alias Opentelemetry.Proto.Common.V1.ArrayValue
   alias Opentelemetry.Proto.Common.V1.InstrumentationScope
   alias Opentelemetry.Proto.Common.V1.KeyValue
   alias Opentelemetry.Proto.Resource.V1.Resource
@@ -10,6 +11,7 @@ defmodule Logflare.TestUtilsGrpc do
   alias Opentelemetry.Proto.Trace.V1.Span
   alias Opentelemetry.Proto.Trace.V1.Span.Event
   alias Opentelemetry.Proto.Trace.V1.ResourceSpans
+  alias Opentelemetry.Proto.Common.V1.KeyValueList
 
   @doc """
   Generates a ExportTraceServiceRequest message which contains a Span and an Event in it
@@ -75,8 +77,90 @@ defmodule Logflare.TestUtilsGrpc do
     boolean = random_key_value(:boolean)
     integer = random_key_value(:integer)
     double = random_key_value(:double)
+    array_of_strings = random_key_value(:array_of_strings)
+    array_of_numbers = random_key_value(:array_of_numbers)
+    array_of_booleans = random_key_value(:array_of_booleans)
 
-    [string, boolean, integer, double]
+    [
+      string,
+      boolean,
+      integer,
+      double,
+      array_of_strings,
+      array_of_numbers,
+      array_of_booleans
+    ]
+  end
+
+  # this is not supported by traces/metrics, only logs
+  # https://github.com/open-telemetry/opentelemetry-specification/pull/2888
+  # https://github.com/open-telemetry/opentelemetry-specification/issues/376
+  defp random_key_value(:array_of_kv) do
+    %KeyValue{
+      key: "random_array_#{TestUtils.random_string()}",
+      value: %AnyValue{
+        value:
+          {:kvlist_value,
+           %KeyValueList{
+             values: [
+               random_key_value(:string),
+               random_key_value(:boolean),
+               random_key_value(:integer),
+               random_key_value(:double)
+             ]
+           }}
+      }
+    }
+  end
+
+  defp random_key_value(:array_of_strings) do
+    %KeyValue{
+      key: "random_array_#{TestUtils.random_string()}",
+      value: %AnyValue{
+        value:
+          {:array_value,
+           %ArrayValue{
+             values: [
+               random_key_value(:string).value,
+               random_key_value(:string).value,
+               random_key_value(:string).value
+             ]
+           }}
+      }
+    }
+  end
+
+  defp random_key_value(:array_of_booleans) do
+    %KeyValue{
+      key: "random_array_#{TestUtils.random_string()}",
+      value: %AnyValue{
+        value:
+          {:array_value,
+           %ArrayValue{
+             values: [
+               random_key_value(:boolean).value,
+               random_key_value(:boolean).value,
+               random_key_value(:boolean).value
+             ]
+           }}
+      }
+    }
+  end
+
+  defp random_key_value(:array_of_numbers) do
+    %KeyValue{
+      key: "random_array_#{TestUtils.random_string()}",
+      value: %AnyValue{
+        value:
+          {:array_value,
+           %ArrayValue{
+             values: [
+               random_key_value(:double).value,
+               random_key_value(:integer).value
+             ]
+           }}
+      }
+    }
   end
 
   defp random_key_value(:string) do

--- a/test/support/test_utils_grpc.ex
+++ b/test/support/test_utils_grpc.ex
@@ -28,8 +28,10 @@ defmodule Logflare.TestUtilsGrpc do
   def random_resource_span do
     [
       %ResourceSpans{
-        resource: %Resource{},
-        scope_spans: random_scope_span()
+        resource: %Resource{
+          attributes: random_attributes()
+        },
+        scope_spans: [random_scope_span()]
       }
     ]
   end
@@ -46,7 +48,7 @@ defmodule Logflare.TestUtilsGrpc do
       spans: random_span()
     }
 
-    [scope_spans]
+    scope_spans
   end
 
   defp random_span do
@@ -58,7 +60,8 @@ defmodule Logflare.TestUtilsGrpc do
         trace_id: :crypto.strong_rand_bytes(16),
         start_time_unix_nano: DateTime.utc_now() |> DateTime.to_unix(:nanosecond),
         end_time_unix_nano: DateTime.utc_now() |> DateTime.to_unix(:nanosecond),
-        events: random_event()
+        events: random_event(),
+        attributes: random_attributes()
       }
     ]
   end
@@ -78,8 +81,9 @@ defmodule Logflare.TestUtilsGrpc do
     integer = random_key_value(:integer)
     double = random_key_value(:double)
     array_of_strings = random_key_value(:array_of_strings)
-    array_of_numbers = random_key_value(:array_of_numbers)
     array_of_booleans = random_key_value(:array_of_booleans)
+    array_of_integers = random_key_value(:array_of_integers)
+    array_of_doubles = random_key_value(:array_of_doubles)
 
     [
       string,
@@ -87,8 +91,9 @@ defmodule Logflare.TestUtilsGrpc do
       integer,
       double,
       array_of_strings,
-      array_of_numbers,
-      array_of_booleans
+      array_of_booleans,
+      array_of_integers,
+      array_of_doubles
     ]
   end
 
@@ -147,7 +152,7 @@ defmodule Logflare.TestUtilsGrpc do
     }
   end
 
-  defp random_key_value(:array_of_numbers) do
+  defp random_key_value(:array_of_doubles) do
     %KeyValue{
       key: "random_array_#{TestUtils.random_string()}",
       value: %AnyValue{
@@ -156,6 +161,22 @@ defmodule Logflare.TestUtilsGrpc do
            %ArrayValue{
              values: [
                random_key_value(:double).value,
+               random_key_value(:double).value
+             ]
+           }}
+      }
+    }
+  end
+
+  defp random_key_value(:array_of_integers) do
+    %KeyValue{
+      key: "random_array_#{TestUtils.random_string()}",
+      value: %AnyValue{
+        value:
+          {:array_value,
+           %ArrayValue{
+             values: [
+               random_key_value(:integer).value,
                random_key_value(:integer).value
              ]
            }}


### PR DESCRIPTION
This PR adds support for otel array attributes, as needed by storage team.

<img width="553" alt="Screenshot 2025-05-12 at 6 58 36 PM" src="https://github.com/user-attachments/assets/3db8fa42-d4f3-4053-98b5-9c4b62cfd747" />
