### PR TITLE
fix: ensure arch tags available for manifest merge

### DIFF
--- a/.github/workflows/docker-base-runner-daily.yml
+++ b/.github/workflows/docker-base-runner-daily.yml
@@ -47,7 +47,9 @@ jobs:
         with:
           file: ./Dockerfile.base
           push: true
-          tags: supabase/logflare:base-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
+          tags: |
+            supabase/logflare:base-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
+            supabase/logflare:base-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -79,7 +81,9 @@ jobs:
         with:
           file: ./Dockerfile.runner
           push: true
-          tags: supabase/logflare:runner-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
+          tags: |
+            supabase/logflare:runner-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
+            supabase/logflare:runner-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
- Add per-architecture tags to base and runner Docker builds while keeping short SHA tags
- Ensure multi-arch manifest creation references tags pushed in the build steps

[Codex Task]: <> (https://chatgpt.com/codex/tasks/task_e_69325b388a2083308075bbaa4aa3cea1)
