### PR TITLE
fix: LQL rule serialization bug

### DIFF
--- a/lib/logflare/ecto/ecto_lql_rules_t.ex
+++ b/lib/logflare/ecto/ecto_lql_rules_t.ex
@@ -1,0 +1,90 @@
+defmodule Ecto.LqlRules do
+  @moduledoc """
+  Custom Ecto type for LQL rule lists that handles legacy format conversion.
+
+  Based on `Ecto.Term` but adds automatic conversion from old LQL rule formats
+  to new formats during load.
+  """
+
+  @behaviour Ecto.Type
+
+  alias Logflare.Lql.Rules.ChartRule
+  alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Lql.Rules.SelectRule
+
+  @spec type :: :binary
+  def type, do: :binary
+
+  def cast(value) do
+    {:ok, value}
+  end
+
+  @spec load(binary() | nil) :: {:ok, any()} | {:error, ArgumentError.t()}
+  def load(nil), do: {:ok, nil}
+  def load(""), do: {:ok, ""}
+
+  def load(value) do
+    try do
+      term = :erlang.binary_to_term(value)
+      converted_term = convert_legacy_rules(term)
+      {:ok, converted_term}
+    rescue
+      e in ArgumentError -> {:error, e}
+    end
+  end
+
+  @spec dump(any()) :: {:ok, binary() | nil}
+  def dump(nil), do: {:ok, nil}
+  def dump(""), do: {:ok, ""}
+
+  def dump(value) do
+    {:ok, :erlang.term_to_binary(value)}
+  end
+
+  def embed_as(_), do: :self
+
+  def equal?(term1, term2), do: term1 === term2
+
+  defp convert_legacy_rules(rules) when is_list(rules) do
+    Enum.map(rules, &convert_legacy_rule/1)
+  end
+
+  defp convert_legacy_rules(other), do: other
+
+  defp convert_legacy_rule(rule) do
+    case rule do
+      %FilterRule{} = rule ->
+        rule
+
+      %SelectRule{} = rule ->
+        rule
+
+      %ChartRule{} = rule ->
+        rule
+
+      %{__struct__: Logflare.Lql.FilterRule} = old_rule ->
+        struct(FilterRule, Map.delete(old_rule, :__struct__))
+
+      %{__struct__: Logflare.Lql.ChartRule} = old_rule ->
+        struct(ChartRule, Map.delete(old_rule, :__struct__))
+
+      map when is_map(map) ->
+        cond do
+          Map.has_key?(map, :path) and Map.has_key?(map, :operator) ->
+            FilterRule.build(Map.to_list(map))
+
+          Map.has_key?(map, :path) and Map.has_key?(map, :wildcard) ->
+            struct(SelectRule, map)
+
+          Map.has_key?(map, :aggregate) and Map.has_key?(map, :period) ->
+            struct(ChartRule, map)
+
+          true ->
+            map
+        end
+
+      other ->
+        other
+    end
+  end
+end

--- a/lib/logflare/rules/rule.ex
+++ b/lib/logflare/rules/rule.ex
@@ -18,7 +18,7 @@ defmodule Logflare.Rules.Rule do
   typed_schema "rules" do
     field :sink, Ecto.UUID.Atom
     field :token, Ecto.UUID, autogenerate: true
-    field :lql_filters, Ecto.Term, default: []
+    field :lql_filters, Ecto.LqlRules, default: []
     field :lql_string, :string
     belongs_to :source, Source
     belongs_to :backend, Backend

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -128,7 +128,7 @@ defmodule Logflare.Source do
     field(:notifications_every, :integer, default: :timer.hours(4))
     field(:lock_schema, :boolean, default: false)
     field(:validate_schema, :boolean, default: true)
-    field(:drop_lql_filters, Ecto.Term, default: [])
+    field(:drop_lql_filters, Ecto.LqlRules, default: [])
     field(:drop_lql_string, :string)
     field(:v2_pipeline, :boolean, default: false)
     field(:disable_tailing, :boolean, default: false)

