### PR TITLE
fix: remove backends that cannot be queried from the list of selectable backends

### DIFF
--- a/lib/logflare/backends/adaptor.ex
+++ b/lib/logflare/backends/adaptor.ex
@@ -97,6 +97,16 @@ defmodule Logflare.Backends.Adaptor do
     |> function_exported?(:map_query_parameters, 4)
   end
 
+  @doc """
+  Returns true if a provided `Backend` supports executing queries.
+  """
+  @spec can_query?(Backend.t()) :: boolean()
+  def can_query?(%Backend{} = backend) do
+    backend
+    |> get_adaptor()
+    |> function_exported?(:execute_query, 3)
+  end
+
   @callback start_link(source_backend()) ::
               {:ok, pid()} | :ignore | {:error, term()}
 
@@ -205,6 +215,7 @@ defmodule Logflare.Backends.Adaptor do
   @optional_callbacks ecto_to_sql: 2,
                       format_batch: 1,
                       format_batch: 2,
+                      execute_query: 3,
                       map_query_parameters: 4,
                       pre_ingest: 3,
                       test_connection: 1,

--- a/lib/logflare/backends/adaptor/datadog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/datadog_adaptor.ex
@@ -51,9 +51,6 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def cast_config(params) do
     {%{}, %{api_key: :string, region: :string}}
     |> Ecto.Changeset.cast(params, [:api_key, :region])

--- a/lib/logflare/backends/adaptor/elastic_adaptor.ex
+++ b/lib/logflare/backends/adaptor/elastic_adaptor.ex
@@ -50,9 +50,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def cast_config(params) do
     {%{}, %{url: :string, username: :string, password: :string}}
     |> Ecto.Changeset.cast(params, [:username, :password, :url])

--- a/lib/logflare/backends/adaptor/incidentio_adaptor.ex
+++ b/lib/logflare/backends/adaptor/incidentio_adaptor.ex
@@ -66,9 +66,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def transform_config(%_{config: config} = backend) do
     url = "https://api.incident.io/v2/alert_events/http/#{config[:alert_source_config_id]}"
 

--- a/lib/logflare/backends/adaptor/loki_adaptor.ex
+++ b/lib/logflare/backends/adaptor/loki_adaptor.ex
@@ -70,9 +70,6 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def transform_config(%_{config: config}) do
     basic_auth = Utils.encode_basic_auth(config)
 

--- a/lib/logflare/backends/adaptor/s3_adaptor.ex
+++ b/lib/logflare/backends/adaptor/s3_adaptor.ex
@@ -44,10 +44,6 @@ defmodule Logflare.Backends.Adaptor.S3Adaptor do
 
   @doc false
   @impl Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @doc false
-  @impl Adaptor
   def cast_config(%{} = params) do
     {%{},
      %{

--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -57,9 +57,6 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def cast_config(params) do
     {%{}, %{dsn: :string}}
     |> Ecto.Changeset.cast(params, [:dsn])

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -52,9 +52,6 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   end
 
   @impl Logflare.Backends.Adaptor
-  def execute_query(_ident, _query, _opts), do: {:error, :not_implemented}
-
-  @impl Logflare.Backends.Adaptor
   def validate_config(changeset) do
     changeset
     |> Ecto.Changeset.validate_required([:url])

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -6,6 +6,7 @@ defmodule LogflareWeb.EndpointsLive do
   require Logger
 
   alias Logflare.Backends
+  alias Logflare.Backends.Adaptor
   alias Logflare.Endpoints
   alias Logflare.Endpoints.PiiRedactor
   alias Logflare.Users
@@ -320,6 +321,7 @@ defmodule LogflareWeb.EndpointsLive do
     backends =
       if flag_enabled? do
         Backends.list_backends_by_user_id(user_id)
+        |> Enum.filter(&Adaptor.can_query?/1)
       else
         []
       end

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -288,13 +288,6 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
     end
   end
 
-  describe "execute_query/3" do
-    test "returns not implemented error" do
-      result = @subject.execute_query(nil, "SELECT 1", [])
-      assert {:error, :not_implemented} = result
-    end
-  end
-
   describe "redact_config/1" do
     test "redacts DSN secret key" do
       config = %{dsn: "https://public_key:secret_key@o123456.ingest.sentry.io/123456"}


### PR DESCRIPTION
Removes non-querying backends from the list of selectable backends by making the callback optional.