### PR TITLE
fix: <.team_link /> not rendering link in EEx template

### DIFF
--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -1,12 +1,12 @@
 <div class="subhead">
   <div class="container mx-auto">
-    <h5>~/logs/<.team_link href={Routes.source_path(@conn, :show, @source)} team={@team} class="text-primary">{@source.name}</.team_link>/edit</h5>
+    <h5>~/logs/<%= link @source.name, to: Routes.source_path(@conn, :show, @source) |> Utils.with_team_param(@team), class:  "text-primary" %>/edit</h5>
     <div class="log-settings">
       <ul>
         <li>
-          <.team_link navigate={Routes.source_live_path(@conn, LogflareWeb.Sources.RulesLive, @source.id)} team={@team}>
+          <%= link to: Routes.source_live_path(@conn, LogflareWeb.Sources.RulesLive, @source.id) |> Utils.with_team_param(@team) do %>
             <i class="fas fa-code-branch"></i><span class="hide-on-mobile"> rules</span>
-          </.team_link>
+        <% end %>
         </li>
         <li><a href="mailto:support@logflare.app?Subject=Logflare%20Help" target="_top"><i
               class="fas fa-question-circle"></i> <span class="hide-on-mobile">help</a></span></li>
@@ -19,7 +19,7 @@
   <%= section_header("Source Name") %>
   <p>For example, <code>YourApp</code> would be good for all logs from your app. <code>YourApp.bots</code> would be a
     good place to keep all bot logs. Route logs with LQL rules using
-    <.team_link navigate={Routes.source_live_path(@conn, LogflareWeb.Sources.RulesLive, @source.id)} team={@team}>rules</.team_link>.</p>
+    <%= link "rules", to: Routes.source_live_path(@conn, LogflareWeb.Sources.RulesLive, @source.id) |> Utils.with_team_param(@team) %>.</p>
   <%= form_for @changeset, Routes.source_path(@conn, :update, @source), fn a -> %>
   <div class="form-group">
     <%= text_input a, :name, placeholder: "YourApp.SourceName", class: "form-control form-control-margin" %>

--- a/lib/logflare_web/views/source_view.ex
+++ b/lib/logflare_web/views/source_view.ex
@@ -1,6 +1,7 @@
 defmodule LogflareWeb.SourceView do
   import LogflareWeb.Helpers.Forms
   alias LogflareWeb.Router.Helpers, as: Routes
+  alias LogflareWeb.Utils
   use LogflareWeb, :view
 
   def log_url(route) do


### PR DESCRIPTION
Fixes a link not rendering correctly in sources edit.  

The `<.team_link >` function component wasn't rendered when used in EEx template so switched it to `link/2`

* tried converting the template to HEEx but it has some DOM structure issues so this was quicker. 
* checked for other instances with `rg '<\.team_link' --glob '*.html.eex'` but found none.


### Before

<img width="2494" height="750" alt="CleanShot 2025-12-03 at 10 57 57@2x" src="https://github.com/user-attachments/assets/285a2189-f465-4185-a442-a56a9dd7b7cb" />


### After
  
<img width="2478" height="680" alt="CleanShot 2025-12-03 at 10 56 19@2x" src="https://github.com/user-attachments/assets/1fe62dfd-4911-408e-88e2-4b9cf43b1228" />
