### PR TITLE
perf: refactor search query executor

### DIFF
--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -15,7 +15,6 @@ defmodule Logflare.Backends.SourceSup do
   alias Logflare.Source.WebhookNotificationServer
   alias Logflare.Source.SlackHookServer
   alias Logflare.Source.BillingWriter
-  alias Logflare.Logs.SearchQueryExecutor
   alias Logflare.Backends.RecentEventsTouch
   alias Logflare.Backends.RecentInsertsBroadcaster
   alias Logflare.Rules.Rule
@@ -54,7 +53,6 @@ defmodule Logflare.Backends.SourceSup do
         {TextNotificationServer, [source: source, plan: plan]},
         {WebhookNotificationServer, [source: source]},
         {SlackHookServer, [source: source]},
-        {SearchQueryExecutor, [source: source]},
         {BillingWriter, [source: source]},
         {SourceSupWorker, [source: source]}
       ] ++ specs

--- a/lib/logflare/logs/search/logs_search_operation.ex
+++ b/lib/logflare/logs/search/logs_search_operation.ex
@@ -7,6 +7,8 @@ defmodule Logflare.Logs.SearchOperation do
 
   typedstruct do
     field :source, Source.t()
+    field :source_token, atom()
+    field :source_id, number()
     field :partition_by, :pseudo | :timestamp, enforce: true
     field :querystring, String.t(), enforce: true
     field :query, Ecto.Query.t()
@@ -41,7 +43,9 @@ defmodule Logflare.Logs.SearchOperation do
       so
       | lql_meta_and_msg_filters: lql_meta_and_msg_filters,
         chart_rules: chart_rules,
-        lql_ts_filters: ts_filters
+        lql_ts_filters: ts_filters,
+        source_token: so.source.token,
+        source_id: so.source.id
     }
   end
 end

--- a/lib/logflare/logs/search/logs_search_query_executor.ex
+++ b/lib/logflare/logs/search/logs_search_query_executor.ex
@@ -9,7 +9,7 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   import LogflareWeb.SearchLV.Utils
   alias Logflare.LogEvent
   alias Logflare.User.BigQueryUDFs
-  alias Logflare.{Users, User}
+  alias Logflare.Users
   alias Logflare.Utils.Tasks
 
   require Logger

--- a/lib/logflare/logs/search/logs_search_query_executor.ex
+++ b/lib/logflare/logs/search/logs_search_query_executor.ex
@@ -6,9 +6,6 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   alias Logflare.LogEvent
   alias Logflare.User.BigQueryUDFs
   alias Logflare.{Users, User}
-  alias Logflare.Logs
-  alias Logflare.Source
-  alias Logflare.Backends
   alias Logflare.Utils.Tasks
   use TypedStruct
   require Logger
@@ -27,11 +24,11 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
   # API
   def start_link(args) do
-    source = Keyword.get(args, :source)
+    caller = self()
 
