### PR TITLE
adjustments to increase batch size/reduce parallel queries for clickhouse pipelines

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -20,8 +20,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @producer_concurrency 1
   @processor_concurrency 5
-  @batcher_concurrency 3
-  @batch_size 5_000
+  @batcher_concurrency 10
+  @batch_size 10_000
   @batch_timeout 4_000
   @max_retries 1
 


### PR DESCRIPTION
Changes the batcher concurrency from 10 -> 3 and increases the batch timeout to 4s.

This _should_ bring our batches more in-line with the size that ClickHouse wants as well as reducing some of the parallel queries, which are also causing some negative effects on CH.