### PR TITLE
fix: allow multiple sources to be linked to a backend as default ingest sources

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
@@ -244,7 +244,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.ConnectionManager do
       {:ok, pid} ->
         Process.monitor(pid)
 
-        Logger.info("Started Clickhouse connection pool (#{state.pool_type})",
+        Logger.info("Started Clickhouse connection pool (#{state.pool_type} - #{source_id})",
           source_id: source_id,
           backend_id: state.backend.id
         )
@@ -256,7 +256,8 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.ConnectionManager do
         {:ok, new_state}
 
       {:error, reason} ->
-        Logger.error("Failed to start Clickhouse connection pool (#{state.pool_type})",
+        Logger.error(
+          "Failed to start Clickhouse connection pool (#{state.pool_type} - #{source_id}))",
           source_id: source_id,
           backend_id: state.backend.id,
           reason: reason

--- a/lib/logflare_web/live/backends/actions/show.html.heex
+++ b/lib/logflare_web/live/backends/actions/show.html.heex
@@ -34,7 +34,7 @@
     Sources configured to use this backend as a default ingest destination.
   </p>
 
-  <div>
+  <div :if={not Enum.empty?(@available_sources || [])}>
     <.button phx-click="toggle_default_ingest_form" variant="secondary">
       <%= if @show_default_ingest_form? do %>
         Cancel
@@ -47,7 +47,7 @@
   <.form :let={f} :if={@show_default_ingest_form?} id="default_ingest" for={%{}} as={:default_ingest} action="#" phx-submit="save_default_ingest">
     <div class="form-group">
       <%= label(f, :source_id, "Source") %>
-      <%= select(f, :source_id, Enum.filter(@sources, & &1.default_ingest_backend_enabled?) |> Enum.map(fn s -> {s.name, s.id} end),
+      <%= select(f, :source_id, Enum.map(@available_sources || [], fn s -> {s.name, s.id} end),
         class: "form-control",
         prompt: [key: "Choose a source"]
       ) %>

--- a/lib/logflare_web/live/backends/backends_live.ex
+++ b/lib/logflare_web/live/backends/backends_live.ex
@@ -317,10 +317,19 @@ defmodule LogflareWeb.BackendsLive do
         []
       end
 
+    # Calculate available sources for the dropdown (excluding already associated ones)
+    available_sources =
+      socket.assigns.sources
+      |> Enum.filter(& &1.default_ingest_backend_enabled?)
+      |> Enum.reject(fn source ->
+        Enum.any?(default_ingest_sources, &(&1.id == source.id))
+      end)
+
     socket
     |> assign(:backend, backend)
     |> assign(:form_type, Atom.to_string(backend.type))
     |> assign(:default_ingest_sources, default_ingest_sources)
+    |> assign(:available_sources, available_sources)
   end
 
   defp transform_params(params) do


### PR DESCRIPTION
Fixes an issue where the system was not allowing more than one source to be linked to a backend as a 'default ingest source'.

This issue was caused by a couple different things going on:
- The logic in `Backends.update_backend/2` calls `handle_default_ingest_associations/4` to handle making the associations between source/backend and was not handling the situation where a default ingest source was already linked due to pattern matching.
- Once that issue ^^^ was resolved, I realized the clickhouse adaptor then would try to spin up a query/read connection pool using a key of `backend_id`. Because we already had one, it was stopping that supervisor from returning successfully within its `init` callback. Now it handles this particular pool situation in a more idempotent way.

<img width="844" height="299" alt="image" src="https://github.com/user-attachments/assets/20234139-15ac-4552-9522-9ef57de02682" />