### PR TITLE
fix: correctly setup source and backend ids in supervisor

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -371,10 +371,11 @@ defmodule Logflare.Backends do
   iex> Backends.via_source(source, :buffer)
   """
   @spec via_source(Source.t(), term()) :: tuple()
-  @spec via_source(Source.t() | non_neg_integer(), module(), non_neg_integer()) :: tuple()
-  def via_source(%Source{id: sid}, mod, %Backend{id: bid}), do: via_source(sid, mod, bid)
-  def via_source(%Source{id: sid}, mod, id), do: via_source(sid, {mod, id})
-  def via_source(source_id, mod, id), do: via_source(source_id, {mod, id})
+  @spec via_source(Source.t() | non_neg_integer(), module(), Backend.t() | non_neg_integer()) ::
+          tuple()
+  def via_source(%Source{id: sid}, mod, backend), do: via_source(sid, mod, backend)
+  def via_source(source, mod, %Backend{id: bid}), do: via_source(source, mod, bid)
+  def via_source(source_id, mod, backend_id), do: via_source(source_id, {mod, backend_id})
 
   def via_source(%Source{id: id}, process_id), do: via_source(id, process_id)
 
@@ -503,6 +504,8 @@ defmodule Logflare.Backends do
   @doc """
   Caches total buffer len. Includes ingested events that are awaiting cleanup.
   """
+  @spec cache_local_buffer_lens(non_neg_integer(), non_neg_integer() | nil) ::
+          {:ok, %{len: non_neg_integer(), queues: map()}}
   def cache_local_buffer_lens(source_id, backend_id \\ nil) do
     queues = IngestEventQueue.list_counts({source_id, backend_id})
 

--- a/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor/pg_repo.ex
@@ -50,7 +50,7 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor.PgRepo do
   end
 
   @doc """
-  Drops the migration table
+  Drops the migration table.
   """
   @spec destroy_instance(Adaptor.source_backend(), timeout()) :: :ok
   def destroy_instance({source, backend}, timeout \\ 5000) do

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -5,16 +5,18 @@ defmodule Logflare.Backends.IngestEventQueue do
   :ets-backed buffer uses an :ets mapping pattern to fan out multiple :ets tables.
   """
   use GenServer
+
   alias Logflare.Source
   alias Logflare.Backends.Backend
   alias Logflare.LogEvent
+
   require Ex2ms
 
   @ets_table_mapper :ingest_event_queue_mapping
   @ets_table :source_ingest_events
   @typep source_backend_pid ::
-           {Source.t() | non_neg_integer(), Backend.t() | nil | non_neg_integer(), pid()}
-  @typep table_key :: {non_neg_integer(), nil | non_neg_integer(), pid()}
+           {Source.t() | non_neg_integer(), Backend.t() | nil | non_neg_integer(), nil | pid()}
+  @typep table_key :: {non_neg_integer(), nil | non_neg_integer(), nil | pid()}
   @typep queues_key :: {non_neg_integer(), nil | non_neg_integer()}
 
   ## Server
@@ -57,7 +59,8 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec upsert_tid(table_key()) ::
           {:ok, reference()} | {:error, :already_exists, reference()}
-  def upsert_tid(sid_bid_pid) do
+  def upsert_tid({sid, bid, pid} = sid_bid_pid)
+      when is_integer(sid) and (is_integer(bid) or is_nil(bid)) and (is_pid(pid) or is_nil(pid)) do
     case get_tid(sid_bid_pid) do
       nil ->
         # create and insert

--- a/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
+++ b/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
@@ -61,9 +61,9 @@ defmodule Logflare.Backends.IngestEventQueue.BroadcastWorker do
     {:noreply, state}
   end
 
-  defp global_broadcast_producer_buffer_len({source_id, backend_id}) do
+  defp global_broadcast_producer_buffer_len({source_id, backend_id})
+       when is_integer(source_id) and (is_integer(backend_id) or is_nil(backend_id)) do
     {:ok, stats} = Backends.cache_local_buffer_lens(source_id, backend_id)
-
     local_buffer = %{Node.self() => stats}
     PubSubRates.global_broadcast_rate({"buffers", source_id, backend_id, local_buffer})
   end

