### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in logflare contexts and util modules

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -362,8 +362,8 @@ defmodule Logflare.Alerting do
   end
 
   defp on_scheduler_node(func) do
-    with pid when is_pid(pid) <- GenServer.whereis(scheduler_name()),
-         node <- node(pid) do
+    with pid when is_pid(pid) <- GenServer.whereis(scheduler_name()) do
+      node = node(pid)
       :erpc.call(node, func, 5000)
     end
   end

--- a/lib/logflare/auth.ex
+++ b/lib/logflare/auth.ex
@@ -165,8 +165,8 @@ defmodule Logflare.Auth do
     resource_owner = Keyword.get(config, :resource_owner)
 
     with {:ok, access_token} <- ExOauth2Provider.authenticate_token(str_token, config),
-         :ok <- check_scopes(access_token, required_scopes),
-         owner <- get_resource_owner_by_id(resource_owner, access_token.resource_owner_id) do
+         :ok <- check_scopes(access_token, required_scopes) do
+      owner = get_resource_owner_by_id(resource_owner, access_token.resource_owner_id)
       {:ok, access_token, owner}
     end
   end

--- a/lib/logflare/billing.ex
+++ b/lib/logflare/billing.ex
@@ -383,7 +383,7 @@ defmodule Logflare.Billing do
 
   @doc "Returns the legacy plan"
   @spec legacy_plan :: Plan.t()
-  def legacy_plan() do
+  def legacy_plan do
     %Plan{
       limit_rate_limit: 150,
       limit_source_rate_limit: 50,

--- a/lib/logflare/generators.ex
+++ b/lib/logflare/generators.ex
@@ -4,7 +4,7 @@ defmodule Logflare.Generators do
   @objects File.read!("priv/generators/objects.txt")
   @teams File.read!("priv/generators/teams.txt")
 
-  def team_name() do
+  def team_name do
     opts = [capitalize: true]
 
     predicate(opts) <> " " <> team(opts)
@@ -15,7 +15,7 @@ defmodule Logflare.Generators do
     |> String.capitalize()
   end
 
-  def predicate() do
+  def predicate do
     @predicates
     |> String.split("\n", trim: true)
     |> Enum.random()
@@ -26,7 +26,7 @@ defmodule Logflare.Generators do
     |> String.capitalize()
   end
 
-  def object() do
+  def object do
     @objects
     |> String.split("\n", trim: true)
     |> Enum.random()
@@ -37,7 +37,7 @@ defmodule Logflare.Generators do
     |> String.capitalize()
   end
 
-  def team() do
+  def team do
     @teams
     |> String.split("\n", trim: true)
     |> Enum.random()

--- a/lib/logflare/partners.ex
+++ b/lib/logflare/partners.ex
@@ -28,7 +28,7 @@ defmodule Logflare.Partners do
   @doc """
   Lists all partners
   """
-  def list_partners(), do: Repo.all(Partner)
+  def list_partners, do: Repo.all(Partner)
 
   @spec get_partner_by_uuid(binary()) :: Partner.t() | nil
   @doc """

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -5,7 +5,7 @@ defmodule Logflare.Utils do
   import Cachex.Spec
   import Logflare.Utils.Guards, only: [is_atom_value: 1]
 
-  def cache_stats() do
+  def cache_stats do
     hook(module: Cachex.Stats)
   end
 

--- a/lib/logflare/vault.ex
+++ b/lib/logflare/vault.ex
@@ -80,7 +80,7 @@ defmodule Logflare.Vault do
   end
 
   # helper, exposed for testing
-  def do_migrate() do
+  def do_migrate do
     for schema <- @schemas do
       Migrator.migrate(Logflare.Repo, schema)
     end
@@ -96,7 +96,7 @@ defmodule Logflare.Vault do
   end
 
   # helper for tests
-  def get_config() do
+  def get_config do
     Cloak.Vault.read_config(@table_name)
   end
 


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.