### PR TITLE
Don't update assets/package-lock.json in make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ setup: check-tools check-version-manager setup.node
 setup.node:
 	@echo -e "$(BOLD)$(BLUE)📦 Installing Node.js dependencies...$(NC)"
 	@echo ""
-	npm --prefix ./assets install
+	npm --prefix ./assets ci 
 	@echo ""
 
 reset:


### PR DESCRIPTION
Right now running `make setup` from https://github.com/Logflare/logflare/blob/main/DEVELOPMENT.md#setup-for-external-contributors results in `modified:   assets/package-lock.json` in `git status` since `npm install` doesn't just install the packages, it also attempts to update them.