### PR TITLE
feat: Add Monaco editor to AlertsLive

### DIFF
--- a/lib/logflare_web/live/alerts/alerts_live.ex
+++ b/lib/logflare_web/live/alerts/alerts_live.ex
@@ -9,6 +9,7 @@ defmodule LogflareWeb.AlertsLive do
   alias Logflare.Alerting
   alias Logflare.Alerting.AlertQuery
   alias Logflare.Backends
+  alias Logflare.Endpoints
 
   embed_templates("actions/*", suffix: "_action")
   embed_templates("components/*")
@@ -51,6 +52,7 @@ defmodule LogflareWeb.AlertsLive do
       |> assign(:params_form, to_form(%{"query" => "", "params" => %{}}, as: "run"))
       |> assign(:declared_params, %{})
       |> assign(:show_add_backend_form, false)
+      |> assign_endpoints_and_sources()
 
     {:ok, socket}
   end
@@ -303,6 +305,16 @@ defmodule LogflareWeb.AlertsLive do
     alerts = Alerting.list_alert_queries(assigns.user)
 
     assign(socket, :alerts, alerts)
+  end
+
+  defp assign_endpoints_and_sources(socket) do
+    %{user_id: user_id} = socket.assigns
+
+    socket
+    |> assign(
+      sources: Logflare.Sources.list_sources_by_user(user_id),
+      endpoints: Endpoints.list_endpoints_by(user_id: user_id)
+    )
   end
 
   defp upsert_alert(alert, user, params) do

--- a/lib/logflare_web/live/alerts/components/alert_form.html.heex
+++ b/lib/logflare_web/live/alerts/components/alert_form.html.heex
@@ -33,14 +33,7 @@
         <p>
           This alert will execute this query periodically. If a non-zero number of rows are returned from this query, the notification will be triggered.
         </p>
-        <%= textarea(f, :query,
-          placeholder: "select timestamp, event_message from `YourApp.SourceName` \nwhere regexp_contains(event_message, 'error')",
-          class: "form-control form-control-margin",
-          id: "alert-query",
-          style: "height: 20rem"
-        ) %>
-        <%= error_tag(f, :query) %>
-        <.alert :if={@parse_error_message} variant="warning"><%= @parse_error_message %></.alert>
+        <.live_component module={LogflareWeb.MonacoEditorComponent} id="alert_query_editor" field={f[:query]} endpoints={@endpoints} alerts={@alerts} sources={@sources} />
       </div>
 
       <.header_with_anchor text="Query Schedule" />

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -41,7 +41,7 @@
           Declare parameters using <code>@parameter_name</code> and pass it to the endpoint via query parameters <code>?parameter_name=some-value</code>
         </p>
 
-        <.live_component module={LogflareWeb.MonacoEditorComponent} id="endpoint_query" field={f[:query]} endpoints={@endpoints} alerts={@alerts} completions={@completions} />
+        <.live_component module={LogflareWeb.MonacoEditorComponent} id="endpoint_query_editor" field={f[:query]} endpoints={@endpoints} alerts={@alerts} sources={@sources} />
       </div>
 
       <div class="form-group">

--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -1,15 +1,43 @@
 defmodule LogflareWeb.MonacoEditorComponent do
   use LogflareWeb, :live_component
 
+  @moduledoc """
+  Provides a Monaco Editor component for creating LQL queries.
+
+  Expects following attributes:
+    - `field`: a `Phoenix.HTML.FormField` for the query.
+    - `endpoints`: A list of endpoints, used for validating LQL queries and completions.
+    - `alerts`: A list of alerts, used for validating LQL queries and completions.
+    - `sources`: A list of sources, used for completions.
+    - `id`: A unique identifier for the editor.
+
+  ## Example
+
+        <.live_component module={LogflareWeb.MonacoEditorComponent}
+          id="endpoint_query"
+          field={f[:query]}
+          endpoints={@endpoints}
+          alerts={@alerts}
+          sources={@sources}
+          />
+  """
+
   def mount(socket) do
     {:ok, assign(socket, parse_error_message: nil)}
