### PR TITLE
ui: remove member delete button from dashboard

### DIFF
--- a/lib/logflare_web/live/dashboard_live/dashboard_components.ex
+++ b/lib/logflare_web/live/dashboard_live/dashboard_components.ex
@@ -163,11 +163,7 @@ defmodule LogflareWeb.DashboardLive.DashboardComponents do
           <.link href={"mailto:#{member.email}"} class="tw-text-white">
             <%= member.name || member.email %>
           </.link>
-
           <span :if={current_team_user?(member, @team_user)}>you</span>
-          <.link :if={not current_team_user?(member, @team_user)} href={~p"/profile/#{member}"} data-confirm="Delete member?" class="dashboard-links" method="delete">
-            <i class="fa fa-trash"></i>
-          </.link>
         </li>
       </ul>
       <.link href={~p"/account/edit#team-members"} class="tw-text-white tw-mt-2">

--- a/test/logflare_web/live/dashboard_live_test.exs
+++ b/test/logflare_web/live/dashboard_live_test.exs
@@ -170,26 +170,6 @@ defmodule LogflareWeb.DashboardLiveTest do
     end
   end
 
-  describe "team member management" do
-    setup %{user: user} do
-      member = insert(:team_user, team: user.team)
-      [member: member]
-    end
-
-    test "removes team member", %{conn: conn, member: member} do
-      {:ok, view, _html} = live(conn, "/dashboard")
-
-      assert view
-             |> has_element?(~s|a[href="/profile/#{member.id}"][data-method="delete"]|)
-
-      delete(conn, ~p"/profile/#{member.id}")
-
-      {:ok, view, _html} = live(conn, "/dashboard")
-
-      refute view |> has_element?("#members li", "#{member.name}")
-    end
-  end
-
   describe "displaying source metrics" do
     test "renders source metrics ", %{conn: conn, source: source} do
       {:ok, view, _html} = live(conn, "/dashboard")


### PR DESCRIPTION
Removes the member delete button from Dashboard. Members can still be removed from `/account/edit`

