### PR TITLE
fix: duplicate id LiveView warning

### DIFF
--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -122,11 +122,11 @@ defmodule LogflareWeb.QueryLive do
                     </span>
                 <% end %>
 
-                <div class="modal fade" id={"modal-#{row_idx}-#{col_idx}"} data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+                <div class="modal fade" id={"modal-#{row_idx}-#{col_idx}"} data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby={"staticBackdropLabel-#{k}"} aria-hidden="true">
                   <div class="modal-dialog modal-xl">
                     <div class="modal-content">
                       <div class="modal-header">
-                        <h5 class="modal-title" id="staticBackdropLabel">{k}</h5>
+                        <h5 class="modal-title" id={"staticBackdropLabel-#{k}"}>{k}</h5>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                           <span aria-hidden="true">&times;</span>
                         </button>


### PR DESCRIPTION
Fixes LiveView warnings:

``` 
warning: Duplicate id found while testing LiveView: staticBackdropLabel

    <h5 class="modal-title" id="staticBackdropLabel">event_message</h5>
    <h5 class="modal-title" id="staticBackdropLabel">id</h5>
    <h5 class="modal-title" id="staticBackdropLabel">timestamp</h5>
    <h5 class="modal-title" id="staticBackdropLabel">ts</h5>


LiveView requires that all elements have unique ids, duplicate IDs will cause
undefined behavior at runtime, as DOM patching will not be able to target the correct
elements.
```