### PR TITLE
perf: benchmark for otel metrics

### DIFF
--- a/test/profiling/otel_metric_bench.exs
+++ b/test/profiling/otel_metric_bench.exs
@@ -242,7 +242,7 @@ Benchee.run(
   %{
     "handle_batch" => fn resource_metrics ->
       OtelMetric.handle_batch(resource_metrics, source)
-    end,
+    end
   },
   inputs: %{
     "mixed (5 each x 1kdp)" => mixed_5m_1kdp


### PR DESCRIPTION
```
##### With input mixed (5 each x 1kdp) #####
Name                           ips        average  deviation         median         99th %
handle_batch (merge)          8.35      119.75 ms    ±15.68%      118.93 ms      167.52 ms

Memory usage statistics:

Name                    Memory usage
handle_batch (merge)        64.28 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                         average  deviation         median         99th %
handle_batch (merge)          4.94 M     ±0.84%         4.92 M         5.01 M
```