### PR TITLE
feat: BQ tagging of queries by labels

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -298,9 +298,13 @@ defmodule Logflare.Endpoints do
            parameterMode: "NAMED",
            maxResults: endpoint_query.max_limit,
            location: endpoint_query.user.bigquery_dataset_location,
-           labels: %{
-             "endpoint_id" => endpoint_query.id
-           }
+           labels:
+             Map.merge(
+               %{
+                 "endpoint_id" => endpoint_query.id
+               },
+               endpoint_query.parsed_labels || %{}
+             )
          ) do
       {:ok, result} ->
         {:ok, result}

--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -20,7 +20,8 @@ defmodule Logflare.Endpoints.Query do
              :cache_duration_seconds,
              :proactive_requerying_seconds,
              :max_limit,
-             :enable_auth
+             :enable_auth,
+             :labels
            ]}
   typed_schema "endpoint_queries" do
     field(:token, Ecto.UUID, autogenerate: true)
@@ -34,7 +35,8 @@ defmodule Logflare.Endpoints.Query do
     field(:proactive_requerying_seconds, :integer, default: 1_800)
     field(:max_limit, :integer, default: 1_000)
     field(:enable_auth, :boolean, default: true)
-
+    field(:labels, :string)
+    field(:parsed_labels, :map, virtual: true)
     field(:metrics, :map, virtual: true)
 
     belongs_to(:user, Logflare.User)
@@ -64,7 +66,8 @@ defmodule Logflare.Endpoints.Query do
       :max_limit,
       :enable_auth,
       :language,
-      :description
+      :description,
+      :labels
     ])
     |> validate_required([:name, :query, :language])
   end
@@ -81,7 +84,8 @@ defmodule Logflare.Endpoints.Query do
       :max_limit,
       :enable_auth,
       :language,
-      :description
+      :description,
+      :labels
     ])
     |> validate_query(:query)
     |> default_validations()

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -129,6 +129,20 @@
           Cached results will be refreshed at this interval. Ignored if caching is disabled.
         </small>
       </div>
+      <div>
+        <%= label(f, :labels, "Query Execution Labels") %>
+        <div class="input-group">
+          <%= text_input(f, :labels,
+            placeholder: if(@show_endpoint, do: nil, else: ""),
+            class: "form-control"
+          ) %>
+        </div>
+        <%= error_tag(f, :labels) %>
+        <small class="form-text text-muted">
+          A comma-separated allowlist of labels to be added to the query execution backend. To reference parameters, use the format <code>my_param=@my_param,my_other_field,meta</code>.
+          Key value pairs will be added to the query execution backend using the <code>LF-ENDPOINT-LABELS: my_other_field=some-val,meta=123</code> request header.
+        </small>
+      </div>
     </section>
   </.form>
   <aside class="tw-w-1/2">

--- a/priv/repo/migrations/20250709072539_add_labels_to_endpoint_queries_table.exs
+++ b/priv/repo/migrations/20250709072539_add_labels_to_endpoint_queries_table.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddLabelsToEndpointQueriesTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      add :labels, :text
+    end
+  end
+end


### PR DESCRIPTION
this adds in BQ label tagging of queries for billing processing.
It adds a `:labels` column to `endpoint_queries`, and uses the `LF-ENDPOINTS-LABELS` header for values.
It also allows referencing of params using `my_label=@my_param` syntax.
Static values can also be set.