### PR TITLE
perf: add Cachex for Logflare Endpoints 

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -54,7 +54,7 @@ defmodule Logflare.Application do
          partitions: max(round(System.schedulers_online() / 8), 1)},
         {PartitionSupervisor, child_spec: Task.Supervisor, name: Logflare.TaskSupervisors},
         {PartitionSupervisor,
-         child_spec: DynamicSupervisor, name: Logflare.Endpoints.Cache.PartitionSupervisor},
+         child_spec: DynamicSupervisor, name: Logflare.Endpoints.ResultsCache.PartitionSupervisor},
         {DynamicSupervisor,
          strategy: :one_for_one,
          restart: :transient,
@@ -114,7 +114,7 @@ defmodule Logflare.Application do
 
         # For Logflare Endpoints
         {PartitionSupervisor,
-         child_spec: DynamicSupervisor, name: Logflare.Endpoints.Cache.PartitionSupervisor},
+         child_spec: DynamicSupervisor, name: Logflare.Endpoints.ResultsCache.PartitionSupervisor},
 
         # Startup tasks after v2 pipeline started
         {Task, fn -> startup_tasks() end},

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -76,7 +76,6 @@ defmodule Logflare.ContextCache.CacheBuster do
         record = handle_record(record),
         record != :noop do
       record
