### PR TITLE
refactor: extract nested code in lib/logflare/billing.ex

### DIFF
--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -348,13 +348,7 @@ defmodule Logflare.Billing do
             get_plan_by(name: "Free")
 
           billing_account ->
-            case Billing.get_billing_account_stripe_plan(billing_account) do
-              nil ->
-                get_plan_by(name: "Free")
-
-              stripe_plan ->
-                get_plan_by(stripe_id: stripe_plan["id"])
-            end
+            get_plan_from_billing_account(billing_account)
         end
     end
   end
@@ -402,4 +396,14 @@ defmodule Logflare.Billing do
 
   @spec cost_estimate(Plan.t(), pos_integer()) :: pos_integer()
   def cost_estimate(%Plan{price: price}, usage), do: price * usage
+
+  defp get_plan_from_billing_account(billing_account) do
+    case Billing.get_billing_account_stripe_plan(billing_account) do
+      nil ->
+        get_plan_by(name: "Free")
+
+      stripe_plan ->
+        get_plan_by(stripe_id: stripe_plan["id"])
+    end
+  end
 end


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.