### PR TITLE
fix: syn conflict resolution

### DIFF
--- a/lib/logflare/syn_event_handler.ex
+++ b/lib/logflare/syn_event_handler.ex
@@ -6,8 +6,6 @@ defmodule Logflare.SynEventHandler do
   """
   @behaviour :syn_event_handler
 
-  alias Logflare.Utils.Tasks
-
   require Logger
   @impl true
 

--- a/lib/logflare/syn_event_handler.ex
+++ b/lib/logflare/syn_event_handler.ex
@@ -86,14 +86,6 @@ defmodule Logflare.SynEventHandler do
   end
 
   defp try_to_stop(pid) do
-    Tasks.start_child(fn ->
-      node_to_kill = node(pid)
-      # Random sleep to prevent concurrent attempts to stop the same process
-      Process.sleep(:rand.uniform(1500))
-
-      if :erpc.call(node_to_kill, Process, :alive?, [pid], 5000) do
-        :erpc.call(node_to_kill, Process, :exit, [pid, :normal], 5000)
-      end
-    end)
+    Process.exit(pid, :syn_resolve_kill)
   end
 end


### PR DESCRIPTION
Stop the process if a conflict arises. Seems like syn does not handle process conflicts automatically if the handler is defined.

> If implemented, this method MUST return the pid() of the process that you wish to keep. **The other process will not be killed, so you will have to decide what to do with it**. If the custom conflict resolution method does not return one of the two Pids, or if the method crashes, none of the Pids will be killed and the conflicting name will be freed.

Likely the cause of the issue we are seeing with multiple GenSingleton servers getting created still.