-      |> maybe_local_proc_restarts()
     end
     |> tap(fn
       [] ->

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -76,6 +76,7 @@ defmodule Logflare.ContextCache.CacheBuster do
         record = handle_record(record),
         record != :noop do
       record
+      |> maybe_local_proc_restarts()
     end
     |> tap(fn
       [] ->
@@ -158,12 +159,28 @@ defmodule Logflare.ContextCache.CacheBuster do
     {Logflare.Auth, String.to_integer(id)}
   end
 
+  defp handle_record(%UpdatedRecord{
+         relation: {_schema, "endpoint_queries"},
+         record: %{"id" => id}
+       })
+       when is_binary(id) do
+    {Logflare.Endpoints, String.to_integer(id)}
+  end
+
   defp handle_record(%NewRecord{
          relation: {_schema, "billing_accounts"},
          record: %{"id" => _id}
        }) do
     # When new records are created they were previously cached as `nil` so we need to bust the :not_found keys
     {Logflare.Billing, :not_found}
+  end
+
+  defp handle_record(%NewRecord{
+         relation: {_schema, "endpoint_queries"},
+         record: %{"id" => _id}
+       }) do
+    # When new records are created they were previously cached as `nil` so we need to bust the :not_found keys
+    {Logflare.Endpoints, :not_found}
   end
 
   defp handle_record(%NewRecord{
@@ -239,6 +256,14 @@ defmodule Logflare.ContextCache.CacheBuster do
        })
        when is_binary(id) do
     {Logflare.Sources, String.to_integer(id)}
+  end
+
+  defp handle_record(%DeletedRecord{
+         relation: {_schema, "endpoint_queries"},
+         old_record: %{"id" => id}
+       })
+       when is_binary(id) do
+    {Logflare.Endpoints, String.to_integer(id)}
   end
 
   defp handle_record(%DeletedRecord{

--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Logflare.ContextCache.Supervisor do
   alias Logflare.TeamUsers
   alias Logflare.Partners
   alias Logflare.Auth
-
+  alias Logflare.Endpoints
   alias Logflare.Repo
 
   def start_link(_) do
@@ -47,7 +47,8 @@ defmodule Logflare.ContextCache.Supervisor do
       Sources.Cache,
       Billing.Cache,
       SourceSchemas.Cache,
-      Auth.Cache
+      Auth.Cache,
+      Endpoints.Cache
     ]
   end
 

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -45,10 +45,10 @@ defmodule Logflare.Endpoints do
   @spec get_endpoint_query(integer()) :: Query.t() | nil
   def get_endpoint_query(id), do: Repo.get(Query, id)
 
-
   def get_mapped_query_by_token(token) when is_binary(token) do
     get_by(token: token)
     |> Query.map_query_sources()
+    |> Repo.preload(:user)
   end
 
   @doc """

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -1,6 +1,6 @@
 defmodule Logflare.Endpoints do
   @moduledoc false
-  alias Logflare.Endpoints.Cache
+  alias Logflare.Endpoints.ResultsCache
   alias Logflare.Endpoints.Query
   alias Logflare.Endpoints.Resolver
   alias Logflare.Repo
@@ -45,23 +45,18 @@ defmodule Logflare.Endpoints do
   @spec get_endpoint_query(integer()) :: Query.t() | nil
   def get_endpoint_query(id), do: Repo.get(Query, id)
 
-  @spec get_query_by_token(binary()) :: Query.t() | nil
-  def get_query_by_token(token) when is_binary(token), do: get_by(token: token)
 
   def get_mapped_query_by_token(token) when is_binary(token) do
-    token
-    |> get_query_by_token()
-    |> then(fn
-      nil -> nil
-      query -> Query.map_query_sources(query)
-    end)
+    get_by(token: token)
+    |> Query.map_query_sources()
   end
 
   @doc """
   Puts the `:query` key of the `Query` with the latest source mappings.
   This ensure that the query will have the latest source names (assuming a name change)
   """
-  @spec map_query_sources(Query.t()) :: Query.t()
+  @spec map_query_sources(Query.t() | nil) :: Query.t() | nil
+  def map_query_sources(nil), do: nil
   def map_query_sources(endpoint), do: Query.map_query_sources(endpoint)
 
   @spec get_by(Keyword.t()) :: Query.t() | nil
@@ -107,7 +102,7 @@ defmodule Logflare.Endpoints do
         # kill all caches
         for pid <- Resolver.list_caches(endpoint) do
           Utils.Tasks.async(fn ->
-            Cache.invalidate(pid)
+            ResultsCache.invalidate(pid)
           end)
         end
         |> Task.await_many(30_000)
@@ -224,7 +219,7 @@ defmodule Logflare.Endpoints do
     if query.cache_duration_seconds > 0 do
       query
       |> Resolver.resolve(params)
-      |> Cache.query()
+      |> ResultsCache.query()
     else
       # execute the query directly
       run_query(query, params)

--- a/lib/logflare/endpoints/cache.ex
+++ b/lib/logflare/endpoints/cache.ex
@@ -21,7 +21,7 @@ defmodule Logflare.Endpoints.Cache do
                  if(stats, do: Utils.cache_stats()),
                  Utils.cache_limit(100_000)
                ]
-               |> Enum.filter(& &1),
+               |> Enum.reject(&is_nil/1),
              expiration: Utils.cache_expiration_min()
            ]
          ]}

--- a/lib/logflare/endpoints/cache.ex
+++ b/lib/logflare/endpoints/cache.ex
@@ -1,231 +1,37 @@
 defmodule Logflare.Endpoints.Cache do
   @moduledoc """
-  Handles the Endpoint caching logic.
+  Cachex for Endpoints context.
   """
-
-  require Logger
 
   alias Logflare.Endpoints
-  alias Logflare.Utils.Tasks
+  alias Logflare.Utils
 
-  use GenServer, restart: :temporary
+  def child_spec(_) do
+    stats = Application.get_env(:logflare, :cache_stats, false)
 
-  defstruct query: nil,
-            query_tasks: [],
-            params: %{},
-            cached_result: nil,
-            disable_cache: false,
-            shutdown_timer: nil,
-            refresh_timer: nil
-
-  @type t :: %__MODULE__{
-          query: %Logflare.Endpoints.Query{},
-          query_tasks: list(%Task{}),
-          params: map(),
-          cached_result: binary(),
-          disable_cache: boolean(),
-          shutdown_timer: reference(),
-          refresh_timer: reference()
-        }
-
-  def start_link({query, params}) do
-    endpoints = endpoints_part(query.id, params)
-
-    name = {:via, :syn, {endpoints, {query.id, params}}}
-
-    GenServer.start_link(__MODULE__, {query, params}, name: name, hibernate_after: 5_000)
-  end
-
-  @doc """
-  Initiate a query. Times out at 30 seconds. BigQuery should also timeout at 25 seconds.
-  We have a %GoogleApi.BigQuery.V2.Model.ErrorProto{} model but it's missing fields we see in error responses.
-  """
-  def query(cache) when is_pid(cache) do
-    GenServer.call(cache, :query, 30_000)
-  catch
-    :exit, {:timeout, _call} ->
-      Logger.warning("Endpoint query timeout")
-
-      message = """
-      Backend query timeout! Optimizing your query will help. Some tips:
-
-      - `select` fewer columns. Only columns in the `select` statement are scanned.
-      - Narrow the date range - e.g `where timestamp > timestamp_sub(current_timestamp, interval 1 hour)`.
-      - Aggregate data. Analytics databases are designed to perform well when using aggregate functions.
-      - Run the query again. This error could be intermittent.
-
-      If you continue to see this error please contact support.
-      """
-
-      err = %{
-        "code" => 504,
-        "errors" => [],
-        "message" => message,
-        "status" => "TIMEOUT"
-      }
-
-      {:error, err}
-
-    :exit, reason ->
-      Logger.error("Endpoint query exited for an unknown reason", error_string: inspect(reason))
-
-      err = %{
-        "code" => 502,
-        "errors" => [],
-        "message" =>
-          "Something went wrong! Unknown error. If this continues please contact support.",
-        "status" => "UNKNOWN"
-      }
-
-      {:error, err}
-  end
-
-  @doc """
-  Invalidates the cache by stopping the cache process.
-  """
-  def invalidate(cache) when is_pid(cache) do
-    GenServer.call(cache, :invalidate)
-  end
-
-  def init({query, params}) do
-    endpoints = endpoints_part(query.id)
-    :syn.join(endpoints, query.id, self())
-
-    timer = query |> cache_duration_ms() |> shutdown()
-
-    state =
-      %__MODULE__{
-        query: query,
-        params: params,
-        shutdown_timer: timer
-      }
-      |> fetch_latest_query_endpoint()
-      |> put_disable_cache()
-
-    unless state.disable_cache, do: refresh(proactive_querying_ms(query))
-
-    {:ok, state}
-  end
-
-  @doc """
-  Queries BigQuery. Public because it's spawned in a task.
-  """
-  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: false} = state) do
-    case do_query(state) do
-      {:ok, result} = response ->
-        state = Map.put(state, :cached_result, result)
-
-        {:reply, response, state}
-
-      {:error, _err} = response ->
-        {:stop, :normal, response, state}
-    end
-  end
-
-  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: true} = state) do
-    case do_query(state) do
-      {:ok, _result} = response ->
-        {:stop, :normal, response, state}
-
-      {:error, _err} = response ->
-        {:stop, :normal, response, state}
-    end
-  end
-
-  def handle_call(:query, _from, %__MODULE__{cached_result: cached_result} = state) do
-    {:reply, {:ok, cached_result}, state}
-  end
-
-  def handle_call(:invalidate, _from, state) do
-    {:stop, :normal, {:ok, :stopped}, state}
-  end
-
-  def handle_info(:refresh, state) do
-    task = Tasks.async(__MODULE__, :do_query, [state])
-    tasks = [task | state.query_tasks]
-
-    running = Enum.count(tasks)
-
-    if running > 1,
-      do: Logger.warning("CacheTaskError: #{running} Endpoints.Cache tasks are running")
-
-    {:noreply, %{state | query_tasks: tasks}}
-  end
-
-  def handle_info(:shutdown, state) do
-    Logger.debug("#{__MODULE__}: shutting down cache normally")
-    {:stop, :normal, state}
-  end
-
-  def handle_info({from_task, {:ok, results}}, state) do
-    tasks = Enum.reject(state.query_tasks, &(&1.pid == from_task))
-
-    if is_reference(state.refresh_timer) do
-      Process.cancel_timer(state.refresh_timer)
-    end
-
-    timer = refresh(proactive_querying_ms(state.query))
-
-    {:noreply, %{state | cached_result: results, query_tasks: tasks, refresh_timer: timer}}
-  end
-
-  def handle_info({_from_task, {:error, _response}}, state) do
-    {:stop, :normal, state}
-  end
-
-  def handle_info({:DOWN, _ref, :process, pid, :normal}, state) do
-    tasks = Enum.reject(state.query_tasks, &(&1.pid == pid))
-
-    {:noreply, %{state | query_tasks: tasks}}
-  end
-
-  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
-    Logger.warning("#{__MODULE__}: task exited with reason #{reason}")
-    {:stop, :normal, state}
-  end
-
-  def do_query(state) do
-    Logflare.Endpoints.run_query(state.query, state.params)
-  end
-
-  def endpoints_part(query_id, params) do
-    part = :erlang.phash2({query_id, params}, System.schedulers_online())
-    "endpoints_#{part}" |> String.to_existing_atom()
-  end
-
-  def endpoints_part(query_id) do
-    part = :erlang.phash2(query_id, System.schedulers_online())
-    "endpoints_#{part}" |> String.to_existing_atom()
-  end
-
-  defp refresh(every) do
-    Process.send_after(self(), :refresh, every)
-  end
-
-  defp shutdown(every) do
-    Process.send_after(self(), :shutdown, every)
-  end
-
-  defp proactive_querying_ms(query) do
-    query.proactive_requerying_seconds * 1_000
-  end
-
-  defp cache_duration_ms(query) do
-    query.cache_duration_seconds * 1_000
-  end
-
-  defp fetch_latest_query_endpoint(state) do
     %{
-      state
-      | query:
-          Endpoints.get_mapped_query_by_token(state.query.token)
-          |> Logflare.Repo.preload(:user)
+      id: __MODULE__,
+      start:
+        {Cachex, :start_link,
+         [
+           __MODULE__,
+           [
+             hooks:
+               [
+                 if(stats, do: Utils.cache_stats()),
+                 Utils.cache_limit(100_000)
+               ]
+               |> Enum.filter(& &1),
+             expiration: Utils.cache_expiration_min()
+           ]
+         ]}
     }
   end
 
-  defp put_disable_cache(state) do
-    if state.query.cache_duration_seconds == 0,
-      do: %{state | disable_cache: true},
-      else: %{state | disable_cache: false}
+  def get_by(kw), do: apply_repo_fun(:get_by, [kw])
+  def get_mapped_query_by_token(token), do: apply_repo_fun(:get_mapped_query_by_token, [token])
+
+  defp apply_repo_fun(arg1, arg2) do
+    Logflare.ContextCache.apply_fun(Endpoints, arg1, arg2)
   end
 end

--- a/lib/logflare/endpoints/resolver.ex
+++ b/lib/logflare/endpoints/resolver.ex
@@ -7,12 +7,12 @@ defmodule Logflare.Endpoints.Resolver do
   require Logger
 
   @doc """
-  Lists all caches for an endpoint
+  Lists all caches for an endpoint across all paritions
   """
   def list_caches(%Logflare.Endpoints.Query{id: id}) do
-    endpoints = ResultsCache.endpoints_part(id)
+    endpoints_partition = ResultsCache.endpoints_part(id)
 
-    :syn.members(endpoints, id)
+    :syn.members(endpoints_partition, id)
     |> Enum.map(fn {pid, _} -> pid end)
   end
 
@@ -21,9 +21,7 @@ defmodule Logflare.Endpoints.Resolver do
   Returns the resolved pid.
   """
   def resolve(%Logflare.Endpoints.Query{id: id} = query, params) do
-    endpoints = ResultsCache.endpoints_part(query.id, params)
-
-    {:via, :syn, {endpoints, {query.id, params}}}
+    ResultsCache.name(query.id, params)
     |> GenServer.whereis()
     |> case do
       pid when is_pid(pid) ->

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -1,0 +1,231 @@
+defmodule Logflare.Endpoints.ResultsCache do
+  @moduledoc """
+  Handles the Endpoint query results caching logic.
+  """
+
+  require Logger
+
+  alias Logflare.Endpoints
+  alias Logflare.Utils.Tasks
+
+  use GenServer, restart: :temporary
+
+  defstruct query: nil,
+            query_tasks: [],
+            params: %{},
+            cached_result: nil,
+            disable_cache: false,
+            shutdown_timer: nil,
+            refresh_timer: nil
+
+  @type t :: %__MODULE__{
+          query: %Logflare.Endpoints.Query{},
+          query_tasks: list(%Task{}),
+          params: map(),
+          cached_result: binary(),
+          disable_cache: boolean(),
+          shutdown_timer: reference(),
+          refresh_timer: reference()
+        }
+
+  def start_link({query, params}) do
+    endpoints = endpoints_part(query.id, params)
+
+    name = {:via, :syn, {endpoints, {query.id, params}}}
+
+    GenServer.start_link(__MODULE__, {query, params}, name: name, hibernate_after: 5_000)
+  end
+
+  @doc """
+  Initiate a query. Times out at 30 seconds. BigQuery should also timeout at 25 seconds.
+  We have a %GoogleApi.BigQuery.V2.Model.ErrorProto{} model but it's missing fields we see in error responses.
+  """
+  def query(cache) when is_pid(cache) do
+    GenServer.call(cache, :query, 30_000)
+  catch
+    :exit, {:timeout, _call} ->
+      Logger.warning("Endpoint query timeout")
+
+      message = """
+      Backend query timeout! Optimizing your query will help. Some tips:
+
+      - `select` fewer columns. Only columns in the `select` statement are scanned.
+      - Narrow the date range - e.g `where timestamp > timestamp_sub(current_timestamp, interval 1 hour)`.
+      - Aggregate data. Analytics databases are designed to perform well when using aggregate functions.
+      - Run the query again. This error could be intermittent.
+
+      If you continue to see this error please contact support.
+      """
+
+      err = %{
+        "code" => 504,
+        "errors" => [],
+        "message" => message,
+        "status" => "TIMEOUT"
+      }
+
+      {:error, err}
+
+    :exit, reason ->
+      Logger.error("Endpoint query exited for an unknown reason", error_string: inspect(reason))
+
+      err = %{
+        "code" => 502,
+        "errors" => [],
+        "message" =>
+          "Something went wrong! Unknown error. If this continues please contact support.",
+        "status" => "UNKNOWN"
+      }
+
+      {:error, err}
+  end
+
+  @doc """
+  Invalidates the cache by stopping the cache process.
+  """
+  def invalidate(cache) when is_pid(cache) do
+    GenServer.call(cache, :invalidate)
+  end
+
+  def init({query, params}) do
+    endpoints = endpoints_part(query.id)
+    :syn.join(endpoints, query.id, self())
+
+    timer = query |> cache_duration_ms() |> shutdown()
+
+    state =
+      %__MODULE__{
+        query: query,
+        params: params,
+        shutdown_timer: timer
+      }
+      |> fetch_latest_query_endpoint()
+      |> put_disable_cache()
+
+    unless state.disable_cache, do: refresh(proactive_querying_ms(query))
+
+    {:ok, state}
+  end
+
+  @doc """
+  Queries BigQuery. Public because it's spawned in a task.
+  """
+  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: false} = state) do
+    case do_query(state) do
+      {:ok, result} = response ->
+        state = Map.put(state, :cached_result, result)
+
+        {:reply, response, state}
+
+      {:error, _err} = response ->
+        {:stop, :normal, response, state}
+    end
+  end
+
+  def handle_call(:query, _from, %__MODULE__{cached_result: nil, disable_cache: true} = state) do
+    case do_query(state) do
+      {:ok, _result} = response ->
+        {:stop, :normal, response, state}
+
+      {:error, _err} = response ->
+        {:stop, :normal, response, state}
+    end
+  end
+
+  def handle_call(:query, _from, %__MODULE__{cached_result: cached_result} = state) do
+    {:reply, {:ok, cached_result}, state}
+  end
+
+  def handle_call(:invalidate, _from, state) do
+    {:stop, :normal, {:ok, :stopped}, state}
+  end
+
+  def handle_info(:refresh, state) do
+    task = Tasks.async(__MODULE__, :do_query, [state])
+    tasks = [task | state.query_tasks]
+
+    running = Enum.count(tasks)
+
+    if running > 1,
+      do: Logger.warning("CacheTaskError: #{running} Endpoints.ResultsCache tasks are running")
+
+    {:noreply, %{state | query_tasks: tasks}}
+  end
+
+  def handle_info(:shutdown, state) do
+    Logger.debug("#{__MODULE__}: shutting down cache normally")
+    {:stop, :normal, state}
+  end
+
+  def handle_info({from_task, {:ok, results}}, state) do
+    tasks = Enum.reject(state.query_tasks, &(&1.pid == from_task))
+
+    if is_reference(state.refresh_timer) do
+      Process.cancel_timer(state.refresh_timer)
+    end
+
+    timer = refresh(proactive_querying_ms(state.query))
+
+    {:noreply, %{state | cached_result: results, query_tasks: tasks, refresh_timer: timer}}
+  end
+
+  def handle_info({_from_task, {:error, _response}}, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, :normal}, state) do
+    tasks = Enum.reject(state.query_tasks, &(&1.pid == pid))
+
+    {:noreply, %{state | query_tasks: tasks}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
+    Logger.warning("#{__MODULE__}: task exited with reason #{reason}")
+    {:stop, :normal, state}
+  end
+
+  def do_query(state) do
+    Logflare.Endpoints.run_query(state.query, state.params)
+  end
+
+  def endpoints_part(query_id, params) do
+    part = :erlang.phash2({query_id, params}, System.schedulers_online())
+    "endpoints_#{part}" |> String.to_existing_atom()
+  end
+
+  def endpoints_part(query_id) do
+    part = :erlang.phash2(query_id, System.schedulers_online())
+    "endpoints_#{part}" |> String.to_existing_atom()
+  end
+
+  defp refresh(every) do
+    Process.send_after(self(), :refresh, every)
+  end
+
+  defp shutdown(every) do
+    Process.send_after(self(), :shutdown, every)
+  end
+
+  defp proactive_querying_ms(query) do
+    query.proactive_requerying_seconds * 1_000
+  end
+
+  defp cache_duration_ms(query) do
+    query.cache_duration_seconds * 1_000
+  end
+
+  defp fetch_latest_query_endpoint(state) do
+    %{
+      state
+      | query:
+          Endpoints.get_mapped_query_by_token(state.query.token)
+          |> Logflare.Repo.preload(:user)
+    }
+  end
+
+  defp put_disable_cache(state) do
+    if state.query.cache_duration_seconds == 0,
+      do: %{state | disable_cache: true},
+      else: %{state | disable_cache: false}
+  end
+end

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -31,10 +31,7 @@ defmodule Logflare.Endpoints.ResultsCache do
         }
 
   def start_link({query, params}) do
