### PR TITLE
chore: change clickhouse ingestion column name back to `body`

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -365,7 +365,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
       end)
 
     opts = [
-      names: ["id", "payload", "timestamp"],
+      names: ["id", "body", "timestamp"],
       types: ["UUID", "String", "DateTime64(6)"]
     ]
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -73,7 +73,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
       """
       CREATE TABLE IF NOT EXISTS #{db_table_string} (
         `id` UUID,
-        `payload` String,
+        `body` String,
         `timestamp` DateTime64(6)
       )
       ENGINE = #{engine}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -160,12 +160,12 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.PipelineTest do
       {:ok, query_result} =
         ClickhouseAdaptor.execute_ch_read_query(
           backend,
-          "SELECT payload FROM #{table_name} ORDER BY timestamp DESC"
+          "SELECT body FROM #{table_name} ORDER BY timestamp DESC"
         )
 
       assert length(query_result) == 2
 
-      query_result = Enum.map(query_result, &Jason.decode!(&1["payload"]))
+      query_result = Enum.map(query_result, &Jason.decode!(&1["body"]))
 
       [first_row, second_row] = query_result
       assert first_row["event_message"] == "Another message"

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
@@ -152,7 +152,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.ProvisionerTest do
 
       column_names = Enum.map(columns, & &1["name"])
       assert "id" in column_names
-      assert "payload" in column_names
+      assert "body" in column_names
       assert "timestamp" in column_names
 
       id_column = Enum.find(columns, &(&1["name"] == "id"))

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -120,12 +120,12 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
         build(:log_event,
           source: source,
           message: "Test message 1",
-          body: %{"level" => "info", "user_id" => 123}
+          metadata: %{"level" => "info", "user_id" => 123}
         ),
         build(:log_event,
           source: source,
           message: "Test message 2",
-          body: %{"level" => "error", "user_id" => 456}
+          metadata: %{"level" => "error", "user_id" => 456}
         )
       ]
 
@@ -139,13 +139,13 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
       query_result =
         ClickhouseAdaptor.execute_ch_read_query(
           backend,
-          "SELECT payload FROM #{table_name} ORDER BY timestamp"
+          "SELECT body FROM #{table_name} ORDER BY timestamp"
         )
 
       assert {:ok, rows} = query_result
       assert length(rows) == 2
 
-      row_payloads = Enum.map(rows, &Jason.decode!(&1["payload"]))
+      row_payloads = Enum.map(rows, &Jason.decode!(&1["body"]))
 
       assert [%{"event_message" => "Test message 1"}, %{"event_message" => "Test message 2"}] =
                row_payloads

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -499,12 +499,12 @@ defmodule Logflare.SqlTest do
         build(:log_event,
           source: source,
           message: "Test message 1",
-          body: %{"value" => 10}
+          metadata: %{"value" => 10}
         ),
         build(:log_event,
           source: source,
           message: "Test message 2",
-          body: %{"value" => 20}
+          metadata: %{"value" => 20}
         )
       ]
 
@@ -514,9 +514,9 @@ defmodule Logflare.SqlTest do
       Process.sleep(200)
 
       cte_query =
-        "with src as (select payload from #{source.name}) select payload from src"
+        "with src as (select body from #{source.name}) select body from src"
 
-      consumer_query = "select payload from src"
+      consumer_query = "select body from src"
 
       assert {:ok, transformed} = Sql.transform(:ch_sql, {cte_query, consumer_query}, user)
       assert {:ok, results} = ClickhouseAdaptor.execute_query(backend, transformed, [])


### PR DESCRIPTION
Changes the clickhouse ingest schema back to `body` from `payload` as requested [here](https://github.com/Logflare/logflare/pull/2879#discussion_r2480442720)