### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in lib/logflare_web/controllers/*

### DIFF
--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -206,13 +206,13 @@ defmodule LogflareWeb.AdminController do
     |> Repo.paginate(%{page_size: @page_size, page: 1})
   end
 
-  defp query() do
+  defp query do
     from s in Source,
       order_by: [desc: s.inserted_at],
       select: s
   end
 
-  defp query_accounts() do
+  defp query_accounts do
     from u in User,
       order_by: [desc: :inserted_at],
       select: u,

--- a/lib/logflare_web/controllers/cloudflare_controller.ex
+++ b/lib/logflare_web/controllers/cloudflare_controller.ex
@@ -20,9 +20,9 @@ defmodule LogflareWeb.CloudflareController do
 
   defp build_response(conn, user_token) when is_nil(user_token) do
     init_json(conn)
-    |> reset_options
-    |> reset_sources
-    |> reset_links
+    |> reset_options()
+    |> reset_sources()
+    |> reset_links()
   end
 
   defp build_response(conn, user_token) do

--- a/lib/logflare_web/controllers/cloudflare_controller_v1.ex
+++ b/lib/logflare_web/controllers/cloudflare_controller_v1.ex
@@ -26,10 +26,10 @@ defmodule LogflareWeb.CloudflareControllerV1 do
 
   defp build_response(conn, user_token) when is_nil(user_token) do
     init_json(conn)
-    |> reset_options
-    |> reset_sources
-    |> reset_links
-    |> reset_properties
+    |> reset_options()
+    |> reset_sources()
+    |> reset_links()
+    |> reset_properties()
   end
 
   defp build_response(conn, user_token) do

--- a/lib/logflare_web/controllers/plugs/bert_parser.ex
+++ b/lib/logflare_web/controllers/plugs/bert_parser.ex
@@ -44,7 +44,7 @@ defmodule LogflareWeb.BertParser do
     raise Plug.BadRequestError
   end
 
-  def atoms() do
+  def atoms do
     # fixes a bug in Bertex where Bertex.safe_decode errors because
     # :bert and :dict atoms returned by :binary_to_term do not exist and are treated
     # as coming from the binary

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -255,7 +255,7 @@ defmodule LogflareWeb.SourceController do
     )
   end
 
-  defp notifications_options() do
+  defp notifications_options do
     env = Application.get_env(:logflare, :env)
 
     plans =


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.