### PR TITLE
fix: add artifactregistry.reader role to GCP CE service acc

### DIFF
--- a/lib/logflare/google/resource_manager.ex
+++ b/lib/logflare/google/resource_manager.ex
@@ -100,10 +100,6 @@ defmodule Logflare.Google.CloudResourceManager do
       },
       %Model.Binding{
         members: ["serviceAccount:#{env_compute_engine_sa()}"],
-        role: "roles/containerregistry.ServiceAgent"
-      },
-      %Model.Binding{
-        members: ["serviceAccount:#{env_compute_engine_sa()}"],
         role: "roles/artifactregistry.reader"
       },
       %Model.Binding{

--- a/lib/logflare/google/resource_manager.ex
+++ b/lib/logflare/google/resource_manager.ex
@@ -104,6 +104,10 @@ defmodule Logflare.Google.CloudResourceManager do
       },
       %Model.Binding{
         members: ["serviceAccount:#{env_compute_engine_sa()}"],
+        role: "roles/artifactregistry.reader"
+      },
+      %Model.Binding{
+        members: ["serviceAccount:#{env_compute_engine_sa()}"],
         role: "roles/logging.logWriter"
       },
       %Model.Binding{


### PR DESCRIPTION
This is necessary if you are using ArtifactRegistry instead of Container Registry. We did this migration recently and deploy would break due to the Cloud Engine service account missing this role.