### PR TITLE
fix: lql negations should consider null as not matching

### DIFF
--- a/lib/logflare/lql/backend_transformer/bigquery.ex
+++ b/lib/logflare/lql/backend_transformer/bigquery.ex
@@ -289,7 +289,10 @@ defmodule Logflare.Lql.BackendTransformer.BigQuery do
       end
 
     if negated?(modifiers) do
-      dynamic([..., n1], not (^clause))
+      case {operator, value} do
+        {:=, :NULL} -> dynamic([..., n1], not (^clause))
+        {_, _} -> dynamic([..., n1], is_nil(field(n1, ^column)) or not (^clause))
+      end
     else
       clause
     end

--- a/test/logflare/bigquery/ecto_query_bq_test.exs
+++ b/test/logflare/bigquery/ecto_query_bq_test.exs
@@ -430,5 +430,48 @@ defmodule Logflare.BigQuery.EctoQueryBQTest do
       assert "FLOAT" in param_types
       assert "BOOL" in param_types
     end
+
+    test "negated operators include NULL values" do
+      for operator <- [:=, :<, :<=, :>, :>=] do
+        filter_rules = [
+          %FilterRule{
+            path: "metadata.a",
+            operator: operator,
+            value: 123,
+            modifiers: %{negate: true}
+          }
+        ]
+
+        query =
+          from(@bq_table_id)
+          |> select([:timestamp, :metadata])
+          |> Lql.apply_filter_rules(filter_rules)
+
+        {sql, _params} = EctoQueryBQ.SQL.to_sql_params(query)
+
+        assert sql =~ "WHERE ((f1.a IS NULL) OR NOT (f1.a #{operator} ?))"
+      end
+    end
+
+    test "negated IS NULL operator should be IS NOT NULL" do
+      filter_rules = [
+        %FilterRule{
+          path: "metadata.a",
+          operator: :=,
+          value: :NULL,
+          modifiers: %{negate: true}
+        }
+      ]
+
+      query =
+        from(@bq_table_id)
+        |> select([:timestamp, :metadata])
+        |> Lql.apply_filter_rules(filter_rules)
+
+      {sql, _params} = EctoQueryBQ.SQL.to_sql_params(query)
+
+      assert sql =~ "WHERE (NOT (f1.a IS NULL))"
+      refute sql =~ "IS NULL) OR NOT"
+    end
   end
 end


### PR DESCRIPTION
When filtering for `-metadata.project:"asd"`, logs without the `metadata.project` key wouldn't show up. This happened due to how LQL negations got translated to SQL:

Before: `-m.project:"asd"` would become:
```sql
WHERE NOT (f1.project = 'asd')
```

If `f1.project` IS NULL, the expression returns NULL, which filters it out of the result set.

Now we translate it to:
```sql
WHERE ((f1.project IS NULL) OR NOT (f1.project = 'asd'))
```

This properly returns logs where m.project is null.