### PR TITLE
Add mirror_image job to docker-retag workflow

### DIFF
--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -23,3 +23,29 @@ jobs:
     needs:
       - retag
     secrets: inherit
+
+  mirror_image:
+    runs-on: ubuntu-latest
+    needs:
+      - retag
+    steps:
+      - id: docker-image
+        run: |
+          tag="supabase/logflare:$(cat ./VERSION)"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: supabase
+          repositories: cli
+          skip-token-revoke: true
+      - name: Dispatch event to CLI repository
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: supabase/cli
+          event-type: mirror-image
+          client-payload: '{"image":"${{ steps.docker-image.outputs.tag }}"}'


### PR DESCRIPTION
Supabase CLI require docker images to be mirrored to ECR and GHCR. Since logflare repo is outside of supabase GitHub org, workflows running within this repo cannot upload to supabase ECR directly.

This PR implements a workaround by triggering repository_dispatch event. This allows logflare to run a workflow from CLI repo, hence obtaining valid credentials for ECR.