### PR TITLE
feat: Add Sentry Adaptor

### DIFF
--- a/docs/docs.logflare.com/docs/backends/sentry.mdx
+++ b/docs/docs.logflare.com/docs/backends/sentry.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 6
+---
+
+# Sentry
+
+The Sentry backend is **ingest-only**, and sends log events to Sentry's [Logs](https://docs.sentry.io/product/explore/logs/) product.
+
+## Behaviour and configurations
+
+### Configuration
+
+The following value is required when creating a Sentry backend:
+
+- `dsn`: (`string`, required) a DSN (Data Source Name) string from your Sentry project. You can find your project's DSN in the Sentry dashboard under: **Settings** → **Projects** → **[Your Project]** → **Client Keys (DSN)**
+
+#### Example DSN
+
+```
+https://abc123@o123456.ingest.sentry.io/123456
+```
+
+### Implementation Details
+
+Implementation is based on the [webhook backend](/backends/webhook).
+
+Log events are transformed into Sentry's envelope format with the following behavior:
+
+- Log levels are normalized to Sentry's expected levels (`debug`, `info`, `warn`, `error`, `fatal`)
+- All log event metadata is flattened and included as Sentry log attributes
+- The source name and ID are included in the log attributes

--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -1,0 +1,250 @@
+defmodule Logflare.Backends.Adaptor.SentryAdaptor do
+  @sdk_name "sentry.logflare"
+  @sdk_version "0.1.0"
+  @sentry_envelope_content_type "application/x-sentry-envelope"
+
+  @moduledoc """
+  Sentry adaptor for sending logs to Sentry's logging API.
+
+  This adaptor wraps the WebhookAdaptor to provide specific functionality
+  for sending logs to Sentry in the expected envelope format.
+
+  ## Configuration
+
+  The adaptor requires a single configuration parameter:
+
+  - `dsn` - The Sentry DSN string in the format:
+    `{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}{PATH}/{PROJECT_ID}`
+
+  ## Example DSN
+
+      https://abc123@o123456.ingest.sentry.io/123456
+  """
+
+  alias Logflare.Backends.Adaptor.WebhookAdaptor
+  alias Logflare.Backends.Adaptor.SentryAdaptor.DSN
+
+  @behaviour Logflare.Backends.Adaptor
+
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def start_link({source, backend}) do
+    backend = %{backend | config: transform_config(backend)}
+    WebhookAdaptor.start_link({source, backend})
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def transform_config(%{config: config}) do
+    case DSN.parse(config.dsn) do
+      {:ok, parsed_dsn} ->
+        %{
+          url: parsed_dsn.endpoint_uri,
+          headers: %{"content-type" => @sentry_envelope_content_type},
+          http: "http2",
+          format_batch: fn log_events ->
+            build_envelope(log_events, parsed_dsn.original_dsn)
+          end
+        }
+
+      {:error, reason} ->
+        raise ArgumentError, "Invalid Sentry DSN: #{reason}"
+    end
+  end
+
+
+  @impl Logflare.Backends.Adaptor
+  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
+
+  @impl Logflare.Backends.Adaptor
+  def cast_config(params) do
+    {%{}, %{dsn: :string}}
+    |> Ecto.Changeset.cast(params, [:dsn])
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def validate_config(changeset) do
+    changeset
+    |> Ecto.Changeset.validate_required([:dsn])
+    |> validate_dsn()
+  end
+
+  defp validate_dsn(changeset) do
+    case Ecto.Changeset.get_field(changeset, :dsn) do
+      nil ->
+        changeset
+
+      dsn ->
+        case DSN.parse(dsn) do
+          {:ok, _parsed_dsn} ->
+            changeset
+
+          {:error, reason} ->
+            Ecto.Changeset.add_error(changeset, :dsn, "Invalid DSN: #{reason}")
+        end
+    end
+  end
+
+  defp build_envelope(log_events, original_dsn) do
+    sentry_logs = Enum.map(log_events, &translate_log_event/1)
+
+    header = %{
+      "dsn" => original_dsn,
+      "sent_at" => DateTime.utc_now() |> DateTime.to_iso8601(:extended)
+    }
+
+    item_header = %{
+      "type" => "log",
+      "item_count" => length(sentry_logs),
+      "content_type" => "application/vnd.sentry.items.log+json"
+    }
+
+    item_payload = %{"items" => sentry_logs}
+
+    Enum.join(
+      [
+        Jason.encode!(header),
+        Jason.encode!(item_header),
+        Jason.encode!(item_payload)
+      ],
+      "\n"
+    )
+  end
+
+  defp translate_log_event(%Logflare.LogEvent{} = le) do
+    # Convert microsecond timestamp to seconds (with fractional part)
+    # Use timestamp from outer body if available, fallback to nested body
+    timestamp_seconds = (le.body["timestamp"] || le.body["body"]["timestamp"]) / 1_000_000
+
+    # Extract message from the log event
+    message = le.body["event_message"] || le.body["body"]["message"] || inspect(le.body)
+
+    # Determine log level - check both body and nested body
+    level =
+      case le.body["body"]["level"] || le.body["level"] do
+        nil -> "info"
+        level when is_binary(level) -> normalize_level(level)
+        level when is_atom(level) -> normalize_level(Atom.to_string(level))
+        _ -> "info"
+      end
+
+    # Extract or generate trace_id
+    trace_id = extract_trace_id(le)
+
+    # Build attributes from log event metadata
+    attributes = build_attributes(le)
+
+    %{
+      "timestamp" => timestamp_seconds,
+      "level" => level,
+      "body" => message,
+      "trace_id" => trace_id,
+      "attributes" => attributes
+    }
+  end
+
+  defp build_attributes(%Logflare.LogEvent{} = le) do
+    base_attrs = %{
+      "sentry.sdk.name" => to_sentry_value(@sdk_name),
+      "sentry.sdk.version" => to_sentry_value(@sdk_version),
+      "logflare.source.name" => to_sentry_value(le.source.name),
+      "logflare.source.id" => to_sentry_value(le.source.id)
+    }
+
+    # Get the nested body data for metadata
+    nested_body = le.body["body"] || %{}
+
+    # Get direct metadata field as well
+    direct_metadata = le.body["metadata"] || %{}
+
+    # Add all metadata from the nested log event body, excluding standard fields
+    nested_attrs =
+      nested_body
+      |> Map.drop(["timestamp", "message", "event_message", "level", "trace_id", "trace.id"])
+      |> Map.new(fn {k, v} -> {k, to_sentry_value(v)} end)
+
+    # Add direct metadata attributes
+    metadata_attrs =
+      direct_metadata
+      |> Map.new(fn {k, v} -> {k, to_sentry_value(v)} end)
+
+    # Also process fields from the top-level body, excluding standard fields and LogEvent management fields
+    # This handles cases where fields are placed directly in le.body
+    top_level_attrs =
+      le.body
+      |> Map.drop(["timestamp", "message", "event_message", "level", "trace_id", "trace.id", "body", "metadata", "id", "valid", "drop", "sys_uint", "params", "ingested_at"])
+      |> Map.new(fn {k, v} -> {k, to_sentry_value(v)} end)
+
+    base_attrs
+    |> Map.merge(nested_attrs)
+    |> Map.merge(metadata_attrs)
+    |> Map.merge(top_level_attrs)
+  end
+
+  defp valid_trace_id?(trace_id) when is_binary(trace_id) do
+    # Valid trace ID should be 32 characters (128 bits) hex string
+    # and not be all zeros
+    with true <- String.length(trace_id) == 32,
+         true <- String.match?(trace_id, ~r/^[0-9a-fA-F]+$/),
+         false <- trace_id == String.duplicate("0", 32) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp valid_trace_id?(_), do: false
+
+  defp extract_trace_id(%Logflare.LogEvent{} = le) do
+    # Look for trace_id in nested body first, then outer body
+    nested_body = le.body["body"] || %{}
+
+    case nested_body["trace_id"] || nested_body["trace.id"] || le.body["trace_id"] || le.body["trace.id"] do
+      nil ->
+        generate_trace_id()
+      trace_id when is_binary(trace_id) ->
+        if valid_trace_id?(trace_id), do: trace_id, else: generate_trace_id()
+      trace_id ->
+        trace_id_string = to_string(trace_id)
+        if valid_trace_id?(trace_id_string), do: trace_id_string, else: generate_trace_id()
+    end
+  end
+
+  defp generate_trace_id do
+    # Generate a 32-character hex string (128 bits) as a fake trace ID
+    :crypto.strong_rand_bytes(16)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp normalize_level(level_string) do
+    case String.downcase(level_string) do
+      "debug" -> "debug"
+      "info" -> "info"
+      "notice" -> "info"
+      "warning" -> "warn"
+      "warn" -> "warn"
+      "error" -> "error"
+      "critical" -> "fatal"
+      "alert" -> "fatal"
+      "emergency" -> "fatal"
+      _ -> "info"
+    end
+  end
+
+  defp to_sentry_value(value) do
+    case value do
+      nil -> %{"value" => "", "type" => "string"}
+      v when is_binary(v) -> %{"value" => v, "type" => "string"}
+      v when is_boolean(v) -> %{"value" => v, "type" => "boolean"}
+      v when is_integer(v) -> %{"value" => v, "type" => "integer"}
+      v when is_float(v) -> %{"value" => v, "type" => "double"}
+      v -> %{"value" => inspect(v), "type" => "string"}
+    end
+  end
+
+end

