### PR TITLE
fix: make unlock schema button work on source edit view

### DIFF
--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -459,41 +459,6 @@ defmodule LogflareWeb.SourceController do
     render(conn, "show_rejected.html", logs: rejected_logs, source: source)
   end
 
-  def toggle_schema_lock(%{assigns: %{source: source}} = conn, _params) do
-    case Sources.update_source(source, %{lock_schema: !source.lock_schema}) do
-      {:ok, source} ->
-        msg = if source.lock_schema, do: "Schema locked!", else: "Schema unlocked!"
-
-        conn
-        |> put_flash(:info, msg)
-        |> redirect(to: Routes.source_path(conn, :edit, source.id))
-
-      {:error, _changeset} ->
-        conn
-        |> put_flash(:error, "Something went wrong. Please contact support if this continues!")
-        |> redirect(to: Routes.source_path(conn, :edit, source.id))
-    end
-  end
-
-  def toggle_schema_validation(%{assigns: %{source: source}} = conn, _params) do
-    case Sources.update_source(source, %{validate_schema: !source.validate_schema}) do
-      {:ok, source} ->
-        msg =
-          if source.validate_schema,
-            do: "Schema validation enabled!",
-            else: "Schema validation disabled!"
-
-        conn
-        |> put_flash(:info, msg)
-        |> redirect(to: Routes.source_path(conn, :edit, source.id))
-
-      {:error, _changeset} ->
-        conn
-        |> put_flash(:error, "Something went wrong. Please contact support if this continues!")
-        |> redirect(to: Routes.source_path(conn, :edit, source.id))
-    end
-  end
-
   defp get_and_encode_logs(%Source{} = source) do
     log_events = Backends.list_recent_logs(source)
 

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -207,14 +207,16 @@
   <%= section_header("Schema Lock") %>
   <p>Lock this source schema to keep it from updating automatically. Any new fields encountered during ingest will be ignored.
   </p>
-  <%= form_for @changeset, Routes.source_path(@conn, :toggle_schema_lock, @source), [method: :post], fn _f -> %>
+  <%= form_for @changeset, ~p"/sources/#{@source}/#schema-lock", [method: :patch], fn f -> %>
+    <%= hidden_input f, :lock_schema, value: !@source.lock_schema %>
     <%= submit "#{if @source.lock_schema, do: "Unlock", else: "Lock"} schema", class: "btn btn-primary form-button" %>
   <% end %>
 
   <%= section_header("Schema Validation") %>
   <p>Disable schema validation on ingest. Use this for high volume sources. Typically schema validation should be disabled for sources seeing >1,000 log events per second.
   </p>
-  <%= form_for @changeset, Routes.source_path(@conn, :toggle_schema_validation, @source), [method: :post], fn _f -> %>
+  <%= form_for @changeset, ~p"/sources/#{@source}/#schema-validation", [method: :patch], fn f -> %>
+    <%= hidden_input f, :validate_schema, value: !@source.validate_schema %>
     <%= submit "#{if @source.validate_schema, do: "Disable", else: "Enable"} schema validation", class: "btn btn-primary form-button" %>
   <% end %>
 


### PR DESCRIPTION
Likely something that recently broke `data-method` handlers as this button (_and two others on the same view_) were not reacting to clicks.

I just followed the pattern of the other working buttons by wrapping these in forms, but my concern is this behavior could be present in other places.

But this _should_ at least get us fixed for now on a schema unlock 🤞 