### PR TITLE
perf:  temp increase of erlsysmon limits

### DIFF
--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -17,8 +17,8 @@ defmodule Logflare.ErlSysMon do
     :erlang.system_monitor(self(), [
       :busy_dist_port,
       :busy_port,
-      {:long_gc, 250},
-      {:long_schedule, 100},
+      {:long_gc, 1000},
+      {:long_schedule, 500},
       {:long_message_queue, {0, 1_000}}
     ])
 


### PR DESCRIPTION
This PR adds in higher limits for ErlSysMon.

A loop can happen when:
1. higher schedule timeouts result in high messages
2. higher messages increases run queues
3. higher run queues causes hgiher schedule timeouts
 