### PR TITLE
fix: event context rendering for nil suggested fields

### DIFF
--- a/lib/logflare_web/live/search_live/event_context_component.ex
+++ b/lib/logflare_web/live/search_live/event_context_component.ex
@@ -198,7 +198,7 @@ defmodule LogflareWeb.SearchLive.EventContextComponent do
       |> String.split(",")
 
     suggested_keys =
-      source.suggested_keys
+      (source.suggested_keys || "")
       |> String.split(",")
       |> Enum.map(fn
         "m." <> suggested_field -> "metadata." <> suggested_field

--- a/test/logflare_web/live/search_live/event_context_component_test.exs
+++ b/test/logflare_web/live/search_live/event_context_component_test.exs
@@ -150,6 +150,23 @@ defmodule LogflareWeb.SearchLive.EventContextComponentTest do
                }
              ] = EventContextComponent.prepare_lql_rules(source, "user_id:1", timestamp)
     end
+
+    test "prepare_lql_rules/1 handles nil suggested_keys", %{
+      user: user,
+      schema: schema,
+      timestamp: timestamp
+    } do
+      source = insert(:source, user: user, suggested_keys: nil)
+      insert(:source_schema, source: source, bigquery_schema: schema)
+
+      assert [
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~U[2025-08-19 02:33:51Z], ~U[2025-08-21 02:33:51Z]]
+               }
+             ] = EventContextComponent.prepare_lql_rules(source, "", timestamp)
+    end
   end
 
   describe "supports legacy  partition types" do


### PR DESCRIPTION
```
      GenServer #PID<0.404165.0> terminating
** (FunctionClauseError) no function clause matching in String.split/3
    (elixir 1.17.3) lib/string.ex:489: String.split(nil, ",", [])
    (logflare 1.25.3) lib/logflare_web/live/search_live/event_context_component.ex:202: LogflareWeb.SearchLive.EventContextComponent.required_fields/1
    (logflare 1.25.3) lib/logflare_web/live/search_live/event_context_component.ex:62: LogflareWeb.SearchLive.EventContextComponent.prepare_lql_rules/3
    (logflare 1.25.3) lib/logflare_web/live/search_live/event_context_component.ex:28: LogflareWeb.SearchLive.EventContextComponent.update/2
    (phoenix_live_view 1.0.18) lib/phoenix_live_view/utils.ex:492: Phoenix.LiveView.Utils.maybe_call_update!/3
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (phoenix_live_view 1.0.18) lib/phoenix_live_view/diff.ex:694: anonymous fn/4 in Phoenix.LiveView.Diff.render_pending_components/6
    (telemetry 1.3.0) /app/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
```
bug when opening a context modal for a source with no suggested fields.