### PR TITLE
Initial ClickHouse Log Drain Functionality

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -1,0 +1,167 @@
+defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
+  @moduledoc """
+  ClickHouse backend adaptor
+
+  ### Table Creation
+
+  Currently this adaptor expects a table to be created with the following schema.
+
+  Adjust the database / table names as needed.
+
+  ```sql
+  CREATE TABLE "default"."supabase_log_ingress" (
+      "id" UUID,
+      "event_message" String,
+      "metadata" String,
+      "service" String,
+      "timestamp" DateTime64(6)
+  )
+  ENGINE MergeTree()
+  ORDER BY ("timestamp")
+  SETTINGS index_granularity = 8192 SETTINGS flatten_nested=0
+  ```
+  """
+
+  use TypedStruct
+
+  alias Ecto.Changeset
+  alias Logflare.Backends.Adaptor.WebhookAdaptor
+
+  typedstruct enforce: true do
+    field(:url, String.t())
+    field(:username, String.t())
+    field(:password, String.t())
+    field(:database, String.t(), default: "default")
+    field(:table, String.t())
+    field(:port, non_neg_integer(), default: 8443)
+  end
+
+  @behaviour Logflare.Backends.Adaptor
+
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def start_link({source, backend}) do
+    backend = %{backend | config: transform_config(backend.config)}
+    WebhookAdaptor.start_link({source, backend})
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def transform_config(config) do
+    headers =
+      %{
+        "X-ClickHouse-Database" => config.database,
+        "X-ClickHouse-User" => config.username,
+        "X-ClickHouse-Key" => config.password
+      }
+
+    # Likely want to handle failures here if the URL is trash
+    uri =
+      case URI.new(config.url) do
+        {:ok, %URI{port: port} = uri_temp} when port in 80..443 ->
+          %URI{uri_temp | port: config.port}
+
+        {:ok, %URI{} = uri_temp} ->
+          uri_temp
+
+        _ ->
+          nil
+      end
+
+    # Generate the insert query we'll append to the URL
+    insert_query =
+      URI.encode_query(
+        %{
+          "query" => "INSERT INTO #{config.table} FORMAT JSONEachRow"
+        },
+        :rfc3986
+      )
+
+    updated_url =
+      URI.append_query(uri, insert_query)
+      |> URI.to_string()
+
+    %{
+      url: updated_url,
+      database: config.database,
+      table: config.table,
+      port: config.port,
+      headers: headers,
+      http: "http2",
+      gzip: true
+    }
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def pre_ingest(_source, _backend, log_events) do
+    Enum.map(log_events, &translate_event/1)
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def execute_query(_ident, _query), do: {:error, :not_implemented}
+
+  @impl Logflare.Backends.Adaptor
+  def cast_config(params) do
+    {%{},
+     %{
+       url: :string,
+       username: :string,
+       password: :string,
+       database: :string,
+       table: :string,
+       port: :integer
+     }}
+    |> Changeset.cast(params, [
+      :url,
+      :username,
+      :password,
+      :database,
+      :table,
+      :port
+    ])
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def validate_config(changeset) do
+    import Ecto.Changeset
+
+    changeset
+    |> validate_required([:url, :database, :table, :port])
+    |> Changeset.validate_format(:url, ~r/https?\:\/\/.+/)
+    |> validate_user_pass()
+  end
+
+  defp validate_user_pass(changeset) do
+    user = Changeset.get_field(changeset, :username)
+    pass = Changeset.get_field(changeset, :password)
+    user_pass = [user, pass]
+
+    if user_pass != [nil, nil] and Enum.any?(user_pass, &is_nil/1) do
+      msg = "Both username and password must be provided for auth"
+
+      changeset
+      |> Changeset.add_error(:username, msg)
+      |> Changeset.add_error(:password, msg)
+    else
+      changeset
+    end
+  end
+
+  defp translate_event(%Logflare.LogEvent{} = le) do
+    %Logflare.LogEvent{
+      le
+      | body: %{
+          "id" => le.id,
+          "event_message" => le.body["message"] || le.body["event_message"] || "",
+          "metadata" => le.body["metadata"],
+          "service" => le.source.service_name || le.source.name,
+          "timestamp" => le.body["timestamp"]
+        }
+    }
+  end
+end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -156,9 +156,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       %{config: stored_config, metadata: backend_metadata} =
         Backends.Cache.get_backend(context.backend_id)
 
