### PR TITLE
fix: properly handles managed service accounts when disabled

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,15 +54,6 @@ config :logflare,
        |> filter_nil_kv_pairs.()
 
 config :logflare,
-       :bigquery_backend_adaptor,
-       [
-         managed_service_account_pool_size:
-           System.get_env("LOGFLARE_BIGQUERY_MANAGED_SA_POOL", "0")
-           |> String.to_integer()
-       ]
-       |> filter_nil_kv_pairs.()
-
-config :logflare,
        Logflare.Alerting,
        [
          min_cluster_size:

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -262,6 +262,14 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   end
 
   @doc """
+  Returns true if managed service accounts are enabled
+  """
+  @spec managed_service_accounts_enabled? :: boolean()
+  def managed_service_accounts_enabled? do
+    managed_service_account_pool_size() > 0
+  end
+
+  @doc """
   Returns the number of partitions for each managed service account
 
     iex> managed_service_account_partition_count()

--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -92,11 +92,10 @@ defmodule Logflare.Google.BigQuery.GenUtils do
     partition = :erlang.phash2(self(), partition_count)
 
     {name, metadata} =
-      if conn_type == :query do
-        service_account_count = BigQueryAdaptor.managed_service_account_pool_size()
+      if conn_type == :query && BigQueryAdaptor.managed_service_accounts_enabled?() do
+        pool_size = BigQueryAdaptor.managed_service_account_pool_size()
 
-        sa_index =
-          if service_account_count > 0, do: :erlang.phash2(self(), service_account_count), else: 0
+        sa_index = :erlang.phash2(self(), pool_size)
 
         {{
            Logflare.GothQuery,
@@ -104,7 +103,7 @@ defmodule Logflare.Google.BigQuery.GenUtils do
            partition
          },
          %{
-           service_account_count: service_account_count,
+           pool_size: pool_size,
            sa_index: sa_index,
            partition: partition
          }}

--- a/lib/logflare/google/resource_manager.ex
+++ b/lib/logflare/google/resource_manager.ex
@@ -110,8 +110,12 @@ defmodule Logflare.Google.CloudResourceManager do
 
   defp get_service_accounts() do
     managed_service_accounts =
-      for %{email: name} <- BigQueryAdaptor.list_managed_service_accounts() do
-        {name, ["roles/bigquery.admin"]}
+      if BigQueryAdaptor.managed_service_accounts_enabled?() do
+        for %{email: name} <- BigQueryAdaptor.list_managed_service_accounts() do
+          {name, ["roles/bigquery.admin"]}
+        end
+      else
+        []
       end
 
     for {member, roles} <-

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -369,7 +369,17 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       # Mock IAM API calls for listing existing service accounts
       expect(GoogleApi.IAM.V1.Api.Projects, :iam_projects_service_accounts_list, fn
         _conn, "projects/" <> _project_id, _opts ->
-          {:ok, %{accounts: [], nextPageToken: nil}}
+          {:ok,
+           %{
+             accounts: [
+               %GoogleApi.IAM.V1.Model.ServiceAccount{
+                 email: "logflare-managed-0@some-project.iam.gserviceaccount.com",
+                 name:
+                   "projects/some-project/serviceAccounts/logflare-managed-0@some-project.iam.gserviceaccount.com"
+               }
+             ],
+             nextPageToken: nil
+           }}
       end)
 
       expect(

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -64,6 +64,8 @@ Mimic.copy(Broadway)
 Mimic.stub(Goth)
 Mimic.stub(Finch)
 
-ExUnit.configure(exclude: [integration: true, failing: true, benchmark: true])
+ExUnit.configure(
+  exclude: [not_implemented: true, integration: true, failing: true, benchmark: true]
+)
 
 Ecto.Adapters.SQL.Sandbox.mode(Logflare.Repo, :manual)


### PR DESCRIPTION
This PR properly handles managed service accounts when it is disabled (it is disabled by default).