### PR TITLE
fix: table name formatting in query debugger

### DIFF
--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -30,6 +30,7 @@ defmodule LogflareWeb.QueryComponents do
       |> assign_new(:formatted_sql, fn ->
         {:ok, formatted} =
           Utils.sql_params_to_sql(assigns.sql_string, assigns.params)
+          |> prepare_table_name()
           |> SqlFmt.format_query()
 
         formatted
@@ -57,5 +58,15 @@ defmodule LogflareWeb.QueryComponents do
       <pre class="tw-flex-grow"><code class="sql"><%= @formatted_sql %></code></pre>
     </div>
     """
+  end
+
+  defp prepare_table_name(sql) do
+    Regex.replace(
+      ~r/`([^`]+)`\.([^\s]+)/,
+      sql,
+      fn _, project, rest ->
+        "`#{project}.#{rest}`"
+      end
+    )
   end
 end

--- a/test/logflare_web/components/query_components_test.exs
+++ b/test/logflare_web/components/query_components_test.exs
@@ -68,5 +68,22 @@ defmodule LogflareWeb.QueryComponentsTest do
 
       assert html =~ "3.14"
     end
+
+    test "ensures table names surrounded by backticks" do
+      [
+        "SELECT t0.timestamp, t0.id FROM `logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6` AS t0",
+        "SELECT t0.timestamp, t0.id FROM `logflare-dev-464423`.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6 AS t0"
+      ]
+      |> Enum.each(fn sql_string ->
+        html =
+          render_component(&QueryComponents.formatted_sql/1, %{
+            sql_string: sql_string,
+            params: []
+          })
+
+        assert html =~
+                 "`logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6`"
+      end)
+    end
   end
 end


### PR DESCRIPTION
BigQuery table names are[ stored with backticks embedded](https://github.com/Logflare/logflare/blob/8681bc4583a99f60a8c255da234f86911a683a65/lib/logflare/sources/source.ex#L279), which can cause formatting issues:

```elixir
iex> "`logflare-dev-464423`.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6" |> SqlFmt.format_query |> elem(1)
"`logflare-dev-464423`.1 _dev.9 db56741_41ca_4fe8_8c05_051a76a4c5d6"
```


This PR ensures that formatted SQL includes backticks around the table name.

<img width="2272" height="1376" alt="CleanShot 2025-10-13 at 20 46 13@2x" src="https://github.com/user-attachments/assets/69cd5f35-283a-48a9-aabb-d4cc31d7db58" />
