### PR TITLE
chore: makefile quality of life additions (mise support, improved messages)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 Pre-requisites:
 
-- asdf
+- asdf (or mise)
 - docker
 
 ### Setup for Supabase Team


### PR DESCRIPTION
Some simple QOL improvements while keeping things backwards compatible:

- Adds support for [mise](https://mise.jdx.dev)
  - Makefile will use `mise`, if it is installed, otherwise it will use `asdf` as before
  - If both binaries are available, defaults to `mise`
  - `mise` handles `.tool-versions` files the same as `asdf`
  - See the _Why mise??_ section below for more details
- Adds basic checks for other tools used by the Makefile such as `docker`, `git`, and `gcloud`
  - Will not error out if these are not available, but will present a warning.
- Adds some basic color support as well as better visual indicators of what is going on - particularly when running `make setup`.

----

## Why mise???

If unfamiliar with mise, [this document](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html) provides a comparison between it and asdf.

While asdf is a fine tool and something I personally used for years, the way shims are handled and potential security differences make mise a bit more attractive.

But as noted above, this PR only _prioritizes_ mise over asdf (if already installed) and does not require you to use mise if you're happy with an existing asdf setup.

----

## Screenshot showing output from make setup

<img width="1228" height="1408" alt="image" src="https://github.com/user-attachments/assets/57ec28e4-4f8f-40d8-95c8-953e578b22d3" />
