### PR TITLE
fix(otel): split scope and resource; project name

### DIFF
--- a/lib/logflare/logs/otel.ex
+++ b/lib/logflare/logs/otel.ex
@@ -16,6 +16,10 @@ defmodule Logflare.Logs.Otel do
     end)
   end
 
+  def resource_project(handled_resource) do
+    handled_resource["service"]["name"]
+  end
+
   def handle_scope(scope) do
     %{name: name, version: version, attributes: scope_attributes} = scope
 

--- a/lib/logflare/logs/otel.ex
+++ b/lib/logflare/logs/otel.ex
@@ -6,7 +6,20 @@ defmodule Logflare.Logs.Otel do
   alias Opentelemetry.Proto.Common.V1.KeyValue
   alias Opentelemetry.Proto.Common.V1.AnyValue
   alias Opentelemetry.Proto.Common.V1.ArrayValue
+  alias Opentelemetry.Proto.Common.V1.InstrumentationScope
+  alias Opentelemetry.Proto.Resource.V1.Resource
 
+  @doc """
+  Converts a Resource struct into a map
+
+  Keys with dot notation are converted into nested maps.
+
+  ### Examples
+
+      iex> handle_resource(%Resource{attributes: [%KeyValue{key: "service.name", value: "foo"}]})
+      %{"service" => %{"name" => "foo"}}
+  """
+  @spec handle_resource(Resource.t()) :: map()
   def handle_resource(%{attributes: attributes}) do
     Enum.reduce(attributes, %{}, fn attribute, acc ->
       {k, v} = extract_key_value(attribute)
@@ -16,10 +29,19 @@ defmodule Logflare.Logs.Otel do
     end)
   end
 
-  def resource_project(handled_resource) do
+  @doc """
+  Extracts the project name from the *handled* resource
+
+  By convention, that's the service name.
+  """
+  def resource_project(handled_resource) when is_non_struct_map(handled_resource) do
     handled_resource["service"]["name"]
   end
 
+  @doc """
+  Converts a InstrumentationScope to a map
+  """
+  @spec handle_scope(InstrumentationScope.t()) :: map()
   def handle_scope(scope) do
     %{name: name, version: version, attributes: scope_attributes} = scope
 
@@ -30,6 +52,10 @@ defmodule Logflare.Logs.Otel do
     }
   end
 
+  @doc """
+  Transforms a KeyValue struct into a tuple
+  """
+  @spec extract_key_value(KeyValue.t()) :: {String.t(), term()}
   def extract_key_value(%KeyValue{key: key, value: nil}), do: {key, nil}
 
   def extract_key_value(%KeyValue{
@@ -39,6 +65,26 @@ defmodule Logflare.Logs.Otel do
     {key, extract_value(value)}
   end
 
+  @doc """
+  Transforms AnyValue into simple elixir terms
+
+  ### Examples
+
+      iex> extract_value(%AnyValue{value: {:string_value, "foo"}})
+      "foo"
+
+      iex> extract_value(
+      ...>   %AnyValue{value: {:array_value, %ArrayValue{values: [
+      ...>     %AnyValue{value: {:string_value, "foo"}},
+      ...>     %AnyValue{value: {:double_value, 0.3}},
+      ...>   ]}}}
+      ...> )
+      ["foo", 0.3]
+
+      iex> extract_value(123)
+      123
+  """
+  @spec extract_value(AnyValue.t() | nil | term()) :: term()
   def extract_value(%AnyValue{value: {:array_value, %ArrayValue{values: values}}}) do
     Enum.map(values, &extract_value/1)
   end
@@ -47,10 +93,18 @@ defmodule Logflare.Logs.Otel do
   def extract_value(nil), do: nil
   def extract_value(value), do: value
 
+  @doc """
+  Transforms a list of KeyValue into a map
+  """
+  @spec handle_attributes([KeyValue.t()]) :: map()
   def handle_attributes(attributes) do
     Map.new(attributes, &extract_key_value/1)
   end
 
+  @doc """
+  Transforms a nanoseconds from unix timestamp into an iso8601 string
+  """
+  @spec nano_to_iso8601(integer()) :: String.t()
   def nano_to_iso8601(time_nano) do
     time_nano
     |> DateTime.from_unix!(:nanosecond)

--- a/lib/logflare/logs/otel.ex
+++ b/lib/logflare/logs/otel.ex
@@ -16,12 +16,14 @@ defmodule Logflare.Logs.Otel do
     end)
   end
 
-  def merge_scope_attributes(resource, scope) do
+  def handle_scope(scope) do
     %{name: name, version: version, attributes: scope_attributes} = scope
 
-    resource
-    |> Map.merge(%{"name" => name, "version" => version})
-    |> Map.merge(handle_attributes(scope_attributes))
+    %{
+      "name" => name,
+      "version" => version,
+      "attributes" => handle_attributes(scope_attributes)
+    }
   end
 
   def extract_key_value(%KeyValue{key: key, value: nil}), do: {key, nil}

--- a/lib/logflare/logs/otel_metric.ex
+++ b/lib/logflare/logs/otel_metric.ex
@@ -49,7 +49,7 @@ defmodule Logflare.Logs.OtelMetric do
       "metadata" => metadata,
       "scope" => scope,
       "resource" => resource,
-      "project" => resource["name"]
+      "project" => Otel.resource_project(resource)
     }
 
     handle_metric_data(metric.data, base)

