### PR TITLE
fix: click outside modal should close it

### DIFF
--- a/assets/js/live_modal.js
+++ b/assets/js/live_modal.js
@@ -5,7 +5,10 @@ export default {
     mounted() {
       const $modal = $(this.el)
 
-      $modal.modal({backdrop: "static"})
+      $modal.modal({ backdrop: "static" }).on("hidePrevented.bs.modal", (e) => {
+        // click outside modal so phx-click-away is triggered
+        $("main").trigger("click");
+      });
     },
     destroyed() {
       $("body").removeClass("modal-open").removeAttr("style")


### PR DESCRIPTION
Clicking outside a modal on search results closes it.

The Bootstrap modal plugin is taking over the full width of the viewport making it impossible to see where to click outside. This change triggers the LiveView `phx-click-away` event when a user clicks outside the modal content.

In this demo I open and close multiple modals by clicking away or using the escape key:

https://github.com/user-attachments/assets/8b018b96-af10-49cb-960a-638cab475d98

