### PR TITLE
test: use retry_assert on flaky test in BillingAccountLive

### DIFF
--- a/test/logflare_web/live/billingaccount_live/edit_test.exs
+++ b/test/logflare_web/live/billingaccount_live/edit_test.exs
@@ -46,7 +46,9 @@ defmodule LogflareWeb.BillingAccountLive.EditTest do
              |> post(~p"/webhooks/stripe", stripe_webhook_payload)
              |> json_response(200) == %{"message" => "ok"}
 
-      assert render(view) =~ "VISA ending in 4242 expires 3/1995"
+      TestUtils.retry_assert(fn ->
+        assert render(view) =~ "VISA ending in 4242 expires 3/1995"
+      end)
     end
   end
 


### PR DESCRIPTION
The setup on this test case was flaky because processing the webhook sometimes took longer than the liveview re-render. Using the retry_assert allows us to retry the test until it passes.