### PR TITLE
fix: endpoint query text wrapping

### DIFF
--- a/lib/logflare_web/live/endpoints/components/run_query_result.heex
+++ b/lib/logflare_web/live/endpoints/components/run_query_result.heex
@@ -5,7 +5,7 @@
     <QueryComponents.query_cost :if={@total_bytes_processed} bytes={@total_bytes_processed} />
   </div>
 
-  <code class="tw-whitespace-pre tw-block tw-text-white tw-bg-zinc-800 tw-rounded tw-p-2 tw-text-xs">
+  <code class="tw-whitespace-pre-wrap tw-overflow-x-auto tw-block tw-text-white tw-bg-zinc-800 tw-rounded tw-p-2 tw-text-xs">
     <%= Jason.encode!(@query_result_rows) |> Jason.Formatter.pretty_print() %>
   </code>
 </div>


### PR DESCRIPTION
before: 
<img width="1189" height="631" alt="Screenshot 2025-10-09 at 10 52 53 AM" src="https://github.com/user-attachments/assets/b59f3f17-a801-4547-9527-39044c111310" />
