### PR TITLE
perf: revert endpoints partition supervisor change

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -53,7 +53,7 @@ defmodule Logflare.Application do
          keys: :unique,
          partitions: max(round(System.schedulers_online() / 8), 1)},
         {PartitionSupervisor, child_spec: Task.Supervisor, name: Logflare.TaskSupervisors},
-        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.ResultsCache},
         {DynamicSupervisor,
          strategy: :one_for_one,
          restart: :transient,
@@ -112,7 +112,7 @@ defmodule Logflare.Application do
         Logflare.Telemetry,
 
         # For Logflare Endpoints
-        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.ResultsCache},
 
         # Startup tasks after v2 pipeline started
         {Task, fn -> startup_tasks() end},

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -53,8 +53,7 @@ defmodule Logflare.Application do
          keys: :unique,
          partitions: max(round(System.schedulers_online() / 8), 1)},
         {PartitionSupervisor, child_spec: Task.Supervisor, name: Logflare.TaskSupervisors},
-        {PartitionSupervisor,
-         child_spec: DynamicSupervisor, name: Logflare.Endpoints.ResultsCache.PartitionSupervisor},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
         {DynamicSupervisor,
          strategy: :one_for_one,
          restart: :transient,
@@ -113,8 +112,7 @@ defmodule Logflare.Application do
         Logflare.Telemetry,
 
         # For Logflare Endpoints
-        {PartitionSupervisor,
-         child_spec: DynamicSupervisor, name: Logflare.Endpoints.ResultsCache.PartitionSupervisor},
+        {DynamicSupervisor, strategy: :one_for_one, name: Logflare.Endpoints.Cache},
 
         # Startup tasks after v2 pipeline started
         {Task, fn -> startup_tasks() end},

--- a/lib/logflare/endpoints/resolver.ex
+++ b/lib/logflare/endpoints/resolver.ex
@@ -31,11 +31,7 @@ defmodule Logflare.Endpoints.Resolver do
         spec = {ResultsCache, {query, params}}
         Logger.debug("Starting up Endpoint.Cache for Endpoint.Query id=#{id}", endpoint_id: id)
 
-        via =
-          {:via, PartitionSupervisor,
-           {Logflare.Endpoints.ResultsCache.PartitionSupervisor, {id, params}}}
-
-        case DynamicSupervisor.start_child(via, spec) do
+        case DynamicSupervisor.start_child(ResultsCache, spec) do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end


### PR DESCRIPTION
This reverts the partition supervisor usage for Endpoints.ResultsCache, as it results in duplicate queries getting executed due to n procs getting created by the PartitionSupervisor, where n is number of schedulers

depends on #2464 

todo: add test