### PR TITLE
fix: update doc links and properly open external links

### DIFF
--- a/lib/logflare_web/core_components.ex
+++ b/lib/logflare_web/core_components.ex
@@ -76,10 +76,11 @@ defmodule LogflareWeb.CoreComponents do
   attr :to, :string
   attr :fa_icon, :string
   attr :live_patch, :boolean, default: false
+  attr :external, :boolean, default: false
 
   def subheader_link(assigns) do
     ~H"""
-    <.dynamic_link to={@to} patch={@live_patch} class="tw-text-black tw-p-1 tw-flex tw-gap-1 tw-items-center tw-justify-center">
+    <.dynamic_link to={@to} patch={@live_patch} external={@external} class="tw-text-black tw-p-1 tw-flex tw-gap-1 tw-items-center tw-justify-center">
       <i :if={@fa_icon} class={"inline-block h-3 w-3 fas fa-#{@fa_icon}"}></i><span> <%= @text %></span>
     </.dynamic_link>
     """
@@ -108,19 +109,28 @@ defmodule LogflareWeb.CoreComponents do
   attr :patch, :boolean
   attr :attrs, :global
   slot :inner_block, required: true
+  attr :external, :boolean, default: false
 
   defp dynamic_link(assigns) do
-    link_type =
-      if assigns.patch do
-        :patch
-      else
-        :navigate
-      end
+    if assigns.external do
+      ~H"""
+      <a href={@to} target="_blank" rel="noopener noreferrer" {@attrs}>
+        <%= render_slot(@inner_block) %>
+      </a>
+      """
+    else
+      link_type =
+        if assigns.patch do
+          :patch
+        else
+          :navigate
+        end
 
-    assigns = assign(assigns, :to, %{link_type => assigns.to})
+      assigns = assign(assigns, :to, %{link_type => assigns.to})
 
-    ~H"""
-    <.link {@to} {@attrs}><%= render_slot(@inner_block) %></.link>
-    """
+      ~H"""
+      <.link {@to} {@attrs}><%= render_slot(@inner_block) %></.link>
+      """
+    end
   end
 end

--- a/lib/logflare_web/live/access_tokens_live.ex
+++ b/lib/logflare_web/live/access_tokens_live.ex
@@ -12,7 +12,7 @@ defmodule LogflareWeb.AccessTokensLive do
       <:path>
         ~/accounts/<.subheader_path_link live_patch to={~p"/access-tokens"}>access tokens</.subheader_path_link>
       </:path>
-      <.subheader_link to="https://docs.logflare.app/concepts/access-tokens/" text="docs" fa_icon="book" />
+      <.subheader_link to="https://docs.logflare.app/concepts/access-tokens/" external={true} text="docs" fa_icon="book" />
     </.subheader>
 
     <section class="content container mx-auto tw-flex tw-flex-col w-full tw-gap-4">

--- a/lib/logflare_web/live/alerts/actions/edit.html.heex
+++ b/lib/logflare_web/live/alerts/actions/edit.html.heex
@@ -4,7 +4,7 @@
       <%= @alert.name %>
     </.subheader_path_link>/edit
   </:path>
-  <.subheader_link to="https://docs.logflare.app/concepts/alerts" text="docs" fa_icon="book" />
+  <.render_docs_link {assigns} />
 </.subheader>
 
 <section class="mx-auto container">

--- a/lib/logflare_web/live/alerts/actions/index.html.heex
+++ b/lib/logflare_web/live/alerts/actions/index.html.heex
@@ -14,7 +14,7 @@
   </p>
 
   <div class="tw-flex tw-gap-4 tw-items-center">
-    <a href="https://docs.logflare.app/concepts/alerts" target="_blank">Documentation</a>
+    <a href="https://docs.logflare.app/alerts" target="_blank">Documentation</a>
     <.link patch={~p"/alerts/new"}>
       <.button variant="primary">
         New alert

--- a/lib/logflare_web/live/alerts/alerts_live.ex
+++ b/lib/logflare_web/live/alerts/alerts_live.ex
@@ -20,7 +20,7 @@ defmodule LogflareWeb.AlertsLive do
 
   defp render_docs_link(assigns) do
     ~H"""
-    <.subheader_link to="https://docs.logflare.app/concepts/endpoints" text="docs" fa_icon="book" />
+    <.subheader_link to="https://docs.logflare.app/alerts" external={true} text="docs" fa_icon="book" />
     """
   end
 

--- a/lib/logflare_web/live/backends/actions/edit.html.heex
+++ b/lib/logflare_web/live/backends/actions/edit.html.heex
@@ -4,7 +4,7 @@
       <%= @backend.name %>
     </.subheader_path_link>/edit
   </:path>
-  <.subheader_link to="https://docs.logflare.app/concepts/backends" text="docs" fa_icon="book" />
+  <.subheader_link to="https://docs.logflare.app/backends" external={true} text="docs" fa_icon="book" />
 </.subheader>
 
 <section class="mx-auto container">

--- a/lib/logflare_web/live/backends/actions/index.html.heex
+++ b/lib/logflare_web/live/backends/actions/index.html.heex
@@ -11,7 +11,7 @@
   </p>
 
   <div class="tw-flex tw-gap-4 tw-items-center">
-    <a href="https://docs.logflare.app/concepts/backends" target="_blank">Documentation</a>
+    <a href="https://docs.logflare.app/backends" target="_blank">Documentation</a>
     <.link patch={~p"/backends/new"}>
       <.button variant="primary">
         New backend

--- a/lib/logflare_web/live/endpoints/actions/edit.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/edit.html.heex
@@ -4,7 +4,7 @@
       <%= @show_endpoint.name %>
     </.subheader_path_link>/edit
   </:path>
-  <.subheader_link to="https://docs.logflare.app/concepts/endpoints#crafting-a-query" text="docs" fa_icon="book" />
+  <.subheader_link to="https://docs.logflare.app/concepts/endpoints#crafting-a-query" external={true} text="docs" fa_icon="book" />
 </.subheader>
 
 <section class="mx-auto container">

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -21,7 +21,7 @@ defmodule LogflareWeb.EndpointsLive do
 
   defp render_docs_link(assigns) do
     ~H"""
-    <.subheader_link to="https://docs.logflare.app/concepts/endpoints" text="docs" fa_icon="book" />
+    <.subheader_link to="https://docs.logflare.app/concepts/endpoints" external={true} text="docs" fa_icon="book" />
     """
   end
 


### PR DESCRIPTION
Fixed docs links that were pointing to pages that no longer exist or were moved.

Additionally, I noticed that `subheader_link` components that point to external URLs (docs) cause an error in the browser console because live view tries to call push state with the external URL. I added an `external` parameter to allow external links to be regular a tags to bypass live view, and added it to all `subheader_link` that point to external urls.