### PR TITLE
fix: monaco editor prevents scrolling

### DIFF
--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -201,7 +201,8 @@ defmodule LogflareWeb.MonacoEditorComponent do
         "scrollbar" => %{
           "vertical" => "auto",
           "horizontal" => "hidden",
-          "verticalScrollbarSize" => 6
+          "verticalScrollbarSize" => 6,
+          "alwaysConsumeMouseWheel" => false
         },
         "lineNumbers" => "off",
         "glyphMargin" => false,

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -58,7 +58,8 @@ defmodule LogflareWeb.QueryLive do
                 "scrollbar" => %{
                   "vertical" => "auto",
                   "horizontal" => "hidden",
-                  "verticalScrollbarSize" => 6
+                  "verticalScrollbarSize" => 6,
+                  "alwaysConsumeMouseWheel" => false
                 },
                 "lineNumbers" => "off",
                 "glyphMargin" => false,


### PR DESCRIPTION
Disables the Monaco editor scroll wheel event listener so the user can scroll the page.


https://github.com/user-attachments/assets/1f5863f5-ff3f-4d82-8d07-ed57273942e3

Closes ANL-1135