### PR TITLE
fix: remove unecessary function match

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -56,7 +56,6 @@
   {"lib/logflare/endpoints.ex", :no_return},
   {"lib/logflare/endpoints.ex", :pattern_match},
   {"lib/logflare/endpoints.ex", :call},
-  {"lib/logflare/endpoints.ex", :pattern_match_cov},
   {"lib/logflare/endpoints.ex", :unknown_type},
   {"lib/logflare/endpoints/query.ex", :pattern_match},
   {"lib/logflare/endpoints/query.ex", :no_return},

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -451,10 +451,6 @@ defmodule Logflare.Endpoints do
     find_backend_by_type_or_default(user_id, backend_type)
   end
 
-  defp get_backend_for_query(%Query{user_id: user_id}) do
-    find_backend_by_type_or_default(user_id, nil)
-  end
-
   @spec language_to_backend_type(language()) :: atom() | nil
   defp language_to_backend_type(:pg_sql), do: :postgres
   defp language_to_backend_type(:ch_sql), do: :clickhouse


### PR DESCRIPTION
This extra clause by being remove removes another warning. This is a follow up of https://github.com/Logflare/logflare/pull/2722.