### PR TITLE
perf: reduce logs emitted on conflict resolution

### DIFF
--- a/lib/logflare/syn_event_handler.ex
+++ b/lib/logflare/syn_event_handler.ex
@@ -45,7 +45,7 @@ defmodule Logflare.SynEventHandler do
         Logger.debug(message)
       end
 
-      Logflare.Utils.try_to_stop_process(to_stop, :syn_resolve_kill)
+      Logflare.Utils.try_to_stop_process(to_stop, :shutdown, :syn_resolve_kill)
     end
 
     original

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -322,12 +322,12 @@ defmodule Logflare.Utils do
   Tries to stop a process gracefully. If it fails, it sends a signal to the process.
   """
   @spec try_to_stop_process(pid(), atom()) :: :ok | :noop
-  def try_to_stop_process(pid, signal \\ :shutdown) do
+  def try_to_stop_process(pid, signal \\ :shutdown, force_signal \\ :kill) do
     GenServer.stop(pid, signal, 5_000)
     :ok
   rescue
     _ ->
-      Process.exit(pid, signal)
+      Process.exit(pid, force_signal)
       :ok
   catch
     :exit, _ ->


### PR DESCRIPTION
Reduces logs emitted on syn conflict resolution, as now it is not attempting with a `:shutdown` reason on first try.