### PR TITLE
chore: add new elixir lsp directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,13 +40,13 @@ npm-debug.log
 /config/secrets
 
 # Local secrets
-
 gcloud.json
 gcloud_staging.json
 gcloud_prod.json
-# IDEs
 
+# IDEs
 /.elixir_ls/
+/.expert/
 /.idea/
 /assets/.idea
 


### PR DESCRIPTION
Adds `.expert/` directory to .gitignore for the [new Elixir language server](https://github.com/elixir-lang/expert)