### PR TITLE
fix: overriding of changeset changes

### DIFF
--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -290,7 +290,14 @@ defmodule Logflare.Sources.Source do
     errors
     |> Enum.uniq()
     |> Enum.reduce(changeset, fn {k, v}, cs -> add_error(cs, k, v) end)
-    |> put_change(:labels, normalized |> Enum.reverse() |> Enum.join(","))
+    |> then(fn
+      changeset when normalized == [] ->
+        changeset
+
+      changeset ->
+        changeset
+        |> put_change(:labels, normalized |> Enum.reverse() |> Enum.join(","))
+    end)
   end
 
   defp get_normalized_and_errors(labels) do

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -12,6 +12,21 @@ defmodule Logflare.SourcesTest do
   alias Logflare.Backends.SourceRegistry
   alias Logflare.Backends.SourceSup
 
+  describe "changesets" do
+    test "update_by_user_changeset" do
+      insert(:plan)
+      source = insert(:source, user: insert(:user), labels: "initial=label")
+
+      assert %Ecto.Changeset{changes: changes} = Source.update_by_user_changeset(source, %{})
+      assert changes == %{}
+
+      assert %Ecto.Changeset{changes: changes} =
+               Source.update_by_user_changeset(source, %{labels: "test=some_label"})
+
+      assert changes == %{labels: "test=some_label"}
+    end
+  end
+
   describe "create_source/2" do
     setup do
       user = insert(:user)

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -289,6 +289,28 @@ defmodule LogflareWeb.SourceControllerTest do
       assert conn.assigns.source.name == new_name
     end
 
+    test "able to update labels", %{conn: conn, users: [u1, _u2], sources: [s1, _s2 | _]} do
+      new_name = TestUtils.random_string()
+
+      params = %{
+        "id" => s1.id,
+        "source" => %{
+          "labels" => "test=some_label"
+        }
+      }
+
+      conn =
+        conn
+        |> login_user(u1)
+        |> patch(~p"/sources/#{s1}", params)
+
+      s1_new = Sources.get_by(token: s1.token)
+
+      assert html_response(conn, 302) =~ "redirected"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Source updated!"
+      assert s1_new.labels == "test=some_label"
+    end
+
     test "returns 406 with invalid params", %{
       conn: conn,
       users: [u1, _u2],


### PR DESCRIPTION
Closes ANL-1259

label is correctly set in db, but changeest validation will set the changes to empty string on edit template load.