### PR TITLE
feat: endpoints PII redaction

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/endpoints.md
+++ b/docs/docs.logflare.com/docs/concepts/endpoints.md
@@ -171,3 +171,37 @@ In this case, the `@value` parameter will be required by the final endpoint as w
 ## Security
 
 Endpoints are unsecure by default. However, you can generate [access tokens](/concepts/access-tokens) to secure the API endpoints.
+
+## PII Redaction
+
+Logflare endpoints support automatic redaction of personally identifiable information (PII) from query results to help protect sensitive data. When enabled, the PII redaction feature will automatically replace IP addresses in query result values with "REDACTED".
+
+PII redaction can be enabled when checking the "Redact PII from query results" checkbox when configuring the endpoint.
+
+Currently, PII redaction targets:
+
+- IPv4 addresses
+- IPv6 addresses
+
+Redaction occurs post-query without affecting performance, only targets string values, and recursively processes nested structures for comprehensive PII protection.
+
+### Example
+
+**With PII redaction enabled:**
+
+```json
+{
+  "result": [
+    {
+      "user_id": 123,
+      "client_ip": "REDACTED",
+      "message": "User connected from REDACTED",
+      "metadata": {
+        "session_data": {
+          "origin_ip": "REDACTED"
+        }
+      }
+    }
+  ]
+}
+```

--- a/lib/logflare/endpoints/pii_redactor.ex
+++ b/lib/logflare/endpoints/pii_redactor.ex
@@ -1,0 +1,93 @@
+defmodule Logflare.Endpoints.PiiRedactor do
+  @moduledoc """
+  Handles PII redaction for endpoint query results.
+
+  Currently supports redaction of IP addresses in query result values.
+  """
+
+  @doc """
+  Redacts PII from query results based on the query's redact_pii flag.
+
+  When redact_pii is true, this function will:
+  - Replace IP addresses (IPv4 and IPv6) with "REDACTED" in all field values
+  - Recursively process nested maps and lists
+  - Leave field names unchanged, only redact values
+
+  ## Examples
+
+      iex> result = [%{"ip" => "192.168.1.1", "message" => "User 10.0.0.1 logged in"}]
+      iex> Logflare.Endpoints.PiiRedactor.redact_query_result(result, true)
+      [%{"ip" => "REDACTED", "message" => "User REDACTED logged in"}]
+
+      iex> result = [%{"ip" => "192.168.1.1", "message" => "User logged in"}]
+      iex> Logflare.Endpoints.PiiRedactor.redact_query_result(result, false)
+      [%{"ip" => "192.168.1.1", "message" => "User logged in"}]
+  """
+  @spec redact_query_result(term(), boolean()) :: term()
+  def redact_query_result(result, false), do: result
+  def redact_query_result(result, true), do: redact_pii_from_value(result)
+
+  @doc """
+  Recursively redacts PII from any data structure.
+
+  Handles maps, lists, and primitive values. For strings, applies IP address redaction.
+  Other data types are passed through unchanged.
+  """
+  @spec redact_pii_from_value(term()) :: term()
+  def redact_pii_from_value(%Date{} = value), do: value
+  def redact_pii_from_value(%DateTime{} = value), do: value
+  def redact_pii_from_value(%Time{} = value), do: value
+  def redact_pii_from_value(%NaiveDateTime{} = value), do: value
+  def redact_pii_from_value(%Regex{} = value), do: value
+  def redact_pii_from_value(%Stream{} = value), do: value
+
+  def redact_pii_from_value(value) when is_map(value) do
+    Map.new(value, fn {key, val} -> {key, redact_pii_from_value(val)} end)
+  end
+
+  def redact_pii_from_value(value) when is_list(value) do
+    Enum.map(value, &redact_pii_from_value/1)
+  end
+
+  def redact_pii_from_value(value) when is_binary(value) do
+    redact_ip_addresses(value)
+  end
+
+  def redact_pii_from_value(value), do: value
+
+  @doc """
+  Redacts IP addresses from a string value.
+
+  Replaces both IPv4 and IPv6 addresses with "REDACTED".
+
+  ## Examples
+
+      iex> Logflare.Endpoints.PiiRedactor.redact_ip_addresses("User 192.168.1.1 logged in")
+      "User REDACTED logged in"
+
+      iex> Logflare.Endpoints.PiiRedactor.redact_ip_addresses("IPv6: 2001:0db8:85a3::8a2e:0370:7334")
+      "IPv6: REDACTED"
+  """
+  @spec redact_ip_addresses(String.t()) :: String.t()
+  def redact_ip_addresses(value) when is_binary(value) do
+    value
+    |> redact_ipv4_addresses()
+    |> redact_ipv6_addresses()
+  end
+
+  # IPv4 regex pattern - matches xxx.xxx.xxx.xxx where xxx is 0-255
+  @ipv4_regex ~r/\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/
+
+  # IPv6 regex pattern - matches various IPv6 formats
+  @ipv6_regex ~r/(?:^|(?<=\s))(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(?=\s|$)/
+
+  @spec redact_ipv4_addresses(String.t()) :: String.t()
+  defp redact_ipv4_addresses(value) do
+    Regex.replace(@ipv4_regex, value, "REDACTED")
+  end
+
+  @spec redact_ipv6_addresses(String.t()) :: String.t()
+  defp redact_ipv6_addresses(value) do
+    Regex.replace(@ipv6_regex, value, "REDACTED")
+  end
+end

--- a/lib/logflare/endpoints/query.ex
+++ b/lib/logflare/endpoints/query.ex
@@ -30,7 +30,8 @@ defmodule Logflare.Endpoints.Query do
              :proactive_requerying_seconds,
              :max_limit,
              :enable_auth,
-             :labels
+             :labels,
+             :redact_pii
            ]}
   typed_schema "endpoint_queries" do
     field(:token, Ecto.UUID, autogenerate: true)
