### PR TITLE
feat: run CI for updated coverage on main every Sunday at midnight (UTC)

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -2,6 +2,8 @@ name: Elixir CI
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * SUN'
   pull_request:
     branches: ["**"]
     paths:


### PR DESCRIPTION
When I opened PR https://github.com/Logflare/logflare/pull/2460, I wanted to have the README badge with the main branch coverage value. However, we never run the CI pipeline in main, so there's no coverage data to report. 

This change will make our CI pipeline run once a week (Sunday at midnight). This way, we make sure the pipeline still passes even if there has not been a PR in a while, and we get an updated badge every week.