### PR TITLE
chore: support lf-prefixed headers

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -424,11 +424,11 @@ if System.get_env("LOGFLARE_OTEL_ENDPOINT") do
     otlp_endpoint: System.get_env("LOGFLARE_OTEL_ENDPOINT"),
     otlp_compression: :gzip,
     otlp_headers: [
-      {"x-source", System.get_env("LOGFLARE_OTEL_SOURCE_UUID")},
-      {"x-api-key", System.get_env("LOGFLARE_OTEL_ACCESS_TOKEN")}
+      {"lf-source", System.get_env("LOGFLARE_OTEL_SOURCE_UUID")},
+      {"lf-api-key", System.get_env("LOGFLARE_OTEL_ACCESS_TOKEN")}
     ],
     max_batch_size: 250
-end
+  end
 
 syn_endpoints_partitions =
   for n <- 0..System.schedulers_online(), do: "endpoints_#{n}" |> String.to_atom()

--- a/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
+++ b/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
@@ -40,11 +40,16 @@ To revoke access tokens, clikc on the **Revoke** button. This would immediately 
 
 ## Authentication
 
-There are 3 supported methods to attach an accees token with an API request:
+There are 4 supported methods to attach an access token with an API request:
 
 1. Using the `Authorization` header, with the format `Authorization: Bearer your-access-token-here`
-2. Using the `X-API-KEY` header, with the format `X-API-KEY: your-access-token-here`
-3. Using the `api_key` query parameter, wuth the format `?api_key=your-access-token-here`
+2. Using the `LF-API-KEY` header, with the format `LF-API-KEY: your-access-token-here`
+3. Using the `X-API-KEY` header, with the format `X-API-KEY: your-access-token-here`
+4. Using the `api_key` query parameter, with the format `?api_key=your-access-token-here`
+
+:::warning Header prefix update
+`X-API-KEY` is supported for backward compatibility only and will be removed in the next major version. Prefer the `LF-API-KEY` header for new integrations.
+:::
 
 ## Client-side is Public
 

