### PR TITLE
refactor: follow Credo.Check.Readability.ParenthesesOnZeroArityDefs in multiple utils and single purpose modules

### DIFF
--- a/lib/logflare/cluster/utils.ex
+++ b/lib/logflare/cluster/utils.ex
@@ -3,17 +3,17 @@ defmodule Logflare.Cluster.Utils do
   require Logger
 
   @spec node_list_all() :: [Node.t()]
-  def node_list_all() do
+  def node_list_all do
     [Node.self() | Node.list()]
   end
 
   @spec cluster_size() :: non_neg_integer()
-  def cluster_size() do
+  def cluster_size do
     max(actual_cluster_size(), min_cluster_size())
   end
 
   @spec actual_cluster_size() :: non_neg_integer()
-  def actual_cluster_size(), do: Enum.count(node_list_all())
+  def actual_cluster_size, do: Enum.count(node_list_all())
 
   def min_cluster_size, do: Application.get_env(:logflare, __MODULE__)[:min_cluster_size]
 

--- a/lib/logflare/ecto/ecto_uuid_atom_t.ex
+++ b/lib/logflare/ecto/ecto_uuid_atom_t.ex
@@ -11,7 +11,7 @@ defmodule Ecto.UUID.Atom do
   def cast(value) when is_binary(value), do: {:ok, String.to_atom(value)}
   def cast(_), do: :error
 
-  def autogenerate(), do: String.to_atom(Ecto.UUID.generate())
+  def autogenerate, do: String.to_atom(Ecto.UUID.generate())
 
   def load(value) do
     with {:ok, value} <- Ecto.UUID.load(value) do

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -299,7 +299,7 @@ defmodule Logflare.SingleTenant do
 
   @doc "Returns postgres backend adapter configurations if single tenant and env is set"
   @spec postgres_backend_adapter_opts :: Keyword.t() | nil
-  def postgres_backend_adapter_opts() do
+  def postgres_backend_adapter_opts do
     if single_tenant?() do
       Application.get_env(:logflare, :postgres_backend_adapter)
     end
@@ -377,7 +377,7 @@ defmodule Logflare.SingleTenant do
   Returns true if postgres backend is enabled for single tenant
   """
   @spec postgres_backend? :: boolean()
-  def postgres_backend?() do
+  def postgres_backend? do
     opts = postgres_backend_adapter_opts() || []
 
     url = Keyword.get(opts, :url)

--- a/lib/logflare/vercel/client.ex
+++ b/lib/logflare/vercel/client.ex
@@ -8,7 +8,7 @@ defmodule Logflare.Vercel.Client do
   defp env_client_secret, do: Application.get_env(:logflare, __MODULE__)[:client_secret]
   defp env_redirect_uri, do: Application.get_env(:logflare, __MODULE__)[:redirect_uri]
 
-  def new() do
+  def new do
     new(%Vercel.Auth{})
   end
 

--- a/lib/logflare_web/views/helpers/page_title.ex
+++ b/lib/logflare_web/views/helpers/page_title.ex
@@ -7,7 +7,7 @@ defmodule LogflareWeb.Helpers.PageTitle do
 
   @suffix "Logflare | Cloudflare, Vercel & Elixir Logging"
 
-  def page_title(conn), do: conn |> get |> put_suffix
+  def page_title(conn), do: conn |> get() |> put_suffix()
 
   defp put_suffix(nil), do: @suffix
   defp put_suffix(title), do: title <> " | " <> @suffix

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -32,8 +32,6 @@ defmodule Logflare.Logs.SearchOperationsTest do
     end
 
     test "unnest_log_level/1 with metadata", %{so: so} do
-      test_pid = self()
-
       GoogleApi.BigQuery.V2.Api.Tables
       |> stub(:bigquery_tables_patch, fn _conn, _project_id, _dataset_id, _table_name, _opts ->
         {:ok, %{}}

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -381,7 +381,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       # ref https://www.notion.so/supabase/Backend-Search-Error-187112eabd094dcc8042c6952f4f5fac
 
       GoogleApi.BigQuery.V2.Api.Tables
-      |> stub(:bigquery_tables_patch, fn _conn, _proj, _dataset, table, opts ->
+      |> stub(:bigquery_tables_patch, fn _conn, _proj, _dataset, _table, _opts ->
         {:ok, %GoogleApi.BigQuery.V2.Model.Table{}}
       end)
 


### PR DESCRIPTION
The goal is to reactivate the rule in credo config once it is done for all.