### PR TITLE
feat: add format button for formatting SQL queries

### DIFF
--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -50,7 +50,14 @@ defmodule LogflareWeb.MonacoEditorComponent do
 
     ~H"""
     <div id={@id}>
-      <LiveMonacoEditor.code_editor value={@field.value} target={@myself} change="parse-query" path="query_string" id="query" opts={@editor_opts} />
+      <.support_scripts completions={@completions} id={@field.id <> "_completions"} />
+      <LiveMonacoEditor.code_editor value={@field.value} target={@myself} change="parse-query" path="query_string" phx-format={JS.hide()} id={"#{@id}_lme"} opts={@editor_opts} />
+      <div class="tw-flex tw-justify-end">
+        <button type="button" class="btn btn-secondary tw-mr-0 tw-mt-2" phx-click={JS.dispatch("editor:format", to: "#" <> @id)}>
+          Format
+        </button>
+      </div>
+
       <%= hidden_input(@field.form, :query, value: @query) %>
       <%= error_tag(@field.form, :query) %>
       <.alert :if={@parse_error_message} variant="warning">
@@ -58,7 +65,6 @@ defmodule LogflareWeb.MonacoEditorComponent do
         <br />
         <span><%= @parse_error_message %></span>
       </.alert>
-      <.completions_script completions={@completions} id={@field.id <> "_completions"} />
     </div>
     """
   end
@@ -66,15 +72,21 @@ defmodule LogflareWeb.MonacoEditorComponent do
   attr :completions, :list, required: true, examples: [["source_name", "logs"]]
   attr :id, :string, required: true
 
-  def completions_script(assigns) do
+  def support_scripts(assigns) do
     ~H"""
     <script phx-update="ignore" id={@id}>
       window.addEventListener("lme:editor_mounted", (event) => {
+        const hook = event.detail.hook;
+        const editor = event.detail.editor.standalone_code_editor;
+
+        window.addEventListener("editor:format", ev => {
+          const value = editor.getValue();
+          hook.pushEventTo(ev.target, "format-query", { value: value });
+        })
+
         const completions = <%= Jason.encode!(@completions) |> raw() %>
 
         if (completions.length == 0) { return; }
-
-        const editor = event.detail.editor.standalone_code_editor;
 
         function createDependencyProposals(range) {
           return completions.map(function (name) {
@@ -105,6 +117,16 @@ defmodule LogflareWeb.MonacoEditorComponent do
       });
     </script>
     """
+  end
+
+  def handle_event("format-query", %{"value" => value}, socket) do
+    case SqlFmt.format_query(value) do
+      {:ok, formatted} ->
+        {:noreply, socket |> LiveMonacoEditor.set_value(formatted, to: "query_string")}
+
+      _ ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("parse-query", %{"value" => query}, socket) do

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -73,6 +73,9 @@ defmodule LogflareWeb.QueryLive do
           }
         />
         <div class="tw-ml-auto">
+          <button type="button" class="btn btn-secondary" phx-click="format-query">
+            Format
+          </button>
           <%= submit("Run query", class: "btn btn-secondary") %>
         </div>
       </.form>
@@ -240,6 +243,16 @@ defmodule LogflareWeb.QueryLive do
   def handle_event("parse-query", %{"_target" => ["live_monaco_editor", _]}, socket) do
     # ignore change events from the editor field
     {:noreply, socket}
+  end
+
+  def handle_event("format-query", _params, socket) do
+    case SqlFmt.format_query(socket.assigns.query_string) do
+      {:ok, formatted} ->
+        {:noreply, LiveMonacoEditor.set_value(socket, formatted, to: "query")}
+
+      _ ->
+        {:noreply, socket}
+    end
   end
 
   defp run_query(socket, user, query_string) do


### PR DESCRIPTION
Adds format button to 
1. query page
2. endpoints edit page
3. alerts edit page



* We use `SqlFmt.format_query/1` for formatting which always returns `{:ok, result}` so no any UI is required.
* Have not included unit tests since most of the actual effects here are in the JS layer.
* Event listeners are now setup before rendering the editor 

https://github.com/user-attachments/assets/46247bd7-1d28-43fd-9cbe-0665ada6d2b4


https://github.com/user-attachments/assets/ec113daa-a9a6-420a-ae55-2c3158854248

