### PR TITLE
fix(sentry): Use json encoding when serializing maps/lists

### DIFF
--- a/lib/logflare/backends/adaptor/sentry_adaptor.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor.ex
@@ -205,12 +205,26 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor do
 
   defp to_sentry_value(value) do
     case value do
-      nil -> %{"value" => "", "type" => "string"}
-      v when is_binary(v) -> %{"value" => v, "type" => "string"}
-      v when is_boolean(v) -> %{"value" => v, "type" => "boolean"}
-      v when is_integer(v) -> %{"value" => v, "type" => "integer"}
-      v when is_float(v) -> %{"value" => v, "type" => "double"}
-      v -> %{"value" => inspect(v), "type" => "string"}
+      nil ->
+        %{"value" => "", "type" => "string"}
+
+      v when is_binary(v) ->
+        %{"value" => v, "type" => "string"}
+
+      v when is_boolean(v) ->
+        %{"value" => v, "type" => "boolean"}
+
+      v when is_integer(v) ->
+        %{"value" => v, "type" => "integer"}
+
+      v when is_float(v) ->
+        %{"value" => v, "type" => "double"}
+
+      v when is_map(v) or is_list(v) ->
+        %{"value" => Jason.encode!(v), "type" => "string"}
+
+      v ->
+        %{"value" => inspect(v), "type" => "string"}
     end
   end
 end

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -259,7 +259,15 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           float_field: 3.14,
           boolean_field: true,
           list_field: [1, 2, 3],
-          map_field: %{"nested" => "value"}
+          metadata: %{
+            "project" => "testing_123",
+            "level" => "info",
+            "region" => "us-west-1",
+            "context" => %{
+              "application" => "realtime",
+              "module" => "Elixir.Realtime.Telemetry.Logger"
+            }
+          }
         )
       ]
 
@@ -279,11 +287,12 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
       assert attributes["integer_field"] == %{"type" => "integer", "value" => 42}
       assert attributes["float_field"] == %{"type" => "double", "value" => 3.14}
       assert attributes["boolean_field"] == %{"type" => "boolean", "value" => true}
-      assert attributes["list_field"] == %{"type" => "string", "value" => "[1, 2, 3]"}
+      assert attributes["list_field"] == %{"type" => "string", "value" => "[1,2,3]"}
 
-      assert attributes["map_field"] == %{
+      assert attributes["metadata"] == %{
                "type" => "string",
-               "value" => "%{\"nested\" => \"value\"}"
+               "value" =>
+                 "{\"context\":{\"application\":\"realtime\",\"module\":\"Elixir.Realtime.Telemetry.Logger\"},\"level\":\"info\",\"project\":\"testing_123\",\"region\":\"us-west-1\"}"
              }
     end
   end


### PR DESCRIPTION
Previously we serialized maps and lists via `inspect`, which would mean the sentry backend couldn't parse it or pretty-print it (because it wasn't a regular json object).

This PR changes serializing map/list attributes to use `Jason.encode`. All other values still have `inspect` being called on it.