### PR TITLE
chore: remove unused sql-formatter npm package

### DIFF
--- a/assets/js/source_lv_hooks.js
+++ b/assets/js/source_lv_hooks.js
@@ -1,7 +1,6 @@
 import {
   activateClipboardForSelector
 } from "./utils"
-import sqlFormatter from "sql-formatter"
 import $ from "jquery"
 import _ from "lodash"
 import idle from "./vendor/idle"
@@ -38,7 +37,7 @@ hooks.SourceLogsSearchList = {
           }
         })
       })
-    
+
     const target = document.querySelector("#observer-target")
     observer.observe(target)
   },
@@ -49,23 +48,7 @@ hooks.SourceLogsSearchList = {
   },
 }
 
-const formatModal = ($modal) => {
-  if ($modal.data("modal-type") === "search-op-debug-modal") {
-    const $code = $modal.find(`code#search-op-sql-string`)
-    const fmtSql = sqlFormatter.format($code.text())
-    // replace with formatted sql
-    $code.text(fmtSql)
-    $modal.find("pre code").each((i, block) => {
-      hljs.highlightBlock(block)
-    })
-  }
-}
-
 hooks.ModalHook = {
-  updated() {
-    const $modal = $(this.el)
-    formatModal($modal)
-  },
   mounted() {
     const $modal = $(this.el)
 
@@ -80,8 +63,6 @@ hooks.ModalHook = {
         this.pushEvent("soft_play", {})
       }
     })
-
-    formatModal($modal)
 
     $modal.modal({
       backdrop: "static"

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -28,8 +28,7 @@
         "react": "^16.11.0",
         "react-bootstrap": "^1.6.6",
         "react-dom": "^16.11.0",
-        "react-spinners": "^0.9.0",
-        "sql-formatter": "^2.3.3"
+        "react-spinners": "^0.9.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.13",
@@ -3808,14 +3807,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sql-formatter": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-2.3.4.tgz",
-      "integrity": "sha512-CajWtvzYoBJbD5PQeVe3E7AOHAIYvRQEPOKgF9kfKNeY8jtjBiiA6pDzkMuAID8jJMluoPvyKveLigSaA5tKQQ==",
-      "dependencies": {
-        "lodash": "^4.17.20"
-      }
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -6734,14 +6725,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
-    },
-    "sql-formatter": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-2.3.4.tgz",
-      "integrity": "sha512-CajWtvzYoBJbD5PQeVe3E7AOHAIYvRQEPOKgF9kfKNeY8jtjBiiA6pDzkMuAID8jJMluoPvyKveLigSaA5tKQQ==",
-      "requires": {
-        "lodash": "^4.17.20"
-      }
     },
     "string-width": {
       "version": "5.1.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,8 +27,7 @@
     "react": "^16.11.0",
     "react-bootstrap": "^1.6.6",
     "react-dom": "^16.11.0",
-    "react-spinners": "^0.9.0",
-    "sql-formatter": "^2.3.3"
+    "react-spinners": "^0.9.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",


### PR DESCRIPTION
This was only used by a model type `search-op-debug-modal` and that was removed in [8804c89d94042288281aebe0f38d93d9cf21708b](https://github.com/Logflare/logflare/commit/8804c89d94042288281aebe0f38d93d9cf21708b)