--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -166,7 +166,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
         "event_message",
         "level",
         "trace_id",
-        "trace.id",
+        "trace.id"
       ])
 
     base_attrs

--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -84,6 +84,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
 
   defp validate_dsn(changeset), do: changeset
 
+  # Based on https://develop.sentry.dev/sdk/data-model/envelopes/
   defp build_envelope(log_events, original_dsn) do
     sentry_logs = Enum.map(log_events, &translate_log_event/1)
 
@@ -110,14 +111,12 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
     )
   end
 
+  # https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload
   defp translate_log_event(%Logflare.LogEvent{} = log_event) do
-    # Convert microsecond timestamp to seconds (with fractional part)
     timestamp_seconds = log_event.body["timestamp"] / 1_000_000
 
-    # Extract message from the log event
     message = log_event.body["event_message"] || ""
 
-    # Determine log level - check both body and nested body
     level =
       case log_event.body["level"] do
         nil -> "info"

--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -217,6 +217,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
       "warning" -> "warn"
       "warn" -> "warn"
       "error" -> "error"
+      "fatal" -> "fatal"
       "critical" -> "fatal"
       "alert" -> "fatal"
       "emergency" -> "fatal"

--- a/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
@@ -31,7 +31,9 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSN do
     uri = URI.parse(dsn)
 
     if uri.query do
-      throw("DSN with query parameters is not supported. Please remove query parameters from the DSN.")
+      throw(
+        "DSN with query parameters is not supported. Please remove query parameters from the DSN."
+      )
     end
 
     unless is_binary(uri.path) do
@@ -80,7 +82,8 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSN do
         {:ok, {Enum.join(path, "/"), project_id}}
 
       _other ->
-        {:error, "expected the DSN path to end with an integer project ID, got: #{inspect(uri_path)}"}
+        {:error,
+         "expected the DSN path to end with an integer project ID, got: #{inspect(uri_path)}"}
     end
   end
 end

--- a/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
@@ -37,11 +37,11 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSN do
     end
 
     unless is_binary(uri.path) do
-      throw("missing project ID at the end of the DSN URI: #{inspect(dsn)}")
+      throw("Configured DSN is missing project ID at the end of the DSN URI.")
     end
 
     unless is_binary(uri.userinfo) do
-      throw("missing user info in the DSN URI: #{inspect(dsn)}")
+      throw("Configured DSN is missing user info.")
     end
 
     {public_key, secret_key} =