--- a/lib/logflare/logs/otel_metric.ex
+++ b/lib/logflare/logs/otel_metric.ex
@@ -32,31 +32,31 @@ defmodule Logflare.Logs.OtelMetric do
 
   defp handle_resource_metrics(%ResourceMetrics{resource: resource, scope_metrics: scope_metrics}) do
     resource = Otel.handle_resource(resource)
-
-    scope_metrics
-    |> Enum.map(&handle_scope_metric(&1, resource))
-    |> List.flatten()
+    Enum.map(scope_metrics, &handle_scope_metric(&1, resource))
   end
 
   defp handle_scope_metric(%ScopeMetrics{scope: scope, metrics: metrics}, resource) do
-    resource = Otel.merge_scope_attributes(resource, scope)
-    Enum.map(metrics, &handle_metric(&1, resource))
+    scope = Otel.handle_scope(scope)
+    Enum.map(metrics, &handle_metric(&1, resource, scope))
   end
 
-  defp handle_metric(%Metric{} = metric, resource) do
+  defp handle_metric(%Metric{} = metric, resource, scope) do
     metadata = %{"type" => "metric"}
-    metadata = Map.merge(metadata, resource)
-    handle_metric_data(metric.data, metric, metadata)
-  end
 
-  defp handle_metric_data({:gauge, %{data_points: data_points}}, metric, metadata) do
     base = %{
-      "metric_type" => "gauge",
       "event_message" => metric.name,
       "unit" => metric.unit,
       "metadata" => metadata,
-      "project" => metadata["name"]
+      "scope" => scope,
+      "resource" => resource,
+      "project" => resource["name"]
     }
+
+    handle_metric_data(metric.data, base)
+  end
+
+  defp handle_metric_data({:gauge, %{data_points: data_points}}, base) do
+    base = Map.merge(base, %{"metric_type" => "gauge"})
 
     Enum.map(data_points, fn data_point ->
       %{value: {_, value}} = data_point
@@ -70,16 +70,13 @@ defmodule Logflare.Logs.OtelMetric do
     end)
   end
 
-  defp handle_metric_data({:sum, sum}, metric, metadata) do
-    base = %{
-      "metric_type" => "sum",
-      "event_message" => metric.name,
-      "unit" => metric.unit,
-      "metadata" => metadata,
-      "aggregation_temporality" => aggregation_temporality(sum.aggregation_temporality),
-      "is_monotonic" => sum.is_monotonic,
-      "project" => metadata["name"]
-    }
+  defp handle_metric_data({:sum, sum}, base) do
+    base =
+      Map.merge(base, %{
+        "metric_type" => "sum",
+        "aggregation_temporality" => aggregation_temporality(sum.aggregation_temporality),
+        "is_monotonic" => sum.is_monotonic
+      })
 
     Enum.map(sum.data_points, fn data_point ->
       %{value: {_, value}} = data_point
@@ -93,15 +90,12 @@ defmodule Logflare.Logs.OtelMetric do
     end)
   end
 
