### PR TITLE
Dynamic suffix on all CH resources based on `source.token`

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -222,10 +222,10 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
   end
 
   @doc """
-  Produces a unique ingress table name for ClickHouse based on a provided `Source` struct.
+  Produces a unique ingest table name for ClickHouse based on a provided `Source` struct.
   """
-  @spec clickhouse_ingress_table_name(Source.t()) :: String.t()
-  def clickhouse_ingress_table_name(%Source{} = source) do
+  @spec clickhouse_ingest_table_name(Source.t()) :: String.t()
+  def clickhouse_ingest_table_name(%Source{} = source) do
     source
     |> clickhouse_source_token()
     |> then(&"log_events_#{&1}")
@@ -315,7 +315,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
           {:ok, Ch.Result.t()} | {:error, Exception.t()}
   def insert_log_events(conn_via, {%Source{} = source, _backend}, events)
       when is_via_tuple(conn_via) and is_list(events) do
-    table_name = clickhouse_ingress_table_name(source)
+    table_name = clickhouse_ingest_table_name(source)
 
     event_params =
       Enum.map(events, fn %LogEvent{} = log_event ->
@@ -352,7 +352,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
           {:ok, Ch.Result.t()} | {:error, Exception.t()}
   def provision_ingest_table({%Source{} = source, %Backend{}} = args) do
     with conn <- connection_via(args),
-         table_name <- clickhouse_ingress_table_name(source),
+         table_name <- clickhouse_ingest_table_name(source),
          statement <-
            QueryTemplates.create_log_ingest_table_statement(table_name,
              ttl_days: source.retention_days
@@ -382,7 +382,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
           {:ok, Ch.Result.t()} | {:error, Exception.t()}
   def provision_materialized_view({%Source{} = source, %Backend{}} = args) do
     with conn <- connection_via(args),
-         source_table_name <- clickhouse_ingress_table_name(source),
+         source_table_name <- clickhouse_ingest_table_name(source),
          view_name <- clickhouse_materialized_view_name(source),
          key_count_table_name <- clickhouse_key_count_table_name(source),
          statement <-

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -124,9 +124,21 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
         :ok
 
       {:ok, %Ch.Result{command: :check, rows: [[0]]}} ->
+        Logger.warning(
+          "ClickHouse GRANT check failed. Required: `CREATE TABLE`, `ALTER TABLE`, `INSERT`, `SELECT`, `DROP TABLE`, `CREATE VIEW`, `DROP VIEW`",
+          source_token: source.token,
+          backend_id: backend.id
+        )
+
         {:error, :permissions_missing}
 
       {:error, _} = error_result ->
+        Logger.warning(
+          "ClickHouse GRANT check failed. Unexpected error #{inspect(error_result)}",
+          source_token: source.token,
+          backend_id: backend.id
+        )
+
         error_result
     end
   end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -5,9 +5,22 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
 
   import Logflare.Utils.Guards
 
-  @default_key_type_counts_view_name "mv_key_type_counts_per_minute"
-  @default_key_type_counts_table_name "key_type_counts_per_minute"
   @default_ttl_days 3
+
+  @doc """
+  Default naming prefix for the log ingest table.
+  """
+  def default_table_name_prefix(), do: "log_events"
+
+  @doc """
+  Default naming prefix for the key type count materialized view.
+  """
+  def default_key_type_counts_view_prefix(), do: "mv_key_type_counts_per_min"
+
+  @doc """
+  Default naming prefix for the key type count table.
+  """
+  def default_key_type_counts_table_prefix(), do: "key_type_counts_per_min"
 
   @doc """
   Generates a ClickHouse query statement to check that the user GRANTs include the needed permissions.
@@ -103,19 +116,21 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
     table = Keyword.get(opts, :table)
     database = Keyword.get(opts, :database)
 
+    default_key_count_table_name = default_key_type_counts_table_prefix()
+
     db_table_string =
       cond do
         is_non_empty_binary(database) and is_non_empty_binary(table) ->
           "#{database}.#{table}"
 
         is_non_empty_binary(database) ->
-          "#{database}.#{@default_key_type_counts_table_name}"
+          "#{database}.#{default_key_count_table_name}"
 
         is_non_empty_binary(table) ->
           table
 
         true ->
-          @default_key_type_counts_table_name
+          default_key_count_table_name
       end
 
     """
@@ -150,19 +165,22 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
     view_name = Keyword.get(opts, :view_name)
     key_table = Keyword.get(opts, :key_table)
 
+    default_key_count_view_name = default_key_type_counts_view_prefix()
+    default_key_count_table_name = default_key_type_counts_table_prefix()
+
     db_view_name_string =
       cond do
         is_non_empty_binary(database) and is_non_empty_binary(view_name) ->
           "#{database}.#{view_name}"
 
         is_non_empty_binary(database) ->
-          "#{database}.#{@default_key_type_counts_view_name}"
+          "#{database}.#{default_key_count_view_name}"
 
         is_non_empty_binary(view_name) ->
           view_name
 
         true ->
-          @default_key_type_counts_view_name
+          default_key_count_view_name
       end
 
     db_key_table_string =
@@ -171,13 +189,13 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
           "#{database}.#{key_table}"
 
         is_non_empty_binary(database) ->
-          "#{database}.#{@default_key_type_counts_table_name}"
+          "#{database}.#{default_key_count_table_name}"
 
         is_non_empty_binary(key_table) ->
           key_table
 
         true ->
-          @default_key_type_counts_table_name
+          default_key_count_table_name
       end
 
     db_source_table_string =

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/query_templates_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/query_templates_test.exs
@@ -55,13 +55,13 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
     test "Generates a valid statement when provided with no options" do
       statement = QueryTemplates.create_key_type_counts_table_statement()
 
-      assert statement =~ "CREATE TABLE IF NOT EXISTS key_type_counts_per_minute"
+      assert statement =~ "CREATE TABLE IF NOT EXISTS key_type_counts_per_min"
     end
 
     test "Will produce a more verbose statement when the `database` option is provided" do
       statement = QueryTemplates.create_key_type_counts_table_statement(database: "foo")
 
-      assert statement =~ "CREATE TABLE IF NOT EXISTS foo.key_type_counts_per_minute"
+      assert statement =~ "CREATE TABLE IF NOT EXISTS foo.key_type_counts_per_min"
     end
 
     test "Allows the default table name to be changed when providing the `table` option" do
@@ -83,7 +83,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
       statement = QueryTemplates.create_materialized_view_statement("source_table_123")
 
       assert statement =~
-               "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_key_type_counts_per_minute TO key_type_counts_per_minute"
+               "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_key_type_counts_per_min TO key_type_counts_per_min"
 
       assert statement =~ "FROM source_table_123"
     end
@@ -93,7 +93,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
         QueryTemplates.create_materialized_view_statement("source_table_123", database: "bla")
 
       assert statement =~
-               "CREATE MATERIALIZED VIEW IF NOT EXISTS bla.mv_key_type_counts_per_minute TO bla.key_type_counts_per_minute"
+               "CREATE MATERIALIZED VIEW IF NOT EXISTS bla.mv_key_type_counts_per_min TO bla.key_type_counts_per_min"
 
       assert statement =~ "FROM bla.source_table_123"
     end
@@ -105,7 +105,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
         )
 
       assert statement =~
-               "CREATE MATERIALIZED VIEW IF NOT EXISTS some_view_name TO key_type_counts_per_minute"
+               "CREATE MATERIALIZED VIEW IF NOT EXISTS some_view_name TO key_type_counts_per_min"
 
       assert statement =~ "FROM source_table_321"
     end
@@ -117,7 +117,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
         )
 
       assert statement =~
