### PR TITLE
chore: minor adjustment to display the query language on the endpoints lv form

### DIFF
--- a/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
+++ b/lib/logflare_web/live/endpoints/components/endpoint_form.html.heex
@@ -41,7 +41,8 @@
       ) %>
       <%= error_tag(f, :backend_id) %>
       <small class="form-text text-muted">
-        Choose which backend to execute this endpoint query against. Defaults to BigQuery if no backend is selected.
+        Choose which backend to execute this endpoint query against. Defaults to BigQuery if no backend is selected. <br />
+        <strong>Query Language: <span id="query-language"><%= format_query_language(@determined_language) %></span></strong>
       </small>
     </div>
 

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -439,13 +439,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
         }
       })
 
-      assigns = get_view_assigns(view)
-      assert assigns.selected_backend_id == to_string(backend.id)
-      assert Logflare.Endpoints.derive_language_from_backend_id(backend.id) == :ch_sql
+      assert has_element?(view, "#query-language", "ClickHouse SQL")
     end
-  end
-
-  defp get_view_assigns(view) do
-    :sys.get_state(view.pid).socket.assigns
   end
 end


### PR DESCRIPTION
Covers [this comment](https://github.com/Logflare/logflare/pull/2710#discussion_r2317596236) made on #2710 by adding a "Query Language" display under the backend selection.

<img width="703" height="207" alt="image" src="https://github.com/user-attachments/assets/5c97b6df-e8bc-4e5b-a983-934e6d50092c" />
