### PR TITLE
fix: CH connection manager bug with multiple sources

### DIFF
--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -80,10 +80,11 @@ defmodule Logflare.DataCase do
   - `:config` - Custom ClickHouse configuration (merged with defaults)
   - `:user` - Existing user to use (creates one if not provided)
   - `:source` - Existing source to use (creates one if not provided)
-
+  - `:default_ingest_backend?` - Whether to set the backend as the default ingest backend (requires a source to be provided with the default ingest backend option set to true)
   """
   def setup_clickhouse_test(opts \\ []) do
     config = Keyword.get(opts, :config, %{})
+    default_ingest_backend? = Keyword.get(opts, :default_ingest_backend?, false)
 
     user =
       case Keyword.get(opts, :user) do
@@ -110,6 +111,7 @@ defmodule Logflare.DataCase do
       Logflare.Factory.insert(:backend,
         type: :clickhouse,
         config: Map.merge(default_config, config),
+        default_ingest?: default_ingest_backend?,
         user: user
       )
 


### PR DESCRIPTION
My prior 'fix' was incorrect and evaluating the wrong process (the connection pool itself) and instead should have been evaluating the connection manager process as that is what is directly managed by the `ClickhouseAdaptor`.

Aside from this problem, I was also attempting to pattern match `{:ok, _pid}` for the results of `GenServer.whereis/1` which returns a pid or nil value.

A test has been added to ensure the logic operates as expected going forward.

#### Validation

Within the CH adaptor's `init` callback, you can add `ConnectionManager.child_spec({backend, query_ch_opts})` to the children variable and comment out the dynamic check on line 522 and run `mix test test/logflare/backends/adaptor/clickhouse_adaptor_test.exs` to see the difference.