### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in test/

### DIFF
--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -929,15 +929,15 @@ defmodule Logflare.Lql.ParserTest do
     end
   end
 
-  def today_dt() do
+  def today_dt do
     Timex.today() |> Timex.to_datetime()
   end
 
-  def now_ndt() do
+  def now_ndt do
     %{Timex.now() | microsecond: {0, 0}}
   end
 
-  def now_udt_zero_sec() do
+  def now_udt_zero_sec do
     %{now_ndt() | second: 0}
   end
 

--- a/test/logflare/vault_test.exs
+++ b/test/logflare/vault_test.exs
@@ -72,7 +72,7 @@ defmodule Logflare.VaultTest do
     end
   end
 
-  defp get_config_encrypted() do
+  defp get_config_encrypted do
     [
       %{
         config: nil,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -167,7 +167,7 @@ defmodule Logflare.Factory do
     end)
   end
 
-  def plan_factory() do
+  def plan_factory do
     %Plan{
       stripe_id: "31415",
       price: 0,
@@ -224,7 +224,7 @@ defmodule Logflare.Factory do
   end
 
   @spec user_preferences_factory :: Logflare.Users.UserPreferences.t()
-  def user_preferences_factory() do
+  def user_preferences_factory do
     %UserPreferences{}
   end
 
@@ -286,7 +286,7 @@ defmodule Logflare.Factory do
     }
   end
 
-  def user_without_billing_account_factory() do
+  def user_without_billing_account_factory do
     build(:user,
       valid_google_account: true,
       billing_account: nil,
@@ -295,7 +295,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def user_without_stripe_subscription_factory() do
+  def user_without_stripe_subscription_factory do
     build(:user,
       provider: "google",
       valid_google_account: true,
@@ -304,7 +304,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def user_with_wrong_stripe_sub_content_factory() do
+  def user_with_wrong_stripe_sub_content_factory do
     build(:user,
       provider: "google",
       valid_google_account: true,
@@ -313,7 +313,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def user_with_lifetime_account_non_google_factory() do
+  def user_with_lifetime_account_non_google_factory do
     build(:user,
       provider: "potato",
       billing_account: insert(:billing_account, lifetime_plan: true),
@@ -321,7 +321,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def user_with_lifetime_account_factory() do
+  def user_with_lifetime_account_factory do
     build(:user,
       provider: "google",
       valid_google_account: true,
@@ -330,7 +330,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def user_with_legacy_account_factory() do
+  def user_with_legacy_account_factory do
     build(:user,
       provider: "google",
       valid_google_account: true,
@@ -353,7 +353,7 @@ defmodule Logflare.Factory do
     )
   end
 
-  def billing_counts_factory() do
+  def billing_counts_factory do
     user = insert(:user)
     source = build(:source, user: user)
 
@@ -365,13 +365,13 @@ defmodule Logflare.Factory do
     }
   end
 
-  def partner_factory() do
+  def partner_factory do
     %Partner{
       name: TestUtils.random_string()
     }
   end
 
-  def alert_factory() do
+  def alert_factory do
     %AlertQuery{
       name: "some name",
       cron: "0 0 1 * *",

--- a/test/support/predefined_users_sources.ex
+++ b/test/support/predefined_users_sources.ex
@@ -1,6 +1,7 @@
 defmodule Logflare.BigQuery.PredefinedTestUser do
   @moduledoc false
-  def table_schema() do
+
+  def table_schema do
     %GoogleApi.BigQuery.V2.Model.TableSchema{
       fields: [
         %GoogleApi.BigQuery.V2.Model.TableFieldSchema{

--- a/test/support/test_utils_grpc.ex
+++ b/test/support/test_utils_grpc.ex
@@ -58,7 +58,7 @@ defmodule Logflare.TestUtilsGrpc do
     ]
   end
 
-  defp random_scope() do
+  defp random_scope do
     %InstrumentationScope{
       name: TestUtils.random_string(),
       version: TestUtils.random_string(),


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.