-    endpoints = endpoints_part(query.id, params)
-
     name = name(query.id, params)
-
     GenServer.start_link(__MODULE__, {query, params}, name: name, hibernate_after: 5_000)
   end
 

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -157,7 +157,6 @@ defmodule Logflare.Endpoints.ResultsCache do
 
     timer = refresh(proactive_querying_ms(query))
     new_state = %{state | cached_result: results, query_tasks: tasks, refresh_timer: timer}
-    dbg(query)
 
     if disable_cache?(query) do
       {:stop, :normal, new_state}

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -200,10 +200,6 @@ defmodule Logflare.Endpoints.ResultsCache do
     "endpoints_#{part}" |> String.to_existing_atom()
   end
 
-  def endpoints_partitions() do
-    for n <- 0..System.schedulers_online(), do: "endpoints_#{n}" |> String.to_existing_atom()
-  end
-
   def name(query_id, params) do
     partition = endpoints_part(query_id, params)
     param_hash = :erlang.phash2(params)

--- a/lib/logflare_web/controllers/plugs/fetch_resource.ex
+++ b/lib/logflare_web/controllers/plugs/fetch_resource.ex
@@ -66,11 +66,14 @@ defmodule LogflareWeb.Plugs.FetchResource do
 
     endpoint =
       case is_uuid?(token_or_name) do
