### PR TITLE
chore/bug: fix issue in `Logflare.DataCase` for clickhouse tests

### DIFF
--- a/test/logflare/backends/adaptor/clickhouse_adaptor/connection_manager_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/connection_manager_test.exs
@@ -5,6 +5,8 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.ConnectionManagerTest do
   alias Logflare.Backends.Adaptor.ClickhouseAdaptor.ConnectionManager
 
   setup do
+    Logflare.Factory.insert(:plan, name: "Free")
+
     {source, backend, ch_cleanup_fn} = setup_clickhouse_test()
     on_exit(ch_cleanup_fn)
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -7,6 +7,8 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.PipelineTest do
   alias Logflare.Backends.SourceRegistry
 
   setup do
+    Logflare.Factory.insert(:plan, name: "Free")
+
     {source, backend, cleanup_fn} = setup_clickhouse_test()
     on_exit(cleanup_fn)
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
@@ -5,6 +5,8 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.ProvisionerTest do
   alias Logflare.Backends.Adaptor.ClickhouseAdaptor.Provisioner
 
   setup do
+    Logflare.Factory.insert(:plan, name: "Free")
+
     {source, backend, cleanup_fn} = setup_clickhouse_test()
     on_exit(cleanup_fn)
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -88,7 +88,6 @@ defmodule Logflare.DataCase do
     user =
       case Keyword.get(opts, :user) do
         nil ->
-          Logflare.Factory.insert(:plan, name: "Free")
           Logflare.Factory.insert(:user)
 
         existing_user ->


### PR DESCRIPTION
Clickhouse tests had a bug that could create an extra free plan which causes issues with `Logflare.Billing.get_plan_by/1`

This moves the plan setup to the responsibility of the test file(s) rather than the datacase helper.