### PR TITLE
fix: endpoints caches should always shutdown

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -221,9 +221,14 @@ defmodule Logflare.Endpoints do
   """
   @spec run_cached_query(Query.t(), map()) :: run_query_return()
   def run_cached_query(query, params \\ %{}) do
-    query
-    |> Resolver.resolve(params)
-    |> Cache.query()
+    if query.cache_duration_seconds > 0 do
+      query
+      |> Resolver.resolve(params)
+      |> Cache.query()
+    else
+      # execute the query directly
+      run_query(query, params)
+    end
   end
 
   defp exec_query_on_backend(

--- a/lib/logflare/endpoints/cache.ex
+++ b/lib/logflare/endpoints/cache.ex
@@ -159,11 +159,10 @@ defmodule Logflare.Endpoints.Cache do
   end
 
   def handle_cast(:touch, state) do
-    state = %{state | last_query_at: DateTime.utc_now()}
     :timer.cancel(state.shutdown_timer)
     timer = state.query |> cache_duration_ms() |> shutdown()
 
-    {:noreply, %{state | shutdown_timer: timer}}
+    {:noreply, %{state | shutdown_timer: timer, last_query_at: DateTime.utc_now()}}
   end
 
   def handle_info(:refresh, state) do

--- a/lib/logflare/endpoints/cache.ex
+++ b/lib/logflare/endpoints/cache.ex
@@ -13,21 +13,19 @@ defmodule Logflare.Endpoints.Cache do
   defstruct query: nil,
             query_tasks: [],
             params: %{},
-            last_query_at: nil,
-            last_update_at: nil,
             cached_result: nil,
             disable_cache: false,
-            shutdown_timer: nil
+            shutdown_timer: nil,
+            refresh_timer: nil
 
   @type t :: %__MODULE__{
           query: %Logflare.Endpoints.Query{},
           query_tasks: list(%Task{}),
           params: map(),
-          last_query_at: DateTime.t(),
-          last_update_at: DateTime.t(),
           cached_result: binary(),
           disable_cache: boolean(),
-          shutdown_timer: reference()
+          shutdown_timer: reference(),
+          refresh_timer: reference()
         }
 
   def start_link({query, params}) do
@@ -89,13 +87,6 @@ defmodule Logflare.Endpoints.Cache do
     GenServer.call(cache, :invalidate)
   end
 
-  @doc """
-  Updates the `last_query_at` key in the process state to act as if a query was recently made.
-  """
-  def touch(cache) when is_pid(cache) do
-    GenServer.cast(cache, :touch)
-  end
-
   def init({query, params}) do
     endpoints = endpoints_part(query.id)
     :syn.join(endpoints, query.id, self())
@@ -106,14 +97,12 @@ defmodule Logflare.Endpoints.Cache do
       %__MODULE__{
         query: query,
         params: params,
-        last_update_at: DateTime.utc_now(),
-        last_query_at: DateTime.utc_now(),
         shutdown_timer: timer
       }
       |> fetch_latest_query_endpoint()
       |> put_disable_cache()
 
-    unless state.disable_cache, do: refresh(proactive_querying_ms(state))
+    unless state.disable_cache, do: refresh(proactive_querying_ms(query))
 
     {:ok, state}
   end
@@ -124,10 +113,7 @@ defmodule Logflare.Endpoints.Cache do
   def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: false} = state) do
     case do_query(state) do
       {:ok, result} = response ->
-        state =
-          state
-          |> Map.put(:last_query_at, DateTime.utc_now())
-          |> Map.put(:cached_result, result)
+        state = Map.put(state, :cached_result, result)
 
         {:reply, response, state}
 
@@ -147,22 +133,11 @@ defmodule Logflare.Endpoints.Cache do
   end
 
   def handle_call(:query, _from, %__MODULE__{cached_result: cached_result} = state) do
-    state =
-      state
-      |> Map.put(:last_query_at, DateTime.utc_now())
-
     {:reply, {:ok, cached_result}, state}
   end
 
   def handle_call(:invalidate, _from, state) do
     {:stop, :normal, {:ok, :stopped}, state}
-  end
-
-  def handle_cast(:touch, state) do
-    :timer.cancel(state.shutdown_timer)
-    timer = state.query |> cache_duration_ms() |> shutdown()
-
-    {:noreply, %{state | shutdown_timer: timer, last_query_at: DateTime.utc_now()}}
   end
 
   def handle_info(:refresh, state) do
@@ -178,16 +153,20 @@ defmodule Logflare.Endpoints.Cache do
   end
 
   def handle_info(:shutdown, state) do
+    Logger.debug("#{__MODULE__}: shutting down cache normally")
     {:stop, :normal, state}
   end
 
   def handle_info({from_task, {:ok, results}}, state) do
     tasks = Enum.reject(state.query_tasks, &(&1.pid == from_task))
 
-    :timer.cancel(state.shutdown_timer)
-    timer = refresh(proactive_querying_ms(state))
+    if is_reference(state.refresh_timer) do
+      Process.cancel_timer(state.refresh_timer)
+    end
 
-    {:noreply, %{state | cached_result: results, query_tasks: tasks, shutdown_timer: timer}}
+    timer = refresh(proactive_querying_ms(state.query))
+
+    {:noreply, %{state | cached_result: results, query_tasks: tasks, refresh_timer: timer}}
   end
 
   def handle_info({_from_task, {:error, _response}}, state) do
@@ -227,8 +206,8 @@ defmodule Logflare.Endpoints.Cache do
     Process.send_after(self(), :shutdown, every)
   end
 
-  defp proactive_querying_ms(state) do
-    state.query.proactive_requerying_seconds * 1_000
+  defp proactive_querying_ms(query) do
+    query.proactive_requerying_seconds * 1_000
   end
 
   defp cache_duration_ms(query) do

--- a/lib/logflare/endpoints/resolver.ex
+++ b/lib/logflare/endpoints/resolver.ex
@@ -27,7 +27,6 @@ defmodule Logflare.Endpoints.Resolver do
     |> GenServer.whereis()
     |> case do
       {pid, _} when is_pid(pid) ->
-        Cache.touch(pid)
         pid
 
       _ ->

--- a/test/logflare/endpoints_cache.test.ex
+++ b/test/logflare/endpoints_cache.test.ex
@@ -12,12 +12,20 @@ defmodule Logflare.EndpointsCacheTest do
           user: user,
           query: "select current_datetime() as testing",
           proactive_requerying_seconds: 1,
+          cache_duration_seconds: 3
+        )
+
+      endpoint_2 =
+        insert(:endpoint,
+          user: user,
+          query: "select current_datetime() as testing",
+          proactive_requerying_seconds: 3,
           cache_duration_seconds: 1
         )
 
       _plan = insert(:plan, name: "Free")
 
-      %{user: user, endpoint: endpoint}
+      %{user: user, endpoint: endpoint, endpoint_2: endpoint_2}
     end
 
     test "cache starts and serves cached results", %{endpoint: endpoint} do
@@ -75,7 +83,7 @@ defmodule Logflare.EndpointsCacheTest do
       end)
 
       # should be larger than :proactive_requerying_seconds
-      Process.sleep(1100)
+      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
 
       refute Process.alive?(cache_pid)
     end
@@ -97,8 +105,11 @@ defmodule Logflare.EndpointsCacheTest do
     test "cache dies after cache_duration_seconds", %{endpoint: endpoint} do
       test_response = [%{"testing" => "123"}]
 
+      expected_calls =
+        (endpoint.cache_duration_seconds / endpoint.proactive_requerying_seconds) |> floor()
+
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_query, expected_calls, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
@@ -108,12 +119,12 @@ defmodule Logflare.EndpointsCacheTest do
       # First query should succeed
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
-      # Cache should still be alive after 500ms
-      Process.sleep(500)
+      # Cache should still be alive before cache_duration_seconds
+      Process.sleep(endpoint.cache_duration_seconds * 1000 - 100)
       assert Process.alive?(cache_pid)
 
-      # Cache should die after cache_duration_seconds (1 second)
-      Process.sleep(600)
+      # Cache should die after cache_duration_seconds
+      Process.sleep(endpoint.cache_duration_seconds * 1000 + 100)
       refute Process.alive?(cache_pid)
     end
 
@@ -132,7 +143,7 @@ defmodule Logflare.EndpointsCacheTest do
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       # Cache should still return first response before proactive_requerying_seconds
-      Process.sleep(500)
+      Process.sleep(endpoint.proactive_requerying_seconds * 1000 - 100)
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       test_response = [%{"testing" => "456"}]
@@ -143,8 +154,30 @@ defmodule Logflare.EndpointsCacheTest do
       end)
 
       # After proactive_requerying_seconds, should return updated response
-      Process.sleep(600)
+      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
       assert {:ok, %{rows: [%{"testing" => "456"}]}} = Endpoints.run_cached_query(endpoint)
+    end
+
+    test "endpoint 2: cache dies before proactive query", %{endpoint_2: endpoint} do
+      test_response = [%{"testing" => "123"}]
+
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+        {:ok, TestUtils.gen_bq_response(test_response)}
+      end)
+
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      assert Process.alive?(cache_pid)
+
+      # First query should succeed
+      assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
+
+      reject(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 4)
+
+      # should be larger than :proactive_requerying_seconds
+      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
+
+      refute Process.alive?(cache_pid)
     end
   end
 end


### PR DESCRIPTION
- fixes tests
- catches cases where Endpoints processes don't always shutdown
- added `hibernate_after: 5_000`