### PR TITLE
chore: change ets metrics to memory usage

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -213,13 +213,13 @@ defmodule Logflare.Telemetry do
         description: "Top processes by memory usage",
         unit: {:byte, :megabyte}
       ),
-      last_value("logflare.system.top_ets_tables.individual.size",
+      last_value("logflare.system.top_ets_tables.individual.memory",
         tags: [:name],
-        description: "Top ETS individual tables by size"
+        description: "Top ETS individual tables by memory"
       ),
-      sum("logflare.system.top_ets_tables.grouped.size",
+      sum("logflare.system.top_ets_tables.grouped.memory",
         tags: [:name],
-        description: "Top ETS tables by size, grouped by name"
+        description: "Top ETS tables by memory, grouped by name"
       ),
       sum("logflare.backends.ingest.count",
         tags: [:backend_type],
@@ -357,7 +357,7 @@ defmodule Logflare.Telemetry do
     top_100_tables
     |> Enum.take(10)
     |> Enum.each(fn table ->
-      metrics = %{size: table[:size]}
+      metrics = %{memory: table[:memory]}
       metadata = %{name: table[:name]}
 
       :telemetry.execute([:logflare, :system, :top_ets_tables, :individual], metrics, metadata)
@@ -366,7 +366,7 @@ defmodule Logflare.Telemetry do
     # send grouped top 100
     top_100_tables
     |> Enum.each(fn table ->
-      metrics = %{size: table[:size]}
+      metrics = %{memory: table[:memory]}
       metadata = %{name: ets_table_base_name(table[:name])}
 
       :telemetry.execute([:logflare, :system, :top_ets_tables, :grouped], metrics, metadata)
@@ -378,7 +378,7 @@ defmodule Logflare.Telemetry do
     |> Stream.map(fn table ->
       case ets_info(table) do
         :undefined -> nil
-        info -> {0, info[:size], info}
+        info -> {0, info[:memory], info}
       end
     end)
     |> Enum.filter(& &1)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -215,11 +215,11 @@ defmodule Logflare.Telemetry do
       ),
       last_value("logflare.system.top_ets_tables.individual.memory",
         tags: [:name],
-        description: "Top ETS individual tables by memory"
+        description: "Top ETS individual tables by memory usage"
       ),
       sum("logflare.system.top_ets_tables.grouped.memory",
         tags: [:name],
-        description: "Top ETS tables by memory, grouped by name"
+        description: "Top ETS tables by memory usage, grouped by name"
       ),
       sum("logflare.backends.ingest.count",
         tags: [:backend_type],

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -28,23 +28,23 @@ defmodule Logflare.TelemetryTest do
   end
 
   describe "ets_table_metrics/1" do
-    test "retrieves and emits top 10 by table size" do
+    test "retrieves and emits top 10 by memory usage" do
       event = [:logflare, :system, :top_ets_tables, :individual]
       TestUtils.attach_forwarder(event)
       Telemetry.ets_table_metrics()
 
       assert_receive {:telemetry_event, ^event, metrics, meta}
-      assert match?(%{size: _}, metrics)
+      assert match?(%{memory: _}, metrics)
       assert match?(%{name: _}, meta)
     end
 
-    test "retrieves and emits top 100 by table size" do
+    test "retrieves and emits top 100 by memory usage" do
       event = [:logflare, :system, :top_ets_tables, :grouped]
       TestUtils.attach_forwarder(event)
       Telemetry.ets_table_metrics()
 
       assert_receive {:telemetry_event, ^event, metrics, meta}
-      assert match?(%{size: _}, metrics)
+      assert match?(%{memory: _}, metrics)
       assert match?(%{name: _}, meta)
     end
 


### PR DESCRIPTION
Make the ETS table metrics measure memory usage instead of table size, as @Ziinc noticed size was not being as useful for monitoring