### PR TITLE
fix: clickhouse queries returning UUID fields

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -701,7 +701,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
     end)
   end
 
-  @spec convert_uuids(data :: map() | list() | binary()) :: map() | list() | binary()
+  @spec convert_uuids(data :: any()) :: any()
   defp convert_uuids(data) when is_struct(data), do: data
 
   defp convert_uuids(data) when is_map(data) do


### PR DESCRIPTION
ClickHouse queries returning UUID columns would fail because they are returned as a binary rather than a string format. This was causing issues when the results are serialized in the UI and other places.