### PR TITLE
fix: add in whitespace rendering to LogEvent modal event body

### DIFF
--- a/lib/logflare_web/templates/log/log_event_body.html.heex
+++ b/lib/logflare_web/templates/log/log_event_body.html.heex
@@ -36,7 +36,7 @@
     </li>
   </ul>
   <ul class="list-group">
-    <li class="list-group-item flex-fill">
+    <li class="list-group-item flex-fill tw-whitespace-pre-line">
       <h6 class="header-margin">Message</h6>
       <%= @message %>
     </li>


### PR DESCRIPTION
Before:
<img width="2242" height="1468" alt="image" src="https://github.com/user-attachments/assets/b7eb4398-ca92-404e-94a1-1c408da2ad2b" />

After:

<img width="2354" height="2292" alt="image" src="https://github.com/user-attachments/assets/02a787f3-4226-4b8e-9a1b-ee11188f2b5e" />
