### PR TITLE
refactor: extract nested code in lib/logflare/rules.ex

### DIFF
--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -119,26 +119,27 @@ defmodule Logflare.Rules do
 
       case Lql.decode(rule.lql_string, source.bq_table_schema) do
         {:ok, lql_filters} ->
-          if lql_filters != rule.lql_filters do
-            rule
-            |> Rule.changeset(%{lql_filters: lql_filters})
-            |> Repo.update()
-            |> case do
-              {:ok, r} ->
-                Logger.info(
-                  "Rule #{r.id} for source #{r.source_id} was successfully upgraded to new LQL filters format."
-                )
-
-              {:error, changeset} ->
-                Logger.error(
-                  "Rule #{rule.id} for source #{rule.source_id} failed to upgrade to new LQL filters format, Repo update erro: #{inspect(changeset.errors)}"
-                )
-            end
-          end
+          maybe_update_lql_filters(rule, lql_filters)
 
         {:error, error} ->
           Logger.error(
             "Rule #{rule.id} for source #{rule.source_id} failed to upgrade to new LQL filters format, LQL decoding error: #{inspect(error)}"
+          )
+      end
+    end
+  end
+
+  defp maybe_update_lql_filters(rule, lql_filters) do
+    if lql_filters != rule.lql_filters do
+      case update_rule(rule, %{lql_filters: lql_filters}) do
+        {:ok, updated_rule} ->
+          Logger.info(
+            "Rule #{updated_rule.id} for source #{updated_rule.source_id} was successfully upgraded to new LQL filters format."
+          )
+
+        {:error, changeset} ->
+          Logger.error(
+            "Rule #{rule.id} for source #{rule.source_id} failed to upgrade to new LQL filters format, Repo update errors: #{inspect(changeset.errors)}"
           )
       end
     end


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.