### PR TITLE
migration to remove system sources with a type of `rejected_events`

### DIFF
--- a/priv/repo/migrations/20251205181853_remove_rejected_event_system_sources.exs
+++ b/priv/repo/migrations/20251205181853_remove_rejected_event_system_sources.exs
@@ -1,0 +1,11 @@
+defmodule Logflare.Repo.Migrations.RemoveRejectedEventSystemSources do
+  use Ecto.Migration
+
+  def up do
+    execute("DELETE FROM sources WHERE system_source_type = 'rejected_events'")
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
This is needed to align with changes to the Ecto enum in #3012
