### PR TITLE
feat/perf: increase clickhouse pipeline batch size

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.Pipeline do
   @producer_concurrency 1
   @processor_concurrency 5
   @batcher_concurrency 5
-  @batch_size 350
+  @batch_size 1_000
 
   @doc false
   def child_spec(arg) do


### PR DESCRIPTION
Bumps the Clickhouse backend ingest batch size from 350 -> 1_000