### PR TITLE
fix(ch): when selecting a list of fields, don't interpret it as an array

### DIFF
--- a/lib/logflare/ecto/clickhouse.ex
+++ b/lib/logflare/ecto/clickhouse.ex
@@ -423,6 +423,9 @@ defmodule Logflare.Ecto.ClickHouse do
       {k, v} ->
         [expr(v, sources, params, query), " AS " | Naming.quote_name(k)]
 
+      v when is_list(v) ->
+        Helpers.intersperse_map(v, ?,, &expr(&1, sources, params, query))
+
       v ->
         expr(v, sources, params, query)
     end)

--- a/test/logflare/ecto/clickhouse_test.exs
+++ b/test/logflare/ecto/clickhouse_test.exs
@@ -481,6 +481,19 @@ defmodule Logflare.Ecto.ClickHouseTest do
     end
   end
 
+  describe "list select handling" do
+    test "converts list select to multiple columns, not array literal" do
+      query = from(t in "logs", select: [t.timestamp, t.id, t.event_message])
+
+      assert {:ok, {sql, _params}} = ClickHouse.to_sql(query)
+
+      assert String.contains?(sql, ~s("timestamp"))
+      assert String.contains?(sql, ~s("id"))
+      assert String.contains?(sql, ~s("event_message"))
+      refute Regex.match?(~r/SELECT\s+\[.*"timestamp".*,.*"id".*,.*"event_message".*\]/, sql)
+    end
+  end
+
   describe "to_sql/2 with inline_params option" do
     test "inlines string parameters when inline_params: true" do
       query = from(t in "logs", where: t.message == ^"test", select: t)


### PR DESCRIPTION
`select(q, t, [t.a, t.b, t.c])` refers to selecting `a`, `b` and `c` columns, but it was being treated as an `[a, b, c]` array.