### PR TITLE
Reduce queries in Search Results page load

### DIFF
--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -44,6 +44,8 @@ defmodule Logflare.BqRepo do
         dryRun: false,
         jobTimeoutMs: @query_request_timeout,
         timeoutMs: @query_request_timeout,
+        # Not enforced for now.
+        # maximumBytesBilled: user.bigquery_processed_bytes_limit,
         labels: %{
           "managed_by" => "logflare",
           "logflare_plan" => GenUtils.format_key(plan),


### PR DESCRIPTION
Following on from #2557

- [x] remove udf creation on search page load - fixed in #2546
- [x] remove all udf usage - fixed in #2546
- [x] 1 query made on page load
  - [x] Remove dry run query
  - [x] Configure per request cost limit
  - [x] Log warning if query cost above limit


⚠️ Query cost is checked and logged but not yet enforced:

https://github.com/Logflare/logflare/pull/2570/files#diff-bef332c925224bac9585297f3254655dd58c669688b52492e2233ba11f75fb0eR47-R48

UI discussion below has been split into a separate PR.