### PR TITLE
fix: legacy artifacts for :explorer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -175,4 +175,7 @@ config :mime, :types, %{
   "application/x-protobuf" => ["protobuf"]
 }
 
+# use legacy artifacts for users on older CPUs or virtualized environments without advanced CPU features
+config :explorer, use_legacy_artifacts: true
+
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/39933

This should not negatively impact performance as it is mostly used for s3 backend. Though it is used for storage write api, we are considering moving off it.