--- a/test/logflare/ecto/ecto_lql_rules_t_test.exs
+++ b/test/logflare/ecto/ecto_lql_rules_t_test.exs
@@ -1,0 +1,120 @@
+defmodule Ecto.LqlRulesTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.LqlRules
+  alias Logflare.Lql.Rules.ChartRule
+  alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Lql.Rules.SelectRule
+
+  describe "basic Ecto.Type functions" do
+    test "type/0, cast/1, dump/1, embed_as/1, equal?/2" do
+      assert LqlRules.type() == :binary
+      assert {:ok, "test"} = LqlRules.cast("test")
+      assert {:ok, nil} = LqlRules.dump(nil)
+      assert {:ok, ""} = LqlRules.dump("")
+      assert LqlRules.embed_as("any") == :self
+      assert LqlRules.equal?("same", "same")
+      refute LqlRules.equal?("", nil)
+    end
+  end
+
+  describe "load/1" do
+    test "handles edge cases and errors" do
+      assert {:ok, nil} = LqlRules.load(nil)
+      assert {:ok, ""} = LqlRules.load("")
+      assert {:error, %ArgumentError{}} = LqlRules.load("invalid")
+    end
+
+    test "converts legacy `FilterRule` from actual error case" do
+      legacy_filter_rule = %{
+        value: "",
+        values: nil,
+        path: "event_message",
+        operator: :"~",
+        modifiers: %{quoted_string: true},
+        __struct__: Logflare.Lql.FilterRule,
+        shorthand: nil
+      }
+
+      {:ok, binary_data} = LqlRules.dump([legacy_filter_rule])
+      {:ok, [converted_rule]} = LqlRules.load(binary_data)
+
+      assert %FilterRule{
+               path: "event_message",
+               operator: :"~",
+               value: "",
+               values: nil,
+               modifiers: %{quoted_string: true},
+               shorthand: nil
+             } = converted_rule
+    end
+
+    test "converts mixed legacy LQL rule types" do
+      legacy_rules = [
+        %{
+          __struct__: Logflare.Lql.FilterRule,
+          path: "metadata.status",
+          operator: :=,
+          value: "error",
+          values: nil,
+          modifiers: %{},
+          shorthand: nil
+        },
+        %{
+          __struct__: Logflare.Lql.ChartRule,
+          aggregate: :count,
+          period: :hour
+        }
+      ]
+
+      {:ok, binary_data} = LqlRules.dump(legacy_rules)
+      {:ok, [filter_rule, chart_rule]} = LqlRules.load(binary_data)
+
+      assert %FilterRule{path: "metadata.status", operator: :=, value: "error"} = filter_rule
+      assert %ChartRule{aggregate: :count, period: :hour} = chart_rule
+    end
+
+    test "handles current rules, plain maps, and mixed data" do
+      current_filter_rule = %FilterRule{
+        path: "test",
+        operator: :=,
+        value: "test",
+        values: nil,
+        modifiers: %{},
+        shorthand: nil
+      }
+
+      current_select_rule = %SelectRule{
+        path: "metadata.user_id",
+        wildcard: false
+      }
+
+      plain_maps = [
+        %{path: "level", operator: :=, value: "error"},
+        %{aggregate: :sum, period: :day}
+      ]
+
+      mixed_data = [%{other: "data"}, "string", current_filter_rule, current_select_rule]
+
+      {:ok, current_binary} = LqlRules.dump([current_filter_rule, current_select_rule])
+      {:ok, [loaded_filter, loaded_select]} = LqlRules.load(current_binary)
+      assert loaded_filter == current_filter_rule
+      assert loaded_select == current_select_rule
+
+      {:ok, maps_binary} = LqlRules.dump(plain_maps)
+      {:ok, [filter_rule, chart_rule]} = LqlRules.load(maps_binary)
+      assert %FilterRule{} = filter_rule
+      assert %ChartRule{} = chart_rule
+
+      {:ok, mixed_binary} = LqlRules.dump(mixed_data)
+
+      {:ok, [other_map, string_val, loaded_filter_rule, loaded_select_rule]} =
+        LqlRules.load(mixed_binary)
+
+      assert other_map == %{other: "data"}
+      assert string_val == "string"
+      assert %FilterRule{} = loaded_filter_rule
+      assert %SelectRule{} = loaded_select_rule
+    end
+  end
+end


### PR DESCRIPTION
Rules were being serialized in the database using the custom `Ecto.Term` type. Unfortunately when changing the namespaces for LQL rules to `Logflare.Lql.Rules`, pattern-matching would fail upon hydrating a value from the DB.

This fix uses a new ecto type for the two cases where these rules are stored this way and handles automatically converting them to the proper structs. 