### PR TITLE
fix: bad pattern matches on reducers in ingest event queue

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -189,13 +189,13 @@ defmodule Logflare.Backends.IngestEventQueue do
     reducer =
       if check_queue_size do
         fn
-          {{{:consolidated, _, nil}, _tid}, _}, acc -> acc
+          {{:consolidated, _, nil}, _}, acc -> acc
           {_obj, count}, acc when count >= @max_queue_size -> acc
           {obj, _count}, acc -> [obj | acc]
         end
       else
         fn
-          {{{:consolidated, _, nil}, _tid}, _}, acc -> acc
+          {{:consolidated, _, nil}, _}, acc -> acc
           {obj, _count}, acc -> [obj | acc]
         end
       end
@@ -254,13 +254,13 @@ defmodule Logflare.Backends.IngestEventQueue do
     reducer =
       if check_queue_size do
         fn
-          {{{_, _, nil}, _tid}, _}, acc -> acc
+          {{_, _, nil}, _}, acc -> acc
           {_obj, count}, acc when count >= @max_queue_size -> acc
           {obj, _count}, acc -> [obj | acc]
         end
       else
         fn
-          {{{_, _, nil}, _tid}, _}, acc -> acc
+          {{_, _, nil}, _}, acc -> acc
           {obj, _count}, acc -> [obj | acc]
         end
       end


### PR DESCRIPTION
I found this gap while going through PR #3088 and PR #3089 again this morning.

So in PR #3069 - we introduced `IngestEventQueue.list_counts_with_tids/1` and some reducer patterns that used the results from that function like `{{sid_bid_pid, tid}, size}`.
The next day in PR #3065 - we changed the return of `list_counts_with_tids/1` to `{table_key, size}`, but did not update the reducer patterns. I then built upon those reducer patterns for the consolidated pipeline efforts.

This PR aligns the reducer patterns with the current return shape of `{table_key, size}`