### PR TITLE
Connection pool workaround for the sake of Clickhouse cloud

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -266,7 +266,10 @@ defmodule Logflare.Application do
          ]
        }},
       {Finch,
-       name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}}
+       name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}},
+      {Finch,
+       name: Logflare.FinchClickhouse,
+       pools: %{default: [protocols: [:http1], size: 50, start_pool_metrics?: true]}}
     ]
   end
 

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -211,6 +211,7 @@ defmodule Logflare.Application do
       {Finch,
        name: Logflare.FinchIngest,
        pools: %{
+         :default => [size: 50],
          "https://bigquery.googleapis.com" => [
            protocols: [:http1],
            size: max(base * 125, 150),
@@ -266,10 +267,7 @@ defmodule Logflare.Application do
          ]
        }},
       {Finch,
-       name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}},
-      {Finch,
-       name: Logflare.FinchClickhouse,
-       pools: %{default: [protocols: [:http1], size: 50, start_pool_metrics?: true]}}
+       name: Logflare.FinchDefaultHttp1, pools: %{default: [protocols: [:http1], size: 50]}}
     ]
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -85,7 +85,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
     %{
       url: updated_url,
       url_override: updated_url,
-      pool_override: Logflare.FinchIngest,
+      pool_name: Logflare.FinchIngest,
       database: config.database,
       table: config.table,
       port: config.port,

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -85,11 +85,12 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
     %{
       url: updated_url,
       url_override: updated_url,
+      pool_override: Logflare.FinchClickhouse,
       database: config.database,
       table: config.table,
       port: config.port,
       headers: headers,
-      http: "http2",
+      http: "http1",
       gzip: true
     }
   end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -85,7 +85,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
     %{
       url: updated_url,
       url_override: updated_url,
-      pool_override: Logflare.FinchClickhouse,
+      pool_override: Logflare.FinchIngest,
       database: config.database,
       table: config.table,
       port: config.port,

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -86,17 +86,15 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       pool_name = Keyword.get(opts, :pool_name)
 
       adaptor =
-        if http_opt == "http1" do
-          {Tesla.Adapter.Finch, name: Logflare.FinchDefaultHttp1, receive_timeout: 5_000}
-        else
-          {Tesla.Adapter.Finch, name: Logflare.FinchDefault, receive_timeout: 5_000}
-        end
+        cond do
+          is_possible_pool(pool_name) ->
+            {Tesla.Adapter.Finch, name: pool_name, receive_timeout: 5_000}
 
-      adaptor =
-        if is_possible_pool(pool_override_opt) do
-          {Tesla.Adapter.Finch, name: pool_name, receive_timeout: 5_000}
-        else
-          adaptor
+          http_opt == "http2" ->
+            {Tesla.Adapter.Finch, name: Logflare.FinchDefault, receive_timeout: 5_000}
+
+          true ->
+            {Tesla.Adapter.Finch, name: Logflare.FinchDefaultHttp1, receive_timeout: 5_000}
         end
 
       opts =

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -83,7 +83,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
     def send(opts) do
       http_opt = Keyword.get(opts, :http)
-      pool_override_opt = Keyword.get(opts, :pool_override)
+      pool_name = Keyword.get(opts, :pool_name)
 
       adaptor =
         if http_opt == "http1" do

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -94,7 +94,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
       adaptor =
         if is_possible_pool(pool_override_opt) do
-          {Tesla.Adapter.Finch, name: pool_override_opt, receive_timeout: 5_000}
+          {Tesla.Adapter.Finch, name: pool_name, receive_timeout: 5_000}
         else
           adaptor
         end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -1,5 +1,24 @@
 defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
-  @moduledoc false
+  @moduledoc """
+  Backend adaptor for webhooks / HTTP posts.
+
+  A number of other adaptors (_ClickHouse, DataDog, Elastic, Loki, etc_) leverage this to handle the final HTTP transaction.
+
+  ### Finch Pool Selection
+
+  By default the pool will be selected automatically based on the `:http` configuration option.
+
+  If you want to manually select a specific Finch pool, you can use the `:pool_override` option and provide the module name.
+
+
+  ### Dynamic URL handling with URL Override
+
+  This adaptor performs a merge on config that will prevent you from leveraging a dynamically generated URL configuration at runtime.
+  To bypass this behavior, you can use the optional `:url_override` attribute.
+
+  See the `Logflare.Backends.Adaptor.ClickhouseAdaptor` for an example that utilizes this.
+  """
+
   use GenServer
   use TypedStruct
 

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -8,7 +8,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   By default the pool will be selected automatically based on the `:http` configuration option.
 
-  If you want to manually select a specific Finch pool, you can use the `:pool_override` option and provide the module name.
+  If you want to manually select a specific Finch pool, you can use the `:pool_name` option and provide the module name.
 
 
   ### Dynamic URL handling with URL Override

--- a/test/logflare/backends/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/clickhouse_adaptor_test.exs
@@ -82,13 +82,9 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
 
       @client
       |> expect(:send, fn req ->
-        expected_url =
-          "http://localhost:8443?query=INSERT%20INTO%20supabase_log_ingress%20FORMAT%20JSONEachRow"
-
-        if req[:url] == expected_url do
-          send(this, {ref, req[:body]})
-          %Tesla.Env{status: 200, body: ""}
-        end
+        assert req[:url] =~ ~r"localhost:8443.+query=INSERT.+EachRow"
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 200, body: ""}
       end)
 
       le = build(:log_event, source: source)

--- a/test/logflare/backends/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/clickhouse_adaptor_test.exs
@@ -82,8 +82,13 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
 
       @client
       |> expect(:send, fn req ->
-        send(this, {ref, req[:body]})
-        %Tesla.Env{status: 200, body: ""}
+        expected_url =
+          "http://localhost:8443?query=INSERT%20INTO%20supabase_log_ingress%20FORMAT%20JSONEachRow"
+
+        if req[:url] == expected_url do
+          send(this, {ref, req[:body]})
+          %Tesla.Env{status: 200, body: ""}
+        end
       end)
 
       le = build(:log_event, source: source)


### PR DESCRIPTION
The current implementation of the Clickhouse log drain relies on the existing `WebhookAdaptor` and the underlying Finch-based connection pooling.

Due to the way Clickhouse cloud URLs are with dynamic subdomain parts - this makes leveraging traditional Finch pooling a bit tricky without doing some sort of runtime management of pools since the pools are keyed by a `{<scheme>, <host>, <port>}` tuple.

Rather than deal with that extra complexity, this change simply defines a new pool dedicated to Clickhouse for now that is specified for use by leveraging a new config opts in the `WebhookAdaptor`.

Again, this should be temporary to push a bit harder on clickhouse logs draining until a deeper implementation with [`:ch`](https://hex.pm/packages/ch) is finished.