### PR TITLE
chore: clickhouse ci improvements

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -60,7 +60,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       clickhouse:
-        image: clickhouse/clickhouse-server:25.4
+        image: clickhouse/clickhouse-server:25.6
         ports:
           - 8123:8123
           - 9000:9000

--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -30,6 +30,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+      clickhouse:
+        image: clickhouse/clickhouse-server:25.6
+        ports:
+          - 8123:8123
+          - 9000:9000
+        env:
+          CLICKHOUSE_DB: logflare_test
+          CLICKHOUSE_USER: logflare
+          CLICKHOUSE_PASSWORD: logflare
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     env:
       MIX_ENV: test
       SHELL: /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - 4317:4317 # OTLP gRPC receiver
       - 4318:4318 # OTLP http receiver
   clickhouse:
-    image: clickhouse/clickhouse-server:25.4
+    image: clickhouse/clickhouse-server:25.6
     ports:
       - "8123:8123" # HTTP interface
       - "9000:9000"  # Native client interface


### PR DESCRIPTION
- adds clickhouse docker image to `.github/workflows/elixir-migration-check.yml`
- updates clickhouse server version to `25.6` in `docker-compose.yml` and CI yamls