### PR TITLE
feat: allow restart to be specified for GenSingleton.Watcher

### DIFF
--- a/test/logflare/gen_singleton_test.exs
+++ b/test/logflare/gen_singleton_test.exs
@@ -77,4 +77,21 @@ defmodule Logflare.GenSingletonTest do
       end)
     end
   end
+
+  describe "Watcher child_spec/1" do
+    test "defaults restart to :permanent" do
+      spec = Logflare.GenSingleton.Watcher.child_spec(child_spec: __MODULE__.TestGenserver)
+      assert spec.restart == :permanent
+    end
+
+    test "allows restart option to be overridden" do
+      spec =
+        Logflare.GenSingleton.Watcher.child_spec(
+          child_spec: __MODULE__.TestGenserver,
+          restart: :transient
+        )
+
+      assert spec.restart == :transient
+    end
+  end
 end


### PR DESCRIPTION
In preparation for #2763 
UserMetricsPoller needs to be a singleton GenServer but allowed to exit.