-      # This was changed to treat the `startup_config` as the source-of-truth
       config =
-        merge_configs(stored_config, startup_config)
+        merge_configs(startup_config, stored_config)
 
       backend_meta =
         for {k, v} <- backend_metadata || %{testing: 123}, into: %{} do
@@ -166,7 +165,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
         end
 
       Client.send(
-        url: config.url,
+        # if a `url_override` key is available in the merged config, use that before falling back to `url`
+        url: Map.get(config, :url_override, config.url),
         body: payload,
         headers: config[:headers] || %{},
         gzip: Map.get(config, :gzip, true),

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -156,8 +156,9 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       %{config: stored_config, metadata: backend_metadata} =
         Backends.Cache.get_backend(context.backend_id)
 
+      # This was changed to treat the `startup_config` as the source-of-truth
       config =
-        merge_configs(startup_config, stored_config)
+        merge_configs(stored_config, startup_config)
 
       backend_meta =
         for {k, v} <- backend_metadata || %{testing: 123}, into: %{} do

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -16,7 +16,8 @@ defmodule Logflare.Backends.Backend do
     datadog: Adaptor.DatadogAdaptor,
     postgres: Adaptor.PostgresAdaptor,
     bigquery: Adaptor.BigQueryAdaptor,
-    loki: Adaptor.LokiAdaptor
+    loki: Adaptor.LokiAdaptor,
+    clickhouse: Adaptor.ClickhouseAdaptor
   }
 
   typed_schema "backends" do

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -186,7 +186,7 @@
             <%= label(f_config, :url, "ClickHouse URL") %>
             <%= text_input(f_config, :url, class: "form-control") %>
             <small class="form-text text-muted">
-              The ClickHouse HTTP(S) endpoint to send events.
+              Provide the ClickHouse hostname URL with the following format, for example: <code>https://hostname</code>
             </small>
           </div>
           <div class="form-group">
@@ -200,9 +200,9 @@
           </div>
           <div class="form-group">
             <%= label(f_config, :database, "Database Name") %>
-            <%= text_input(f_config, :database, class: "form-control") %>
+            <%= text_input(f_config, :database, class: "form-control", default: "default") %>
             <%= label(f_config, :table, "Table Name") %>
-            <%= text_input(f_config, :table, class: "form-control") %>
+            <%= text_input(f_config, :table, class: "form-control", default: "supabase_log_ingress") %>
             <small class="form-text text-muted">
               The database and table names within ClickHouse where events will be stored.
             </small>

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -31,7 +31,7 @@
   </div>
 
   <div :if={@live_action == :new}>