-               "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_key_type_counts_per_minute TO other_key_table_name"
+               "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_key_type_counts_per_min TO other_key_table_name"
 
       assert statement =~ "FROM source_table_456"
     end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -1,7 +1,90 @@
 defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
   use Logflare.DataCase, async: false
 
-  @subject Logflare.Backends.Adaptor.ClickhouseAdaptor
+  alias Logflare.Backends.Adaptor.ClickhouseAdaptor
+  alias Logflare.Source
 
-  doctest @subject
+  doctest ClickhouseAdaptor
+
+  describe "table name generation" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      stringified_source_token =
+        source.token
+        |> Atom.to_string()
+        |> String.replace("-", "_")
+
+      [source: source, stringified_source_token: stringified_source_token]
+    end
+
+    test "clickhouse_ingest_table_name/1 generates a unique log ingest table name based on the source token",
+         %{source: source, stringified_source_token: stringified_source_token} do
+      assert ClickhouseAdaptor.clickhouse_ingest_table_name(source) ==
+               "log_events_#{stringified_source_token}"
+    end
+
+    test "clickhouse_ingest_table_name/1 will raise an exception if the table name is equal to or exceeds 200 chars",
+         %{source: source} do
+      assert_raise RuntimeError,
+                   ~r/^The dynamically generated ClickHouse resource name starting with `log_events_/,
+                   fn ->
+                     source
+                     |> modify_source_with_long_token()
+                     |> ClickhouseAdaptor.clickhouse_ingest_table_name()
+                   end
+    end
+
+    test "clickhouse_key_count_table_name/1 generates a unique key count table name based on the source token",
+         %{source: source, stringified_source_token: stringified_source_token} do
+      assert ClickhouseAdaptor.clickhouse_key_count_table_name(source) ==
+               "key_type_counts_per_min_#{stringified_source_token}"
+    end
+
+    test "clickhouse_key_count_table_name/1 will raise an exception if the table name is equal to or exceeds 200 chars",
+         %{source: source} do
+      assert_raise RuntimeError,
+                   ~r/^The dynamically generated ClickHouse resource name starting with `key_type_counts_per_min_/,
+                   fn ->
+                     source
+                     |> modify_source_with_long_token()
+                     |> ClickhouseAdaptor.clickhouse_key_count_table_name()
+                   end
+    end
+
+    test "clickhouse_materialized_view_name/1 generates a unique mat view name based on the source token",
+         %{source: source, stringified_source_token: stringified_source_token} do
+      assert ClickhouseAdaptor.clickhouse_materialized_view_name(source) ==
+               "mv_key_type_counts_per_min_#{stringified_source_token}"
+    end
+
+    test "clickhouse_materialized_view_name/1 will raise an exception if the view name is equal to or exceeds 200 chars",
+         %{source: source} do
+      assert_raise RuntimeError,
+                   ~r/^The dynamically generated ClickHouse resource name starting with `mv_key_type_counts_per_min_/,
+                   fn ->
+                     source
+                     |> modify_source_with_long_token()
+                     |> ClickhouseAdaptor.clickhouse_materialized_view_name()
+                   end
+    end
+  end
+
+  defp modify_source_with_long_token(%Source{} = source) do
+    long_token = random_string(200) |> String.to_atom()
+
+    %Source{
+      source
+      | token: long_token
+    }
+  end
+
+  defp random_string(length) do
+    alphanumeric = Enum.concat([?0..?9, ?a..?z])
+
+    1..length
+    |> Enum.map(fn _ -> Enum.random(alphanumeric) end)
+    |> List.to_string()
+  end
 end


### PR DESCRIPTION
Minor change to create both the key counts table and materialized view with a dynamic suffix based on the `source.token` the same as the log ingress table.

Generated resource names (tables, views, etc) are also checked to ensure their length is in a 'safe' area.

![image](https://github.com/user-attachments/assets/63ee1519-8d72-4b8a-8470-12e1c1b1f122)

This also adds improved logger messages when a GRANT check fails.