### PR TITLE
refactor: move delete team_user to DashboardLive

### DIFF
--- a/lib/logflare/teams.ex
+++ b/lib/logflare/teams.ex
@@ -35,8 +35,8 @@ defmodule Logflare.Teams do
   def preload_user(team), do: Repo.preload(team, :user)
 
   @doc "Preloads the `:team_users` assoc"
-  @spec preload_team_users(nil | Team.t()) :: Team.t() | nil
-  def preload_team_users(team), do: Repo.preload(team, :team_users)
+  @spec preload_team_users(nil | Team.t(), Keyword.t()) :: Team.t() | nil
+  def preload_team_users(team, opts \\ []), do: Repo.preload(team, :team_users, opts)
 
   @doc "Preloads given fields of a Team"
   @spec preload_fields(nil | Team.t(), list(keyword() | atom())) :: Team.t() | nil

--- a/lib/logflare_web/controllers/team_user_controller.ex
+++ b/lib/logflare_web/controllers/team_user_controller.ex
@@ -2,8 +2,6 @@ defmodule LogflareWeb.TeamUserController do
   use LogflareWeb, :controller
   use Phoenix.HTML
 
-  plug LogflareWeb.Plugs.AuthMustBeOwner when action in [:delete]
-
   alias Logflare.TeamUsers
   alias Logflare.Users
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
@@ -25,25 +23,6 @@ defmodule LogflareWeb.TeamUserController do
         conn
         |> put_flash(:error, "Something went wrong!")
         |> render("edit.html", changeset: changeset, team_user: team_user)
-    end
-  end
-
-  def delete(%{assigns: %{user: user}} = conn, %{"id" => team_user_id} = _params) do
-    team_user = TeamUsers.get_team_user!(team_user_id)
-
-    case TeamUsers.delete_team_user(team_user) do
-      {:ok, _team_user} ->
-        BigQueryAdaptor.update_iam_policy()
-        BigQueryAdaptor.patch_dataset_access(user)
-
-        conn
-        |> put_flash(:info, "Member profile deleted!")
-        |> redirect(to: Routes.user_path(conn, :edit))
-
-      {:error, _changeset} ->
-        conn
-        |> put_flash(:error, "Something went wrong!")
-        |> redirect(to: Routes.user_path(conn, :edit))
     end
   end
 

--- a/lib/logflare_web/live/dashboard_live/dashboard_components.ex
+++ b/lib/logflare_web/live/dashboard_live/dashboard_components.ex
@@ -165,9 +165,9 @@ defmodule LogflareWeb.DashboardLive.DashboardComponents do
           </.link>
 
           <span :if={current_team_user?(member, @team_user)}>you</span>
-          <.link :if={not current_team_user?(member, @team_user)} href={~p"/profile/#{member}"} data-confirm="Delete member?" class="dashboard-links" method="delete">
+          <span :if={not current_team_user?(member, @team_user)} phx-click="delete_team_member" phx-value-id={member.id} data-confirm="Delete member?" class="dashboard-links tw-cursor-pointer">
             <i class="fa fa-trash"></i>
-          </.link>
+          </span>
         </li>
       </ul>
       <.link href={~p"/account/edit#team-members"} class="tw-text-white tw-mt-2">

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -279,12 +279,6 @@ defmodule LogflareWeb.Router do
     delete("/", TeamUserController, :delete_self)
   end
 
-  scope "/profile/:id", LogflareWeb do
-    pipe_through([:browser, :require_auth])
-
-    delete("/", TeamUserController, :delete)
-  end
-
   scope "/profile/switch", LogflareWeb do
     pipe_through([:browser, :require_auth, :auth_switch])
 


### PR DESCRIPTION
Move TeamUsers#delete to DashboardLive

Follows on from https://github.com/Logflare/logflare/pull/2752