### PR TITLE
refactor: extract nested code in lib/logflare_web/controllers/plugs/set_team_user.ex

### DIFF
--- a/lib/logflare_web/controllers/plugs/set_team_user.ex
+++ b/lib/logflare_web/controllers/plugs/set_team_user.ex
@@ -18,21 +18,25 @@ defmodule LogflareWeb.Plugs.SetTeamUser do
         conn
 
       team_user_id ->
-        case TeamUsers.get_team_user(team_user_id) do
-          nil ->
-            drop(conn)
+        set_team_user(conn, team_user_id)
+    end
+  end
 
-          t ->
-            case TeamUsers.touch_team_user(t) do
-              {1, [team_user]} ->
-                team_user |> TeamUsers.preload_defaults()
+  defp set_team_user(conn, team_user_id) do
+    case TeamUsers.get_team_user(team_user_id) do
+      nil ->
+        drop(conn)
 
-                conn
-                |> assign(:team_user, team_user)
+      t ->
+        case TeamUsers.touch_team_user(t) do
+          {1, [team_user]} ->
+            team_user |> TeamUsers.preload_defaults()
 
-              _ ->
-                error(conn)
-            end
+            conn
+            |> assign(:team_user, team_user)
+
+          _ ->
+            error(conn)
         end
     end
   end


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.