### PR TITLE
fix: admin check

### DIFF
--- a/lib/logflare/admin.ex
+++ b/lib/logflare/admin.ex
@@ -3,7 +3,6 @@ defmodule Logflare.Admin do
   require Logger
 
   alias Logflare.Repo
-  alias Logflare.Users
   alias Logflare.User
   alias Logflare.Teams.Team
   alias Logflare.TeamUsers.TeamUser
@@ -27,7 +26,8 @@ defmodule Logflare.Admin do
     {:ok, task}
   end
 
-  def is_admin?(email) when is_binary(email) do
+  @spec admin?(String.t() | nil) :: boolean()
+  def admin?(email) when is_binary(email) do
     from(u in User,
       left_join: t in Team,
       on: t.user_id == u.id,
@@ -43,5 +43,5 @@ defmodule Logflare.Admin do
     end
   end
 
-  def is_admin?(_), do: false
+  def admin?(_), do: false
 end

--- a/lib/logflare_web/controllers/plugs/check_admin.ex
+++ b/lib/logflare_web/controllers/plugs/check_admin.ex
@@ -13,7 +13,7 @@ defmodule LogflareWeb.Plugs.CheckAdmin do
   def call(conn, _params) do
     email = Plug.Conn.get_session(conn, :current_email)
 
-    if Admin.is_admin?(email) do
+    if Admin.admin?(email) do
       conn
       |> assign(:admin, true)
     else

--- a/test/logflare/admin_test.exs
+++ b/test/logflare/admin_test.exs
@@ -1,30 +1,25 @@
 defmodule Logflare.AdminTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Sources
-  alias Logflare.User
-  alias Logflare.Users
   alias Logflare.Admin
 
   setup do
     insert(:plan)
-    user = insert(:user)
-
-    {:ok, user: user}
+    :ok
   end
 
-  test "is_admin?/1" do
+  test "admin?/1" do
     user = insert(:user, admin: true)
     home_team = insert(:team, user: user)
     other_user = insert(:user)
     team_user = insert(:team_user, email: "some@other_email.com", team: home_team)
     other_team_user = insert(:team_user)
 
-    assert Admin.is_admin?(user.email)
-    assert Admin.is_admin?(team_user.email)
+    assert Admin.admin?(user.email)
+    assert Admin.admin?(team_user.email)
 
-    refute Admin.is_admin?("invalid@email.com")
-    refute Admin.is_admin?(other_user.email)
-    refute Admin.is_admin?(other_team_user.email)
+    refute Admin.admin?("invalid@email.com")
+    refute Admin.admin?(other_user.email)
+    refute Admin.admin?(other_team_user.email)
   end
 end


### PR DESCRIPTION
properly fixes admin checks, verified fixed with an invited user with home team, is able to navigate and search accounts without needing team query param to be set.