### PR TITLE
doc: fix openapi spec for log endpoints

### DIFF
--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -59,7 +59,7 @@ defmodule LogflareWeb.LogController do
       ]
     ],
     responses: %{
-      201 => Created.response(LogsCreated),
+      200 => Created.response(LogsCreated),
       500 => ServerError.response()
     }
   )


### PR DESCRIPTION
They return 200, not 201. Noticed this while doing the integration from Supavisor's side.