### PR TITLE
fix: correctly parse lql aggregates

### DIFF
--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -95,16 +95,6 @@ defmodule Logflare.Logs.SearchOperations do
       ListUtils.at_least?(so.chart_rules, 2) ->
         SearchUtils.halt(so, "Only one chart rule can be used in a query")
 
-      match?([_], so.chart_rules) and
-        hd(so.chart_rules).value_type not in ~w[integer float]a and
-          hd(so.chart_rules).path != "timestamp" ->
-        chart_rule = hd(so.chart_rules)
-
-        msg =
-          "Can't aggregate on a non-numeric field type '#{chart_rule.value_type}' for path #{chart_rule.path}. Check the source schema for the field used with chart operator."
-
-        SearchUtils.halt(so, msg)
-
       Timex.diff(max_ts, min_ts, chart_period) == 0 and chart_period != :second ->
         msg =
           "Selected chart period #{chart_period} is longer than the timestamp filter interval. Please select a shorter chart period."
@@ -432,10 +422,19 @@ defmodule Logflare.Logs.SearchOperations do
             |> List.last()
             |> String.to_existing_atom()
 
+          # Only create UNNEST joins for nested fields (containing ".")
+          # Top-level fields should reference the base table directly
+          is_nested_field = String.contains?(p, ".")
+
           q =
-            query
-            |> Lql.handle_nested_field_access(p)
-            |> select_merge_agg_value(agg, last_chart_field)
+            if is_nested_field do
+              query
+              |> Lql.handle_nested_field_access(p)
+              |> select_merge_agg_value(agg, last_chart_field, :joined_table)
+            else
+              query
+              |> select_merge_agg_value(agg, last_chart_field, :base_table)
+            end
 
           Enum.reduce(filter_rules, q, fn
             %FilterRule{

--- a/lib/logflare/lql/parser/combinators.ex
+++ b/lib/logflare/lql/parser/combinators.ex
@@ -212,7 +212,11 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> unwrap_and_tag(:aggregate)
     |> ignore(string("("))
     |> concat(
-      choice([string("*") |> replace("timestamp") |> unwrap_and_tag(:path), metadata_field()])
+      choice([
+        string("*") |> replace("timestamp") |> unwrap_and_tag(:path),
+        metadata_field(),
+        any_field()
+      ])
     )
     |> ignore(string(")"))
   end

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -1,8 +1,12 @@
 defmodule Logflare.Logs.SearchOperationsTest do
   use Logflare.DataCase, async: false
+  import Ecto.Query
 
   alias Logflare.Logs.SearchOperations
   alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Logs.SearchOperation, as: SO
+  alias Logflare.Lql.Rules.ChartRule
+  alias Logflare.Lql.Rules.FilterRule
 
   describe "unnesting metadata if present" do
     setup do
@@ -62,6 +66,73 @@ defmodule Logflare.Logs.SearchOperationsTest do
 
         assert sql =~ "UNNEST(t0.metadata)"
       end)
+    end
+  end
+
+  describe "chart aggregation query generation" do
+    setup do
+      insert(:plan)
+      source = insert(:source, user: insert(:user), bq_table_id: "test_table")
+
+      base_so = %SO{
+        source: source,
+        querystring: "",
+        chart_data_shape_id: nil,
+        tailing?: false,
+        partition_by: :timestamp,
+        type: :aggregates,
+        lql_ts_filters: [],
+        lql_meta_and_msg_filters: []
+      }
+
+      [base_so: base_so]
+    end
+
+    test "top-level field aggregation should reference base table, not joined table", %{
+      base_so: base_so
+    } do
+      chart_rule = %ChartRule{
+        path: "value",
+        aggregate: :max,
+        period: :minute,
+        value_type: :integer
+      }
+
+      nested_filter = %FilterRule{
+        path: "attributes.name",
+        operator: :"~",
+        value: "jose",
+        modifiers: %{}
+      }
+
+      so = %{
+        base_so
+        | chart_rules: [chart_rule],
+          lql_meta_and_msg_filters: [nested_filter],
+          query: from(base_so.source.bq_table_id)
+      }
+
+      so = SearchOperations.apply_numeric_aggs(so)
+      {sql, _} = Logflare.EctoQueryBQ.SQL.to_sql_params(so.query)
+
+      assert sql =~ "MAX(t0.value)"
+      refute sql =~ "MAX(f1.value)"
+    end
+
+    test "nested field aggregation should reference joined table correctly", %{base_so: base_so} do
+      chart_rule = %ChartRule{
+        path: "metadata.level",
+        aggregate: :count,
+        period: :minute,
+        value_type: :string
+      }
+
+      so = %{base_so | chart_rules: [chart_rule], query: from(base_so.source.bq_table_id)}
+      so = SearchOperations.apply_numeric_aggs(so)
+      {sql, _} = Logflare.EctoQueryBQ.SQL.to_sql_params(so.query)
+
+      assert sql =~ "UNNEST"
+      assert sql =~ "COUNT(f1.level)"
     end
   end
 end


### PR DESCRIPTION
This PR fixes LQL aggregate parsing for charts query.

improvements include:
- allow aggregates on non-numeric fields (such as counts on string fields)
- aggregates on top-level fields
- more test coverage

<img width="1506" height="1042" alt="image" src="https://github.com/user-attachments/assets/059a2dc0-40ec-4df2-a196-466867f00c52" />
