### PR TITLE
chore: update README coverage badge to show main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logflare
 
-[![Coverage Status](https://coveralls.io/repos/github/Logflare/logflare/badge.svg?branch=ziinc/anl-658-add-coveralls-to-logflarelogflare)](https://coveralls.io/github/Logflare/logflare?branch=ziinc/anl-658-add-coveralls-to-logflarelogflare)
+[![Coverage Status](https://coveralls.io/repos/github/Logflare/logflare/badge.svg?branch=main)](https://coveralls.io/github/Logflare/logflare?branch=main)
 
 ## About
 


### PR DESCRIPTION
I notice we are over 61% and the badge still was showing 60%. The problem was we were pointing to the branch that originally added the coverage badge.