### PR TITLE
test: add equal comparison to System.system_time when comparing to next_update

### DIFF
--- a/lib/logflare/source/bigquery/schema.ex
+++ b/lib/logflare/source/bigquery/schema.ex
@@ -123,7 +123,7 @@ defmodule Logflare.Source.BigQuery.Schema do
     schema = try_schema_update(body, state.schema)
 
     if not same_schemas?(state.schema, schema) and
-         state.next_update < System.system_time(:millisecond) and
+         state.next_update <= System.system_time(:millisecond) and
          !SingleTenant.postgres_backend?() do
       case BigQuery.patch_table(
              state.source_token,


### PR DESCRIPTION
test/logflare/source/bigquery/schema_test.exs:21 was a flaky test, and with this change, it is no longer flaky. I tested it locally using:

$ mix test --repeat-until-failure 1000 test/logflare/source/bigquery/schema_test.exs:21