### PR TITLE
fix: handle :syn_resolve_kill

### DIFF
--- a/lib/logflare/gen_singleton/watcher.ex
+++ b/lib/logflare/gen_singleton/watcher.ex
@@ -66,6 +66,10 @@ defmodule Logflare.GenSingleton.Watcher do
   defp try_start_child(state) do
     pid =
       case Supervisor.start_child(state.sup_pid, state.child_spec) do
+        {:error, {:syn_resolve_kill, _spec}} ->
+          Logger.debug("GenSingleton | Process conflict detected, child did not start")
+          nil
+
         {:error, {:already_started, pid}} ->
           Logger.debug(
             "GenSingleton | process #{inspect(pid)} is already started on server: #{inspect(node(pid))}"


### PR DESCRIPTION
correctly handles syn resolve kill on Supervisor startup attempt