### PR TITLE
Clickhouse test improvement and moduledoc for backend webhook adaptor

### DIFF
--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -1,5 +1,17 @@
 defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
-  @moduledoc false
+  @moduledoc """
+  Backend adaptor for webhooks / HTTP posts.
+
+  A number of other adaptors (_ClickHouse, DataDog, Elastic, Loki, etc_) leverage this to handle the final HTTP transaction.
+
+  ### Dynamic URL handling with URL Override
+
+  This adaptor performs a merge on config that will prevent you from leveraging a dynamically generated URL configuration at runtime.
+  To bypass this behavior, you can use the optional `:url_override` attribute.
+
+  See the `Logflare.Backends.Adaptor.ClickhouseAdaptor` for an example that utilizes this.
+  """
+
   use GenServer
   use TypedStruct
 

--- a/test/logflare/backends/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/clickhouse_adaptor_test.exs
@@ -82,8 +82,12 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
 
       @client
       |> expect(:send, fn req ->
-        send(this, {ref, req[:body]})
-        %Tesla.Env{status: 200, body: ""}
+        expected_url = "http://localhost:8443?query=INSERT%20INTO%20supabase_log_ingress%20FORMAT%20JSONEachRow"
+
+        if req[:url] == expected_url do
+          send(this, {ref, req[:body]})
+          %Tesla.Env{status: 200, body: ""}
+        end
       end)
 
       le = build(:log_event, source: source)


### PR DESCRIPTION
Very minor changes to address notes in previous PR #2396 

### Dynamic URL assertion

Added static logic to assert the dynamic URL is built correctly and called to `Logflare.Backends.Adaptor.ClickhouseAdaptorTest`

Addresses https://github.com/Logflare/logflare/pull/2396#discussion_r2086275706


### Webhook adaptor moduledoc

Moduledoc added to `Logflare.Backends.Adaptor.WebhookAdaptor` with an explanation of the optional `:url_override` - _which should not live for that long_

Addresses https://github.com/Logflare/logflare/pull/2396#discussion_r2086276402