### PR TITLE
test: add missing test for put request in TeamController and validate all schema responses

### DIFF
--- a/lib/logflare_web/controllers/api/team_controller.ex
+++ b/lib/logflare_web/controllers/api/team_controller.ex
@@ -8,6 +8,7 @@ defmodule LogflareWeb.Api.TeamController do
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
 
   alias LogflareWeb.OpenApiSchemas.Team
 
@@ -46,7 +47,8 @@ defmodule LogflareWeb.Api.TeamController do
     request_body: Team.params(),
     responses: %{
       201 => Created.response(Team),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -64,9 +66,10 @@ defmodule LogflareWeb.Api.TeamController do
     parameters: [token: [in: :path, description: "Team Token", type: :string]],
     request_body: Team.params(),
     responses: %{
-      204 => Accepted.response(),
       201 => Created.response(Team),
-      404 => NotFound.response()
+      204 => Accepted.response(),
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -85,6 +85,8 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :cloudflare, false
+
   def cloudflare(%{assigns: %{source: source}} = conn, %{"batch" => batch}) when is_list(batch) do
     batch
     |> Processor.ingest(Logs.Raw, source)
@@ -99,11 +101,15 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :syslog, false
+
   def syslog(%{assigns: %{source: source}} = conn, %{"batch" => batch}) when is_list(batch) do
     batch
     |> Processor.ingest(Logs.Raw, source)
     |> handle(conn)
   end
+
+  operation :generic_json, false
 
   def generic_json(%{assigns: %{source: source}} = conn, %{"_json" => batch})
       when is_list(batch) do
@@ -119,6 +125,8 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :vector, false
+
   def vector(%{assigns: %{source: source}} = conn, %{"_json" => batch})
       when is_list(batch) do
     batch
@@ -132,6 +140,8 @@ defmodule LogflareWeb.LogController do
     |> Processor.ingest(Logs.Vector, source)
     |> handle(conn)
   end
+
+  operation :browser_reports, false
 
   def browser_reports(%{assigns: %{source: source}} = conn, %{"_json" => batch})
       when is_list(batch) do
@@ -147,12 +157,16 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :elixir_logger, false
+
   def elixir_logger(%{assigns: %{source: source}} = conn, %{"batch" => batch})
       when is_list(batch) do
     batch
     |> Processor.ingest(Logs.Raw, source)
     |> handle(conn)
   end
+
+  operation :create_with_typecasts, false
 
   def create_with_typecasts(%{assigns: %{source: source}} = conn, %{"batch" => batch})
       when is_list(batch) do
@@ -161,12 +175,16 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :vercel_ingest, false
+
   def vercel_ingest(%{assigns: %{source: source}} = conn, %{"_json" => batch})
       when is_list(batch) do
     batch
     |> Processor.ingest(Logs.Vercel, source)
     |> handle(conn)
   end
+
+  operation :netlify, false
 
   def netlify(%{assigns: %{source: source}} = conn, %{"_json" => batch}) when is_list(batch) do
     batch
@@ -181,11 +199,15 @@ defmodule LogflareWeb.LogController do
     |> handle(conn)
   end
 
+  operation :github, false
+
   def github(%{assigns: %{source: source}, body_params: params} = conn, _params) do
     [params]
     |> Processor.ingest(Logs.Github, source)
     |> handle(conn)
   end
+
+  operation :cloud_event, false
 
   def cloud_event(%Plug.Conn{} = conn, %{"_json" => batch})
       when is_list(batch) do
@@ -230,6 +252,8 @@ defmodule LogflareWeb.LogController do
     end
   end
 
+  operation :otel_traces, false
+
   def otel_traces(
         %{assigns: %{source: source}} = conn,
         %ExportTraceServiceRequest{resource_spans: resource_spans}
@@ -243,6 +267,8 @@ defmodule LogflareWeb.LogController do
       reraise exception, __STACKTRACE__
   end
 
+  operation :otel_metrics, false
+
   def otel_metrics(
         %{assigns: %{source: source}} = conn,
         %ExportMetricsServiceRequest{resource_metrics: resource_metrics}
@@ -255,6 +281,8 @@ defmodule LogflareWeb.LogController do
       send_proto_error(conn, 500, "Internal server error")
       reraise exception, __STACKTRACE__
   end
+
+  operation :otel_logs, false
 
   def otel_logs(
         %{assigns: %{source: source}} = conn,

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -22,15 +22,19 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule List do
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{type: :array, items: Endpoint})
+    def schema(module) do
+      %Schema{
+        title: "#{module.schema().title}ListResponse",
+        type: :array,
+        items: module
+      }
+    end
 
     def response(module) do
       {
         "#{module.schema().title} List Response",
         "application/json",
-        %Schema{type: :array, items: module}
+        schema(module)
       }
     end
   end
@@ -45,18 +49,36 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule Accepted do
-    require OpenApiSpex
-    OpenApiSpex.schema(%{})
+    def schema, do: %Schema{title: "AcceptedResponse"}
 
-    def response(), do: {"Accepted Response", "text/plain", __MODULE__}
+    def response(), do: {"Accepted Response", "text/plain", schema()}
     def response(module), do: {"Accepted Response", "application/json", module}
   end
 
   defmodule NotFound do
-    require OpenApiSpex
-    OpenApiSpex.schema(%{})
+    def schema do
+      %Schema{
+        title: "NotFoundResponse",
+        type: :object,
+        properties: %{error: %Schema{type: :string}},
+        required: [:error]
+      }
+    end
 
-    def response(), do: {"Not found", "text/plain", __MODULE__}
+    def response(), do: {"Not found", "text/plain", schema()}
+  end
+
+  defmodule UnprocessableEntity do
+    def schema do
+      %Schema{
+        title: "UnprocessableEntityResponse",
+        type: :object,
+        properties: %{errors: %Schema{type: :object}},
+        required: [:errors]
+      }
+    end
+
+    def response(), do: {"Unprocessable Entity", "application/json", schema()}
   end
 
   defmodule BadRequest do

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -164,19 +164,19 @@ defmodule LogflareWeb.OpenApiSchemas do
       api_key: %Schema{type: :string},
       email_preferred: %Schema{type: :string},
       name: %Schema{type: :string},
-      image: %Schema{type: :string},
+      image: %Schema{type: :string, nullable: true},
       email_me_product: %Schema{type: :boolean},
-      phone: %Schema{type: :string},
-      bigquery_project_id: %Schema{type: :string},
-      bigquery_dataset_location: %Schema{type: :string},
-      bigquery_dataset_id: %Schema{type: :string},
+      phone: %Schema{type: :string, nullable: true},
+      bigquery_project_id: %Schema{type: :string, nullable: true},
+      bigquery_dataset_location: %Schema{type: :string, nullable: true},
+      bigquery_dataset_id: %Schema{type: :string, nullable: true},
       api_quota: %Schema{type: :integer},
-      company: %Schema{type: :string},
+      company: %Schema{type: :string, nullable: true},
       token: %Schema{type: :string}
     }
     use LogflareWeb.OpenApi,
       properties: @properties,
-      required: [:email, :provider, :token, :provider_uid, :api_key]
+      required: [:email, :provider, :token, :api_key]
   end
 
   defmodule TeamUser do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -106,4 +106,8 @@ defmodule LogflareWeb.ConnCase do
 
     Plug.Conn.put_req_header(conn, "authorization", "Bearer #{access_token.token}")
   end
+
+  def assert_schema(data, schema_name) do
+    OpenApiSpex.TestAssertions.assert_schema(data, schema_name, LogflareWeb.ApiSpec.spec())
+  end
 end


### PR DESCRIPTION
Following up on the work of PR https://github.com/Logflare/logflare/pull/2470, we can now validate the response schemas according to the OpenAPI spec making sure a consistent behavior is enforced for all common operations (not found, unprocessable entity, etc).