### PR TITLE
fix: use existing backend database value in form if set

### DIFF
--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -211,7 +211,7 @@
           </div>
           <div class="form-group">
             {label(f_config, :database, "Database Name")}
-            {text_input(f_config, :database, class: "form-control", value: "default")}
+            {text_input(f_config, :database, class: "form-control", value: input_value(f_config, "database") || "default")}
             <small class="form-text text-muted">
               The ClickHouse database name where events will be stored.
             </small>


### PR DESCRIPTION
Fixes a UI bug where editing a backend would always set the database field to `default`

## Before
https://github.com/user-attachments/assets/65b3754d-326e-4884-9bc8-10d01c0dbd04

## After


https://github.com/user-attachments/assets/e698a186-c8f9-4b66-8acd-9df7ae0323db

