### PR TITLE
chore: remove unneeded Logger warning in clickhouse adaptor

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -689,7 +689,6 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
       if MapSet.member?(allowed_set, param) do
         "{#{param}:String}"
       else
-        Logger.warning("SQL parameter `@#{param}` not in allowed list")
         match
       end
     end)


### PR DESCRIPTION
Follow-up to [this](https://github.com/Logflare/logflare/pull/2697#discussion_r2308313818) callout in #2697.
