### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in Telemetry related modules

### DIFF
--- a/lib/logflare_web/open_telemetry_sampler.ex
+++ b/lib/logflare_web/open_telemetry_sampler.ex
@@ -98,12 +98,12 @@ defmodule LogflareWeb.OpenTelemetrySampler do
     end
   end
 
-  defp ingest_config() do
+  defp ingest_config do
     prob = Application.get_env(:logflare, :ingest_sample_ratio)
     :otel_sampler_trace_id_ratio_based.setup(prob)
   end
 
-  defp endpoint_config() do
+  defp endpoint_config do
     prob = Application.get_env(:logflare, :endpoint_sample_ratio)
     :otel_sampler_trace_id_ratio_based.setup(prob)
   end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -200,7 +200,7 @@ defmodule Logflare.Telemetry do
     ])
   end
 
-  defp periodic_measurements() do
+  defp periodic_measurements do
     cache_stats? = Application.get_env(:logflare, :cache_stats, false)
 
     if cache_stats? do


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.