### PR TITLE
fix: race condition for finch pool metrics collection on startup

### DIFF
--- a/lib/logflare/system_metrics/cluster.ex
+++ b/lib/logflare/system_metrics/cluster.ex
@@ -33,7 +33,8 @@ defmodule Logflare.SystemMetrics.Cluster do
           Logflare.FinchDefault,
           Logflare.FinchIngest,
           Logflare.FinchQuery
-        ] do
+        ],
+        GenServer.whereis(pool) != nil do
       case Finch.get_pool_status(pool, url) do
         {:ok, metrics} ->
           counts =

--- a/test/logflare/system_metrics/cluster_test.exs
+++ b/test/logflare/system_metrics/cluster_test.exs
@@ -1,0 +1,19 @@
+defmodule Logflare.SystemMetrics.ClusterTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  alias Logflare.SystemMetrics.Cluster
+
+  describe "finch/0" do
+    test "does not raise when pool is not available" do
+      capture_log(fn ->
+        GenServer.stop(Logflare.FinchDefault)
+        GenServer.stop(Logflare.FinchIngest)
+        GenServer.stop(Logflare.FinchQuery)
+        assert Cluster.finch()
+
+        Process.sleep(100)
+      end) =~ ":gen_statem"
+    end
+  end
+end


### PR DESCRIPTION
Fixes ArgumentError

```
supabase-analytics  | 12:58:35.619 [error] Error when calling MFA defined by measurement: Logflare.SystemMetrics.Cluster :finch []
supabase-analytics  | Class=:error
supabase-analytics  | Reason=%ArgumentError{message: "unknown registry: Logflare.FinchIngest"}
supabase-analytics  | Stacktrace=[
supabase-analytics  |   {Registry, :key_info!, 1, [file: ~c"lib/registry.ex", line: 1400]},
supabase-analytics  |   {Registry, :lookup, 2, [file: ~c"lib/registry.ex", line: 590]},
supabase-analytics  |   {Finch.PoolManager, :lookup_pool, 2,
supabase-analytics  |    [file: ~c"lib/finch/pool_manager.ex", line: 51]},
supabase-analytics  |   {Finch.PoolManager, :get_pool, 3,
supabase-analytics  |    [file: ~c"lib/finch/pool_manager.ex", line: 39]},
supabase-analytics  |   {Finch, :get_pool_status, 2, [file: ~c"lib/finch.ex", line: 652]},
supabase-analytics  |   {Logflare.SystemMetrics.Cluster, :"-finch/0-fun-3-", 3,
supabase-analytics  |    [file: ~c"lib/logflare/system_metrics/cluster.ex", line: 37]},
supabase-analytics  |   {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: ~c"lib/enum.ex", line: 2531]},
supabase-analytics  |   {Logflare.SystemMetrics.Cluster, :finch, 0,
supabase-analytics  |    [file: ~c"lib/logflare/system_metrics/cluster.ex", line: 24]}
supabase-analytics  | ]
```