### PR TITLE
perf: add broadcast interval scaling for global broadcasts

### DIFF
--- a/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
+++ b/lib/logflare/backends/ingest_event_queue/broadcast_worker.ex
@@ -39,7 +39,11 @@ defmodule Logflare.Backends.IngestEventQueue.BroadcastWorker do
       @ets_table_mapper
     )
 
-    Process.send_after(self(), :global_broadcast, state.interval * 2)
+    # scale broadcasting interval to cluster size
+    cluster_size = Logflare.Cluster.Utils.actual_cluster_size()
+    broadcast_interval = max(state.interval, round(:rand.uniform(cluster_size * 100)))
+
+    Process.send_after(self(), :global_broadcast, broadcast_interval)
     {:noreply, state}
   end
 

--- a/lib/logflare/backends/recent_inserts_broadcaster.ex
+++ b/lib/logflare/backends/recent_inserts_broadcaster.ex
@@ -113,6 +113,9 @@ defmodule Logflare.Backends.RecentInsertsBroadcaster do
   end
 
   defp broadcast() do
-    Process.send_after(self(), :broadcast, @broadcast_every)
+    # scale broadcasting interval to cluster size
+    cluster_size = Logflare.Cluster.Utils.actual_cluster_size()
+    broadcast_every = max(@broadcast_every, round(:rand.uniform(cluster_size * 200)))
+    Process.send_after(self(), :broadcast, broadcast_every)
   end
 end


### PR DESCRIPTION
Adds in scaled broadcast intervals based on cluster sizes. Also spreads out message broadcasting to prevent spikes from fast cluster startups.