### PR TITLE
fix: query errors should be on the `error` field

### DIFF
--- a/lib/logflare_web/controllers/endpoints_controller.ex
+++ b/lib/logflare_web/controllers/endpoints_controller.ex
@@ -73,7 +73,7 @@ defmodule LogflareWeb.EndpointsController do
         render(conn, "query.json", result: result.rows)
 
       {:error, errors} ->
-        render(conn, "query.json", errors: errors)
+        render(conn, "query.json", error: errors)
     end
   end
 

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -4,7 +4,7 @@ defmodule LogflareWeb.OpenApiSchemas do
   defmodule EndpointQuery do
     @properties %{
       result: %Schema{type: :array, allOf: %Schema{type: :object}},
-      errors: %Schema{
+      error: %Schema{
         oneOf: [
           %Schema{type: :object},
           %Schema{type: :string}

--- a/lib/logflare_web/views/endpoints_view.ex
+++ b/lib/logflare_web/views/endpoints_view.ex
@@ -5,7 +5,7 @@ defmodule LogflareWeb.EndpointsView do
     %{result: data}
   end
 
-  def render("query.json", %{errors: errors}) do
-    %{errors: errors}
+  def render("query.json", %{error: errors}) do
+    %{error: errors}
   end
 end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -39,7 +39,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
         |> json_response(200)
         |> assert_schema("EndpointQuery")
 
-      assert response.errors == %{"message" => "failed_request"}
+      assert response.error == %{"message" => "failed_request"}
       refute response.result
       refute conn.halted
 
@@ -73,7 +73,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                }
              ] = response.result
 
-      refute response.errors
+      refute response.error
       refute conn.halted
 
       reject(&GoogleApi.BigQuery.V2.Api.Jobs.bigquery_jobs_query/3)
@@ -95,7 +95,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                }
              ] = response.result
 
-      refute response.errors
+      refute response.error
 
       refute conn.halted
     end
@@ -126,7 +126,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                }
              ] = response.result
 
-      refute response.errors
+      refute response.error
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -153,7 +153,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                }
              ] = response.result
 
-      refute response.errors
+      refute response.error
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -180,7 +180,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                }
              ] = response.result
 
-      refute response.errors
+      refute response.error
       refute conn.halted
     end
 
@@ -231,7 +231,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  }
                ] = response.result
 
-        refute response.errors
+        refute response.error
         refute conn.halted
       end
     end


### PR DESCRIPTION
Bugfix for how errors should be passed, it should not break prior implementations, and should always be singular since the message is always passed to client as an object.

Closes ANL-1032