### PR TITLE
perf: remove touch team user on login

### DIFF
--- a/lib/logflare/team_users.ex
+++ b/lib/logflare/team_users.ex
@@ -155,11 +155,6 @@ defmodule Logflare.TeamUsers do
     |> Repo.update()
   end
 
-  def touch_team_user(%TeamUser{} = team_user) do
-    from(t in TeamUser, select: t, where: t.id == ^team_user.id)
-    |> Repo.update_all(set: [updated_at: DateTime.utc_now()])
-  end
-
   @doc """
   Deletes a TeamUser.
 

--- a/lib/logflare/teams/team_context.ex
+++ b/lib/logflare/teams/team_context.ex
@@ -53,18 +53,8 @@ defmodule Logflare.Teams.TeamContext do
 
   defp do_resolve(%Team{} = team, %TeamUser{} = team_user) do
     user = team.user |> Logflare.Users.preload_defaults()
-
-    case TeamUsers.touch_team_user(team_user) do
-      {1, [touched]} ->
-        touched =
-          touched
-          |> TeamUsers.preload_defaults()
-
-        {:ok, %__MODULE__{user: user, team: team, team_user: touched}}
-
-      _ ->
-        {:error, :not_authorized}
-    end
+    team_user = TeamUsers.preload_defaults(team_user)
+    {:ok, %__MODULE__{user: user, team: team, team_user: team_user}}
   end
 
   defp do_resolve(%Team{} = team, %User{} = _user) do


### PR DESCRIPTION
Removes team_users touch on login, reducing wal events propagated throguhout clusters.