### PR TITLE
fix: tz links in graph

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -210,7 +210,6 @@ const chartSettings = (type) => {
       };
   }
 };
-
 const periods = ["day", "hour", "minute", "second"];
 const LogEventsChart = ({
   data,
@@ -220,7 +219,7 @@ const LogEventsChart = ({
   display_timezone: userTz,
   pushEvent,
 }) => {
-  const tz = userTz
+  const tz = userTz || "Etc/UTC";
   const onClick = (event) => {
     pushEvent("soft_pause", {});
     const utcDatetime = event.data.datetime;

--- a/lib/logflare_web/live/search_live/templates/logs_search.html.heex
+++ b/lib/logflare_web/live/search_live/templates/logs_search.html.heex
@@ -85,6 +85,7 @@
       %{
         data: if(@search_op_log_aggregates, do: @search_op_log_aggregates.rows, else: []),
         loading: @chart_loading,
+        display_timezone: @search_timezone || "Etc/UTC",
         chart_period: get_chart_period(@lql_rules, "minute"),
         chart_data_shape_id:
           if(@search_op_log_aggregates,

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -180,6 +180,19 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert view |> element(".subhead") |> render() =~ "(+08:00)"
       assert render(view) =~ "something123"
     end
+
+    test "chart - timezone passed to chart component", %{conn: conn, source: source} do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/sources/#{source.id}/search?querystring=something123&tailing%3F=&tz=Singapore"
+        )
+
+      assert view
+             |> element(~s|div[data-live-react-class="Components.LogEventsChart"]|)
+             |> render() =~
+               Plug.HTML.html_escape(~s|"display_timezone":"Singapore"|)
+    end
   end
 
   describe "preference timezone for team_user" do


### PR DESCRIPTION
* Fix: search performed after clicking a bar in the log events chart.
* Add test to verify the timezone is passed the log events chart component 


https://github.com/user-attachments/assets/a1ddccd8-1de7-4ddd-a455-f677562f4b7f

In this demo I have group by hour, and click on `06:00` bar and redirected to the query `t:2025-07-17T{06..07}:00:00 c:count(*) c:group_by(t::minute)`
