### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in lib/logflare/backends

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -31,7 +31,7 @@ defmodule Logflare.Backends do
   Retrieves the hardcoded max pending buffer length of an individual queue
   """
   @spec max_buffer_queue_len() :: non_neg_integer()
-  def max_buffer_queue_len(), do: @max_pending_buffer_len_per_queue
+  def max_buffer_queue_len, do: @max_pending_buffer_len_per_queue
 
   @doc """
   Lists `Backend`s for a given source.

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -168,7 +168,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @doc """
   Returns a list of all managed service account ids
   """
-  def managed_service_account_ids() do
+  def managed_service_account_ids do
     for i <- 0..(managed_service_account_pool_size() - 1),
         do: managed_service_account_id(i)
   end
@@ -309,7 +309,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   if no base service account is set, no child spec is returned.
   """
   @spec partitioned_goth_child_spec() :: Supervisor.child_spec() | nil
-  def partitioned_goth_child_spec() do
+  def partitioned_goth_child_spec do
     if json = Application.get_env(:goth, :json) do
       {PartitionSupervisor,
        child_spec: goth_child_spec(json),
@@ -368,7 +368,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
     iex> impersonated_goth_child_specs()
     [{PartitionSupervisor, ...}, ...]
   """
-  def impersonated_goth_child_specs() do
+  def impersonated_goth_child_specs do
     project_id = Application.get_env(:logflare, Logflare.Google)[:project_id]
     pool_size = managed_service_account_pool_size()
     json = Application.get_env(:goth, :json)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -11,17 +11,17 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
   @doc """
   Default naming prefix for the log ingest table.
   """
-  def default_table_name_prefix(), do: "log_events"
+  def default_table_name_prefix, do: "log_events"
 
   @doc """
   Default naming prefix for the key type count materialized view.
   """
-  def default_key_type_counts_view_prefix(), do: "mv_key_type_counts_per_min"
+  def default_key_type_counts_view_prefix, do: "mv_key_type_counts_per_min"
 
   @doc """
   Default naming prefix for the key type count table.
   """
-  def default_key_type_counts_table_prefix(), do: "key_type_counts_per_min"
+  def default_key_type_counts_table_prefix, do: "key_type_counts_per_min"
 
   @doc """
   Generates a ClickHouse query statement to check that the user GRANTs include the needed permissions.
@@ -70,8 +70,6 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
     ttl_days =
       if is_pos_integer(ttl_days_temp) do
         ttl_days_temp
-      else
-        nil
       end
 
     db_table_string =

--- a/lib/logflare/backends/adaptor/s3_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/s3_adaptor/pipeline.ex
@@ -86,7 +86,7 @@ defmodule Logflare.Backends.Adaptor.S3Adaptor.Pipeline do
   # splits batch sizes based on message body size OR message count, whichever limit is reached first
   # https://hexdocs.pm/broadway/Broadway.html#start_link/2
   @spec batch_size_splitter() :: {tuple(), (any(), tuple() -> {:emit | :cont, tuple()})}
-  defp batch_size_splitter() do
+  defp batch_size_splitter do
     {
       {@max_batch_size, @max_batch_length},
       fn

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -49,7 +49,7 @@ defmodule Logflare.Backends.Backend do
     timestamps()
   end
 
-  def adaptor_mapping(), do: @adaptor_mapping
+  def adaptor_mapping, do: @adaptor_mapping
 
   def changeset(backend, attrs) do
     backend

--- a/lib/logflare/backends/recent_events_touch.ex
+++ b/lib/logflare/backends/recent_events_touch.ex
@@ -44,7 +44,7 @@ defmodule Logflare.Backends.RecentEventsTouch do
      }}
   end
 
-  defp random_interval_ms() do
+  defp random_interval_ms do
     min = :timer.minutes(30)
     max = :timer.minutes(120)
     Enum.random(min..max)

--- a/lib/logflare/backends/recent_inserts_broadcaster.ex
+++ b/lib/logflare/backends/recent_inserts_broadcaster.ex
@@ -112,7 +112,7 @@ defmodule Logflare.Backends.RecentInsertsBroadcaster do
     {:ok, current_cluster_inserts, current_inserts}
   end
 
-  defp broadcast() do
+  defp broadcast do
     # scale broadcasting interval to cluster size
     cluster_size = Logflare.Cluster.Utils.actual_cluster_size()
     broadcast_every = max(@broadcast_every, round(:rand.uniform(cluster_size * 200)))


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.