### PR TITLE
refactor: fix pattern_match_cover, invalid_contracts and pattern_match in backends

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -8,7 +8,7 @@
   {"lib/logflare/backends.ex", :no_return},
   {"lib/logflare/backends.ex", :pattern_match},
   # {"lib/logflare/backends.ex", :pattern_match_cov},
-  {"lib/logflare/backends.ex", :invalid_contract},
+  # {"lib/logflare/backends.ex", :invalid_contract},
   {"lib/logflare/backends.ex", :unknown_type},
   {"lib/logflare/backends/adaptor.ex", :unknown_type},
   {"lib/logflare/backends/adaptor/bigquery_adaptor.ex", :no_return},

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -809,20 +809,4 @@ defmodule Logflare.Backends do
       %{source_id: le.source.id, source_token: le.source.token}
     )
   end
-
-  defp do_telemetry(:buffer_full, le) do
-    :telemetry.execute(
-      [:logflare, :logs, :ingest_logs],
-      %{buffer_full: true},
-      %{source_id: le.source.id, source_token: le.source.token}
-    )
-  end
-
-  defp do_telemetry(:unknown_error, le) do
-    :telemetry.execute(
-      [:logflare, :logs, :ingest_logs],
-      %{unknown_error: true},
-      %{source_id: le.source.id, source_token: le.source.token}
-    )
-  end
 end

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -15,9 +15,9 @@ defmodule Logflare.Backends.IngestEventQueue do
   @ets_table_mapper :ingest_event_queue_mapping
   @ets_table :source_ingest_events
   @typep source_backend_pid ::
-           {Source.t() | non_neg_integer(), Backend.t() | nil | non_neg_integer(), nil | pid()}
-  @typep table_key :: {non_neg_integer(), nil | non_neg_integer(), nil | pid()}
-  @typep queues_key :: {non_neg_integer(), nil | non_neg_integer()}
+           {Source.t() | non_neg_integer(), Backend.t() | non_neg_integer() | nil, pid() | nil}
+  @typep table_key :: {non_neg_integer(), non_neg_integer() | nil, pid() | nil}
+  @typep queues_key :: {non_neg_integer(), non_neg_integer() | nil}
 
   ## Server
   def start_link(_args) do


### PR DESCRIPTION
This removes 3 typing errors in backends, another follow up of https://github.com/Logflare/logflare/pull/2722.