@@ -44,6 +45,7 @@ defmodule Logflare.Endpoints.Query do
     field(:proactive_requerying_seconds, :integer, default: 1_800)
     field(:max_limit, :integer, default: 1_000)
     field(:enable_auth, :boolean, default: true)
+    field(:redact_pii, :boolean, default: false)
     field(:labels, :string)
     field(:parsed_labels, :map, virtual: true)
     field(:metrics, :map, virtual: true)
@@ -75,6 +77,7 @@ defmodule Logflare.Endpoints.Query do
       :proactive_requerying_seconds,
       :max_limit,
       :enable_auth,
+      :redact_pii,
       :language,
       :description,
       :backend_id,
@@ -95,6 +98,7 @@ defmodule Logflare.Endpoints.Query do
       :proactive_requerying_seconds,
       :max_limit,
       :enable_auth,
+      :redact_pii,
       :language,
       :description,
       :backend_id,

--- a/lib/logflare_web/live/endpoints/actions/show.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/show.html.heex
@@ -55,7 +55,13 @@
         </span>
       </li>
       <li class="list-group-item">
-        <span><strong>query sandboxing:</strong> disabled</span>
+        <span><strong>query sandboxing:</strong> <%= if @show_endpoint.sandboxable, do: "enabled", else: "disabled" %></span>
+      </li>
+      <li class="list-group-item">
+        <span><strong>redact PII:</strong> <%= if @show_endpoint.redact_pii, do: "enabled", else: "disabled" %></span>
+      </li>
+      <li :if={@show_endpoint.labels} class="list-group-item">
+        <span><strong>labels:</strong> <%= @show_endpoint.labels %></span>
       </li>
     </ul>
   </div>
@@ -88,7 +94,7 @@
       <span :if={length(@declared_params) > 0}>-G <%= Enum.map(@declared_params, fn p -> "-d \"#{p}=VALUE\"" end) |> Enum.join(" ") %></span>
     </code>
 
-    <code :if={@show_endpoint.enable_auth} class="tw-whitespace-pre-wrap">
+    <code :if={@show_endpoint.enable_auth} class="tw-whitespace-pre-line">
       # By name
       curl "<%= "https://api.logflare.app" <> ~p"/api/endpoints/query/#{@show_endpoint.name}" %>" \
       -H 'X-API-KEY: YOUR-ACCESS-TOKEN' \

--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -109,6 +109,18 @@
           This restricts users of the endpoint to only query within the defined CTE result sets.
         </small>
       </div>
+
+      <div class="">
+        <%= checkbox(f, :redact_pii, id: "redact-pii-checkbox", class: "form-check-input") %>
+        <%= label(f, :redact_pii, "Redact PII from query results",
+          for: "redact-pii-checkbox",
+          class: "form-check-label"
+        ) %>
+        <%= error_tag(f, :redact_pii) %>
+        <small class="form-text text-muted">
+          When enabled, PII such as IP addresses in query results will be "REDACTED"
+        </small>
+      </div>
     </section>
 
     <.header_with_anchor text="Caching" />

