### PR TITLE
chore: reduce max surge for canary deploy

### DIFF
--- a/cloudbuild/prod/deploy.yaml
+++ b/cloudbuild/prod/deploy.yaml
@@ -12,7 +12,7 @@ steps:
       - --project=logflare-232118
       - --zone=europe-west3-c
       - --type=proactive
-      - --max-surge=2
+      - --max-surge=1
       - --max-unavailable=0
       - --min-ready=90
       - --minimal-action=replace


### PR DESCRIPTION
drops it to 1 max surge for a more conservative rolling deploy