--- a/docs/docs.logflare.com/docs/concepts/index.mdx
+++ b/docs/docs.logflare.com/docs/concepts/index.mdx
@@ -68,15 +68,19 @@ Logflare provides a fully featured [querying interface](./concepts/ingestion#que
 
    Replace `YOUR-SOURCE-ID-HERE` and `YOUR-API-KEY-HERE` placeholders with the values from step 2.
 
-   ```bash
-   curl -X "POST" "https://api.logflare.app/logs/json?source=YOUR-SOURCE-ID-HERE" \
-           -H 'Content-Type: application/json; charset=utf-8' \
-           -H 'X-API-KEY: YOUR-API-KEY-HERE' \
-           -d $'[{
-           "message": "This is the main event message",
-           "metadata": {"some": "log event"}
-       }]'
-   ```
+    ```bash
+    curl -X "POST" "https://api.logflare.app/logs/json?source=YOUR-SOURCE-ID-HERE" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -H 'LF-API-KEY: YOUR-API-KEY-HERE' \
+            -d $'[{ 
+            "message": "This is the main event message",
+            "metadata": {"some": "log event"}
+        }]'
+    ```
+
+:::warning Header prefix update
+`X-API-KEY` remains available for backwards compatibility but is deprecated and will be removed in the next major version. Prefer the `LF-API-KEY` header going forward.
+:::
 
 4. **Check the Source**
 

--- a/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
+++ b/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
@@ -306,7 +306,7 @@ The supported spec is [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/c
 ```
 POST https://api.logflare.app/api/logs/cloud-event?source=f6cccd3a-c42e-40f7-9b01-95d3699d3113
 Content-Type: application/json
-X-API-KEY: XXXXX
+LF-API-KEY: XXXXX
 CE-specversion: 1.0
 CE-id: 01HPPC9X0HPKB8E1RSPA5YFZB2
 CE-source: flyd
@@ -339,6 +339,10 @@ The corresponding event will be processed and ingested, where ellipsis represent
 }
 ```
 
+:::warning Header prefix update
+`X-API-KEY` remains available for backward compatibility but is deprecated and will be removed in the next major version. Prefer sending access tokens with the `LF-API-KEY` header.
+:::
+
 ## Cloudflare Logpush
 
 Logflare supports ingestion of logs from Cloudflare through the [**Logpush API**](https://developers.cloudflare.com/logs/about/). This allows you to send logs directly from Cloudflare to Logflare for processing and storage.
@@ -346,12 +350,16 @@ Logflare supports ingestion of logs from Cloudflare through the [**Logpush API**
 To ingest logs from Cloudflare, use the following configuration for the [HTTP Destination](https://developers.cloudflare.com/logs/get-started/enable-destinations/http/):
 
 ```text
-https://api.logflare.app/api/logs/cloudflare?source=f6cccd3a-c42e-40f7-9b01-95d3699d3113&header_X_API_KEY=xxxxxxx
+https://api.logflare.app/api/logs/cloudflare?source=f6cccd3a-c42e-40f7-9b01-95d3699d3113&header_lf-api-key=xxxxxxx
 ```
 
 Replace the source UUID and the api key value with your own source UUID and [access token](/concepts/access-tokens/). We recommend using a source-scoped ingest access token for better security.
 
 The configuration is identical for both Logpush and Edge Log Delivery.
+
+:::warning Cloudflare header deprecation
+`header_X_API_KEY` is still accepted for Cloudflare destinations but will be removed in the next major version. Update configurations to use `header_lf-api-key`.
+:::
 
 ## Ingestion Validation
 

--- a/docs/docs.logflare.com/docs/integrations/open-telemetry/index.mdx
+++ b/docs/docs.logflare.com/docs/integrations/open-telemetry/index.mdx
@@ -37,8 +37,8 @@ Supported ingestion formats:
     {otlp_compression, gzip},
     {otlp_endpoint, "https://otel.logflare.app:443"},
     {otlp_headers, [
-      {"x-source", "my-source-id"},
-      {"x-api-key", "my-access-token"}
+      {"lf-source", "my-source-id"},
+      {"lf-api-key", "my-access-token"}
     ]}
   ]}
 ].
@@ -58,8 +58,8 @@ config :opentelemetry_exporter,
   otlp_compression: :gzip,
   otlp_endpoint: "https://otel.logflare.app:443",
   otlp_headers: [
-    {"x-source", "my-source-uuid"},
-    {"x-api-key", "my-access-token"}
+    {"lf-source", "my-source-uuid"},
+    {"lf-api-key", "my-access-token"}
   ]
 ```
 
@@ -77,8 +77,12 @@ docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d db logfl
 docker compose -f docker-compose.yml -f docker-compose.pg.yml -f docker-compose.latest.yml up -d db logflare
 ```
 
-1. Create a new source to populate the `x-source` header with the source UUID.
-2. Use the api-key found in `.docker.env` and set it to `x-api-key` header
+:::warning Header prefix update
+`x-source` and `x-api-key` are deprecated and will be removed in the next major version. Use `lf-source` and `lf-api-key` instead.
+:::
+
+1. Create a new source to populate the `lf-source` header with the source UUID.
+2. Use the api-key found in `.docker.env` and set it to `lf-api-key` header
 3. Set the otlp endpoint to `http://localhost:50051`
 4. Start your OpenTelemetry instrumented app.
 

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -263,7 +263,7 @@ defmodule Logflare.Utils do
       fn
         {[key | _], value}
         when is_binary(value) and
-               key in ["authorization", "x-api-key", "Authorization", "X-API-Key"] ->
+               key in ["authorization", "lf-api-key", "x-api-key", "Authorization", "LF-API-Key", "X-API-Key"] ->
           "REDACTED"
 
         self ->

--- a/lib/logflare_grpc/interceptors/verify_api_resource_access.ex
+++ b/lib/logflare_grpc/interceptors/verify_api_resource_access.ex
@@ -45,6 +45,9 @@ defmodule LogflareGrpc.Interceptors.VerifyApiResourceAccess do
       %{"authorization" => "Bearer " <> token} ->
         {:ok, token}
 
+      %{"lf-api-key" => token} ->
+        {:ok, token}
+
       %{"x-api-key" => token} ->
         {:ok, token}
 
@@ -59,6 +62,9 @@ defmodule LogflareGrpc.Interceptors.VerifyApiResourceAccess do
 
   defp fetch_source_id(stream) do
     case GRPC.Stream.get_headers(stream) do
+      %{"lf-source" => source_uuid} ->
+        {:ok, source_uuid}
+
       %{"x-collection" => source_uuid} ->
         {:ok, source_uuid}
 

--- a/lib/logflare_web/controllers/plugs/fetch_resource.ex
+++ b/lib/logflare_web/controllers/plugs/fetch_resource.ex
@@ -104,7 +104,8 @@ defmodule LogflareWeb.Plugs.FetchResource do
   defp uuid?(_), do: false
 
   def get_source_from_headers(conn) do
-    (Plug.Conn.get_req_header(conn, "x-source") ||
+    (Plug.Conn.get_req_header(conn, "lf-source") ||
+       Plug.Conn.get_req_header(conn, "x-source") ||
        Plug.Conn.get_req_header(conn, "x-collection"))
     |> case do
       [value] -> value

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -113,8 +113,17 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
 
     api_key =
       conn
-      |> Plug.Conn.get_req_header("x-api-key")
-      |> List.first(Utils.Map.get(conn.params, :api_key))
+      |> Plug.Conn.get_req_header("lf-api-key")
+      |> List.first()
+      |> case do
+        nil ->
+          conn
+          |> Plug.Conn.get_req_header("x-api-key")
+          |> List.first(Utils.Map.get(conn.params, :api_key))
+
+        api_key ->
+          api_key
+      end
 
     cond do
       bearer != nil -> {:ok, bearer}


### PR DESCRIPTION
- Accept lf-api-key and lf-source headers for HTTP and gRPC ingestion while keeping x- headers as deprecated fallbacks.
- Update OTLP exporter defaults and sensitive header redaction to prefer lf- prefixed names.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693269bf1c44833082c870812dffe724)