### PR TITLE
fix: reject :ets.info :undefined returns on ets tables metrics

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -374,6 +374,7 @@ defmodule Logflare.Telemetry do
   defp get_ets_tables_info do
     :ets.all()
     |> Enum.map(&:ets.info/1)
+    |> Enum.reject(& &1 == :undefined)
     |> Enum.sort_by(& &1[:size], :desc)
   end
 


### PR DESCRIPTION
Fix some cases of `Logflare.Telemetry.ets_table_metrics` crashing.

Bug explanation: there are some cases where some table will be deleted during the small time between the calls of :ets.all() and :ets.info(), so the info function returns :undefined instead of a list of attributes, which causes crash down in the pipeline.

Solution: put a rejection on the Enum items that returns :undefined, as its done at :observer_cli