-        true ->
-          Endpoints.Cache.get_by(token: token_or_name, user_id: user_id)
-
         false when user_id != nil ->
           Endpoints.Cache.get_by(name: token_or_name, user_id: user_id)
+
+        true when user_id != nil ->
+          Endpoints.Cache.get_by(token: token_or_name, user_id: user_id)
+
+        true when user_id == nil ->
+          Endpoints.Cache.get_by(token: token_or_name)
 
         _ ->
           nil

--- a/lib/logflare_web/controllers/plugs/fetch_resource.ex
+++ b/lib/logflare_web/controllers/plugs/fetch_resource.ex
@@ -67,10 +67,10 @@ defmodule LogflareWeb.Plugs.FetchResource do
     endpoint =
       case is_uuid?(token_or_name) do
         true ->
-          Endpoints.get_query_by_token(token_or_name)
+          Endpoints.Cache.get_by(token: token_or_name, user_id: user_id)
 
         false when user_id != nil ->
-          Endpoints.get_by(name: token_or_name, user_id: user_id)
+          Endpoints.Cache.get_by(name: token_or_name, user_id: user_id)
 
         _ ->
           nil
@@ -84,7 +84,7 @@ defmodule LogflareWeb.Plugs.FetchResource do
           conn,
         _opts
       ) do
