### PR TITLE
chore: add make test.failed to automatically run only the failed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test:
 	-epmd -daemon
 	mix test
 
+test.failed:
+	-epmd -daemon
+	mix test --failed
+
 test.only:
 	-epmd -daemon
 	mix test.only


### PR DESCRIPTION
This makes it convenient when working on a lot of tests :pray: 