### PR TITLE
Redact backend config attributes from the show view

### DIFF
--- a/lib/logflare_web/live/backends/actions/show.html.heex
+++ b/lib/logflare_web/live/backends/actions/show.html.heex
@@ -17,7 +17,7 @@
       <li class="list-group-item">
         <strong>config:</strong>
         <pre>
-          <%= Jason.encode!(@backend.config, pretty: true) %>
+          <%= Jason.encode!(LogflareWeb.Live.DisplayHelpers.sanitize_backend_config(@backend.config), pretty: true) %>
         </pre>
       </li>
       <li :if={@backend.metadata} class="list-group-item tw-flex-col tw-gap-2 ">

--- a/lib/logflare_web/live/display_helpers.ex
+++ b/lib/logflare_web/live/display_helpers.ex
@@ -1,0 +1,19 @@
+defmodule LogflareWeb.Live.DisplayHelpers do
+  @moduledoc false
+
+  def sanitize_backend_config(%{} = config) do
+    allowed_keys = ~w(database hostname pool_size port project_id region schema table url)a
+
+    config
+    |> Enum.map(fn {key, value} ->
+      if key in allowed_keys do
+        {key, value}
+      else
+        {key, "**********"}
+      end
+    end)
+    |> Map.new()
+  end
+
+  def sanitize_backend_config(_config), do: %{}
+end

--- a/test/logflare_web/live/backends_live_test.exs
+++ b/test/logflare_web/live/backends_live_test.exs
@@ -39,6 +39,17 @@ defmodule LogflareWeb.BackendsLiveTest do
     assert html =~ "#{backend.type}"
   end
 
+  test "show redacts certain config attributes from display", %{
+    conn: conn,
+    user: user,
+    source: source
+  } do
+    backend = insert(:backend, sources: [source], user: user)
+    {:ok, view, _html} = live(conn, ~p"/backends/#{backend.id}")
+    html = render(view)
+    assert html =~ "&quot;dataset_id&quot;: &quot;**********&quot;"
+  end
+
   test "show with backend metadata", %{conn: conn, user: user, source: source} do
     backend =
       insert(:backend, sources: [source], user: user, metadata: %{some: "custom-metadata"})


### PR DESCRIPTION
As requested, this change adds a new helper module with a function that redacts the values of any attributes in a backend config that are not in the list of `allowed_keys`. This is done to better future proof the functionality rather than relying on a filter.

Includes a simple test to validate the behavior as well.