-    endpoint = Endpoints.get_by(name: name, user_id: user_id)
+    endpoint = Endpoints.Cache.get_by(name: name, user_id: user_id)
     assign(conn, :endpoint, endpoint)
   end
 

--- a/test/logflare/endpoints_cache.test.ex
+++ b/test/logflare/endpoints_cache.test.ex
@@ -38,7 +38,7 @@ defmodule Logflare.EndpointsCacheTest do
       end)
 
       # Start cache process
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       # First query should hit backend
@@ -54,7 +54,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:error, :timeout}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       assert {:error, %{"message" => :timeout}} = Endpoints.run_cached_query(endpoint)
@@ -70,7 +70,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       # First query should succeed
@@ -94,7 +94,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:error, TestUtils.gen_bq_error("BQ Error")}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       assert {:error, %{"message" => "BQ Error"}} = Endpoints.run_cached_query(endpoint)
@@ -113,7 +113,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       # First query should succeed
@@ -136,7 +136,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       # First query should return first test response
@@ -176,7 +176,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:ok, TestUtils.gen_bq_response()}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
       assert {:ok, %{rows: [_]}} = Endpoints.run_cached_query(endpoint)
 
@@ -196,7 +196,7 @@ defmodule Logflare.EndpointsCacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert Process.alive?(cache_pid)
 
       # First query should succeed

