### PR TITLE
chore: add json handlers to the error view

### DIFF
--- a/lib/logflare_web/views/error_view.ex
+++ b/lib/logflare_web/views/error_view.ex
@@ -21,6 +21,22 @@ defmodule LogflareWeb.ErrorView do
     render("500_page.html", assigns)
   end
 
+  def render("401.json", _assigns) do
+    %{error: "Unauthorized"}
+  end
+
+  def render("403.json", _assigns) do
+    %{error: "Forbidden"}
+  end
+
+  def render("404.json", _assigns) do
+    %{error: "Not Found"}
+  end
+
+  def render("500.json", _assigns) do
+    %{error: "Internal Server Error"}
+  end
+
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/test/logflare_web/views/error_view_test.exs
+++ b/test/logflare_web/views/error_view_test.exs
@@ -32,4 +32,20 @@ defmodule LogflareWeb.ErrorViewTest do
     assert render_to_string(ErrorView, "500_page.html", conn: conn) =~ "500"
     assert render_to_string(ErrorView, "500_page.html", conn: conn) =~ "Server error"
   end
+
+  test "renders 401.json" do
+    assert render(ErrorView, "401.json", %{}) == %{error: "Unauthorized"}
+  end
+
+  test "renders 403.json" do
+    assert render(ErrorView, "403.json", %{}) == %{error: "Forbidden"}
+  end
+
+  test "renders 404.json" do
+    assert render(ErrorView, "404.json", %{}) == %{error: "Not Found"}
+  end
+
+  test "renders 500.json" do
+    assert render(ErrorView, "500.json", %{}) == %{error: "Internal Server Error"}
+  end
 end


### PR DESCRIPTION
Adds json handlers to `LogflareWeb.ErrorView` - which should return JSON bodies for API errors rather than HTML.

Generally this is more for JS/TS clients so they are not trying to parse non-JSON responses.