### PR TITLE
fix: flaky shutdown idle sources test

### DIFF
--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -327,7 +327,9 @@ defmodule Logflare.SourcesTest do
 
       :ok = Sources.shutdown_idle_sources()
 
-      refute Backends.source_sup_started?(source)
+      TestUtils.retry_assert(fn ->
+        refute Backends.source_sup_started?(source)
+      end)
     end
 
     test "does NOT shut down sources with active ingest", %{source: source} do


### PR DESCRIPTION
- Wraps the idle source shutdown assertion in TestUtils.retry_assert to handle registry cleanup delays.

[Codex Task]: <> (https://chatgpt.com/codex/tasks/task_e_6912e42e94fc8330a8547317a981e16f)