### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in lib/logflare/source*

### DIFF
--- a/lib/logflare/source/bigquery/pipeline.ex
+++ b/lib/logflare/source/bigquery/pipeline.ex
@@ -301,7 +301,7 @@ defmodule Logflare.Source.BigQuery.Pipeline do
   # https://hexdocs.pm/broadway/Broadway.html#start_link/2
   # split batch sizes based on json size
   # ensure that we are well below the 10MB limit
-  def bq_batch_size_splitter() do
+  def bq_batch_size_splitter do
     {
       {@max_batch_size, @max_batch_length},
       fn

--- a/lib/logflare/source/bigquery/schema.ex
+++ b/lib/logflare/source/bigquery/schema.ex
@@ -225,7 +225,7 @@ defmodule Logflare.Source.BigQuery.Schema do
     System.system_time(:millisecond) + ms
   end
 
-  defp next_update() do
+  defp next_update do
     updates_per_minute = Application.get_env(:logflare, __MODULE__)[:updates_per_minute]
     next_update_ts(updates_per_minute)
   end

--- a/lib/logflare/source/bigquery/schema_builder.ex
+++ b/lib/logflare/source/bigquery/schema_builder.ex
@@ -150,7 +150,7 @@ defmodule Logflare.Source.BigQuery.SchemaBuilder do
     |> deep_sort_by_fields_name()
   end
 
-  def initial_table_schema() do
+  def initial_table_schema do
     %Model.TableSchema{
       fields: [
         %TFS{

--- a/lib/logflare/source/billing_writer.ex
+++ b/lib/logflare/source/billing_writer.ex
@@ -48,7 +48,7 @@ defmodule Logflare.Source.BillingWriter do
     {:noreply, %{state | billing_last_node_count: node_count}}
   end
 
-  defp write() do
+  defp write do
     every = :timer.minutes(Enum.random(45..75))
     Process.send_after(self(), :write_count, every)
   end

--- a/lib/logflare/source/supervisor.ex
+++ b/lib/logflare/source/supervisor.ex
@@ -172,7 +172,7 @@ defmodule Logflare.Source.Supervisor do
     |> Enum.each(fn s -> reset_source(s.token) end)
   end
 
-  defp do_pg_ops?() do
+  defp do_pg_ops? do
     !!Application.get_env(:logflare, :single_tenant) &&
       !!Application.get_env(:logflare, :postgres_backend_adapter)
   end

--- a/lib/logflare/source/webhook_notification_server/discord_client.ex
+++ b/lib/logflare/source/webhook_notification_server/discord_client.ex
@@ -7,7 +7,7 @@ defmodule Logflare.Source.WebhookNotificationServer.DiscordClient do
 
   @middleware [Tesla.Middleware.JSON]
 
-  def new() do
+  def new do
     middleware =
       [
         #  {Tesla.Middleware.Retry,

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -476,7 +476,7 @@ defmodule Logflare.Sources do
   end
 
   @doc "Checks if all ETS tables used for source ingestion are started"
-  def ingest_ets_tables_started?() do
+  def ingest_ets_tables_started? do
     case {:ets.whereis(:rate_counters), :ets.whereis(:table_counters)} do
       {a, b} when is_reference(a) and is_reference(b) -> true
       _ -> false


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.