--- a/lib/logflare/pubsub_rates.ex
+++ b/lib/logflare/pubsub_rates.ex
@@ -85,7 +85,6 @@ defmodule Logflare.PubSubRates do
   def global_broadcast_rate({topic, source_id, backend_id, _payload} = data)
       when topic in @topics do
     partitioned_topic = partitioned_topic(topic, {source_id, backend_id})
-
     Phoenix.PubSub.broadcast(Logflare.PubSub, partitioned_topic, data)
   end
 

--- a/test/logflare/backends/adaptor/postgres_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/postgres_adaptor_test.exs
@@ -1,6 +1,8 @@
 defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
   use Logflare.DataCase
+
   import ExUnit.CaptureLog
+
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.PostgresAdaptor

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -18,7 +18,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     backend = insert(:backend, type: :bigquery)
 
     # create the startup queue
-    IngestEventQueue.upsert_tid({source, backend, nil})
+    IngestEventQueue.upsert_tid({source.id, backend.id, nil})
 
     [
       name: Backends.via_source(source, :some_mod, backend),

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -46,9 +46,9 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     end
 
     test "list_queues/1 returns list of table keys", %{source: source, backend: backend} do
-      IngestEventQueue.upsert_tid({source.id, backend.id, 1})
-      IngestEventQueue.upsert_tid({source.id, backend.id, 12})
-      IngestEventQueue.upsert_tid({source.id, backend.id, 123})
+      IngestEventQueue.upsert_tid({source.id, backend.id, :erlang.list_to_pid(~c"<0.12.34>")})
+      IngestEventQueue.upsert_tid({source.id, backend.id, :erlang.list_to_pid(~c"<0.12.35>")})
+      IngestEventQueue.upsert_tid({source.id, backend.id, :erlang.list_to_pid(~c"<0.12.36>")})
       assert IngestEventQueue.list_queues({source.id, backend.id}) |> length() == 3
     end
 

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -684,7 +684,7 @@ defmodule Logflare.BackendsTest do
     user = insert(:user)
     source = insert(:source, user: user)
     backend = insert(:backend, user: user)
-    {:ok, tid} = IngestEventQueue.upsert_tid({source, backend})
+    {:ok, tid} = IngestEventQueue.upsert_tid({source.id, backend.id})
     sb = {source.id, backend.id}
 
     Benchee.run(

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -19,7 +19,7 @@ defmodule Logflare.BigQuery.PipelineTest do
     end
 
     test "ack will remove items from pipeline if average rate is above 100", %{source: source} do
-      sid_bid_pid = {source.id, nil, make_ref()}
+      sid_bid_pid = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(sid_bid_pid)
       le = build(:log_event)
       IngestEventQueue.add_to_table(sid_bid_pid, [le])

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -41,7 +41,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     source: source,
     table_key: table_key
   } do
-    other_table_key = {source.id, nil, make_ref()}
+    other_table_key = {source.id, nil, self()}
     IngestEventQueue.upsert_tid(other_table_key)
 
     for _ <- 1..round(Backends.max_buffer_queue_len() / 2) do

--- a/test/profiling/buffer_producer.exs
+++ b/test/profiling/buffer_producer.exs
@@ -15,7 +15,7 @@ batch =
     %Logflare.LogEvent{id: "123", message: :something}
   end
 
-Logflare.Backends.IngestEventQueue.upsert_tid({source, nil})
+Logflare.Backends.IngestEventQueue.upsert_tid({source.id, nil})
 
 for _ <- 1..1000 do
   :ok = Logflare.Backends.IngestEventQueue.add_to_table({source, nil}, batch)

--- a/test/profiling/queue_janitor.exs
+++ b/test/profiling/queue_janitor.exs
@@ -6,7 +6,7 @@ import Logflare.Factory
 source = insert(:source, user: insert(:user))
 
 le = build(:log_event, message: "some value")
-IngestEventQueue.upsert_tid({source, nil})
+IngestEventQueue.upsert_tid({source.id, nil})
 :ok = IngestEventQueue.add_to_table({source, nil}, [le])
 QueueJanitor.start_link(source: source, backend: nil)
 :timer.sleep(5_000)


### PR DESCRIPTION
The fixes are related to IngestEventQueue.upsert_tid/1 which was incorrectly sometimes passing the source and backend instead of the ids. I added some guards to help me catch these mistakes and I keep them so we avoid making the same errors in the future. This removes some noisy messages that didn't appear all the time (but most of the time).