### PR TITLE
refactor: extract nested code in lib/logflare_web/live/search_live/timezone_component.ex

### DIFF
--- a/lib/logflare_web/live/search_live/timezone_component.ex
+++ b/lib/logflare_web/live/search_live/timezone_component.ex
@@ -41,7 +41,7 @@ defmodule LogflareWeb.SearchLive.TimezoneComponent do
 
   defp user_timezone(preferences), do: preferences && Map.get(preferences, :timezone)
 
-  defp build_timezones_select_form_options() do
+  defp build_timezones_select_form_options do
     Timex.timezones()
     |> Enum.map(&[offset: Timex.Timezone.get(&1).offset_utc, t: &1])
     |> Enum.sort_by(& &1[:offset])


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.