### PR TITLE
fix: correctly fix return error as a string

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -60,7 +60,6 @@
   {"lib/logflare/ecto/bigquery/bq_repo.ex", :call},
   {"lib/logflare/ecto/bigquery/bq_repo.ex", :unused_fun},
   {"lib/logflare/ecto/ecto_lql_rules_t.ex", :unknown_type},
-  {"lib/logflare/ecto/ecto_term_t.ex", :unknown_type},
   {"lib/logflare/endpoints.ex", :no_return},
   {"lib/logflare/endpoints.ex", :pattern_match},
   {"lib/logflare/endpoints.ex", :call},

--- a/lib/logflare/ecto/ecto_term_t.ex
+++ b/lib/logflare/ecto/ecto_term_t.ex
@@ -12,14 +12,14 @@ defmodule Ecto.Term do
     {:ok, value}
   end
 
-  @spec load(binary() | nil) :: {:ok, any()} | {:error, ArgumentError.t()}
+  @spec load(binary() | nil) :: {:ok, any()} | {:error, String.t()}
   def load(nil), do: {:ok, nil}
   def load(""), do: {:ok, ""}
 
   def load(value) do
     {:ok, :erlang.binary_to_term(value)}
   rescue
-    e in ArgumentError -> {:error, e}
+    e in ArgumentError -> {:error, e.message}
   end
 
   @spec dump(any()) :: {:ok, binary() | nil}

--- a/test/logflare/ecto/ecto_term_t_test.exs
+++ b/test/logflare/ecto/ecto_term_t_test.exs
@@ -40,9 +40,11 @@ defmodule Ecto.TermTest do
     end
 
     test "returns error for invalid binary or non-binary input" do
-      assert {:error, %ArgumentError{}} = Term.load("not a term binary")
-      assert {:error, %ArgumentError{}} = Term.load(123)
-      assert {:error, %ArgumentError{}} = Term.load([1, 2, 3])
+      assert {:error, "errors were found at the given arguments:" <> _rest} =
+               Term.load("not a term binary")
+
+      assert {:error, "errors were found at the given arguments:" <> _rest} = Term.load(123)
+      assert {:error, "errors were found at the given arguments:" <> _rest} = Term.load([1, 2, 3])
     end
   end
 


### PR DESCRIPTION
I could use `Exception.t()` but I think returning the string error is better in this situation.