### PR TITLE
fix: clean up Monaco editor CSP errors

### DIFF
--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -37,7 +37,7 @@ defmodule LogflareWeb.Router do
            script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://buttons.github.io https://platform.twitter.com https://cdnjs.cloudflare.com https://js.stripe.com;\
            style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://api.github.com;\
            img-src 'self' data: https://*.googleusercontent.com https://www.gravatar.com https://avatars.githubusercontent.com https://platform.slack-edge.com;\
-           font-src 'self' https://use.fontawesome.com;\
+           font-src 'self' data: https://use.fontawesome.com https://cdn.jsdelivr.net;\
            frame-src 'self' https://platform.twitter.com https://install.cloudflareapps.com https://datastudio.google.com https://js.stripe.com https://www.youtube.com https://lookerstudio.google.com/;\
            """
          end).(),


### PR DESCRIPTION
Clean up some non-critical errors from the browser console. i don't think they were impacting users but prefer keeps the console clear of noise.

<img width="2024" height="66" alt="CleanShot 2025-10-29 at 11 42 25@2x" src="https://github.com/user-attachments/assets/aaee9a77-c1e6-46cc-a30b-25b2a1f8387b" />
