### PR TITLE
fix: include labels when running Endpoint test queries

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -278,12 +278,12 @@ defmodule Logflare.Endpoints do
     iex> run_query_string(%User{...}, {:bq_sql, "select current_time() where @value > 4"}, params: %{"value" => "123"})
     {:ok, %{rows:  [...]} }
   """
-  @typep run_query_string_opts :: [sandboxable: boolean(), params: map()]
+  @typep run_query_string_opts :: [sandboxable: boolean(), params: map(), parsed_labels: map()]
   @typep language :: :bq_sql | :pg_sql | :lql
   @spec run_query_string(User.t(), {language(), String.t()}, run_query_string_opts()) ::
           run_query_return()
   def run_query_string(user, {language, query_string}, opts \\ %{}) do
-    opts = Enum.into(opts, %{sandboxable: false, params: %{}})
+    opts = Enum.into(opts, %{sandboxable: false, parsed_labels: %{}, params: %{}})
 
     source_mapping =
       user
@@ -297,6 +297,7 @@ defmodule Logflare.Endpoints do
       sandboxable: opts.sandboxable,
       user: user,
       user_id: user.id,
+      parsed_labels: opts.parsed_labels,
       source_mapping: source_mapping
     }
 

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -199,8 +199,11 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
   describe "run queries" do
     setup do
+      pid = self()
+
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
+        send(pid, {:labels, opts[:body].labels})
         {:ok, TestUtils.gen_bq_response([%{"testing" => "results-123"}])}
       end)
 
@@ -220,6 +223,8 @@ defmodule LogflareWeb.EndpointsLiveTest do
           params: %{}
         }
       }) =~ "results-123"
+
+      assert_received {:labels, %{"endpoint_id" => "nil", "managed_by" => "logflare"}}
 
       assert has_element?(view, "label", "Description")
       assert has_element?(view, "h5", "Caching")
@@ -262,7 +267,11 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
     test "show endpoint, with params", %{conn: conn, user: user} do
       endpoint =
-        insert(:endpoint, user: user, query: "select 'id' as id, @test_param as param;\n\n")
+        insert(:endpoint,
+          user: user,
+          query: "select 'id' as id, @test_param as param;\n\n",
+          labels: "session_id,test=@test_param"
+        )
 
       {:ok, view, _html} = live(conn, "/endpoints/#{endpoint.id}")
       refute render(view) =~ "results-123"
@@ -286,6 +295,9 @@ defmodule LogflareWeb.EndpointsLiveTest do
              }) =~ "results-123"
 
       assert has_element?(view, "input[value='my_param_value']")
+
+      assert_received {:labels, labels = %{"test" => "my_param_value", "session_id" => "nil"}}
+      assert labels["endpoint_id"] == endpoint.id |> to_string()
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where running a test query from the Endpoints UI would not include query execution labels.

Labels included in the endpoint allowlist will be sent with the test query.
* a label that references a parameter will use the parameter specified in the test query
* an allowlist key (eg. `session_id`, without a static value) will use `"nil"` for the value
* the label `endpoint_id` will be the id of the endpoint, or `nil` if the endpoint is not yet persisted.

Example output from BigQuery jobs explorer, with labels set to `session_id,user_tag=@user_id`

<img width="428" height="404" alt="CleanShot 2025-08-20 at 14 38 22@2x" src="https://github.com/user-attachments/assets/5cdc6113-95f8-4723-a743-0da23b0b2a40" />