-    <%= select(f, :type, ["Select a backend type...", Webhook: :webhook, Postgres: :postgres, BigQuery: :bigquery, Datadog: :datadog, Elastic: :elastic, Loki: :loki],
+    <%= select(f, :type, ["Select a backend type...", Webhook: :webhook, Postgres: :postgres, BigQuery: :bigquery, Datadog: :datadog, Elastic: :elastic, Loki: :loki, ClickHouse: :clickhouse],
       phx_change: :change_form_type,
       class: "form-control form-control-margin",
       id: "type"
@@ -180,6 +180,39 @@
             <%= text_input(f_config, :header1_key, class: "form-control") %>
             <%= label(f_config, :header1_value, "Header 1 Value") %>
             <%= text_input(f_config, :header1_value, class: "form-control") %>
+          </div>
+        <% "clickhouse" -> %>
+          <div class="form-group">
+            <%= label(f_config, :url, "ClickHouse URL") %>
+            <%= text_input(f_config, :url, class: "form-control") %>
+            <small class="form-text text-muted">
+              The ClickHouse HTTP(S) endpoint to send events.
+            </small>
+          </div>
+          <div class="form-group">
+            <%= label(f_config, :username, "ClickHouse Username") %>
+            <%= text_input(f_config, :username, class: "form-control") %>
+            <%= label(f_config, :password, "ClickHouse Password") %>
+            <%= text_input(f_config, :password, class: "form-control", type: "password") %>
+            <small class="form-text text-muted">
+              Both username and password must be provided.
+            </small>
+          </div>
+          <div class="form-group">
+            <%= label(f_config, :database, "Database Name") %>
+            <%= text_input(f_config, :database, class: "form-control") %>
+            <%= label(f_config, :table, "Table Name") %>
+            <%= text_input(f_config, :table, class: "form-control") %>
+            <small class="form-text text-muted">
+              The database and table names within ClickHouse where events will be stored.
+            </small>
+          </div>
+          <div class="form-group">
+            <%= label(f_config, :port, "Port") %>
+            <%= text_input(f_config, :port, class: "form-control", default: 8443) %>
+            <small class="form-text text-muted">
+              The port number for the ClickHouse server.
+            </small>
           </div>
         <% _ -> %>
           <div>Select a Backend Type</div>

--- a/test/logflare/backends/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/clickhouse_adaptor_test.exs
@@ -1,0 +1,102 @@
+defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
+  use Logflare.DataCase, async: false
+
+  alias Logflare.Backends.Adaptor
+  alias Logflare.Backends
+  alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.SystemMetrics.AllLogsLogged
+
+  @subject Logflare.Backends.Adaptor.ClickhouseAdaptor
+  @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
+
+  doctest @subject
+
+  setup do
+    start_supervised!(AllLogsLogged)
+    :ok
+  end
+
+  describe "cast and validate" do
+    test "Username and Password are required" do
+      changeset = Adaptor.cast_and_validate_config(@subject, %{})
+
+      refute changeset.valid?
+
+      assert Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "http://localhost:1234",
+               "database" => "default",
+               "table" => "supabase_log_ingress",
+               "port" => 8443,
+               "username" => "foo",
+               "password" => "bar"
+             }).valid?
+
+      refute Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "foobarbaz",
+               "database" => "default",
+               "table" => "supabase_log_ingress",
+               "port" => 8443,
+               "username" => "foo",
+               "password" => "bar"
+             }).valid?
+
+      refute Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "http://localhost:1234",
+               "database" => "default",
+               "table" => "supabase_log_ingress",
+               "port" => nil,
+               "username" => "foo",
+               "password" => "bar"
+             }).valid?
+    end
+  end
+
+  describe "logs ingestion" do
+    setup do
+      insert(:plan)
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :clickhouse,
+          sources: [source],
+          config: %{
+            url: "http://localhost:1234",
+            database: "default",
+            table: "supabase_log_ingress",
+            port: 8443,
+            username: "foo",
+            password: "bar"
+          }
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+      :timer.sleep(500)
+      [backend: backend, source: source]
+    end
+
+    test "payload is a properly formatted log event", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      le = build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, [log_entry]}, 2000
+
+      assert is_map(log_entry)
+      assert log_entry["id"] == le.id
+      assert log_entry["event_message"] == "test-msg"
+      assert log_entry["timestamp"] == le.body["timestamp"]
+
+      assert is_map(log_entry["body"])
+    end
+  end
+end


### PR DESCRIPTION
Super simple/naive approach to doing some basic smoke testing on sinking logs into Clickhouse by fronting the existing webhook adaptor.

Includes just enough UI to configure a Clickhouse backend and some simple tests based off the Loki backend test.

Long-term, we'll want to rework this to be its own first-class adaptor that leverages something like [ch](https://hex.pm/packages/ch) under the hood.

I did have to introduce a _workaround_ for dynamically providing a URL to the webhook adaptor given that configs are merged within that adaptor at runtime - paving over the URL manipulation performed to inject the table name into the querystring. This will go away at a later time when we roll out a more robust implementation.

Worth noting that to use this backend, it does expect the table to exist in CH. See the module doc in the clickhouse adaptor for an example `CREATE TABLE` statement.