### PR TITLE
fix: sql postgres translation

### DIFF
--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -632,7 +632,9 @@ defmodule Logflare.Sql.DialectTranslation do
   end
 
   defp select_json_operator(data, is_complex_path) do
-    need_text = Map.get(data, :in_between, false) or Map.get(data, :in_binaryop, false)
+    need_text =
+      Map.get(data, :in_between, false) or Map.get(data, :in_binaryop, false) or
+        Map.get(data, :in_inlist, false)
 
     case {is_complex_path, need_text} do
       {true, true} -> "HashLongArrow"

--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -824,7 +824,7 @@ defmodule Logflare.Sql.DialectTranslation do
     if normalized_identifier do
       {"ExprWithAlias",
        %{
-         "alias" => %{"quote_style" => nil, "value" => get_identifier_alias(identifier)},
+         "alias" => %{"quote_style" => nil, "value" => normalized_identifier},
          "expr" => traverse_convert_identifiers(identifier, data)
        }}
     else
@@ -943,13 +943,13 @@ defmodule Logflare.Sql.DialectTranslation do
 
   defp numeric_value?(%{"Value" => %{"Number" => _}}), do: true
   defp numeric_value?(_), do: false
-  defp json_access?(%{"Nested" => %{"JsonAccess" => _}}), do: true
+
+  defp json_access?(%{"Nested" => nested}), do: json_access?(nested)
   defp json_access?(%{"JsonAccess" => _}), do: true
 
-  defp json_access?(%{"Nested" => %{"BinaryOp" => %{"op" => op}}}),
-    do: op in ["Arrow", "LongArrow"]
+  defp json_access?(%{"BinaryOp" => %{"op" => op}}),
+    do: op in ["Arrow", "LongArrow", "HashLongArrow", "HashArrow"]
 
-  defp json_access?(%{"BinaryOp" => %{"op" => op}}), do: op in ["Arrow", "LongArrow"]
   defp json_access?(_), do: false
 
   defp timestamp_identifier?(%{"Identifier" => %{"value" => "timestamp"}}), do: true

--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -128,7 +128,7 @@ defmodule Logflare.Sql.DialectTranslation do
     AstUtils.transform_recursive(ast, nil, &do_bq_to_pg_convert_functions/2)
   end
 
-  defp do_bq_to_pg_convert_functions({k, v} = kv, data)
+  defp do_bq_to_pg_convert_functions({k, v} = kv, _data)
        when k in ["Function", "AggregateExpressionWithFilter"] do
     function_name = v |> get_in(["name", Access.at(0), "value"]) |> String.downcase()
 

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -709,6 +709,34 @@ defmodule Logflare.SqlTest do
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
       assert {:ok, [%{"count" => 1}]} = PostgresAdaptor.execute_query(backend, transformed)
     end
+
+    test "CTE translation with cross join",
+         %{user: user, source: source, backend: backend} = ctx do
+      insert_log_event(ctx, %{
+        "event_message" => "something",
+        "metadata" => %{
+          "request" => %{"method" => "GET", "path" => "/"},
+          "response" => %{"status_code" => 200}
+        }
+      })
+
+      bq_query = ~s"""
+      select count(CASE WHEN (req.method IN ('GET', 'POST')) THEN 1 END) as count,
+      from  `#{source.name}` t
+      cross join unnest(metadata) as m
+      cross join unnest(m.request) as req
+      """
+
+      {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
+      assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
+
+      assert {:ok,
+              [
+                %{
+                  "count" => 1
+                }
+              ]} = PostgresAdaptor.execute_query(backend, transformed)
+    end
   end
 
   describe "translate/2 with CTEs" do
@@ -1257,7 +1285,7 @@ defmodule Logflare.SqlTest do
     # tes "offset() and indexing is translated"
   end
 
-  defp setup_postgres_backend(context) do
+  defp setup_postgres_backend(_context) do
     repo = Application.get_env(:logflare, Logflare.Repo)
 
     config = %{


### PR DESCRIPTION
Fixes 3 translation bugs:
- casting of nested field references to numeric
- regexp_contains when field reference is present
- cross join unnest without CTE with a between operator present 


todo: 
- [ ] test with cli