### PR TITLE
feat: export all metrics through otel

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -70,7 +70,9 @@ defmodule Logflare.Telemetry do
 
     database_metrics = [
       distribution("logflare.repo.query.total_time", unit: {:native, :millisecond}),
-      distribution("logflare.repo.query.decode_time", unit: {:native, :millisecond}),
+      # TODO: decode_time is `nil` in some of the ecto queries
+      # In most telemetry adapters this is fine, but it causes issues in OtelMetricExporter
+      # distribution("logflare.repo.query.decode_time", unit: {:native, :millisecond}),
       distribution("logflare.repo.query.query_time", unit: {:native, :millisecond}),
       distribution("logflare.repo.query.queue_time", unit: {:native, :millisecond}),
       distribution("logflare.repo.query.idle_time", unit: {:native, :millisecond})

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -190,6 +190,6 @@ defmodule Logflare.Telemetry do
   end
 
   defp batch_size_reporter_opts do
-    [buckets: [0, 5, 10, 25, 50, 100, 150, 250, 350, 1000]]
+    [buckets: [0, 1, 5, 10, 50, 100, 150, 250, 500, 1000, 2000]]
   end
 end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -117,11 +117,11 @@ defmodule Logflare.Telemetry do
       ),
       distribution("logflare.ingest.pipeline.handle_batch.batch_size",
         tags: [:pipeline],
-        reporter_opts: batch_size_buckets()
+        reporter_opts: batch_size_reporter_opts()
       ),
       distribution("logflare.ingest.common_pipeline.handle_batch.batch_size",
         tags: [:pipeline],
-        reporter_opts: batch_size_buckets()
+        reporter_opts: batch_size_reporter_opts()
       ),
       counter("logflare.context_cache.busted.count", tags: [:schema, :table]),
       counter("logflare.context_cache.handle_record.count", tags: [:schema, :table]),


### PR DESCRIPTION
This is a follow up to #2412, and is dependent on it working well. Instead of exporting a selected subset of metrics, we export all of them.

A bunch of metrics had to be converted from summaries to distributions, since the exporter doesn't support summaries (and distributions are generally better anyway). Some of them had wrong types (e.g.: we probably aren't interested in a distribution of memory but in the last value available).