### PR TITLE
fix: bq->pg translation error when field contains

### DIFF
--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -632,7 +632,9 @@ defmodule Logflare.Sql.DialectTranslation do
   end
 
   defp select_json_operator(data, is_complex_path) do
-    need_text = Map.get(data, :in_between, false) or Map.get(data, :in_binaryop, false)
+    need_text =
+      Map.get(data, :in_between, false) or Map.get(data, :in_binaryop, false) or
+        Map.get(data, :in_inlist, false)
 
     case {is_complex_path, need_text} do
       {true, true} -> "HashLongArrow"

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -728,7 +728,6 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      dbg(translated)
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
       assert {:ok,
@@ -1286,7 +1285,7 @@ defmodule Logflare.SqlTest do
     # tes "offset() and indexing is translated"
   end
 
-  defp setup_postgres_backend(context) do
+  defp setup_postgres_backend(_context) do
     repo = Application.get_env(:logflare, Logflare.Repo)
 
     config = %{


### PR DESCRIPTION
wrong:
```
"SELECT count(CASE WHEN ((body #> '{metadata,request,method}') IN ('GET', 'POST')) THEN 1 END) AS count FROM \"c.d.e\" AS t"
```

correct:
```
"SELECT count(CASE WHEN ((body #>> '{metadata,request,method}') IN ('GET', 'POST')) THEN 1 END) AS count FROM \"c.d.e\" AS t"
```