-    GenServer.start_link(__MODULE__, args,
+    GenServer.start_link(__MODULE__, Keyword.put(args, :caller, caller),
       spawn_opt: [fullsweep_after: 5_000],
-      name: Backends.via_source(source, __MODULE__)
+      hibernate_after: 5_000
     )
   end
 
@@ -42,148 +39,98 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
     {:ok,
      %{
+       caller: Keyword.get(args, :caller),
        source_token: source.token,
        user_id: source.user_id,
        source_id: source.id,
-       agg_tasks: %{},
-       event_tasks: %{}
+       agg_task: {nil, nil},
+       event_task: {nil, nil}
      }}
   end
 
-  def maybe_cancel_query(source_token) when is_atom(source_token) do
-    case Backends.lookup(__MODULE__, source_token) do
-      {:ok, _} ->
-        :ok = cancel_query(source_token)
-        :ok = cancel_agg(source_token)
-
-      {:error, _} ->
-        :ok
-    end
-  end
-
-  def maybe_execute_events_query(source_token, params) when is_atom(source_token) do
-    case Backends.lookup(__MODULE__, source_token) do
-      {:ok, _} ->
-        :ok = query(params)
-
-      {:error, _} ->
-        Logger.error("Query failed: SearchQueryExecutor process for #{source_token} not alive")
-
-        :error
-    end
-  end
-
-  def maybe_execute_agg_query(source_token, params) when is_atom(source_token) do
-    case Backends.lookup(__MODULE__, source_token) do
-      {:ok, _} ->
-        :ok = query_agg(params)
-
-      {:error, _} ->
-        Logger.error("Query failed: SearchQueryExecutor process for #{source_token} not alive")
-
-        :error
-    end
-  end
-
-  def query(params) do
-    {:ok, pid} = Backends.lookup(__MODULE__, params.source.token)
+  def query(pid, params) do
     GenServer.call(pid, {:query, params}, @query_timeout)
   end
 
-  def query_agg(params) do
-    {:ok, pid} = Backends.lookup(__MODULE__, params.source.token)
+  def query_agg(pid, params) do
     GenServer.call(pid, {:query_agg, params}, @query_timeout)
   end
 
-  def cancel_agg(source_token) when is_atom(source_token) do
-    {:ok, pid} = Backends.lookup(__MODULE__, source_token)
+  def cancel_agg(pid) do
     GenServer.call(pid, :cancel_agg, @query_timeout)
   end
 
-  def cancel_query(source_token) when is_atom(source_token) do
-    {:ok, pid} = Backends.lookup(__MODULE__, source_token)
+  def cancel_query(pid) do
     GenServer.call(pid, :cancel_query, @query_timeout)
   end
 
   # Callbacks
 
   @impl true
-  def handle_call({:query, params}, {lv_pid, _ref}, state) do
-    Logger.info(
-      "Starting search query from #{pid_to_string(lv_pid)} for #{params.source.token} source..."
+  def handle_call({:query, new_params}, {lv_pid, _ref}, state) do
+    Logger.debug(
+      "Starting search query from #{pid_to_string(lv_pid)} for #{state.source_id} source..."
     )
 
     user = Users.Cache.get(state.user_id) |> Users.Cache.preload_defaults()
 
     BigQueryUDFs.create_if_not_exists_udfs_for_user_dataset(user)
 
-    current_lv_task_params = state.event_tasks[lv_pid]
+    {ref, _params} = state.event_task
 
-    if current_lv_task_params && current_lv_task_params[:task] do
-      Logger.info(
-        "SearchQueryExecutor: cancelling query task for #{pid_to_string(lv_pid)} live_view..."
+    if ref do
+      Logger.debug(
+        "SearchQueryExecutor: cancelling query task for #{pid_to_string(lv_pid)} live_view of #{state.source_id} source..."
       )
 
-      Task.shutdown(current_lv_task_params.task, :brutal_kill)
+      Task.shutdown(ref, :brutal_kill)
     end
 
-    event_tasks =
-      Map.put(state.event_tasks, lv_pid, %{
-        task: start_search_task(lv_pid, params),
-        params: params
-      })
+    new_ref = start_search_task(lv_pid, new_params)
 
-    {:reply, :ok, %{state | event_tasks: event_tasks}}
+    {:reply, :ok, %{state | event_task: {new_ref, new_params}}}
   end
 
-  def handle_call({:query_agg, params}, {lv_pid, _ref}, state) do
-    current_lv_task_params = state.agg_tasks[lv_pid]
+  def handle_call({:query_agg, new_params}, {lv_pid, _ref}, state) do
+    {ref, _params} = state.agg_task
 
-    if current_lv_task_params && current_lv_task_params[:task] do
-      Task.shutdown(current_lv_task_params.task, :brutal_kill)
+    if ref do
+      Task.shutdown(ref, :brutal_kill)
     end
 
-    agg_tasks =
-      Map.put(state.agg_tasks, lv_pid, %{
-        task: start_aggs_task(lv_pid, params),
-        params: params
-      })
+    new_ref = start_aggs_task(lv_pid, new_params)
 
-    {:reply, :ok, %{state | agg_tasks: agg_tasks}}
+    {:reply, :ok, %{state | agg_task: {new_ref, new_params}}}
   end
 
   @impl true
   def handle_call(:cancel_agg, {lv_pid, _ref}, state) do
-    current_lv_task_params = state.agg_tasks[lv_pid]
+    {ref, _params} = state.agg_task
 
-    if current_lv_task_params && current_lv_task_params[:task] do
-      Logger.info(
+    if ref do
+      Logger.debug(
         "SearchQueryExecutor: Cancelling agg task from #{pid_to_string(lv_pid)} live_view..."
       )
 
-      Task.shutdown(current_lv_task_params.task, :brutal_kill)
+      Task.shutdown(ref, :brutal_kill)
     end
 
-    agg_tasks = Map.put(state.agg_tasks, lv_pid, %{})
-
-    {:reply, :ok, %{state | agg_tasks: agg_tasks}}
+    {:reply, :ok, %{state | agg_task: {nil, nil}}}
   end
 
   @impl true
   def handle_call(:cancel_query, {lv_pid, _ref}, state) do
-    current_lv_task_params = state.event_tasks[lv_pid]
+    {ref, _params} = state.event_task
 
-    if current_lv_task_params && current_lv_task_params[:task] do
-      Logger.info(
+    if ref do
+      Logger.debug(
         "SearchQueryExecutor: Cancelling query task from #{pid_to_string(lv_pid)} live_view..."
       )
 
-      Task.shutdown(current_lv_task_params.task, :brutal_kill)
+      Task.shutdown(ref, :brutal_kill)
     end
 
-    event_tasks = Map.put(state.event_tasks, lv_pid, %{})
-
-    {:reply, :ok, %{state | event_tasks: event_tasks}}
+    {:reply, :ok, %{state | event_task: {nil, nil}}}
   end
 
   @impl true
@@ -192,7 +139,7 @@ defmodule Logflare.Logs.SearchQueryExecutor do
       "SearchQueryExecutor: Getting search events for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
     )
 
-    {%{params: params}, new_event_tasks} = Map.pop(state.event_tasks, lv_pid)
+    {_ref, params} = state.event_task
 
     rows = Enum.map(events_so.rows, &LogEvent.make_from_db(&1, %{source: params.source}))
 
@@ -208,15 +155,15 @@ defmodule Logflare.Logs.SearchQueryExecutor do
       |> Enum.sort_by(& &1.body["timestamp"], &>=/2)
       |> Enum.take(100)
 
-    maybe_send(
-      lv_pid,
+    send(
+      state.caller,
       {:search_result,
        %{
          events: %{events_so | rows: log_events}
        }}
     )
 
-    {:noreply, %{state | event_tasks: new_event_tasks}}
+    {:noreply, %{state | event_task: {nil, nil}}}
   end
 
   @impl true
@@ -225,22 +172,22 @@ defmodule Logflare.Logs.SearchQueryExecutor do
       "SearchQueryExecutor: Getting search aggregates for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
     )
 
-    {_, new_agg_tasks} = Map.pop(state.agg_tasks, lv_pid)
+    {_ref, _params} = state.agg_task
 
-    maybe_send(
-      lv_pid,
+    send(
+      state.caller,
       {:search_result,
        %{
          aggregates: aggregates_so
        }}
     )
 
-    {:noreply, %{state | agg_tasks: new_agg_tasks}}
+    {:noreply, %{state | agg_task: {nil, nil}}}
   end
 
   @impl true
-  def handle_info({_ref, {:search_error, lv_pid, %SO{} = search_op}}, state) do
-    maybe_send(lv_pid, {:search_error, search_op})
+  def handle_info({_ref, {:search_error, _lv_pid, %SO{} = search_op}}, state) do
+    send(state.caller, {:search_error, search_op})
     {:noreply, state}
   end
 
@@ -253,26 +200,12 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
   @impl true
   def handle_info(msg, state) do
-    Logger.error("SearchQueryExecutor received unknown message: #{inspect(msg)}")
+    Logger.warning("SearchQueryExecutor received unknown message: #{inspect(msg)}")
     {:noreply, state}
-  end
-
-  def maybe_send(lv_pid, msg) do
-    if Process.alive?(lv_pid) do
-      send(lv_pid, msg)
-    else
-      Logger.info(
-        "SearchQueryExecutor not sending msg to #{pid_to_string(lv_pid)} because it's not alive} "
-      )
-    end
   end
 
   def start_search_task(lv_pid, params) do
     so = SO.new(params)
-
-    if so.tailing? do
-      start_cache_streaming_buffer_task(so.source)
-    end
 
     Tasks.async(fn ->
       so
@@ -299,32 +232,6 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
         {:error, result} ->
           {:search_error, lv_pid, result}
-      end
-    end)
-  end
-
-  def start_cache_streaming_buffer_task(%Source{} = source) do
-    Tasks.start_child(fn ->
-      source
-      |> Search.query_source_streaming_buffer()
-      |> case do
-        {:ok, query_result} ->
-          %{rows: rows} = query_result
-
-          for row <- rows do
-            le = LogEvent.make_from_db(row, %{source: source})
-
-            Logs.LogEvents.Cache.put(
-              source.token,
-              {"uuid", le.id},
-              le
-            )
-          end
-
-          :ok
-
-        {:error, _result} ->
-          Logger.warning("Streaming buffer not found for source #{source.token}")
       end
     end)
   end

--- a/lib/logflare/logs/search/logs_search_query_executor.ex
+++ b/lib/logflare/logs/search/logs_search_query_executor.ex
@@ -1,5 +1,9 @@
 defmodule Logflare.Logs.SearchQueryExecutor do
+  @moduledoc """
+  Handles all search queries for the specific source
+  """
   use GenServer
+
   alias Logflare.Logs.Search
   alias Logflare.Logs.SearchOperation, as: SO
   import LogflareWeb.SearchLV.Utils
@@ -7,26 +11,14 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   alias Logflare.User.BigQueryUDFs
   alias Logflare.{Users, User}
   alias Logflare.Utils.Tasks
-  use TypedStruct
+
   require Logger
+
   @query_timeout 60_000
-
-  @moduledoc """
-  Handles all search queries for the specific source
-  """
-
-  typedstruct do
-    field :source_id, atom, enforce: true
-    field :user, User.t(), enforce: true
-    field :event_tasks, map, enforce: true
-    field :agg_tasks, map, enforce: true
-  end
 
   # API
   def start_link(args) do
-    caller = self()
-
-    GenServer.start_link(__MODULE__, Keyword.put(args, :caller, caller),
+    GenServer.start_link(__MODULE__, Keyword.put(args, :caller, self()),
       spawn_opt: [fullsweep_after: 5_000],
       hibernate_after: 5_000
     )

--- a/lib/logflare/source/v1_source_sup.ex
+++ b/lib/logflare/source/v1_source_sup.ex
@@ -13,7 +13,6 @@ defmodule Logflare.Source.V1SourceSup do
   alias Logflare.Backends
   alias Logflare.Backends.Backend
   alias Logflare.Billing
-  alias Logflare.Logs.SearchQueryExecutor
 
   require Logger
   use Supervisor
@@ -48,7 +47,6 @@ defmodule Logflare.Source.V1SourceSup do
       {TextNotificationServer, [source: source, plan: plan]},
       {WebhookNotificationServer, [source: source]},
       {SlackHookServer, [source: source]},
-      {SearchQueryExecutor, [source: source]},
       {BillingWriter, [source: source]}
     ]
 


### PR DESCRIPTION
Major refactor of SearchQueryExecutor, to minimize memory and cpu impact, as well as to narrow down on cpu leak that we are observing on main cluster.

This starts up the executor on a per search basis, and only allows for one search at a time. It does not deviate too much from existing behaviour, however some additional performance tweaks are put in:
- add in genserver hibernation after 5s
- remove streaming buffer caching and associated task spawning
- reduce chart default query query range for day/hour
- reduce default querying intervals based on ingest rate - high ingest rate sources will now query last minute and this scales based on avg ingestion rate - closes ANL-504
