### PR TITLE
ci: Updates postgresql docker images to bitnamilegacy repo

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -45,7 +45,7 @@ jobs:
           #   run: mix test.typings
     services:
       postgres:
-        image: bitnami/postgresql:15
+        image: bitnamilegacy/postgresql:15
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: bitnami/postgresql:13.15.0
+        image: bitnamilegacy/postgresql:13.15.0
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
This fixes CI builds by using the [Bitnami legacy repository](https://hub.docker.com/u/bitnamilegacy).

Announcement about these changes is here: https://github.com/bitnami/containers/issues/83267