### PR TITLE
refactor: improve nested code in lib/logflare/source/bigquery/schema.ex

### DIFF
--- a/lib/logflare_web/channels/lv_socket.ex
+++ b/lib/logflare_web/channels/lv_socket.ex
@@ -3,12 +3,13 @@ defmodule Logflare.LiveView.Socket do
   The LiveView socket for Phoenix Endpoints.
   """
   use Phoenix.Socket, log: false
+
+  alias Phoenix.LiveView
+
   require Logger
 
-  if Version.match?(System.version(), ">= 1.8.0") do
-    @derive {Inspect,
-             only: [:id, :endpoint, :router, :view, :parent_pid, :root_pid, :assigns, :changed]}
-  end
+  @derive {Inspect,
+           only: [:id, :endpoint, :router, :view, :parent_pid, :root_pid, :assigns, :changed]}
 
   defstruct id: nil,
             endpoint: nil,
@@ -20,12 +21,12 @@ defmodule Logflare.LiveView.Socket do
             assigns: %{},
             changed: %{},
             private: %{},
-            fingerprints: Phoenix.LiveView.Diff.new_fingerprints(),
+            fingerprints: LiveView.Diff.new_fingerprints(),
             redirected: nil,
             host_uri: nil,
             connected?: false
 
-  @type assigns :: map | Phoenix.LiveView.Socket.AssignsNotInSocket.t()
+  @type assigns :: map | LiveView.Socket.AssignsNotInSocket.t()
   @type fingerprints :: {nil, map} | {binary, map}
 
   @type t :: %__MODULE__{
@@ -45,7 +46,7 @@ defmodule Logflare.LiveView.Socket do
           connected?: boolean()
         }
 
-  channel "lv:*", Phoenix.LiveView.Channel
+  channel "lv:*", LiveView.Channel
 
   @doc """
   Connects the Phoenix.Socket for a LiveView client.


### PR DESCRIPTION
This should be the last one before we can enable back the rule [Credo.Check.Refactor.Nesting](https://github.com/Logflare/logflare/blob/1d5760494c345c934fc115efe65541b1086c668c/config/.credo.exs#L178). 

Other than this one, the only one needed to be merged is https://github.com/Logflare/logflare/pull/2671.