### PR TITLE
chore: remove warnings in migrations regarding Application.get_env

### DIFF
--- a/priv/repo/migrations/20210322193905_rename_columns_for_mnesia_compatibility.exs
+++ b/priv/repo/migrations/20210322193905_rename_columns_for_mnesia_compatibility.exs
@@ -1,6 +1,7 @@
 defmodule Logflare.Repo.Migrations.RenameColumnsForMnesiaCompatibility do
   use Ecto.Migration
-  @env Application.get_env(:logflare, :env)
+
+  @env Application.compile_env(:logflare, :env)
 
   def change do
     alter table(:users) do

--- a/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
+++ b/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
@@ -16,10 +16,10 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
   use Ecto.Migration
   @disable_ddl_transaction true
   @disable_migration_lock true
-  @username Application.get_env(:logflare, Logflare.Repo)[:username]
-  @slot Application.get_env(:logflare, Logflare.ContextCache.CacheBuster)[:replication_slot]
-  @env Application.get_env(:logflare, :env)
-  @publications Application.get_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
+  @username Application.compile_env(:logflare, Logflare.Repo)[:username]
+  @slot Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:replication_slot]
+  @env Application.compile_env(:logflare, :env)
+  @publications Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
   @publication_tables [
     "billing_accounts",
     "plans",

--- a/priv/repo/migrations/20240708025030_recreate_publication_for_tables.exs
+++ b/priv/repo/migrations/20240708025030_recreate_publication_for_tables.exs
@@ -2,7 +2,7 @@ defmodule Logflare.Repo.Migrations.RecreatePublicationForTables do
   use Ecto.Migration
   use Ecto.Migration
 
-  @publications Application.get_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
+  @publications Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
   @publication_tables [
     "billing_accounts",
     "plans",

--- a/priv/repo/migrations/20241204120824_recreate_tables_publication.exs
+++ b/priv/repo/migrations/20241204120824_recreate_tables_publication.exs
@@ -2,7 +2,7 @@ defmodule Logflare.Repo.Migrations.RecreateTablesPublication do
   use Ecto.Migration
   use Ecto.Migration
 
-  @publications Application.get_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
+  @publications Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
   @table "oauth_access_tokens"
 
   def up do


### PR DESCRIPTION
In practice, it does not change much but removes the annoying warnings :point_down: 

![image](https://github.com/user-attachments/assets/b08285e5-ea84-4807-9e5c-54b866368e55)
