### PR TITLE
perf: only load source socket conditionally

### DIFF
--- a/assets/build.mjs
+++ b/assets/build.mjs
@@ -57,12 +57,12 @@ let sassPostcssPlugin = sassPlugin({
 
 const options = {
   logLevel: "info",
-  entryPoints: ["js/app.js"],
+  entryPoints: ["js/app.js", "js/source.js"],
   bundle: true,
   minify: watch ? false : true,
   sourcemap: true,
   loader: { ".svg": "file", ".png": "file" },
-  outfile: "../priv/static/js/app.js",
+  outdir: "../priv/static/js",
   plugins: [sassPostcssPlugin, externalizeCssImages, copyStatic],
   jsx: "automatic",
   treeShaking: watch ? false : true,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,7 +5,6 @@ import "../css/tailwind.css";
 import "bootstrap";
 import ClipboardJS from "clipboard";
 import * as Dashboard from "./dashboard";
-import * as Source from "./source";
 import * as Logs from "./logs";
 import * as User from "./user";
 import BillingHooks from "./billing";
@@ -39,7 +38,6 @@ const liveReactHooks = { LiveReact };
 window.Components = { LogEventsChart, Loader, AdminChart: Chart };
 window.Dashboard = Dashboard;
 window.Logs = Logs;
-window.Source = Source;
 window.User = User;
 window.ClipboardJS = ClipboardJS;
 
@@ -94,9 +92,9 @@ let liveSocket = new LiveSocket("/live", Socket, {
     },
   },
 });
+liveSocket.enableDebug()
 
 liveSocket.connect();
-
 window.initLiveReact = initLiveReact;
 window.liveSocket = liveSocket;
 

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -1,5 +1,4 @@
 import $ from "jquery"
-import socket from "./socket"
 import {activateClipboardForSelector} from "./utils"
 import {timestampNsToAgo} from "./formatters"
 import {applyToAllLogTimestamps} from "./logs"
@@ -11,9 +10,6 @@ export async function main() {
   await initApiClipboard()
   await initTooltips()
 
-  for (let token of sourceTokens) {
-    joinSourceChannel(token, currentNode)
-  }
   await applyToAllLogTimestamps(timestampNsToAgo)
 
   $(".dashboard.container").removeAttr("hidden")
@@ -31,41 +27,6 @@ async function initApiClipboard() {
   activateClipboardForSelector("#api-key")
 }
 
-function joinSourceChannel(sourceToken, currentNode) {
-  let channel = socket.channel(`dashboard:${sourceToken}`, {})
-
-  channel
-    .join()
-    .receive("ok", (resp) => {
-      console.log(
-        `Dashboard channel for source ${sourceToken} joined successfully on node ${currentNode}`,
-        resp
-      )
-    })
-    .receive("error", (resp) => {
-      console.log("Unable to join", resp)
-    })
-
-  const sourceSelector = `#${sourceToken}`
-
-  channel.on(`log_count`, (event) => {
-    $(`${sourceSelector}-latest`).html(
-      timestampNsToAgo(new Date().getTime() * 1000)
-    )
-    $(sourceSelector).html(
-      `<small class="my-badge my-badge-info fade-in">${event.log_count}</small>`
-    )
-  })
-
-  channel.on(`rate`, (event) => {
-    $(`${sourceSelector}-rate`).html(`${event.rate}`)
-    $(`${sourceSelector}-avg-rate`).html(`${event.average_rate}`)
-    $(`${sourceSelector}-max-rate`).html(`${event.max_rate}`)
-  })
-  channel.on(`buffer`, (event) => {
-    $(`${sourceSelector}-buffer`).html(`${event.buffer}`)
-  })
-}
 
 export function showApiKey(apiKey) {
   const apiKeyElem = $("#api-key")

--- a/assets/js/source.js
+++ b/assets/js/source.js
@@ -27,7 +27,6 @@ export async function main({
   })
 
   await initClipboards()
-  await initTooltips()
 
   if (avgEventsPerSecond < 25) {
     joinSourceChannel(sourceToken)
@@ -43,15 +42,6 @@ export async function main({
 async function initClipboards() {
   activateClipboardForSelector("#source-id", {
     container: document.getElementById('sourceHelpModal')
-  })
-}
-
-async function initTooltips() {
-  $(".logflare-tooltip").tooltip({
-    delay: {
-      show: 100,
-      hide: 200
-    }
   })
 }
 
@@ -190,4 +180,11 @@ export function scrollOverflowBottom() {
   if ($lastLog) {
     $lastLog.scrollIntoView()
   }
+}
+window.Source = {
+  main,
+  initLogsUiFunctions,
+  trackScroll,
+  scrollBottom,
+  scrollOverflowBottom
 }

--- a/lib/logflare_web/templates/source/show.html.heex
+++ b/lib/logflare_web/templates/source/show.html.heex
@@ -75,6 +75,9 @@
 <!-- Modal -->
 <%= render(LogflareWeb.SourceView, "no_logs_modal.html", user: @user, source: @source, conn: @conn) %>
 <div id="__phx-assigns__" data-source-token={@source.token} data-logs={Poison.encode!(@logs)}></div>
+<script src={Routes.static_path(@conn, "/js/source.js")}>
+</script>
+
 <script>
   document.addEventListener("DOMContentLoaded", async () => {
       await Source.main({scrollTracker: true}, {avgEventsPerSecond: <%= @source.metrics.avg %>})


### PR DESCRIPTION
this loads the source socket for receiving broadcasted log events conditionally. With new UserMetricsPoller, we no longer need the dashboard to connect to the socket.
this removes ws connection on the search page, speeding it up and removes it from the app js bundle, speeding up execution as well.

On a separate note: There is still an occasional noticeable "lag" when the ws upgrades from the initial liveview mount, but nothing is standing out to me at the moment as culprit. This lag time in the ws connection upgrade does not always happen consistently though, and usually only occurs on first page load of the server. It could be that the Endpoint is not ready to accept the connections, but would be rather odd...