+  end
+
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_completions()}
   end
 
   def render(assigns) do
     assigns = assigns |> assign(editor_opts: editor_opts())
 
     ~H"""
-    <div>
+    <div id={@id}>
       <LiveMonacoEditor.code_editor value={@field.value} target={@myself} change="parse-query" path="query_string" id="query" opts={@editor_opts} />
       <%= hidden_input(@field.form, :query, value: @field.value) %>
       <%= error_tag(@field.form, :query) %>
@@ -90,6 +118,8 @@ defmodule LogflareWeb.MonacoEditorComponent do
   end
 
   def parse_query(query_string, endpoints, alerts)
+  @spec parse_query(String.t(), [%Logflare.Endpoints.Query{}], [%Logflare.Alerting.AlertQuery{}]) ::
+          :ok | {:error, String.t()}
   def parse_query("", _endpoints, _alerts), do: :ok
 
   def parse_query(query_string, endpoints, alerts) do
@@ -109,6 +139,15 @@ defmodule LogflareWeb.MonacoEditorComponent do
         message = if(is_binary(err), do: err, else: inspect(err))
         {:error, message}
     end
+  end
+
+  defp assign_completions(socket) do
+    %{endpoints: endpoints, alerts: alerts, sources: sources} = socket.assigns
+
+    completions =
+      [sources, endpoints, alerts] |> List.flatten() |> Enum.map(fn item -> item.name end)
+
+    assign(socket, completions: completions)
   end
 
   defp editor_opts do

--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -117,7 +117,6 @@ defmodule LogflareWeb.MonacoEditorComponent do
     {:noreply, socket}
   end
 
-  def parse_query(query_string, endpoints, alerts)
   @spec parse_query(String.t(), [%Logflare.Endpoints.Query{}], [%Logflare.Alerting.AlertQuery{}]) ::
           :ok | {:error, String.t()}
   def parse_query("", _endpoints, _alerts), do: :ok

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -17,8 +17,8 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
           id: "test-editor",
           field: assigns.form[:query],
           endpoints: [],
-          alerts: [],
-          completions: []
+          sources: [],
+          alerts: []
         })
 
       assert html =~ ~s(phx-hook="CodeEditorHook")
@@ -29,13 +29,13 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
         render_component(MonacoEditorComponent, %{
           id: "test-editor",
           field: assigns.form[:query],
-          endpoints: [],
-          alerts: [],
-          completions: ["First", "Second"]
+          endpoints: [%{id: "endpoint1", name: "Endpoint 1"}],
+          sources: [%{id: "source1", name: "Source 1"}],
+          alerts: []
         })
 
       assert html =~ ~s(<script phx-update="ignore" id="query_completions">)
-      assert html =~ ~s(const completions = ["First","Second"])
+      assert html =~ ~s(const completions = ["Source 1","Endpoint 1"])
     end
 
     test "renders with parser error message set", %{assigns: assigns} do
@@ -44,8 +44,8 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
           id: "test-editor",
           field: assigns.form[:query],
           endpoints: [],
+          sources: [],
           alerts: [],
-          completions: [],
           parse_error_message: "Invalid SQL syntax"
         })
 
@@ -61,8 +61,8 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
           id: "test-editor",
           field: form[:query],
           endpoints: [],
-          alerts: [],
-          completions: []
+          sources: [],
+          alerts: []
         })
 
       assert html =~ "SELECT * FROM MyApp.Logs"

--- a/test/logflare_web/live_views/alerts_live_test.exs
+++ b/test/logflare_web/live_views/alerts_live_test.exs
@@ -82,6 +82,22 @@ defmodule LogflareWeb.AlertsLiveTest do
       assert render(view) =~ alert_query.name
     end
 
+    test "validates query", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/alerts/new")
+
+      valid_query = "select current_timestamp() as my_time"
+      invalid_query = "bad_query"
+
+      # triggering event handler directly since Monaco does this via JavaScript
+      assert view
+             |> with_target("#alert_query_editor")
+             |> render_hook("parse-query", %{"value" => invalid_query}) =~ "SQL Parse error!"
+
+      refute view
+             |> with_target("#alert_query_editor")
+             |> render_hook("parse-query", %{"value" => valid_query}) =~ "SQL Parse error!"
+    end
+
     test "show for nonexistent query", %{conn: conn} do
       {:error, {:live_redirect, %{flash: %{"info" => "Alert not found" <> _}}}} =
         live(conn, ~p"/alerts/123")

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -127,7 +127,6 @@ defmodule LogflareWeb.EndpointsLiveTest do
     test "new endpoint", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/endpoints/new")
 
-      # validates the changes
       valid_query = "select current_timestamp() as my_time"
       invalid_query = "bad_query"
 

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -127,6 +127,19 @@ defmodule LogflareWeb.EndpointsLiveTest do
     test "new endpoint", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/endpoints/new")
 
+      # validates the changes
+      valid_query = "select current_timestamp() as my_time"
+      invalid_query = "bad_query"
+
+      # triggering event handler directly since Monaco does this via JavaScript
+      assert view
+             |> with_target("#endpoint_query_editor")
+             |> render_hook("parse-query", %{"value" => invalid_query}) =~ "SQL Parse error!"
+
+      refute view
+             |> with_target("#endpoint_query_editor")
+             |> render_hook("parse-query", %{"value" => valid_query}) =~ "SQL Parse error!"
+
       # saves the change
       assert view
              |> element("form", "Save")


### PR DESCRIPTION
* AlertsLive uses MonacoEditorComponent
* refactor: build completions to MonacoEditorComponent
* refactor: update EndpointsLive with MonacoEditorComponent changes
* add "parse_query" hook test to AlertsLive and EndpointsLive
* remove unused handle_event("parse_query"...) from EndpointsLive (handled in MonacoEditorComponent)