### PR TITLE
fix: give local secrets precedence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ __start__:
 	@if [ ! -f ${ENV_FILE} ]; then \
 		touch ${ENV_FILE}; \
 	fi
-	@env $$(cat .dev.env ${ENV_FILE} | xargs) PORT=${PORT} LOGFLARE_GRPC_PORT=${LOGFLARE_GRPC_PORT} LOGFLARE_SUPABASE_MODE=${LOGFLARE_SUPABASE_MODE} iex --sname ${ERL_NAME} --cookie ${ERL_COOKIE} -S mix phx.server
+	@env $$(cat ${ENV_FILE} .dev.env | xargs) PORT=${PORT} LOGFLARE_GRPC_PORT=${LOGFLARE_GRPC_PORT} LOGFLARE_SUPABASE_MODE=${LOGFLARE_SUPABASE_MODE} iex --sname ${ERL_NAME} --cookie ${ERL_COOKIE} -S mix phx.server
 
 
 migrate:


### PR DESCRIPTION
I tried https://github.com/Logflare/logflare/pull/2526 but found the repo secrets were overriding the local `.dev.env` secrets. 

This PR fixes it by ordering `.dev.env` after `$ENV_FILE`