### PR TITLE
perf: remove telemetry event and size check from QueueJanitor

### DIFF
--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -52,18 +52,8 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
   # expose for benchmarking
   def do_drop(state, metrics) do
     sid_bid = {state.source_id, state.backend_id}
-    # safety measure, drop all if still exceed
-    queues = IngestEventQueue.list_queues(sid_bid)
 
-    :telemetry.execute(
-      [:logflare, :backends, :ingest_event_queue, :queue_janitor],
-      %{length: length(queues)},
-      %{source_id: state.source_id, backend_id: state.backend_id}
-    )
-
-    for {_sid, bid, pid} = sid_bid_pid <- queues,
-        size = IngestEventQueue.get_table_size(sid_bid_pid),
-        is_integer(size) do
+    for {_sid, bid, pid} = sid_bid_pid <- IngestEventQueue.list_queues(sid_bid) do
       if metrics.avg > 100 or bid != nil do
         IngestEventQueue.truncate_table(sid_bid_pid, :ingested, 0)
       else


### PR DESCRIPTION
Remove unnecessary telemetry event and size check

split from #3063  