--- a/priv/repo/migrations/20250902185149_add_redact_pii_to_endpoint_queries.exs
+++ b/priv/repo/migrations/20250902185149_add_redact_pii_to_endpoint_queries.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddRedactPiiToEndpointQueries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      add(:redact_pii, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/logflare/endpoints/pii_redactor_test.exs
+++ b/test/logflare/endpoints/pii_redactor_test.exs
@@ -1,0 +1,78 @@
+defmodule Logflare.Endpoints.PiiRedactorTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Endpoints.PiiRedactor
+
+  describe "redact_query_result/2" do
+    test "returns original result when redact_pii is false" do
+      result = [%{"ip" => "192.168.1.1", "message" => "User 10.0.0.1 logged in"}]
+      assert PiiRedactor.redact_query_result(result, false) == result
+    end
+
+    test "redacts IP addresses in various data structures" do
+      # Simple redaction
+      result = [%{"ip" => "192.168.1.1", "message" => "User 10.0.0.1 logged in"}]
+      expected = [%{"ip" => "REDACTED", "message" => "User REDACTED logged in"}]
+      assert PiiRedactor.redact_query_result(result, true) == expected
+
+      # Nested maps
+      nested_result = [
+        %{"user" => %{"ip" => "192.168.1.1", "id" => 123}, "log" => "Connection from 10.0.0.1"}
+      ]
+
+      nested_expected = [
+        %{"user" => %{"ip" => "REDACTED", "id" => 123}, "log" => "Connection from REDACTED"}
+      ]
+
+      assert PiiRedactor.redact_query_result(nested_result, true) == nested_expected
+
+      # Lists of values
+      list_result = [%{"ips" => ["192.168.1.1", "10.0.0.1"], "count" => 2}]
+      list_expected = [%{"ips" => ["REDACTED", "REDACTED"], "count" => 2}]
+      assert PiiRedactor.redact_query_result(list_result, true) == list_expected
+    end
+
+    test "preserves non-string data types" do
+      result = [%{"timestamp" => ~D[2023-01-01], "count" => 42, "active" => true}]
+      assert PiiRedactor.redact_query_result(result, true) == result
+    end
+  end
+
+  describe "redact_ip_addresses/1" do
+    test "redacts various IP address formats" do
+      test_cases = [
+        {"User connected from 192.168.1.1 and 10.0.0.1",
+         "User connected from REDACTED and REDACTED"},
+        {"IPv6 address: 2001:0db8:85a3:0000:0000:8a2e:0370:7334", "IPv6 address: REDACTED"},
+        {"Compressed: 2001:db8::8a2e:370:7334", "Compressed: REDACTED"},
+        {"IPv4: 192.168.1.1, IPv6: 2001:db8::1", "IPv4: REDACTED, IPv6: REDACTED"},
+        {"IP: 192.168.1.1, not 12192.168.1.11", "IP: REDACTED, not 12192.168.1.11"},
+        {"Localhost: 127.0.0.1 and ::1", "Localhost: REDACTED and REDACTED"}
+      ]
+
+      for {input, expected} <- test_cases do
+        assert PiiRedactor.redact_ip_addresses(input) == expected
+      end
+    end
+
+    test "handles strings without IP addresses" do
+      input = "No IPs here!"
+      assert PiiRedactor.redact_ip_addresses(input) == input
+    end
+  end
+
+  describe "redact_pii_from_value/1" do
+    test "preserves non-string primitive types" do
+      assert PiiRedactor.redact_pii_from_value(nil) == nil
+      assert PiiRedactor.redact_pii_from_value(42) == 42
+      assert PiiRedactor.redact_pii_from_value(:test) == :test
+      assert PiiRedactor.redact_pii_from_value(3.14) == 3.14
+    end
+
+    test "recursively processes nested structures" do
+      input = %{"level1" => %{"level2" => ["192.168.1.1", %{"level3" => "10.0.0.1"}]}}
+      expected = %{"level1" => %{"level2" => ["REDACTED", %{"level3" => "REDACTED"}]}}
+      assert PiiRedactor.redact_pii_from_value(input) == expected
+    end
+  end
+end

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -248,7 +248,7 @@ defmodule Logflare.EndpointsTest do
     end
 
     test "run_query/1 applies PII redaction based on redact_pii flag" do
-      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 2, fn _conn, _proj_id, _opts ->
         {:ok,
          TestUtils.gen_bq_response([
            %{"ip" => "192.168.1.1", "message" => "User 10.0.0.1 logged in"}
@@ -261,7 +261,7 @@ defmodule Logflare.EndpointsTest do
       endpoint =
         insert(:endpoint,
           user: user,
-          query: "select ip, message from logs",
+          query: "select '1.2.3.4' as ip",
           redact_pii: true
         )
 
@@ -272,7 +272,7 @@ defmodule Logflare.EndpointsTest do
       endpoint =
         insert(:endpoint,
           user: user,
-          query: "select ip, message from logs",
+          query: "select 'test' as ip",
           redact_pii: false
         )
 
@@ -290,7 +290,7 @@ defmodule Logflare.EndpointsTest do
       endpoint =
         insert(:endpoint,
           user: user,
-          query: "select ip from logs",
+          query: "select '1.2.3.4' as ip",
           redact_pii: true,
           # Disable caching to ensure fresh query
           cache_duration_seconds: 0


### PR DESCRIPTION
This PR adds in config flag for ipv4 and ipv6 redaction from endpoints query results.

This PR also fixes some bugs relating to displaying of logflare endpoints configuration in the show page.