### PR TITLE
chore: tweak canary deploy

### DIFF
--- a/cloudbuild/prod/deploy.yaml
+++ b/cloudbuild/prod/deploy.yaml
@@ -12,9 +12,9 @@ steps:
       - --project=logflare-232118
       - --zone=europe-west3-c
       - --type=proactive
-      - --max-surge=4
-      - --max-unavailable=1
-      - --min-ready=60
+      - --max-surge=2
+      - --max-unavailable=0
+      - --min-ready=90
       - --minimal-action=replace
       - --most-disruptive-allowed-action=replace
       - --replacement-method=substitute


### PR DESCRIPTION
tweak canary deployment to prevent cpu spiking when traffic shifts