--- a/test/logflare/endpoints_cache_test.exs
+++ b/test/logflare/endpoints_cache_test.exs
@@ -128,6 +128,29 @@ defmodule Logflare.EndpointsCacheTest do
       refute Process.alive?(cache_pid)
     end
 
+    test "cache dies after cache_duration_seconds gets set to 0", %{endpoint: endpoint} do
+      test_response = [%{"testing" => "123"}]
+
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_query, 2, fn _conn, _proj_id, _opts ->
+        {:ok, TestUtils.gen_bq_response(test_response)}
+      end)
+
+      {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
+      assert Process.alive?(cache_pid)
+
+      # First query should succeed
+      assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
+      assert Process.alive?(cache_pid)
+
+      Logflare.Repo.update_all(Endpoints.Query, set: [cache_duration_seconds: 0]) |> dbg()
+      Logflare.ContextCache.bust_keys([{Logflare.Endpoints, endpoint.id}])
+
+      # Cache should still be alive before cache_duration_seconds
+      Process.sleep(endpoint.proactive_requerying_seconds * 1000 * 2)
+      refute Process.alive?(cache_pid)
+    end
+
     test "cache updates cached results after proactive_requerying_seconds", %{endpoint: endpoint} do
       test_response = [%{"testing" => "123"}]
 

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -26,11 +26,6 @@ defmodule Logflare.EndpointsTest do
     assert endpoint.id == Endpoints.get_by(name: "some endpoint").id
   end
 
-  test "get_query_by_token/1" do
-    %{id: id, token: token} = insert(:endpoint)
-    assert %Query{id: ^id} = Endpoints.get_query_by_token(token)
-  end
-
   test "get_mapped_query_by_token/1 transforms renamed source names correctly" do
     user = insert(:user)
     source = insert(:source, user: user, name: "my_table")
@@ -193,7 +188,7 @@ defmodule Logflare.EndpointsTest do
           cache_duration_seconds: 4
         )
 
