### PR TITLE
fix: skip nil slack adaptor event values

### DIFF
--- a/lib/logflare/backends/adaptor/slack_adaptor.ex
+++ b/lib/logflare/backends/adaptor/slack_adaptor.ex
@@ -152,14 +152,12 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
 
   def to_rich_text_preformatted(%{} = row) do
     row
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Enum.sort_by(fn {k, _} -> k end)
     |> Enum.map_intersperse([line_break()], fn {k, v} ->
       v_str = stringify(v)
 
       cond do
-        v == nil ->
-          []
-
         is_number(v) and String.length(v_str) == 16 ->
           # convert to timestamp
           {:ok, dt} = DateTime.from_unix(v, :microsecond)
@@ -195,6 +193,9 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
     %{type: "text", text: v}
   end
 
+  defp stringify(nil), do: nil
+  defp stringify(v) when is_binary(v), do: v
+
   defp stringify(v) when is_integer(v) do
     Integer.to_string(v)
   end
@@ -204,5 +205,5 @@ defmodule Logflare.Backends.Adaptor.SlackAdaptor do
   end
 
   defp stringify(%{} = v), do: Jason.encode!(v)
-  defp stringify(v), do: v
+  defp stringify(v), do: inspect(v)
 end

--- a/test/logflare/backends/adaptor/slack_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/slack_adaptor_test.exs
@@ -206,6 +206,16 @@ defmodule Logflare.Backends.SlackAdaptorTest do
     assert [] = SlackAdaptor.to_rich_text_preformatted(%{"123" => nil})
   end
 
+  test "to_rich_text_preformatted/1 skips nil event values" do
+    assert [%{text: "message:"}, %{text: " "}, %{text: "ok"}] =
+             SlackAdaptor.to_rich_text_preformatted(%{"message" => "ok", "status" => nil})
+  end
+
+  test "to_rich_text_preformatted/1 with non-string values" do
+    assert [%{text: "status:"}, %{text: " "}, %{text: ":ok"}] =
+             SlackAdaptor.to_rich_text_preformatted(%{"status" => :ok})
+  end
+
   test "to_rich_text_preformatted/1 with maps" do
     assert [%{text: "123:"}, %{text: " "}, %{text: "{\"test\":\"test\"}"}] =
              SlackAdaptor.to_rich_text_preformatted(%{"123" => %{"test" => "test"}})


### PR DESCRIPTION
- skip nil Slack adaptor entries before rich text formatting to avoid empty separators
- add regression coverage ensuring nil event fields are ignored


Closes ANL-40