### PR TITLE
refactor: rework of the default backend logic

### DIFF
--- a/lib/logflare_web/live/backends/actions/show.html.heex
+++ b/lib/logflare_web/live/backends/actions/show.html.heex
@@ -28,6 +28,50 @@
   </div>
 </section>
 
+<section :if={LogflareWeb.Utils.flag("multibackend", @user) == true and Logflare.Backends.Adaptor.supports_default_ingest?(@backend)} class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-4">
+  <h4>Default Ingest Sources</h4>
+  <p>
+    Sources configured to use this backend as a default ingest destination.
+  </p>
+
+  <div>
+    <.button phx-click="toggle_default_ingest_form" variant="secondary">
+      <%= if @show_default_ingest_form? do %>
+        Cancel
+      <% else %>
+        Add a Source
+      <% end %>
+    </.button>
+  </div>
+
+  <.form :let={f} :if={@show_default_ingest_form?} id="default_ingest" for={%{}} as={:default_ingest} action="#" phx-submit="save_default_ingest">
+    <div class="form-group">
+      <%= label(f, :source_id, "Source") %>
+      <%= select(f, :source_id, Enum.filter(@sources, & &1.default_ingest_backend_enabled?) |> Enum.map(fn s -> {s.name, s.id} end),
+        class: "form-control",
+        prompt: [key: "Choose a source"]
+      ) %>
+      <small id="source_id" class="form-text text-muted">This source will use this backend as its default ingest destination. Only sources with default ingest backend support enabled are shown.</small>
+    </div>
+
+    <%= hidden_input(f, :backend_id, value: @backend.id) %>
+    <%= submit("Save", class: "btn btn-primary") %>
+  </.form>
+
+  <p :if={Enum.empty?(@default_ingest_sources || [])}>No sources configured for default ingest</p>
+  <ul :for={source <- @default_ingest_sources || []} class="tw-flex tw-flex-row tw-gap-4">
+    <li class="list-group-item tw-pointer-none tw-w-full tw-flex tw-flex-row tw-justify-between">
+      <span>
+        Source <code><%= source.name %></code> uses this backend as default ingest
+      </span>
+
+      <.button phx-click="remove_default_ingest" phx-value-source_id={source.id} variant="danger">
+        Remove
+      </.button>
+    </li>
+  </ul>
+</section>
+
 <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-4">
   <h4>Drain Rules</h4>
   <p>

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -302,17 +302,4 @@
       <% end %>
     </div>
   </.inputs_for>
-
-  <%= if @backend != nil and LogflareWeb.Utils.flag("multibackend", @user) == true and Logflare.Backends.Adaptor.supports_default_ingest?(@backend) do %>
-    <div class="form-group mt-2">
-      <%= label f, :default_ingest? do %>
-        Default Ingest Backend
-      <% end %>
-      <%= checkbox(f, :default_ingest?, checked: @backend && @backend.default_ingest?, value: @backend && @backend.default_ingest?) %>
-      <%= error_tag(f, :default_ingest?) %>
-      <small class="form-text text-muted">
-        Mark this backend as a default ingest backend.
-      </small>
-    </div>
-  <% end %>
 </.form>


### PR DESCRIPTION
Relies on the `sources_backends` join table as this allows for more efficient/targeted lookups when ingesting logs through existing functions such as `Logflare.Backends.list_backends/1` and its cached implementation. While this does go against the idea of moving away from the join table, it seems to be the most sane way to handle this situation.

- UX updated to behave similarly to the drain rules form shown when viewing a backend (_see screenshot below_)
- Only allows the selection of a source that has `default_ingest_backend_enabled?` set to true
- Handles log ingest and routing logic
- Spins up backend supervision trees when added as a default ingest target
- Load tests show no breakdown or connection issues when working with Clickhouse Cloud and BigQuery for backends

<img width="1470" height="471" alt="Screenshot 2025-08-17 at 2 09 53 PM" src="https://github.com/user-attachments/assets/ea18b915-6a01-4b51-aedb-4a8bc1697678" />
