### PR TITLE
refactor: extract nested code in lib/logflare_web/live/source_backends_live.ex

### DIFF
--- a/lib/logflare_web/live/source_backends_live.ex
+++ b/lib/logflare_web/live/source_backends_live.ex
@@ -89,12 +89,6 @@ defmodule LogflareWeb.SourceBackendsLive do
     {:noreply, socket}
   end
 
-  defp _to_string(val) when is_list(val) do
-    Enum.join(val, ", ")
-  end
-
-  defp _to_string(val), do: to_string(val)
-
   defp refresh_data(%{assigns: %{source_id: source_id}} = socket) do
     source =
       Logflare.Sources.get(source_id)
@@ -108,4 +102,10 @@ defmodule LogflareWeb.SourceBackendsLive do
     |> assign(:backends, backends)
     |> assign(:attached_backend_ids, attached_backend_ids)
   end
+
+  defp _to_string(val) when is_list(val) do
+    Enum.join(val, ", ")
+  end
+
+  defp _to_string(val), do: to_string(val)
 end


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.