### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in lib/logflare/pubsub_rates*

### DIFF
--- a/lib/logflare/pubsub_rates.ex
+++ b/lib/logflare/pubsub_rates.ex
@@ -99,7 +99,7 @@ defmodule Logflare.PubSubRates do
   The number of partitions for a paritioned child.
   """
   @spec partitions() :: integer()
-  def partitions(), do: Application.get_env(:logflare, Logflare.PubSub)[:pool_size]
+  def partitions, do: Application.get_env(:logflare, Logflare.PubSub)[:pool_size]
 
   @doc """
   Partitions a topic for a key.

--- a/lib/logflare/pubsub_rates/cache.ex
+++ b/lib/logflare/pubsub_rates/cache.ex
@@ -31,7 +31,7 @@ defmodule Logflare.PubSubRates.Cache do
     }
   end
 
-  def clear() do
+  def clear do
     Cachex.clear(__MODULE__)
   end
 


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.