### PR TITLE
chore: make parens false in Credo.Check.Readability.ParenthesesOnZeroArityDefs

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -100,7 +100,7 @@
           {Credo.Check.Readability.ModuleAttributeNames, []},
           {Credo.Check.Readability.ModuleNames, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
-          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, [parens: false]},
           {Credo.Check.Readability.PredicateFunctionNames, []},
           {Credo.Check.Readability.PreferImplicitTry, []},
           {Credo.Check.Readability.RedundantBlankLines, []},


### PR DESCRIPTION
Depending on last one https://github.com/Logflare/logflare/pull/2625.