### PR TITLE
fix: set clickhouse log event table to be ordered descending

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -88,7 +88,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
       )
       ENGINE MergeTree()
       PARTITION BY toYYYYMMDD(timestamp)
-      ORDER BY (timestamp)
+      ORDER BY (timestamp) DESC
       """,
       if is_pos_integer(ttl_days) do
         """


### PR DESCRIPTION
Order newly created log ingest tables to be sorted descending by default