### PR TITLE
refactor: extract nested code in lib/logflare/logs/log_event.ex

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -281,32 +281,30 @@ defmodule Logflare.LogEvent do
     |> validate_required([:stage, :message])
   end
 
-  defp make_message(le, source) do
-    message = le.body["message"] || le.body["event_message"]
+  defp make_message(log_event, source) do
+    keys
+    |> String.split(",", trim: true)
+    |> Enum.map_join(" | ", fn key -> build_message(key, log_event) end)
+  end
 
-    if keys = source.custom_event_message_keys do
-      keys
-      |> String.split(",", trim: true)
-      |> Enum.map_join(" | ", fn x ->
-        case String.trim(x) do
-          "id" ->
-            le.id
+  defp build_message(key, log_event) do
+    message = log_event.body["message"] || log_event.body["event_message"]
 
-          "message" ->
-            message
+    case String.trim(key) do
+      "id" ->
+        log_event.id
 
-          "event_message" ->
-            message
+      "message" ->
+        message
 
-          "m." <> rest ->
-            query_json(le.body, "$.metadata.#{rest}")
+      "event_message" ->
+        message
 
-          keys ->
-            query_json(le.body, "$.#{keys}")
-        end
-      end)
-    else
-      message
+      "m." <> rest ->
+        query_json(log_event.body, "$.metadata.#{rest}")
+
+      keys ->
+        query_json(log_event.body, "$.#{keys}")
     end
   end
 


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.