### PR TITLE
perf: remove autoconnection between nodes on same network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,17 @@ start.orange: __start__
 start.pink: ERL_NAME = pink
 start.pink: PORT = 4001
 start.pink: ENV_FILE = .dev.env
-# start.pink: ERL_COOKIE = pinkmonster
 start.pink: LOGFLARE_GRPC_PORT = 50052
 start.pink: __start__
+
+
+start.green: ERL_NAME = green
+start.green: PORT = 4002
+start.green: ERL_COOKIE = greenmonster
+start.green: ENV_FILE = .dev.env
+start.green: LOGFLARE_GRPC_PORT = 50053
+start.green: __start__
+
 
 # temp alias
 
@@ -181,7 +189,7 @@ migrate:
 	@env $$(cat .dev.env | xargs) mix ecto.migrate
 
 
-.PHONY: __start__ migrate start.sb.pg start.sb.bq start.st.pg start.st.bq start.orange start.pink
+.PHONY: __start__ migrate start.sb.pg start.sb.bq start.st.pg start.st.bq start.orange start.pink start.green
 
 # Encryption and decryption of secrets
 # Usage:

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ start.orange: __start__
 start.pink: ERL_NAME = pink
 start.pink: PORT = 4001
 start.pink: ENV_FILE = .dev.env
+# start.pink: ERL_COOKIE = pinkmonster
 start.pink: LOGFLARE_GRPC_PORT = 50052
 start.pink: __start__
 
@@ -172,7 +173,8 @@ __start__:
 	@if [ ! -f ${ENV_FILE} ]; then \
 		touch ${ENV_FILE}; \
 	fi
-	@env $$(cat ${ENV_FILE} .dev.env | xargs) PORT=${PORT} LOGFLARE_GRPC_PORT=${LOGFLARE_GRPC_PORT} LOGFLARE_SUPABASE_MODE=${LOGFLARE_SUPABASE_MODE} iex --sname ${ERL_NAME} --cookie ${ERL_COOKIE} -S mix phx.server
+# kernel options should match  vm.args.eex
+	@env $$(cat ${ENV_FILE} .dev.env | xargs) PORT=${PORT} LOGFLARE_GRPC_PORT=${LOGFLARE_GRPC_PORT} LOGFLARE_SUPABASE_MODE=${LOGFLARE_SUPABASE_MODE} iex --sname ${ERL_NAME} --cookie ${ERL_COOKIE} --erl "-kernel dist_auto_connect never" -S mix phx.server
 
 
 migrate:

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -45,3 +45,8 @@
 
 ## Reduce net_ticktime from default 60 to 45 seconds for faster detection of disconnected nodes
 -kernel net_ticktime 45
+
+## Disable automatic connection to other nodes
+## Prevents automatic connection attempt between nodes on same network and uses libcluster instead
+## https://www.erlang.org/doc/apps/kernel/kernel_app#configuration
+-kernel dist_auto_connect never


### PR DESCRIPTION
This removes the auto-connection behaviour when nodes detect each other via epmd. This does not prevent libcluster from managing the connections, it only prevents auto-connection attempts. this occurs when there are multiple clusters on the same network but with different cookies for each cluster.

<img width="1568" height="631" alt="image" src="https://github.com/user-attachments/assets/e595cbd9-1ced-4b2c-ab95-5f9e24eacc39" />

closes ANL-1113