### PR TITLE
Remove `ClickHouse Web` from backend selection dropdown

### DIFF
--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -31,7 +31,7 @@
   </div>
 
   <div :if={@live_action == :new}>
-    <%= select(f, :type, ["Select a backend type...", Webhook: :webhook, Postgres: :postgres, BigQuery: :bigquery, Datadog: :datadog, Elastic: :elastic, Loki: :loki, ClickHouse: :clickhouse, ClickHouseWeb: :clickhouse_webhook],
+    <%= select(f, :type, ["Select a backend type...", Webhook: :webhook, Postgres: :postgres, BigQuery: :bigquery, Datadog: :datadog, Elastic: :elastic, Loki: :loki, ClickHouse: :clickhouse],
       phx_change: :change_form_type,
       class: "form-control form-control-margin",
       id: "type"


### PR DESCRIPTION
I noticed the old ClickHouse webhook adaptor was still lingering in the dropdown when configuring a new backend from earlier parallel testing.

This removes that option.