### PR TITLE
chore: remove init option from LogflareWeb.Endpoint

### DIFF
--- a/lib/logflare_web/endpoint.ex
+++ b/lib/logflare_web/endpoint.ex
@@ -46,22 +46,4 @@ defmodule LogflareWeb.Endpoint do
   plug(Plug.Session, @session_options)
 
   plug(LogflareWeb.Router)
-
-  @doc """
-  Callback invoked for dynamically configuring the endpoint.
-
-  It receives the endpoint configuration and checks if
-  configuration should be loaded from the system environment.
-  """
-  def init(_key, config) do
-    if config[:load_from_system_env] do
-      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-
-      config = Keyword.put(config, :http, [:inet6, port: port])
-
-      {:ok, config}
-    else
-      {:ok, config}
-    end
-  end
 end


### PR DESCRIPTION
This is no longer used since we started using PHX_HTTP_PORT. This way, we remove a warning related to use the `init/2` option from endpoint (it shouldn't be used since the introduction of `config/runtime.exs`).