-  defp handle_metric_data({:histogram, histogram}, metric, metadata) do
-    base = %{
-      "metric_type" => "histogram",
-      "event_message" => metric.name,
-      "unit" => metric.unit,
-      "metadata" => metadata,
-      "aggregation_temporality" => aggregation_temporality(histogram.aggregation_temporality),
-      "project" => metadata["name"]
-    }
+  defp handle_metric_data({:histogram, histogram}, base) do
+    base =
+      Map.merge(base, %{
+        "metric_type" => "histogram",
+        "aggregation_temporality" => aggregation_temporality(histogram.aggregation_temporality)
+      })
 
     Enum.map(histogram.data_points, fn data_point ->
       Map.merge(base, %{
@@ -118,15 +112,12 @@ defmodule Logflare.Logs.OtelMetric do
     end)
   end
 
-  defp handle_metric_data({:exponential_histogram, histogram}, metric, metadata) do
-    base = %{
-      "metric_type" => "exponential_histogram",
-      "event_message" => metric.name,
-      "unit" => metric.unit,
-      "metadata" => metadata,
-      "aggregation_temporality" => aggregation_temporality(histogram.aggregation_temporality),
-      "project" => metadata["name"]
-    }
+  defp handle_metric_data({:exponential_histogram, histogram}, base) do
+    base =
+      Map.merge(base, %{
+        "metric_type" => "exponential_histogram",
+        "aggregation_temporality" => aggregation_temporality(histogram.aggregation_temporality)
+      })
 
     Enum.map(histogram.data_points, fn data_point ->
       Map.merge(base, %{
@@ -146,7 +137,7 @@ defmodule Logflare.Logs.OtelMetric do
     end)
   end
 
-  defp handle_metric_data({type, _}, _, _) do
+  defp handle_metric_data({type, _}, _) do
     Logger.warning("Unsupported metric type #{inspect(type)}, dropping")
 
     []

--- a/lib/logflare/logs/otel_trace.ex
+++ b/lib/logflare/logs/otel_trace.ex
@@ -51,7 +51,7 @@ defmodule Logflare.Logs.OtelTrace do
         "end_time" => Otel.nano_to_iso8601(span.end_time_unix_nano),
         "attributes" => Otel.handle_attributes(span.attributes),
         "timestamp" => start_time,
-        "project" => resource["name"]
+        "project" => Otel.resource_project(resource)
       }
     ] ++ events
   end
@@ -68,7 +68,7 @@ defmodule Logflare.Logs.OtelTrace do
       "trace_id" => Ecto.UUID.cast!(trace_id),
       "attributes" => Otel.handle_attributes(event.attributes),
       "timestamp" => Otel.nano_to_iso8601(event.time_unix_nano),
-      "project" => resource["name"]
+      "project" => Otel.resource_project(resource)
     }
   end
 end

--- a/lib/logflare/logs/otel_trace.ex
+++ b/lib/logflare/logs/otel_trace.ex
@@ -18,33 +18,32 @@ defmodule Logflare.Logs.OtelTrace do
   @behaviour Logflare.Logs.Processor
 
   def handle_batch(resource_spans, _source) when is_list(resource_spans) do
-    Enum.map(resource_spans, &handle_event/1)
+    resource_spans
+    |> Enum.map(&handle_resource_span/1)
     |> List.flatten()
   end
 
-  defp handle_event(%ResourceSpans{resource: resource, scope_spans: scope_spans}) do
+  defp handle_resource_span(%ResourceSpans{resource: resource, scope_spans: scope_spans}) do
     resource = Otel.handle_resource(resource)
-
-    scope_spans
-    |> Enum.map(&handle_scope_span(&1, resource))
-    |> List.flatten()
+    Enum.map(scope_spans, &handle_scope_span(&1, resource))
   end
 
   defp handle_scope_span(%{scope: scope, spans: spans}, resource) do
-    resource = Otel.merge_scope_attributes(resource, scope)
-    Enum.map(spans, &handle_span(&1, resource))
+    scope = Otel.handle_scope(scope)
+    Enum.map(spans, &handle_span(&1, resource, scope))
   end
 
-  defp handle_span(span, resource) do
+  defp handle_span(span, resource, scope) do
     start_time = Otel.nano_to_iso8601(span.start_time_unix_nano)
     metadata = %{"type" => "span"}
-    metadata = Map.merge(metadata, resource)
-    events = Enum.map(span.events, &handle_event(&1, span, resource))
+    events = Enum.map(span.events, &handle_event(&1, span, resource, scope))
 
     [
       %{
         "event_message" => span.name,
         "metadata" => metadata,
+        "resource" => resource,
+        "scope" => scope,
         "span_id" => Base.encode16(span.span_id),
         "parent_span_id" => Base.encode16(span.parent_span_id),
         "trace_id" => Ecto.UUID.cast!(span.trace_id),
@@ -57,17 +56,19 @@ defmodule Logflare.Logs.OtelTrace do
     ] ++ events
   end
 
-  defp handle_event(event, %{span_id: span_id, trace_id: trace_id}, resource) do
+  defp handle_event(event, %{span_id: span_id, trace_id: trace_id}, resource, scope) do
     metadata = %{"type" => "event"}
-    metadata = Map.merge(metadata, resource)
 
     %{
       "event_message" => event.name,
       "metadata" => metadata,
+      "resource" => resource,
+      "scope" => scope,
       "parent_span_id" => Base.encode16(span_id),
       "trace_id" => Ecto.UUID.cast!(trace_id),
       "attributes" => Otel.handle_attributes(event.attributes),
-      "timestamp" => Otel.nano_to_iso8601(event.time_unix_nano)
+      "timestamp" => Otel.nano_to_iso8601(event.time_unix_nano),
+      "project" => resource["name"]
     }
   end
 end

--- a/test/logflare/logs/otel_test.exs
+++ b/test/logflare/logs/otel_test.exs
@@ -1,0 +1,10 @@
+defmodule Logflare.Logs.OtelTest do
+  use Logflare.DataCase
+  alias Opentelemetry.Proto.Common.V1.KeyValue
+  alias Opentelemetry.Proto.Common.V1.AnyValue
+  alias Opentelemetry.Proto.Common.V1.ArrayValue
+  alias Opentelemetry.Proto.Resource.V1.Resource
+  import Logflare.Logs.Otel
+
+  doctest Logflare.Logs.Otel
+end


### PR DESCRIPTION
This PR does two things:

## Split resource and scope into separate fields

OTel traces and metrics always have two entities: resource and scope. We are currently merging both of them and putting them in metadata. This is a bit limiting. This PR changes it to keep them separate maps, and moves the data from `metadata` to root (not sure about this part, though).

Before:
```json
{
  "metadata": {
    "type": "span",
    "service": {
      "name": "Logflare",
      "version": "1.14.2"
    },
    "name": "opentelemetry_bandit",
    "version": "1.2.3",
    "asd": "bsd"
  },
  "event_message": "POST /a/b",
  "span_id": 391283921,
  "trace_id": 30921803120
}
```

After:
```json
{
  "metadata": {
    "type": "span"
  },
  "resource": {
    "service": {
      "name": "Logflare",
      "version": "1.14.2"
    }
  },
  "scope": {
    "name": "opentelemetry_bandit",
    "version": "1.2.3",
    "attributes": {
       "asd": "bsd"
    }
  },
  "event_message": "POST /a/b",
  "span_id": 391283921,
  "trace_id": 30921803120
}
```

I'm happy to keep it **inside** metadata, but I'd really prefer to avoid merging them.

## Project name

Currently, we read the `resource.name` field to determine the project name. Instead, we should probably use `resource.service.name` , according to OTel docs:

>There are attributes provided by the OpenTelemetry SDK. One of them is the `service.name`, which represents the logical name of the service. By default, SDKs will assign the value `unknown_service` for this value, so it is recommended to set it explicitly, either in code or via setting the environment variable `OTEL_SERVICE_NAME`.

In my understanding, there’s currently no “standardizing” for the `resource.name` field, so we shouldn’t assume that it's there. But we can probably rely on `resource.service.name`