### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in lib/logflare/google*

### DIFF
--- a/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils/gen_utils.ex
@@ -16,7 +16,7 @@ defmodule Logflare.Google.BigQuery.GenUtils do
   @doc """
   Returns the default TTL used (in days) for initializing the table.
   """
-  def default_table_ttl_days() do
+  def default_table_ttl_days do
     @table_ttl / :timer.hours(24)
   end
 

--- a/lib/logflare/google/cloud_resource_manager.ex
+++ b/lib/logflare/google/cloud_resource_manager.ex
@@ -1,6 +1,5 @@
 defmodule Logflare.Google.CloudResourceManager do
   @moduledoc false
-  require Logger
 
   alias GoogleApi.CloudResourceManager.V1.Api
   alias GoogleApi.CloudResourceManager.V1.Model
@@ -11,12 +10,14 @@ defmodule Logflare.Google.CloudResourceManager do
   alias Logflare.Utils.Tasks
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
 
-  def list_projects() do
+  require Logger
+
+  def list_projects do
     conn = GenUtils.get_conn()
     Api.Projects.cloudresourcemanager_projects_list(conn)
   end
 
-  def get_iam_policy() do
+  def get_iam_policy do
     conn = GenUtils.get_conn()
 
     body = %Model.GetIamPolicyRequest{}
@@ -181,7 +182,7 @@ defmodule Logflare.Google.CloudResourceManager do
     Logger.error("Set IAM policy unknown error: #{inspect(err)}")
   end
 
-  defp get_service_accounts() do
+  defp get_service_accounts do
     managed_service_accounts =
       if BigQueryAdaptor.managed_service_accounts_enabled?() do
         for %{email: name} <- BigQueryAdaptor.list_managed_service_accounts() do
@@ -237,7 +238,7 @@ defmodule Logflare.Google.CloudResourceManager do
     end
   end
 
-  defp build_members() do
+  defp build_members do
     emails =
       Users.list_users(paying: true, provider: :google)
       |> Users.preload_valid_google_team_users()


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.