### PR TITLE
chore: Change clickhouse ingest table naming convention

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -344,14 +344,14 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
   end
 
   @doc """
-  Attempts to provision a new log ingest table, if it does not already exist.
+  Attempts to provision a new ingest table for a particular source, if it does not already exist.
   """
   @spec provision_ingest_table(source_backend_tuple()) ::
           {:ok, Ch.Result.t()} | {:error, Exception.t()}
   def provision_ingest_table({%Source{} = source, %Backend{} = backend}) do
     with table_name <- clickhouse_ingest_table_name(source),
          statement <-
-           QueryTemplates.create_log_ingest_table_statement(table_name,
+           QueryTemplates.create_ingest_table_statement(table_name,
              ttl_days: source.retention_days
            ) do
       execute_ch_query(backend, statement)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -9,9 +9,9 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
   @default_ttl_days 5
 
   @doc """
-  Default naming prefix for the log ingest table.
+  Default naming prefix for ingest tables.
   """
-  def default_table_name_prefix, do: "ingest_logs"
+  def default_table_name_prefix, do: "ingest"
 
   @doc """
   Generates a ClickHouse query statement to check that the user GRANTs include the needed permissions.
@@ -41,7 +41,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
   end
 
   @doc """
-  Generates a ClickHouse query statement to provision an ingest table for logs.
+  Generates a ClickHouse query statement to provision an ingest table.
 
   ###Options
 
@@ -50,8 +50,8 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplates do
   - `:ttl_days` - (Optional) Will add a TTL statement to the table creation query. Defaults to `5`. `nil` will disable the TTL.
 
   """
-  @spec create_log_ingest_table_statement(table :: String.t(), opts :: Keyword.t()) :: String.t()
-  def create_log_ingest_table_statement(table, opts \\ [])
+  @spec create_ingest_table_statement(table :: String.t(), opts :: Keyword.t()) :: String.t()
+  def create_ingest_table_statement(table, opts \\ [])
       when is_non_empty_binary(table) and is_list(opts) do
     database = Keyword.get(opts, :database)
     engine = Keyword.get(opts, :engine, @default_table_engine)

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/query_templates_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/query_templates_test.exs
@@ -17,10 +17,10 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
     end
   end
 
-  describe "create_log_ingest_table_statement/2" do
+  describe "create_ingest_table_statement/2" do
     test "Generates a valid statement when given a table name" do
       table_name = "foo"
-      statement = QueryTemplates.create_log_ingest_table_statement(table_name)
+      statement = QueryTemplates.create_ingest_table_statement(table_name)
 
       assert statement =~ "CREATE TABLE IF NOT EXISTS #{table_name}"
       assert statement =~ "TTL toDateTime(timestamp) + INTERVAL 5 DAY"
@@ -29,14 +29,14 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
     test "prefixes the database name to the table name" do
       database = "bar"
       table_name = "foo"
-      statement = QueryTemplates.create_log_ingest_table_statement(table_name, database: database)
+      statement = QueryTemplates.create_ingest_table_statement(table_name, database: database)
 
       assert statement =~ "CREATE TABLE IF NOT EXISTS #{database}.#{table_name}"
       assert statement =~ "TTL toDateTime(timestamp) + INTERVAL 5 DAY"
     end
 
     test "Defaults to using the `MergeTree` engine" do
-      statement = QueryTemplates.create_log_ingest_table_statement("foo")
+      statement = QueryTemplates.create_ingest_table_statement("foo")
 
       assert statement =~ "ENGINE = MergeTree"
     end
@@ -46,14 +46,14 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
       custom_engine = "ReplacingMergeTree"
 
       statement =
-        QueryTemplates.create_log_ingest_table_statement(table_name, engine: custom_engine)
+        QueryTemplates.create_ingest_table_statement(table_name, engine: custom_engine)
 
       assert statement =~ "ENGINE = #{custom_engine}"
     end
 
     test "Allows the TTL to be adjusted via opts" do
       table_name = "foo"
-      statement = QueryTemplates.create_log_ingest_table_statement(table_name, ttl_days: 10)
+      statement = QueryTemplates.create_ingest_table_statement(table_name, ttl_days: 10)
 
       assert statement =~ "CREATE TABLE IF NOT EXISTS #{table_name}"
       assert statement =~ "TTL toDateTime(timestamp) + INTERVAL 10 DAY"
@@ -61,7 +61,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
 
     test "Removes the TTL when `ttl_days` is set to nil" do
       table_name = "foo"
-      statement = QueryTemplates.create_log_ingest_table_statement(table_name, ttl_days: nil)
+      statement = QueryTemplates.create_ingest_table_statement(table_name, ttl_days: nil)
 
       assert statement =~ "CREATE TABLE IF NOT EXISTS #{table_name}"
       refute statement =~ "TTL"
@@ -69,7 +69,7 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor.QueryTemplatesTest do
 
     test "Removes the TTL when `ttl_days` is set to something other than a positive integer" do
       table_name = "foo"
-      statement = QueryTemplates.create_log_ingest_table_statement(table_name, ttl_days: "pizza")
+      statement = QueryTemplates.create_ingest_table_statement(table_name, ttl_days: "pizza")
 
       assert statement =~ "CREATE TABLE IF NOT EXISTS #{table_name}"
       refute statement =~ "TTL"

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -31,13 +31,13 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptorTest do
     test "`clickhouse_ingest_table_name/1` generates a unique log ingest table name based on the source token",
          %{source: source, stringified_source_token: stringified_source_token} do
       assert ClickhouseAdaptor.clickhouse_ingest_table_name(source) ==
-               "ingest_logs_#{stringified_source_token}"
+               "ingest_#{stringified_source_token}"
     end
 
     test "`clickhouse_ingest_table_name/1` will raise an exception if the table name is equal to or exceeds 200 chars",
          %{source: source} do
       assert_raise RuntimeError,
-                   ~r/^The dynamically generated ClickHouse resource name starting with `ingest_logs_/,
+                   ~r/^The dynamically generated ClickHouse resource name starting with `ingest_/,
                    fn ->
                      source
                      |> modify_source_with_long_token()


### PR DESCRIPTION
Switch from `ingest_logs_<source_token>` to `ingest_<source_token>`.

Note that this **will not** modify existing tables, but will provision a new one for any configured source going into ClickHouse.