-      _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+      _pid = start_supervised!({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
       assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
       # 2nd query should hit local cache
       assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
@@ -232,7 +227,7 @@ defmodule Logflare.EndpointsTest do
 
         user = insert(:user)
         endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
-        cache_pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+        cache_pid = start_supervised!({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
         assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
 
         params =
@@ -309,7 +304,7 @@ defmodule Logflare.EndpointsTest do
              }
            } = Endpoints.calculate_endpoint_metrics(endpoint)
 
-    _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+    _pid = start_supervised!({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
 
     assert %_{
              metrics: %Query.Metrics{

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -194,6 +194,26 @@ defmodule Logflare.EndpointsTest do
       assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
     end
 
+    test "run_cached_query/1 only 1 query run" do
+      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      end)
+
+      user = insert(:user)
+
+      endpoint =
+        insert(:endpoint,
+          user: user,
+          query: "select current_datetime() as testing",
+          cache_duration_seconds: 1
+        )
+
+      _pid = start_supervised!({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
+      assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
+      # 2nd query should hit local cache
+      assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_cached_query(endpoint)
+    end
+
     test "run_cached_query/1 with cache disabled" do
       expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 2, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -92,7 +92,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
   test "index - show cache count", %{conn: conn, user: user} do
     endpoint = insert(:endpoint, user: user)
-    _pid = start_supervised!({Logflare.Endpoints.Cache, {endpoint, %{}}})
+    _pid = start_supervised!({Logflare.Endpoints.ResultsCache, {endpoint, %{}}})
 
     {:ok, view, _html} = live(conn, "/endpoints")
 


### PR DESCRIPTION
This PR adds in Cachex for Logflare Endpoints, allowing us to remove the Query storage in the GenServer, and ensuring that no cross-cluster stale queries are present.
This renames Endpoints.Cache to Endpoints.ResultsCache, and uses the convention Endpoints.Cache module for context caching as per other contexts in the codebase.
This also hashes the params when creating the Endpoint.ResultsCache name, allowing us to reduce the impact of large params on the proc registration tables.