### PR TITLE
feat: Use monaco editor in EndpointsLive

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,6 +33,8 @@ import "./vendor/daterangepicker.css";
 // interfaces
 import * as Interfaces from "./interfaces";
 
+import MonacoEditorCompletionProvider from "./monaco_editor_completion_provider";
+
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
@@ -54,8 +56,9 @@ const hooks = {
   ...LiveModalHooks,
   ...BillingHooks,
   CodeEditorHook
-  
 };
+
+window.addEventListener("lme:editor_mounted", MonacoEditorCompletionProvider);
 
 let liveSocket = new LiveSocket("/live", Socket, {
   hooks,

--- a/assets/js/monaco_editor_completion_provider.js
+++ b/assets/js/monaco_editor_completion_provider.js
@@ -1,0 +1,49 @@
+/*
+Listen for editor mount and register completion provider
+Supports MonacoEditorComponent
+*/
+const editorMountedHandler = (ev) => {
+  // build a list of completions for the editor
+  const dataCompletionsName = ev.detail.hook.el.getAttribute(
+    "data-completions-name",
+  );
+  const completionsEl = document.querySelector(
+    `[name="${dataCompletionsName}"]`,
+  );
+
+  let completions = [];
+
+  if (completionsEl != null) {
+    completions = JSON.parse(completionsEl.value);
+  }
+
+  const editor = ev.detail.editor.standalone_code_editor;
+
+  function createDependencyProposals(range) {
+    return completions.map(function (name) {
+      return {
+        label: name,
+        kind: monaco.languages.CompletionItemKind.Module,
+        insertText: name,
+        range: range,
+      };
+    });
+  }
+
+  monaco.languages.registerCompletionItemProvider("sql", {
+    provideCompletionItems: function (model, position) {
+      var word = model.getWordUntilPosition(position);
+      var range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      return {
+        suggestions: createDependencyProposals(range),
+      };
+    },
+  });
+};
+
+export default editorMountedHandler;

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -40,16 +40,8 @@
           This endpoint will execute this query on each <code>GET</code> request.
           Declare parameters using <code>@parameter_name</code> and pass it to the endpoint via query parameters <code>?parameter_name=some-value</code>
         </p>
-        <%= textarea(f, :query,
-          placeholder: "select timestamp, event_message from `YourApp.SourceName`",
-          class: "form-control form-control-margin",
-          "phx-change": "parse-query",
-          id: "endpoint-query",
-          value: Map.get(@params_form.params, "query"),
-          style: "height: 20rem"
-        ) %>
-        <%= error_tag(f, :query) %>
-        <.alert :if={@parse_error_message} variant="warning"><%= @parse_error_message %></.alert>
+
+        <.live_component module={LogflareWeb.MonacoEditorComponent} id="endpoint_query" field={f[:query]} endpoints={@endpoints} alerts={@alerts} completions={@completions} />
       </div>
 
       <div class="form-group">

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -55,6 +55,7 @@ defmodule LogflareWeb.EndpointsLive do
       |> assign(:params_form, to_form(%{"query" => "", "params" => %{}}, as: "run"))
       |> assign(:declared_params, %{})
       |> assign(:alerts, alerts)
+      |> assign_completions()
       |> assign(:parsed_result, nil)
 
     {:ok, socket}
@@ -97,7 +98,10 @@ defmodule LogflareWeb.EndpointsLive do
         other ->
           other
           # reset the changeset
-          |> assign(:endpoint_changeset, nil)
+          |> assign(
+            :endpoint_changeset,
+            Endpoints.change_query(%Endpoints.Query{query: placeholder_sql()})
+          )
           # reset test results
           |> assign(:query_result_rows, nil)
       end)
@@ -227,10 +231,26 @@ defmodule LogflareWeb.EndpointsLive do
     assign(socket, :endpoints, endpoints)
   end
 
+  defp assign_completions(socket) do
+    %{user_id: user_id, alerts: alerts, endpoints: endpoints} = socket.assigns
+
+    sources = Logflare.Sources.list_sources_by_user(user_id)
+
+    completions =
+      [sources, endpoints, alerts] |> List.flatten() |> Enum.map(fn item -> item.name end)
+
+    assign(socket, :completions, completions)
+  end
+
   defp upsert_query(show_endpoint, user, params) do
     case show_endpoint do
       nil -> Endpoints.create_query(user, params)
       %_{} -> Endpoints.update_query(show_endpoint, params)
     end
   end
+
+  defp placeholder_sql,
+    do: """
+    select timestamp, event_message from `YourApp.SourceName`"
+    """
 end

--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -1,0 +1,100 @@
+defmodule LogflareWeb.MonacoEditorComponent do
+  use LogflareWeb, :live_component
+
+  def mount(socket) do
+    {:ok, assign(socket, parse_error_message: nil)}
+  end
+
+  def render(assigns) do
+    assigns = assigns |> assign(editor_opts: editor_opts())
+
+    ~H"""
+    <div>
+      <LiveMonacoEditor.code_editor value={@field.value} target={@myself} change="parse-query" path="query_string" id="query" data-completions-name={[@field.name, "_completions"]} opts={@editor_opts} />
+      <input type="hidden" name={[@field.name, "_completions"]} value={Jason.encode!(@completions)} />
+      <%= hidden_input(@field.form, :query, value: @field.value) %>
+      <%= error_tag(@field.form, :query) %>
+      <.alert :if={@parse_error_message} variant="warning">
+        <strong>SQL Parse error!</strong>
+        <br />
+        <span><%= @parse_error_message %></span>
+      </.alert>
+    </div>
+    """
+  end
+
+  def handle_event("parse-query", %{"value" => query}, socket) do
+    %{endpoints: endpoints, alerts: alerts} = socket.assigns
+
+    field = socket.assigns.field |> Map.put(:value, query)
+
+    socket =
+      case parse_query(query, endpoints, alerts) do
+        :ok ->
+          assign(socket, field: field, parse_error_message: nil)
+
+        {:error, message} ->
+          assign(socket, field: field, parse_error_message: message)
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("parse-query", %{"_target" => ["live_monaco_editor", _]}, socket) do
+    # ignore change events from the editor field
+    {:noreply, socket}
+  end
+
+  def parse_query(query_string, endpoints, alerts)
+  def parse_query("", _endpoints, _alerts), do: :ok
+
+  def parse_query(query_string, endpoints, alerts) do
+    case Logflare.Endpoints.parse_query_string(
+           :bq_sql,
+           query_string,
+           endpoints,
+           alerts
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, "sql parser error: " <> message} ->
+        {:error, message}
+
+      {:error, err} ->
+        message = if(is_binary(err), do: err, else: inspect(err))
+        {:error, message}
+    end
+  end
+
+  defp editor_opts do
+    Map.merge(
+      LiveMonacoEditor.default_opts(),
+      %{
+        "wordWrap" => "on",
+        "language" => "sql",
+        "fontSize" => 12,
+        "padding" => %{
+          "top" => 14,
+          "bottom" => 14
+        },
+        "contextmenu" => false,
+        "hideCursorInOverviewRuler" => true,
+        "smoothScrolling" => true,
+        "scrollbar" => %{
+          "vertical" => "auto",
+          "horizontal" => "hidden",
+          "verticalScrollbarSize" => 6
+        },
+        "lineNumbers" => "off",
+        "glyphMargin" => false,
+        "lineNumbersMinChars" => 0,
+        "folding" => false,
+        "roundedSelection" => true,
+        "minimap" => %{
+          "enabled" => false
+        }
+      }
+    )
+  end
+end

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -1,0 +1,102 @@
+defmodule LogflareWeb.MonacoEditorComponentTest do
+  use LogflareWeb.ConnCase, async: true
+
+  alias LogflareWeb.MonacoEditorComponent
+
+  import Phoenix.Component, only: [to_form: 1]
+
+  describe "rendering the live component" do
+    setup do
+      form = %{"query" => ""} |> to_form()
+      [assigns: %{form: form}]
+    end
+
+    test "renders the live component", %{assigns: assigns} do
+      html =
+        render_component(MonacoEditorComponent, %{
+          id: "test-editor",
+          field: assigns.form[:query],
+          endpoints: [],
+          alerts: [],
+          completions: []
+        })
+
+      assert html =~ ~s(phx-hook="CodeEditorHook")
+      assert html =~ ~s(data-completions-name="query_completions")
+      assert html =~ ~s(<input type="hidden" name="query_completions" value="[]")
+    end
+
+    test "renders with completions set", %{assigns: assigns} do
+      html =
+        render_component(MonacoEditorComponent, %{
+          id: "test-editor",
+          field: assigns.form[:query],
+          endpoints: [],
+          alerts: [],
+          completions: ["First", "Second"]
+        })
+
+      escaped = ~s(["First","Second"]) |> Plug.HTML.html_escape()
+
+      assert html =~
+               ~s(<input type="hidden" name="query_completions" value="#{escaped})
+    end
+
+    test "renders with parser error message set", %{assigns: assigns} do
+      html =
+        render_component(MonacoEditorComponent, %{
+          id: "test-editor",
+          field: assigns.form[:query],
+          endpoints: [],
+          alerts: [],
+          completions: [],
+          parse_error_message: "Invalid SQL syntax"
+        })
+
+      assert html =~ ~s(<div class="alert alert-warning)
+      assert html =~ "Invalid SQL syntax"
+    end
+
+    test "renders field value when set" do
+      form = %{"query" => "SELECT * FROM `MyApp.Logs`"} |> to_form()
+
+      html =
+        render_component(MonacoEditorComponent, %{
+          id: "test-editor",
+          field: form[:query],
+          endpoints: [],
+          alerts: [],
+          completions: []
+        })
+
+      assert html =~ "SELECT * FROM `MyApp.Logs`"
+    end
+  end
+
+  describe "parsing the query" do
+    test "parse_query/3 returns :ok for valid query" do
+      query = "SELECT * FROM `MyApp.Logs` WHERE timestamp > '2023-01-01'"
+      endpoints = []
+      alerts = []
+
+      assert MonacoEditorComponent.parse_query(query, endpoints, alerts) == :ok
+    end
+
+    test "parse_query/3 returns {:error, message} for invalid query" do
+      query = "INVALID SQL QUERY"
+      endpoints = []
+      alerts = []
+
+      assert {:error, message} = MonacoEditorComponent.parse_query(query, endpoints, alerts)
+      assert is_binary(message)
+    end
+
+    test "parse_query/3 ignores empty query" do
+      query = ""
+      endpoints = []
+      alerts = []
+
+      assert :ok = MonacoEditorComponent.parse_query(query, endpoints, alerts)
+    end
+  end
+end

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -127,27 +127,6 @@ defmodule LogflareWeb.EndpointsLiveTest do
     test "new endpoint", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/endpoints/new")
 
-      # Error
-      assert view
-             |> element("#endpoint-query")
-             |> render_change(%{
-               endpoint: %{
-                 query: "select current_datetime() order-by invalid"
-               }
-             }) =~ "parser error"
-
-      # no error
-      refute view
-             |> element("#endpoint-query")
-             |> render_change(%{
-               endpoint: %{
-                 query: "select @my_param as valid"
-               }
-             }) =~ "parser error"
-
-      # detects params correctly
-      assert has_element?(view, "form label", "my_param")
-
       # saves the change
       assert view
              |> element("form", "Save")
@@ -166,27 +145,6 @@ defmodule LogflareWeb.EndpointsLiveTest do
     test "edit endpoint", %{conn: conn, user: user} do
       endpoint = insert(:endpoint, user: user, query: "select @other as initial")
       {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}/edit")
-
-      # Error
-      assert view
-             |> element("*#endpoint-query")
-             |> render_change(%{
-               endpoint: %{
-                 query: "select current_datetime() order-by invalid"
-               }
-             }) =~ "parser error"
-
-      # no error
-      refute view
-             |> element("*#endpoint-query")
-             |> render_change(%{
-               endpoint: %{
-                 query: "select @my_param as valid"
-               }
-             }) =~ "parser error"
-
-      # detects params correctly
-      assert has_element?(view, "form label", "my_param")
 
       # saves the change
       assert view
@@ -231,14 +189,6 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
       refute render(view) =~ "results-123"
 
-      refute view
-             |> element("#endpoint-query")
-             |> render_change(%{
-               endpoint: %{
-                 query: "select current_datetime() as new"
-               }
-             }) =~ "parser error"
-
       view
       |> element("form", "Test query")
       |> render_submit(%{
@@ -270,12 +220,6 @@ defmodule LogflareWeb.EndpointsLiveTest do
       endpoint = insert(:endpoint, user: user)
       {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}/edit")
       refute render(view) =~ "results-123"
-
-      view
-      |> element("#endpoint-query")
-      |> render_change(%{
-        query: "select current_datetime() as updated"
-      })
 
       view
       |> element("form", "Test query")


### PR DESCRIPTION
* Add MonacoEditorComponent to be used as a LiveComponent
* Support providing list of strings to be used as completions in editor
* Remove some tests from EndpointsLive: change events are handled with a JS hook, so render_change no longer works for the query field