### PR TITLE
chore: exclude node_modules from tailwind build

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./**/*.{js,jsx,ts,tsx}",
+    "./js/*.{js,jsx,ts,tsx}",
     "../lib/logflare_web/*.{eex,leex,heex,ex}",
     "../lib/logflare_web/**/*.{eex,leex,heex,ex}",
   ],


### PR DESCRIPTION
Removes unnecessary folders from being scanned when building the Tailwind stylesheet.

All folders in `/assets/` were being included in the `content` configuration, which meant Tailwind was looking for classes used in a large number of files. Only `/assets/js/` needs to be scanned.

After this change the compiled CSS is only marginally smaller but the build time is significantly faster which improves startup  times in development. 

The following classes are no longer included in the generated CSS but I couldn't find them used in the app UI:

* -tw-inset-1
* -tw-top-1
* dark
* tw--inset-1
* tw--top-1
* tw-contain-layout
* tw-contain-paint
* tw-contain-size
* tw-contain-style
* tw-divide-x-reverse
* tw-divide-y-reverse
* tw-ordinal
* tw-ring-inset
* tw-slashed-zero
* tw-space-x-reverse
* tw-space-y-reverse

`dark` is referenced but is the Bootstrap class:

```
lib/logflare_web/live/plans_live.ex
90:                <.link navigate={~p"/auth/login"} class="btn btn-dark text-white w-75 mr-0">Continue</.link>
```
