### PR TITLE
chore: make sql dialect transformer tests async

### DIFF
--- a/test/logflare/sql/dialect_transformer/bigquery_test.exs
+++ b/test/logflare/sql/dialect_transformer/bigquery_test.exs
@@ -9,7 +9,7 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
   @user_dataset_id "user-dataset-id"
 
   setup do
-    insert(:plan)
+    build(:plan)
     values = Application.get_env(:logflare, Logflare.Google)
     to_put = Keyword.put(values, :project_id, @logflare_project_id)
     Application.put_env(:logflare, Logflare.Google, to_put)
@@ -33,8 +33,8 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
 
   describe "transform_source_name/2" do
     test "uses logflare project when user project is nil" do
-      user = insert(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
-      source = insert(:source, name: "test_source", user: user)
+      user = build(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
+      source = build(:source, name: "test_source", user: user)
 
       data = %{
         sources: [source],
@@ -51,12 +51,12 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
 
     test "uses user project when configured" do
       user =
-        insert(:user,
+        build(:user,
           bigquery_project_id: @user_project_id,
           bigquery_dataset_id: @user_dataset_id
         )
 
-      source = insert(:source, name: "test_source", user: user)
+      source = build(:source, name: "test_source", user: user)
 
       data = %{
         sources: [source],
@@ -72,8 +72,8 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
     end
 
     test "sanitizes hyphens in tokens" do
-      user = insert(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
-      source = insert(:source, name: "hyphenated_source", user: user)
+      user = build(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
+      source = build(:source, name: "hyphenated_source", user: user)
 
       data = %{
         sources: [source],
@@ -89,9 +89,9 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
     end
 
     test "finds correct source by name" do
-      user = insert(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
-      source1 = insert(:source, name: "source_one", user: user)
-      source2 = insert(:source, name: "source_two", user: user)
+      user = build(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
+      source1 = build(:source, name: "source_one", user: user)
+      source2 = build(:source, name: "source_two", user: user)
 
       data = %{
         sources: [source1, source2],
@@ -165,7 +165,7 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
   describe "build_transformation_data/2" do
     test "builds data with user's BigQuery configuration" do
       user =
-        insert(:user,
+        build(:user,
           bigquery_project_id: @user_project_id,
           bigquery_dataset_id: @user_dataset_id
         )
@@ -188,7 +188,7 @@ defmodule Logflare.Sql.DialectTransformer.BigQueryTest do
     end
 
     test "preserves base data fields" do
-      user = insert(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
+      user = build(:user, bigquery_project_id: nil, bigquery_dataset_id: nil)
 
       base_data = %{
         sources: [:source1],

--- a/test/logflare/sql/dialect_transformer/clickhouse_test.exs
+++ b/test/logflare/sql/dialect_transformer/clickhouse_test.exs
@@ -18,8 +18,8 @@ defmodule Logflare.Sql.DialectTransformer.ClickhouseTest do
 
   describe "transform_source_name/2" do
     test "delegates to ClickhouseAdaptor.clickhouse_ingest_table_name/1" do
-      user = insert(:user)
-      source = insert(:source, name: "test_source", user: user)
+      user = build(:user)
+      source = build(:source, name: "test_source", user: user)
 
       data = %{
         sources: [source],
@@ -33,9 +33,9 @@ defmodule Logflare.Sql.DialectTransformer.ClickhouseTest do
     end
 
     test "finds correct source by name from multiple sources" do
-      user = insert(:user)
-      source1 = insert(:source, name: "source_one", user: user)
-      source2 = insert(:source, name: "source_two", user: user)
+      user = build(:user)
+      source1 = build(:source, name: "source_one", user: user)
+      source2 = build(:source, name: "source_two", user: user)
 
       data = %{
         sources: [source1, source2],
@@ -49,8 +49,8 @@ defmodule Logflare.Sql.DialectTransformer.ClickhouseTest do
     end
 
     test "handles source with special characters in token" do
-      user = insert(:user)
-      source = insert(:source, name: "special_source", user: user)
+      user = build(:user)
+      source = build(:source, name: "special_source", user: user)
 
       data = %{
         sources: [source],

--- a/test/logflare/sql/dialect_transformer/postgres_test.exs
+++ b/test/logflare/sql/dialect_transformer/postgres_test.exs
@@ -18,8 +18,8 @@ defmodule Logflare.Sql.DialectTransformer.PostgresTest do
 
   describe "transform_source_name/2" do
     test "delegates to PostgresAdaptor.table_name/1" do
-      user = insert(:user)
-      source = insert(:source, name: "test_source", user: user)
+      user = build(:user)
+      source = build(:source, name: "test_source", user: user)
 
       data = %{
         sources: [source],
@@ -33,9 +33,9 @@ defmodule Logflare.Sql.DialectTransformer.PostgresTest do
     end
 
     test "finds correct source by name from multiple sources" do
-      user = insert(:user)
-      source1 = insert(:source, name: "source_one", user: user)
-      source2 = insert(:source, name: "source_two", user: user)
+      user = build(:user)
+      source1 = build(:source, name: "source_one", user: user)
+      source2 = build(:source, name: "source_two", user: user)
 
       data = %{
         sources: [source1, source2],
@@ -49,8 +49,8 @@ defmodule Logflare.Sql.DialectTransformer.PostgresTest do
     end
 
     test "handles source with special characters in token" do
-      user = insert(:user)
-      source = insert(:source, name: "special_source", user: user)
+      user = build(:user)
+      source = build(:source, name: "special_source", user: user)
 
       data = %{
         sources: [source],

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -62,7 +62,7 @@ defmodule Logflare.Factory do
   def source_factory do
     %Source{
       name: TestUtils.random_string(10),
-      token: TestUtils.gen_uuid(),
+      token: TestUtils.gen_uuid_atom(),
       rules: [],
       favorite: false,
       metrics: %{

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -123,9 +123,11 @@ defmodule Logflare.TestUtils do
     Float.to_string(exp_first_part) <> "E9"
   end
 
-  def gen_uuid do
-    Ecto.UUID.generate()
-  end
+  @spec gen_uuid() :: String.t()
+  def gen_uuid, do: Ecto.UUID.generate()
+
+  @spec gen_uuid_atom() :: atom()
+  def gen_uuid_atom, do: gen_uuid() |> String.to_atom()
 
   @spec gen_email() :: String.t()
   def gen_email, do: "#{random_string()}@#{random_string()}.com"


### PR DESCRIPTION
Minor adjustments to ensure the dialect transformer tests are asynchronous by using the ex_machina `build` callback rather `insert`.

This did require a minor change to the factory for `Source` as it uses a custom ecto type (`Ecto.UUID.Atom`) for the `token` attribute to ensure that build serializes the value as an atom.