### PR TITLE
refactor: extract nested code in lib/logflare/source/text_notification_server.ex

### DIFF
--- a/lib/logflare/source/text_notification_server.ex
+++ b/lib/logflare/source/text_notification_server.ex
@@ -67,14 +67,14 @@ defmodule Logflare.Source.TextNotificationServer do
 
     ExTwilio.Message.create(to: user.phone, from: @twilio_phone, body: body)
 
-    if source.notifications.team_user_ids_for_sms do
-      Enum.each(source.notifications.team_user_ids_for_sms, fn x ->
-        team_user = TeamUsers.Cache.get_team_user(x)
+    source.notifications
+    |> Map.get(:team_user_ids_for_sms, [])
+    |> Enum.each(fn x ->
+      team_user = TeamUsers.Cache.get_team_user(x)
 
-        if team_user do
-          ExTwilio.Message.create(to: team_user.phone, from: @twilio_phone, body: body)
-        end
-      end)
-    end
+      if team_user do
+        ExTwilio.Message.create(to: team_user.phone, from: @twilio_phone, body: body)
+      end
+    end)
   end
 end


### PR DESCRIPTION
The goal is to reactivate the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). I am opening multiple PRs because I though it would be easier to review.