--- a/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor/dsn.ex
@@ -1,0 +1,86 @@
+defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSN do
+  @moduledoc """
+  Parser for Sentry DSN strings to extract endpoint and authentication information.
+  See: https://develop.sentry.dev/sdk/overview/#parsing-the-dsn
+  """
+
+  @type t() :: %__MODULE__{
+          original_dsn: String.t(),
+          endpoint_uri: String.t(),
+          public_key: String.t(),
+          secret_key: String.t() | nil
+        }
+
+  defstruct [
+    :original_dsn,
+    :endpoint_uri,
+    :public_key,
+    :secret_key
+  ]
+
+  @doc """
+  Parses a Sentry DSN string and returns the parsed DSN struct.
+
+  ## Examples
+
+      iex> DSN.parse("https://key@sentry.io/123")
+      {:ok, %DSN{endpoint_uri: "https://sentry.io/api/123/envelope/", public_key: "key", secret_key: nil, original_dsn: "https://key@sentry.io/123"}}
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, String.t()}
+  def parse(dsn) when is_binary(dsn) do
+    uri = URI.parse(dsn)
+
+    if uri.query do
+      throw("DSN with query parameters is not supported. Please remove query parameters from the DSN.")
+    end
+
+    unless is_binary(uri.path) do
+      throw("missing project ID at the end of the DSN URI: #{inspect(dsn)}")
+    end
+
+    unless is_binary(uri.userinfo) do
+      throw("missing user info in the DSN URI: #{inspect(dsn)}")
+    end
+
+    {public_key, secret_key} =
+      case String.split(uri.userinfo, ":", parts: 2) do
+        [public, secret] -> {public, secret}
+        [public] -> {public, nil}
+      end
+
+    with {:ok, {base_path, project_id}} <- pop_project_id(uri.path) do
+      new_path = Enum.join([base_path, "api", project_id, "envelope"], "/") <> "/"
+      endpoint_uri = %URI{uri | userinfo: nil, path: new_path}
+
+      parsed_dsn = %__MODULE__{
+        endpoint_uri: URI.to_string(endpoint_uri),
+        public_key: public_key,
+        secret_key: secret_key,
+        original_dsn: dsn
+      }
+
+      {:ok, parsed_dsn}
+    end
+  catch
+    message -> {:error, message}
+  end
+
+  def parse(other) do
+    {:error, "expected DSN to be a string, got: #{inspect(other)}"}
+  end
+
+  ## Helpers
+
+  defp pop_project_id(uri_path) do
+    path = String.split(uri_path, "/")
+    {project_id, path} = List.pop_at(path, -1)
+
+    case Integer.parse(project_id) do
+      {_project_id, ""} ->
+        {:ok, {Enum.join(path, "/"), project_id}}
+
+      _other ->
+        {:error, "expected the DSN path to end with an integer project ID, got: #{inspect(uri_path)}"}
+    end
+  end
+end

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -17,6 +17,7 @@ defmodule Logflare.Backends.Backend do
     webhook: Adaptor.WebhookAdaptor,
     elastic: Adaptor.ElasticAdaptor,
     datadog: Adaptor.DatadogAdaptor,
+    sentry: Adaptor.SentryAdaptor,
     postgres: Adaptor.PostgresAdaptor,
     bigquery: Adaptor.BigQueryAdaptor,
     loki: Adaptor.LokiAdaptor,

--- a/test/logflare/backends/adaptor/sentry_adaptor/dsn_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor/dsn_test.exs
@@ -1,0 +1,132 @@
+defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSNTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends.Adaptor.SentryAdaptor.DSN
+
+  doctest DSN
+
+  describe "parse/1" do
+    test "successfully parses minimal valid DSN" do
+      dsn = "https://public@host.com/123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "public"
+      assert parsed.secret_key == nil
+      assert parsed.endpoint_uri == "https://host.com/api/123/envelope/"
+    end
+
+    test "successfully parses DSN with secret key" do
+      dsn = "https://public:secret@host.com/123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "public"
+      assert parsed.secret_key == "secret"
+      assert parsed.endpoint_uri == "https://host.com/api/123/envelope/"
+    end
+
+    test "successfully parses DSN with path prefix" do
+      dsn = "https://public@host.com/path/to/sentry/123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "public"
+      assert parsed.secret_key == nil
+      assert parsed.endpoint_uri == "https://host.com/path/to/sentry/api/123/envelope/"
+    end
+
+    test "successfully parses real Sentry.io DSN" do
+      dsn = "https://abc123@o123456.ingest.sentry.io/123456"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "abc123"
+      assert parsed.secret_key == nil
+      assert parsed.endpoint_uri == "https://o123456.ingest.sentry.io/api/123456/envelope/"
+    end
+
+    test "successfully parses Sentry.io DSN with secret" do
+      dsn = "https://public:secret@o123456.ingest.sentry.io/123456"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "public"
+      assert parsed.secret_key == "secret"
+      assert parsed.endpoint_uri == "https://o123456.ingest.sentry.io/api/123456/envelope/"
+    end
+
+    test "handles different protocols" do
+      for protocol <- ["http", "https"] do
+        dsn = "#{protocol}://public@host.com/123"
+
+        assert {:ok, parsed} = DSN.parse(dsn)
+        assert parsed.endpoint_uri == "#{protocol}://host.com/api/123/envelope/"
+      end
+    end
+
+    test "handles ports in host" do
+      dsn = "https://public@localhost:8080/123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.endpoint_uri == "https://localhost:8080/api/123/envelope/"
+    end
+
+    test "fails when DSN is not a string" do
+      assert {:error, error} = DSN.parse(123)
+      assert error =~ "expected DSN to be a string"
+
+      assert {:error, error} = DSN.parse(nil)
+      assert error =~ "expected DSN to be a string"
+    end
+
+    test "fails when DSN has query parameters" do
+      dsn = "https://public@host.com/123?param=value"
+
+      assert {:error, error} = DSN.parse(dsn)
+      assert error =~ "query parameters"
+    end
+
+    test "fails when missing user info" do
+      dsn = "https://host.com/123"
+
+      assert {:error, error} = DSN.parse(dsn)
+      assert error =~ "missing user info"
+    end
+
+    test "fails when missing path (project ID)" do
+      dsn = "https://public@host.com"
+
+      assert {:error, error} = DSN.parse(dsn)
+      assert error =~ "missing project ID"
+    end
+
+    test "fails when project ID is not a number" do
+      dsn = "https://public@host.com/not-a-number"
+
+      assert {:error, error} = DSN.parse(dsn)
+      assert error =~ "expected the DSN path to end with an integer project ID"
+    end
+
+    test "fails when project ID has non-numeric suffix" do
+      dsn = "https://public@host.com/123abc"
+
+      assert {:error, error} = DSN.parse(dsn)
+      assert error =~ "expected the DSN path to end with an integer project ID"
+    end
+
+    test "handles edge case with empty path segments" do
+      dsn = "https://public@host.com//123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.endpoint_uri == "https://host.com//api/123/envelope/"
+    end
+
+    test "handles project ID with leading zeros" do
+      dsn = "https://public@host.com/0123"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.endpoint_uri == "https://host.com/api/0123/envelope/"
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/sentry_adaptor/dsn_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor/dsn_test.exs
@@ -6,54 +6,82 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSNTest do
   doctest DSN
 
   describe "parse/1" do
-    test "successfully parses minimal valid DSN" do
-      dsn = "https://public@host.com/123"
+    test "successfully parses valid DSNs" do
+      test_cases = [
+        %{
+          name: "minimal valid DSN",
+          dsn: "https://public@host.com/123",
+          expected_public_key: "public",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://host.com/api/123/envelope/"
+        },
+        %{
+          name: "DSN with secret key",
+          dsn: "https://public:secret@host.com/123",
+          expected_public_key: "public",
+          expected_secret_key: "secret",
+          expected_endpoint_uri: "https://host.com/api/123/envelope/"
+        },
+        %{
+          name: "DSN with path prefix",
+          dsn: "https://public@host.com/path/to/sentry/123",
+          expected_public_key: "public",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://host.com/path/to/sentry/api/123/envelope/"
+        },
+        %{
+          name: "real Sentry.io DSN",
+          dsn: "https://abc123@o123456.ingest.sentry.io/123456",
+          expected_public_key: "abc123",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://o123456.ingest.sentry.io/api/123456/envelope/"
+        },
+        %{
+          name: "Sentry.io DSN with secret",
+          dsn: "https://public:secret@o123456.ingest.sentry.io/123456",
+          expected_public_key: "public",
+          expected_secret_key: "secret",
+          expected_endpoint_uri: "https://o123456.ingest.sentry.io/api/123456/envelope/"
+        },
+        %{
+          name: "DSN with port in host",
+          dsn: "https://public@localhost:8080/123",
+          expected_public_key: "public",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://localhost:8080/api/123/envelope/"
+        },
+        %{
+          name: "DSN with empty path segments",
+          dsn: "https://public@host.com//123",
+          expected_public_key: "public",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://host.com//api/123/envelope/"
+        },
+        %{
+          name: "DSN with project ID with leading zeros",
+          dsn: "https://public@host.com/0123",
+          expected_public_key: "public",
+          expected_secret_key: nil,
+          expected_endpoint_uri: "https://host.com/api/0123/envelope/"
+        }
+      ]
 
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.original_dsn == dsn
-      assert parsed.public_key == "public"
-      assert parsed.secret_key == nil
-      assert parsed.endpoint_uri == "https://host.com/api/123/envelope/"
-    end
+      for test_case <- test_cases do
+        assert {:ok, parsed} = DSN.parse(test_case.dsn),
+               "Failed to parse #{test_case.name}: #{test_case.dsn}"
 
-    test "successfully parses DSN with secret key" do
-      dsn = "https://public:secret@host.com/123"
+        assert parsed.original_dsn == test_case.dsn,
+               "Original DSN mismatch for #{test_case.name}"
 
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.original_dsn == dsn
-      assert parsed.public_key == "public"
-      assert parsed.secret_key == "secret"
-      assert parsed.endpoint_uri == "https://host.com/api/123/envelope/"
-    end
+        assert parsed.public_key == test_case.expected_public_key,
+               "Public key mismatch for #{test_case.name}"
 
-    test "successfully parses DSN with path prefix" do
-      dsn = "https://public@host.com/path/to/sentry/123"
+        assert parsed.secret_key == test_case.expected_secret_key,
+               "Secret key mismatch for #{test_case.name}"
 
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.original_dsn == dsn
-      assert parsed.public_key == "public"
-      assert parsed.secret_key == nil
-      assert parsed.endpoint_uri == "https://host.com/path/to/sentry/api/123/envelope/"
-    end
-
-    test "successfully parses real Sentry.io DSN" do
-      dsn = "https://abc123@o123456.ingest.sentry.io/123456"
-
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.original_dsn == dsn
-      assert parsed.public_key == "abc123"
-      assert parsed.secret_key == nil
-      assert parsed.endpoint_uri == "https://o123456.ingest.sentry.io/api/123456/envelope/"
-    end
-
-    test "successfully parses Sentry.io DSN with secret" do
-      dsn = "https://public:secret@o123456.ingest.sentry.io/123456"
-
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.original_dsn == dsn
-      assert parsed.public_key == "public"
-      assert parsed.secret_key == "secret"
-      assert parsed.endpoint_uri == "https://o123456.ingest.sentry.io/api/123456/envelope/"
+        assert parsed.endpoint_uri == test_case.expected_endpoint_uri,
+               "Endpoint URI mismatch for #{test_case.name}"
+      end
     end
 
     test "handles different protocols" do
@@ -65,68 +93,52 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.DSNTest do
       end
     end
 
-    test "handles ports in host" do
-      dsn = "https://public@localhost:8080/123"
+    test "fails to parse invalid DSNs" do
+      error_cases = [
+        %{
+          name: "non-string DSN (integer)",
+          input: 123,
+          expected_error_pattern: "expected DSN to be a string"
+        },
+        %{
+          name: "non-string DSN (nil)",
+          input: nil,
+          expected_error_pattern: "expected DSN to be a string"
+        },
+        %{
+          name: "DSN with query parameters",
+          input: "https://public@host.com/123?param=value",
+          expected_error_pattern: "query parameters"
+        },
+        %{
+          name: "DSN missing user info",
+          input: "https://host.com/123",
+          expected_error_pattern: "missing user info"
+        },
+        %{
+          name: "DSN missing path (project ID)",
+          input: "https://public@host.com",
+          expected_error_pattern: "missing project ID"
+        },
+        %{
+          name: "DSN with non-numeric project ID",
+          input: "https://public@host.com/not-a-number",
+          expected_error_pattern: "expected the DSN path to end with an integer project ID"
+        },
+        %{
+          name: "DSN with project ID having non-numeric suffix",
+          input: "https://public@host.com/123abc",
+          expected_error_pattern: "expected the DSN path to end with an integer project ID"
+        }
+      ]
 
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.endpoint_uri == "https://localhost:8080/api/123/envelope/"
-    end
+      for error_case <- error_cases do
+        assert {:error, error} = DSN.parse(error_case.input),
+               "Expected #{error_case.name} to fail, but parsing succeeded"
 
-    test "fails when DSN is not a string" do
-      assert {:error, error} = DSN.parse(123)
-      assert error =~ "expected DSN to be a string"
-
-      assert {:error, error} = DSN.parse(nil)
-      assert error =~ "expected DSN to be a string"
-    end
-
-    test "fails when DSN has query parameters" do
-      dsn = "https://public@host.com/123?param=value"
-
-      assert {:error, error} = DSN.parse(dsn)
-      assert error =~ "query parameters"
-    end
-
-    test "fails when missing user info" do
-      dsn = "https://host.com/123"
-
-      assert {:error, error} = DSN.parse(dsn)
-      assert error =~ "missing user info"
-    end
-
-    test "fails when missing path (project ID)" do
-      dsn = "https://public@host.com"
-
-      assert {:error, error} = DSN.parse(dsn)
-      assert error =~ "missing project ID"
-    end
-
-    test "fails when project ID is not a number" do
-      dsn = "https://public@host.com/not-a-number"
-
-      assert {:error, error} = DSN.parse(dsn)
-      assert error =~ "expected the DSN path to end with an integer project ID"
-    end
-
-    test "fails when project ID has non-numeric suffix" do
-      dsn = "https://public@host.com/123abc"
-
-      assert {:error, error} = DSN.parse(dsn)
-      assert error =~ "expected the DSN path to end with an integer project ID"
-    end
-
-    test "handles edge case with empty path segments" do
-      dsn = "https://public@host.com//123"
-
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.endpoint_uri == "https://host.com//api/123/envelope/"
-    end
-
-    test "handles project ID with leading zeros" do
-      dsn = "https://public@host.com/0123"
-
-      assert {:ok, parsed} = DSN.parse(dsn)
-      assert parsed.endpoint_uri == "https://host.com/api/0123/envelope/"
+        assert error =~ error_case.expected_error_pattern,
+               "Error message for #{error_case.name} doesn't match expected pattern. Got: #{error}"
+      end
     end
   end
 end

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -1,0 +1,568 @@
+defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
+  use Logflare.DataCase, async: false
+
+  alias Logflare.Backends.Adaptor
+  alias Logflare.Backends
+  alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.SystemMetrics.AllLogsLogged
+  alias Logflare.Backends.Adaptor.SentryAdaptor
+  alias Logflare.Backends.Adaptor.SentryAdaptor.DSN
+
+  @subject SentryAdaptor
+  @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
+
+  doctest @subject
+
+  setup do
+    start_supervised!(AllLogsLogged)
+    insert(:plan)
+    :ok
+  end
+
+  describe "cast and validate" do
+    test "DSN is required" do
+      changeset = Adaptor.cast_and_validate_config(@subject, %{})
+
+      refute changeset.valid?
+      assert %{dsn: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "valid DSN passes validation" do
+      valid_dsn = "https://abc123@o123456.ingest.sentry.io/123456"
+
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "dsn" => valid_dsn
+        })
+
+      assert changeset.valid?
+    end
+
+    test "DSN with secret key passes validation" do
+      valid_dsn = "https://public:secret@o123456.ingest.sentry.io/123456"
+
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "dsn" => valid_dsn
+        })
+
+      assert changeset.valid?
+    end
+
+    test "invalid DSN format fails validation" do
+      invalid_dsn = "not-a-valid-dsn"
+
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "dsn" => invalid_dsn
+        })
+
+      refute changeset.valid?
+      assert %{dsn: [error]} = errors_on(changeset)
+      assert error =~ "Invalid DSN"
+    end
+
+    test "DSN without project ID fails validation" do
+      invalid_dsn = "https://abc123@sentry.io/not-a-number"
+
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "dsn" => invalid_dsn
+        })
+
+      refute changeset.valid?
+      assert %{dsn: [error]} = errors_on(changeset)
+      assert error =~ "Invalid DSN"
+    end
+
+    test "DSN with query parameters fails validation" do
+      invalid_dsn = "https://abc123@sentry.io/123456?param=value"
+
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "dsn" => invalid_dsn
+        })
+
+      refute changeset.valid?
+      assert %{dsn: [error]} = errors_on(changeset)
+      assert error =~ "Invalid DSN"
+    end
+  end
+
+  describe "DSN parsing" do
+    test "parse/1 successfully parses valid DSN" do
+      dsn = "https://abc123@o123456.ingest.sentry.io/123456"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.original_dsn == dsn
+      assert parsed.public_key == "abc123"
+      assert parsed.secret_key == nil
+      assert parsed.endpoint_uri == "https://o123456.ingest.sentry.io/api/123456/envelope/"
+    end
+
+    test "parse/1 handles DSN with secret key" do
+      dsn = "https://public:secret@o123456.ingest.sentry.io/123456"
+
+      assert {:ok, parsed} = DSN.parse(dsn)
+      assert parsed.public_key == "public"
+      assert parsed.secret_key == "secret"
+    end
+
+    test "parse/1 fails with invalid format" do
+      assert {:error, _reason} = DSN.parse("invalid-dsn")
+    end
+
+    test "parse/1 fails with query parameters" do
+      dsn = "https://abc123@sentry.io/123456?param=value"
+      assert {:error, reason} = DSN.parse(dsn)
+      assert reason =~ "query parameters"
+    end
+  end
+
+  describe "transform_config/1" do
+    test "converts DSN to webhook configuration" do
+      backend = %{
+        config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
+      }
+
+      config = @subject.transform_config(backend)
+
+      assert config.url == "https://o123456.ingest.sentry.io/api/123456/envelope/"
+      assert config.headers == %{"content-type" => "application/x-sentry-envelope"}
+      assert config.http == "http2"
+      assert is_function(config.format_batch)
+    end
+
+    test "raises error with invalid DSN" do
+      backend = %{
+        config: %{dsn: "invalid-dsn"}
+      }
+
+      assert_raise ArgumentError, ~r/Invalid Sentry DSN/, fn ->
+        @subject.transform_config(backend)
+      end
+    end
+  end
+
+  describe "logs ingestion" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :sentry,
+          sources: [source],
+          config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+      :timer.sleep(500)
+      [backend: backend, source: source]
+    end
+
+    # Helper function to normalize envelope for snapshot comparison
+    defp normalize_envelope_for_snapshot(envelope_body) do
+      lines = String.split(envelope_body, "\n")
+      [header_line, item_header_line, item_payload_line] = lines
+
+      # Parse and normalize header (replace dynamic timestamp)
+      header = Jason.decode!(header_line)
+      normalized_header = Map.put(header, "sent_at", "2024-01-01T00:00:00.000000Z")
+
+      # Parse and normalize item payload (replace dynamic log timestamps and trace_ids)
+      item_payload = Jason.decode!(item_payload_line)
+      normalized_items =
+        Enum.map(item_payload["items"], fn item ->
+          item
+          |> Map.put("timestamp", 1.7040672e9) # Keep scientific notation format
+          |> Map.delete("trace_id") # Remove dynamic trace_id for consistent snapshots
+        end)
+      normalized_item_payload = Map.put(item_payload, "items", normalized_items)
+
+      # Reconstruct envelope with normalized data
+      [
+        Jason.encode!(normalized_header),
+        item_header_line,
+        Jason.encode!(normalized_item_payload)
+      ]
+      |> Enum.join("\n")
+    end
+
+    test "sent logs are delivered as Sentry envelope", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        envelope_body = req[:body]
+
+        send(this, {ref, envelope_body})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      # Create log event with fixed timestamp for consistent snapshot
+      le = build(:log_event,
+        source: source,
+        body: %{
+          "timestamp" => 1704067200_000_000, # 2024-01-01T00:00:00Z in microseconds
+          "message" => "Test log message"
+        }
+      )
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, envelope_body}, 2000
+
+      # Normalize envelope and compare against snapshot
+      normalized_envelope = normalize_envelope_for_snapshot(envelope_body)
+
+      expected_envelope = """
+      {"dsn":"https://abc123@o123456.ingest.sentry.io/123456","sent_at":"2024-01-01T00:00:00.000000Z"}
+      {"content_type":"application/vnd.sentry.items.log+json","item_count":1,"type":"log"}
+      {"items":[{"attributes":{"logflare.source.id":{"type":"integer","value":#{source.id}},"logflare.source.name":{"type":"string","value":"#{source.name}"},"sentry.sdk.name":{"type":"string","value":"sentry.logflare"},"sentry.sdk.version":{"type":"string","value":"0.1.0"}},"body":"test-msg","level":"info","timestamp":1.7040672e9}]}\
+      """
+
+      assert normalized_envelope == expected_envelope
+    end
+
+    test "log events are properly transformed to Sentry format", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        envelope_body = req[:body]
+
+        send(this, {ref, envelope_body})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      le =
+        build(:log_event,
+          source: source,
+          message: "Test log message",
+          body: %{
+            "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+            "message" => "Test log message",
+            "level" => "error",
+            "user_id" => 123,
+            "metadata" => %{"request_id" => "abc-123"}
+          }
+        )
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, envelope_body}, 2000
+
+      # Normalize envelope and compare against snapshot
+      normalized_envelope = normalize_envelope_for_snapshot(envelope_body)
+
+      expected_envelope = """
+      {"dsn":"https://abc123@o123456.ingest.sentry.io/123456","sent_at":"2024-01-01T00:00:00.000000Z"}
+      {"content_type":"application/vnd.sentry.items.log+json","item_count":1,"type":"log"}
+      {"items":[{"attributes":{"logflare.source.id":{"type":"integer","value":#{source.id}},"logflare.source.name":{"type":"string","value":"#{source.name}"},"metadata":{"type":"string","value":"%{\\\"request_id\\\" => \\\"abc-123\\\"}"},"sentry.sdk.name":{"type":"string","value":"sentry.logflare"},"sentry.sdk.version":{"type":"string","value":"0.1.0"},"user_id":{"type":"integer","value":123}},"body":"Test log message","level":"error","timestamp":1.7040672e9}]}\
+      """
+
+      assert normalized_envelope == expected_envelope
+    end
+
+    test "handles log events without explicit level", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        envelope_body = req[:body]
+
+        send(this, {ref, envelope_body})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      le =
+        build(:log_event,
+          source: source,
+          body: %{
+            "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+            "message" => "Test message without level"
+          }
+        )
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, envelope_body}, 2000
+
+      # Normalize envelope and compare against snapshot
+      normalized_envelope = normalize_envelope_for_snapshot(envelope_body)
+
+      expected_envelope = """
+      {"dsn":"https://abc123@o123456.ingest.sentry.io/123456","sent_at":"2024-01-01T00:00:00.000000Z"}
+      {"content_type":"application/vnd.sentry.items.log+json","item_count":1,"type":"log"}
+      {"items":[{"attributes":{"logflare.source.id":{"type":"integer","value":#{source.id}},"logflare.source.name":{"type":"string","value":"#{source.name}"},"sentry.sdk.name":{"type":"string","value":"sentry.logflare"},"sentry.sdk.version":{"type":"string","value":"0.1.0"}},"body":"test-msg","level":"info","timestamp":1.7040672e9}]}\
+      """
+
+      assert normalized_envelope == expected_envelope
+    end
+
+    test "properly maps different log levels", %{source: source} do
+      level_mappings = [
+        {"debug", "debug"},
+        {"info", "info"},
+        {"notice", "info"},
+        {"warning", "warn"},
+        {"warn", "warn"},
+        {"error", "error"},
+        {"critical", "fatal"},
+        {"alert", "fatal"},
+        {"emergency", "fatal"},
+        {"unknown", "info"}
+      ]
+
+      for {input_level, expected_level} <- level_mappings do
+        this = self()
+        ref = make_ref()
+
+        le =
+          build(:log_event,
+            source: source,
+            body: %{
+              "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+              "message" => "Test message",
+              "level" => input_level
+            }
+          )
+
+        @client
+        |> expect(:send, fn req ->
+          envelope_body = req[:body]
+          send(this, {ref, envelope_body})
+          %Tesla.Env{status: 200, body: ""}
+        end)
+
+        assert {:ok, _} = Backends.ingest_logs([le], source)
+        assert_receive {^ref, envelope_body}, 2000
+
+        # Normalize envelope and verify level mapping via snapshot
+        normalized_envelope = normalize_envelope_for_snapshot(envelope_body)
+
+        # Build expected envelope dynamically to ensure proper interpolation
+        expected_envelope = [
+          "{\"dsn\":\"https://abc123@o123456.ingest.sentry.io/123456\",\"sent_at\":\"2024-01-01T00:00:00.000000Z\"}",
+          "{\"content_type\":\"application/vnd.sentry.items.log+json\",\"item_count\":1,\"type\":\"log\"}",
+          "{\"items\":[{\"attributes\":{\"logflare.source.id\":{\"type\":\"integer\",\"value\":#{source.id}},\"logflare.source.name\":{\"type\":\"string\",\"value\":\"#{source.name}\"},\"sentry.sdk.name\":{\"type\":\"string\",\"value\":\"sentry.logflare\"},\"sentry.sdk.version\":{\"type\":\"string\",\"value\":\"0.1.0\"}},\"body\":\"test-msg\",\"level\":\"#{expected_level}\",\"timestamp\":1.7040672e9}]}"
+        ] |> Enum.join("\n")
+
+        assert normalized_envelope == expected_envelope,
+               "Expected #{input_level} to map to #{expected_level} in envelope"
+      end
+    end
+
+    test "handles multiple log events in single batch", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        envelope_body = req[:body]
+        send(this, {ref, envelope_body})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      log_events = [
+        build(:log_event,
+          source: source,
+          message: "Log 1",
+          body: %{
+            "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+            "message" => "Log 1"
+          }
+        ),
+        build(:log_event,
+          source: source,
+          message: "Log 2",
+          body: %{
+            "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+            "message" => "Log 2"
+          }
+        ),
+        build(:log_event,
+          source: source,
+          message: "Log 3",
+          body: %{
+            "timestamp" => 1704067200_000_000, # Fixed timestamp for snapshot
+            "message" => "Log 3"
+          }
+        )
+      ]
+
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert_receive {^ref, envelope_body}, 2000
+
+      # Normalize envelope and compare against snapshot
+      normalized_envelope = normalize_envelope_for_snapshot(envelope_body)
+
+      # Parse the normalized envelope to verify structure and content
+      lines = String.split(normalized_envelope, "\n")
+      [header_line, item_header_line, item_payload_line] = lines
+
+      # Check header
+      header = Jason.decode!(header_line)
+      assert header["dsn"] == "https://abc123@o123456.ingest.sentry.io/123456"
+      assert header["sent_at"] == "2024-01-01T00:00:00.000000Z"
+
+      # Check item header
+      item_header = Jason.decode!(item_header_line)
+      assert item_header["content_type"] == "application/vnd.sentry.items.log+json"
+      assert item_header["item_count"] == 3
+      assert item_header["type"] == "log"
+
+      # Check items (order-agnostic since log processing can vary order)
+      item_payload = Jason.decode!(item_payload_line)
+      items = item_payload["items"]
+      assert length(items) == 3
+
+      # Check that all expected messages are present
+      messages = Enum.map(items, fn item -> item["body"] end)
+      assert "Log 1" in messages
+      assert "Log 2" in messages
+      assert "Log 3" in messages
+
+      # Check that all items have the expected normalized structure
+      for item <- items do
+        assert item["level"] == "info"
+        assert item["timestamp"] == 1.7040672e9 # Normalized timestamp
+        assert is_nil(item["trace_id"]) # trace_id removed for normalization
+
+        attributes = item["attributes"]
+        assert attributes["logflare.source.id"]["value"] == source.id
+        assert attributes["logflare.source.name"]["value"] == source.name
+        assert attributes["sentry.sdk.name"]["value"] == "sentry.logflare"
+        assert attributes["sentry.sdk.version"]["value"] == "0.1.0"
+      end
+    end
+
+    test "handles empty log events list without crashing", %{source: _source} do
+      backend = %Logflare.Backends.Backend{
+        type: :sentry,
+        config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
+      }
+
+      transformed_config = @subject.transform_config(backend)
+
+      # Call format_batch with empty list - should not crash
+      result = transformed_config.format_batch.([])
+
+      # Normalize and compare against snapshot
+      normalized_envelope = normalize_envelope_for_snapshot(result)
+
+      expected_envelope = """
+      {"dsn":"https://abc123@o123456.ingest.sentry.io/123456","sent_at":"2024-01-01T00:00:00.000000Z"}
+      {"content_type":"application/vnd.sentry.items.log+json","item_count":0,"type":"log"}
+      {"items":[]}\
+      """
+
+      assert normalized_envelope == expected_envelope
+    end
+  end
+
+  describe "trace ID handling" do
+    test "extract_trace_id generates consistent ID for invalid trace_id", %{} do
+      backend = %Logflare.Backends.Backend{
+        type: :sentry,
+        config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
+      }
+
+      transformed_config = @subject.transform_config(backend)
+
+      test_cases = [
+        {
+          "invalid short trace_id",
+          %{
+            "trace_id" => "invalid-too-short",
+            "message" => "Test message",
+            "timestamp" => 1704067200_000_000
+          }
+        },
+        {
+          "all zeros trace_id",
+          %{
+            "trace_id" => "00000000000000000000000000000000",
+            "message" => "Test message",
+            "timestamp" => 1704067200_000_000
+          }
+        },
+        {
+          "no trace_id present",
+          %{
+            "message" => "Test message",
+            "timestamp" => 1704067200_000_000
+          }
+        }
+      ]
+
+      for {description, body_data} <- test_cases do
+        le = build(:log_event, body: body_data)
+        result = transformed_config.format_batch.([le])
+
+        # Parse the envelope to check trace_id format
+        lines = String.split(result, "\n")
+        item_payload = Jason.decode!(Enum.at(lines, 2))
+        item = Enum.at(item_payload["items"], 0)
+
+        # Should be a valid 32-character hex string
+        assert String.length(item["trace_id"]) == 32, "Failed for case: #{description}"
+        assert String.match?(item["trace_id"], ~r/^[0-9a-f]+$/), "Failed for case: #{description}"
+
+        # Should not be the invalid input values
+        case description do
+          "invalid short trace_id" -> assert item["trace_id"] != "invalid-too-short"
+          "all zeros trace_id" -> assert item["trace_id"] != "00000000000000000000000000000000"
+          _ -> :ok
+        end
+      end
+    end
+  end
+
+  describe "attribute building and data type conversion" do
+    test "handles different data types in attributes", %{} do
+      le = build(:log_event, body: %{
+        "timestamp" => 1704067200_000_000,
+        "message" => "Test message",
+        "string_field" => "text_value",
+        "integer_field" => 42,
+        "float_field" => 3.14,
+        "boolean_field" => true,
+        "null_like_field" => "null",
+        "list_field" => [1, 2, 3],
+        "map_field" => %{"nested" => "value"}
+      })
+
+      backend = %Logflare.Backends.Backend{
+        type: :sentry,
+        config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
+      }
+
+      transformed_config = @subject.transform_config(backend)
+      result = transformed_config.format_batch.([le])
+
+      # Parse the envelope to inspect data type conversion
+      lines = String.split(result, "\n")
+      item_payload = Jason.decode!(Enum.at(lines, 2))
+      item = Enum.at(item_payload["items"], 0)
+      attributes = item["attributes"]
+
+      # Check data type conversions
+      assert attributes["string_field"] == %{"type" => "string", "value" => "text_value"}
+      assert attributes["integer_field"] == %{"type" => "integer", "value" => 42}
+      assert attributes["float_field"] == %{"type" => "double", "value" => 3.14}
+      assert attributes["boolean_field"] == %{"type" => "boolean", "value" => true}
+      assert attributes["null_like_field"] == %{"type" => "string", "value" => "null"}
+      assert attributes["list_field"] == %{"type" => "string", "value" => "[1, 2, 3]"}
+      assert attributes["map_field"] == %{"type" => "string", "value" => "%{\"nested\" => \"value\"}"}
+    end
+  end
+
+  describe "execute_query/3" do
+    test "returns not implemented error" do
+      result = @subject.execute_query(nil, "SELECT 1", [])
+      assert {:error, :not_implemented} = result
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -115,14 +115,17 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
                "type" => "string",
                "value" => source.name
              }
+
       assert item["attributes"]["logflare.source.uuid"] == %{
                "type" => "string",
                "value" => inspect(source.token)
              }
+
       assert item["attributes"]["sentry.sdk.name"] == %{
                "type" => "string",
                "value" => "sentry.logflare"
              }
+
       assert item["attributes"]["sentry.sdk.version"]
       assert item["body"] == "Test log message"
       assert item["level"] == "info"
@@ -377,6 +380,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
       assert attributes["float_field"] == %{"type" => "double", "value" => 3.14}
       assert attributes["boolean_field"] == %{"type" => "boolean", "value" => true}
       assert attributes["list_field"] == %{"type" => "string", "value" => "[1, 2, 3]"}
+
       assert attributes["map_field"] == %{
                "type" => "string",
                "value" => "%{\"nested\" => \"value\"}"

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -151,6 +151,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         {"warning", "warn"},
         {"warn", "warn"},
         {"error", "error"},
+        {"fatal", "fatal"},
         {"critical", "fatal"},
         {"alert", "fatal"},
         {"emergency", "fatal"},

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -88,7 +88,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         build(:log_event,
           source: source,
           event_message: "Test log message",
-          timestamp: 1704067200_000_000
+          timestamp: 1_704_067_200_000_000
         )
       ]
 
@@ -164,7 +164,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           build(:log_event,
             source: source,
             event_message: "Test log message",
-            timestamp: 1704067200_000_000,
+            timestamp: 1_704_067_200_000_000,
             level: input_level,
             test_index: index
           )
@@ -203,17 +203,17 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         build(:log_event,
           source: source,
           event_message: "Log 1",
-          timestamp: 1704067200_000_000
+          timestamp: 1_704_067_200_000_000
         ),
         build(:log_event,
           source: source,
           event_message: "Log 2",
-          timestamp: 1704067200_000_000
+          timestamp: 1_704_067_200_000_000
         ),
         build(:log_event,
           source: source,
           event_message: "Log 3",
-          timestamp: 1704067200_000_000
+          timestamp: 1_704_067_200_000_000
         )
       ]
 
@@ -253,7 +253,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           source: source,
           event_message: "Test message",
           trace_id: "efdb9350effb47959d48bd0aaf395824",
-          timestamp: 1704067200_000_000,
+          timestamp: 1_704_067_200_000_000,
           string_field: "text_value",
           integer_field: 42,
           float_field: 3.14,


### PR DESCRIPTION
This PR adds a backend for [Sentry](https://sentry.io/about/), specifically for Sentry's new [structured logging product](https://docs.sentry.io/product/explore/logs/).

resolves https://github.com/getsentry/sentry/issues/95914

<img width="3024" height="1664" alt="image" src="https://github.com/user-attachments/assets/a90c3933-adfd-4023-bd96-11ed388e0cc6" />

To configure the Sentry backend, you need to add a DSN (data source name), which indicates which sentry instance to send logs to. This was chosen over just a regular URL as most users are familiar with getting a DSN from sentry.

To parse the DSN into an endpoint, we use the same logic as we do with Sentry's Elixir SDK: https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/dsn.ex

The Sentry adapter itself is based on the webhook backend. The only thing that is different is that to send data to Sentry, it needs to be sent as an envelope instead of plain JSON.

Docs for envelopes can be found here: https://develop.sentry.dev/sdk/data-model/envelopes/
And the docs for log envelope items can be found here: https://develop.sentry.dev/sdk/data-model/envelope-items/#log