### PR TITLE
feat: use recharts

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -1,13 +1,22 @@
-import $ from "jquery";
 import React from "react";
 import { DateTime } from "luxon";
-import { ResponsiveBarCanvas } from "@nivo/bar";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
 
 import { BarLoader } from "react-spinners";
 
 const brandLightBlack = "#1d1d1d";
 const brandGray = "#9a9a9a";
 const brandGreen = "#5eeb8f";
+const chartGridLineColor = "rgba(255,255,255,0.08)";
+const chartHorizontalPoints = [20, 33, 45, 58, 70, 83, 95, 108, 120];
 
 const warnColor = "#f1ba58";
 const criticalColor = "#bd1550";
@@ -19,27 +28,23 @@ const noticeColor = "#03C03C";
 const infoColor = "#5eeb8f";
 const secondInfoColor = "#6286db";
 
-const theme = {
-  grid: {
-    line: {
-      stroke: brandLightBlack,
-      strokeWidth: 2,
-      strokeDasharray: "4 4",
-    },
-  },
-};
-
-const renderDefaultTooltip = ({ value, color, indexValue }) => {
+const renderDefaultTooltip = ({ active, payload, label }) => {
+  if (!active || !payload || !payload.length) return null;
+  const value = payload[0].value;
+  const color = payload[0].fill;
   return (
     <div style={{ backgroundColor: brandLightBlack, padding: "6px" }}>
-      <strong style={{ color }}>Timestamp: {indexValue}</strong>
+      <strong style={{ color }}>Timestamp: {label}</strong>
       <br />
       <strong style={{ color }}>Value: {value}</strong>
     </div>
   );
 };
 
-const renderCfStatusCodeTooltip = ({ data, color }) => {
+const renderCfStatusCodeTooltip = ({ active, payload }) => {
+  if (!active || !payload || !payload.length) return null;
+  const data = payload[0]?.payload;
+  if (!data) return null;
   return (
     <div style={{ backgroundColor: brandLightBlack, padding: "6px" }}>
       <strong style={{ color: brandGray }}>Timestamp: {data.timestamp}</strong>
@@ -61,7 +66,10 @@ const renderCfStatusCodeTooltip = ({ data, color }) => {
   );
 };
 
-const renderElixirLoggerTooltip = ({ data, color }) => {
+const renderElixirLoggerTooltip = ({ active, payload }) => {
+  if (!active || !payload || !payload.length) return null;
+  const data = payload[0]?.payload;
+  if (!data) return null;
   const tooltips = [
     { c: brandGray, p: "timestamp", t: "Timestamp" },
     { c: brandGray, p: "total", t: "Total" },
@@ -77,14 +85,14 @@ const renderElixirLoggerTooltip = ({ data, color }) => {
   ];
   return (
     <div style={{ backgroundColor: brandLightBlack, padding: "6px" }}>
-      {tooltips.map(({ c: color, p: property, t }) => {
-        return [
+      {tooltips.map(({ c: color, p: property, t }, index) => (
+        <React.Fragment key={property}>
           <strong style={{ color }}>
             {t}: {data[property]}
-          </strong>,
-          <br />,
-        ];
-      })}
+          </strong>
+          {index < tooltips.length - 1 && <br />}
+        </React.Fragment>
+      ))}
     </div>
   );
 };
@@ -94,9 +102,7 @@ const tooltipFactory = (dataShape) => {
     case "elixir_logger_levels":
       return renderElixirLoggerTooltip;
     case "cloudflare_status_codes":
-      return renderCfStatusCodeTooltip;
     case "vercel_status_codes":
-      return renderCfStatusCodeTooltip;
     case "netlify_status_codes":
       return renderCfStatusCodeTooltip;
     default:
@@ -108,19 +114,16 @@ const chartSettings = (type) => {
   switch (type) {
     case "elixir_logger_levels":
       return {
-        colors: ({ id }) => {
-          const color = {
-            level_info: infoColor,
-            level_error: errorColor,
-            level_warn: warnColor,
-            level_debug: debugColor,
-            level_critical: criticalColor,
-            level_notice: noticeColor,
-            level_alert: alertColor,
-            level_emergency: emergencyColor,
-            other: brandGray,
-          }[id];
-          return color || brandGray;
+        colors: {
+          level_info: infoColor,
+          level_error: errorColor,
+          level_warn: warnColor,
+          level_debug: debugColor,
+          level_critical: criticalColor,
+          level_notice: noticeColor,
+          level_alert: alertColor,
+          level_emergency: emergencyColor,
+          other: brandGray,
         },
         keys: [
           "level_info",
@@ -136,81 +139,37 @@ const chartSettings = (type) => {
       };
 
     case "cloudflare_status_codes":
-      return {
-        colors: ({ id }) => {
-          const color = {
-            status_5xx: errorColor,
-            status_4xx: warnColor,
-            status_3xx: secondInfoColor,
-            status_2xx: infoColor,
-            status_1xx: debugColor,
-            other: brandGray,
-          }[id];
-          return color || brandGray;
-        },
-        keys: [
-          "status_5xx",
-          "status_4xx",
-          "status_3xx",
-          "status_2xx",
-          "status_1xx",
-          "other",
-        ],
-      };
-
     case "netlify_status_codes":
-      return {
-        colors: ({ id }) => {
-          const color = {
-            status_5xx: errorColor,
-            status_4xx: warnColor,
-            status_3xx: secondInfoColor,
-            status_2xx: infoColor,
-            status_1xx: debugColor,
-            other: brandGray,
-          }[id];
-          return color || brandGray;
-        },
-        keys: [
-          "status_5xx",
-          "status_4xx",
-          "status_3xx",
-          "status_2xx",
-          "status_1xx",
-          "other",
-        ],
-      };
-
     case "vercel_status_codes":
       return {
-        colors: ({ id }) => {
-          const color = {
-            status_5xx: errorColor,
-            status_4xx: warnColor,
-            status_3xx: secondInfoColor,
-            status_2xx: infoColor,
-            status_1xx: debugColor,
-            other: brandGray,
-          }[id];
-          return color || brandGray;
+        colors: {
+          status_5xx: errorColor,
+          status_4xx: warnColor,
+          status_3xx: secondInfoColor,
+          status_2xx: infoColor,
+          status_1xx: debugColor,
+          other: brandGray,
         },
         keys: [
-          "status_5xx",
-          "status_4xx",
-          "status_3xx",
           "status_2xx",
           "status_1xx",
+          "status_3xx",
+          "status_4xx",
+          "status_5xx",
           "other",
         ],
       };
+
     default:
       return {
-        colors: (_) => infoColor,
+        colors: { value: infoColor },
         keys: ["value"],
       };
   }
 };
+
 const periods = ["day", "hour", "minute", "second"];
+
 const LogEventsChart = ({
   data,
   loading,
@@ -220,9 +179,10 @@ const LogEventsChart = ({
   pushEvent,
 }) => {
   const tz = userTz || "Etc/UTC";
-  const onClick = (event) => {
+  const triggerTimeSearch = (utcDatetime) => {
+    if (!utcDatetime) return;
+
     pushEvent("soft_pause", {});
-    const utcDatetime = event.data.datetime;
 
     const start = DateTime.fromISO(utcDatetime, { zone: tz }).toISO({
       includeOffset: false,
@@ -245,7 +205,17 @@ const LogEventsChart = ({
       period: newPeriod,
     });
   };
-  const renderTooltip = tooltipFactory(chartDataShapeId);
+
+  const handleBarClick = (entry) => {
+    const payload = entry?.payload;
+    if (!payload) return;
+    const utcDatetime = payload.datetime || payload.timestamp;
+    triggerTimeSearch(utcDatetime);
+  };
+
+  const TooltipContent = tooltipFactory(chartDataShapeId);
+  const settings = chartSettings(chartDataShapeId);
+
   return (
     <div
       style={{
@@ -267,25 +237,38 @@ const LogEventsChart = ({
           />
         </div>
       ) : (
-        <ResponsiveBarCanvas
-          data={data}
-          margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
-          padding={0.3}
-          enableGridY={true}
-          indexBy={"timestamp"}
-          tooltip={renderTooltip}
-          axisTop={null}
-          axisRight={null}
-          axisBottom={null}
-          axisLeft={null}
-          enableLabel={false}
-          animate={true}
-          onClick={onClick}
-          motionStiffness={90}
-          motionDamping={15}
-          theme={theme}
-          {...chartSettings(chartDataShapeId)}
-        />
+        <ResponsiveContainer width="100%" height={100}>
+          <BarChart
+            data={data}
+            margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
+            style={{ cursor: "pointer" }}
+          >
+            <CartesianGrid
+              stroke={chartGridLineColor}
+              strokeWidth={1}
+              horizontalPoints={chartHorizontalPoints}
+              vertical={false}
+            />
+            <XAxis dataKey="timestamp" hide={true} />
+            <YAxis hide={true} />
+            <Tooltip
+              isAnimationActive={false}
+              wrapperStyle={{ zIndex: 500 }}
+              content={<TooltipContent />}
+              cursor={{ fill: "rgba(255,255,255,0.05)" }}
+            />
+            {settings.keys.map((key) => (
+              <Bar
+                key={key}
+                dataKey={key}
+                stackId="stack"
+                fill={settings.colors[key]}
+                isAnimationActive={false}
+                onClick={handleBarClick}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
       )}
     </div>
   );

--- a/assets/js/admin_dashboard_charts.jsx
+++ b/assets/js/admin_dashboard_charts.jsx
@@ -1,29 +1,28 @@
-import React from "react"
-import { ResponsiveBarCanvas } from "@nivo/bar"
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
 
-const brandLightBlack = "#1d1d1d"
-const brandGreen = "#5eeb8f"
+const brandLightBlack = "#1d1d1d";
+const brandGreen = "#5eeb8f";
 
-const theme = {
-  grid: {
-    line: {
-      stroke: brandLightBlack,
-      strokeWidth: 2,
-      strokeDasharray: "4 4",
-    },
-  },
-  axis: { ticks: { text: { fill: brandGreen } } },
-}
-
-const renderDefaultTooltip = ({ value, color, indexValue }) => {
+const DefaultTooltipContent = ({ active, payload, label }) => {
+  if (!active || !payload || !payload.length) return null;
+  const total = payload.reduce((sum, entry) => sum + (entry.value || 0), 0);
   return (
     <div style={{ backgroundColor: brandLightBlack }}>
-      <strong style={{ color }}>Timestamp: {indexValue}</strong>
+      <strong style={{ color: brandGreen }}>Timestamp: {label}</strong>
       <br />
-      <strong style={{ color }}>Value: {value}</strong>
+      <strong style={{ color: brandGreen }}>Value: {total}</strong>
     </div>
-  )
-}
+  );
+};
 
 const Chart = ({ data, keys }) => {
   return (
@@ -32,25 +31,36 @@ const Chart = ({ data, keys }) => {
         height: 200,
       }}
     >
-      <ResponsiveBarCanvas
-        data={data}
-        margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
-        padding={0.3}
-        enableGridY={true}
-        keys={keys}
-        indexBy={"timestamp"}
-        tooltip={renderDefaultTooltip}
-        axisTop={null}
-        axisRight={null}
-        axisBottom={null}
-        enableLabel={false}
-        motionStiffness={90}
-        motionDamping={15}
-        theme={theme}
-        colors={(_) => brandGreen}
-      />
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart
+          data={data}
+          margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
+        >
+          <CartesianGrid
+            strokeDasharray="4 4"
+            stroke={brandLightBlack}
+            strokeWidth={2}
+            vertical={false}
+          />
+          <XAxis dataKey="timestamp" hide={true} />
+          <YAxis tick={{ fill: brandGreen }} />
+          <Tooltip
+            content={<DefaultTooltipContent />}
+            cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          />
+          {keys.map((key) => (
+            <Bar
+              key={key}
+              dataKey={key}
+              stackId="stack"
+              fill={brandGreen}
+              isAnimationActive={true}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
     </div>
-  )
-}
+  );
+};
 
-export default Chart
+export default Chart;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -46,7 +46,7 @@
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "3.3.4"
+      "version": "4.3.0"
     },
     "../deps/phoenix_live_react": {
       "version": "0.4.2",
@@ -2973,6 +2973,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6104,6 +6105,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,8 +7,6 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.8.2",
-        "@nivo/bar": "^0.99.0",
-        "@nivo/core": "^0.99.0",
         "bootstrap": "^4.6.0",
         "bootstrap-select": "^1.13.12",
         "clipboard": "^2.0.4",
@@ -27,7 +25,8 @@
         "react": "^18.00.0",
         "react-bootstrap": "^1.6.6",
         "react-dom": "^18.00.0",
-        "react-spinners": "^0.17.0"
+        "react-spinners": "^0.17.0",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.13",
@@ -102,7 +101,8 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.3.tgz",
       "integrity": "sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==",
       "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -609,310 +609,6 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
-    "node_modules/@nivo/annotations": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
-      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/annotations/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/axes": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
-      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.99.0",
-        "@nivo/scales": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-format": "^1.4.1",
-        "@types/d3-time-format": "^2.3.1",
-        "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/axes/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/bar": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.99.0.tgz",
-      "integrity": "sha512-9yfMn7H6UF/TqtCwVZ/vihVAXUff9wWvSaeF2Z1DCfgr5S07qs31Qb2p0LZA+YgCWpaU7zqkeb3VZ4WCpZbrDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/annotations": "0.99.0",
-        "@nivo/axes": "0.99.0",
-        "@nivo/canvas": "0.99.0",
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/legends": "0.99.0",
-        "@nivo/scales": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@nivo/tooltip": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-shape": "^3.1.6",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.2.0",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/bar/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/canvas": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/canvas/-/canvas-0.99.0.tgz",
-      "integrity": "sha512-UxA8zb+NPwqmNm81hoyUZSMAikgjU1ukLf4KybVNyV8ejcJM+BUFXsb8DxTcLdt4nmCFHqM56GaJQv2hnAHmzg==",
-      "license": "MIT"
-    },
-    "node_modules/@nivo/colors": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
-      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@types/d3-color": "^3.0.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-scale-chromatic": "^3.0.0",
-        "d3-color": "^3.1.0",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/core": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
-      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/theming": "0.99.0",
-        "@nivo/tooltip": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "react-virtualized-auto-sizer": "^1.0.26",
-        "use-debounce": "^10.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
-      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/legends": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
-      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@types/d3-scale": "^4.0.8",
-        "d3-scale": "^4.0.2"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/scales": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
-      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-time": "^1.1.1",
-        "@types/d3-time-format": "^3.0.0",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-time": "^1.0.11",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
-      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
-      "license": "MIT"
-    },
-    "node_modules/@nivo/text": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
-      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/text/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nivo/theming": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
-      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/tooltip": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
-      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-      }
-    },
-    "node_modules/@nivo/tooltip/node_modules/@react-spring/web": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/core": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1278,61 +974,41 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@react-spring/animated": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.3.tgz",
-      "integrity": "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==",
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@react-spring/core": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.3.tgz",
-      "integrity": "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==",
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
       "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "url": "https://opencollective.com/immer"
       }
-    },
-    "node_modules/@react-spring/rafz": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.3.tgz",
-      "integrity": "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/shared": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.3.tgz",
-      "integrity": "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/rafz": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@react-spring/types": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.3.tgz",
-      "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==",
-      "license": "MIT"
     },
     "node_modules/@restart/context": {
       "version": "2.1.4",
@@ -1353,16 +1029,34 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -1389,12 +1083,6 @@
         "@types/d3-time": "*"
       }
     },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
@@ -1405,15 +1093,15 @@
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
-      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-time-format": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
-      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/invariant": {
@@ -1427,13 +1115,12 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
+      "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -1444,10 +1131,11 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -1577,7 +1265,6 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "peer": true,
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -1628,7 +1315,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -1647,7 +1333,8 @@
       "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
       "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
       "dev": true,
-      "license": "MIT/X11"
+      "license": "MIT/X11",
+      "peer": true
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
@@ -1732,6 +1419,15 @@
         "tiny-emitter": "^2.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1755,7 +1451,8 @@
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -1799,21 +1496,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -1824,85 +1510,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
       "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/d3-time": {
       "version": "1.1.0",
@@ -1919,6 +1540,15 @@
         "d3-time": "1 - 2"
       }
     },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -1930,6 +1560,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/delegate": {
       "version": "3.2.0",
@@ -2009,6 +1645,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
@@ -2016,7 +1662,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2089,6 +1734,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -2310,6 +1961,16 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
@@ -2451,8 +2112,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2847,7 +2507,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -2973,7 +2632,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3017,7 +2675,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3058,7 +2715,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3095,6 +2751,29 @@
       "peerDependencies": {
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-spinners": {
@@ -3143,6 +2822,57 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -3204,6 +2934,7 @@
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3242,6 +2973,7 @@
       "integrity": "sha512-Hf2burRA/y5PGxsg6jB9UpoK/xZ6g/pgrkOcdl6j+rRg1Zj8XhGKZ1MTysZGtTPUUmiiErqzkP5+Kzp95yv9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
         "buffer-builder": "^0.2.0",
@@ -3294,6 +3026,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3311,6 +3044,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3328,6 +3062,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3345,6 +3080,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3362,6 +3098,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3379,6 +3116,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3396,6 +3134,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3413,6 +3152,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3430,6 +3170,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3447,6 +3188,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3464,6 +3206,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3481,6 +3224,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3498,6 +3242,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3515,6 +3260,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3532,6 +3278,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3549,6 +3296,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3566,6 +3314,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3583,6 +3332,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3600,6 +3350,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3617,6 +3368,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3627,6 +3379,7 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3922,6 +3675,7 @@
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sync-message-port": "^1.0.0"
       },
@@ -3935,6 +3689,7 @@
       "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4014,6 +3769,12 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4037,7 +3798,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/uncontrollable": {
       "version": "7.2.1",
@@ -4088,16 +3850,13 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/use-debounce": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
-      "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 16.0.0"
-      },
       "peerDependencies": {
-        "react": "*"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4111,7 +3870,103 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -4247,7 +4102,8 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.3.tgz",
       "integrity": "sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -4490,247 +4346,6 @@
         }
       }
     },
-    "@nivo/annotations": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
-      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
-      "requires": {
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        }
-      }
-    },
-    "@nivo/axes": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
-      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
-      "requires": {
-        "@nivo/core": "0.99.0",
-        "@nivo/scales": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-format": "^1.4.1",
-        "@types/d3-time-format": "^2.3.1",
-        "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        }
-      }
-    },
-    "@nivo/bar": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.99.0.tgz",
-      "integrity": "sha512-9yfMn7H6UF/TqtCwVZ/vihVAXUff9wWvSaeF2Z1DCfgr5S07qs31Qb2p0LZA+YgCWpaU7zqkeb3VZ4WCpZbrDA==",
-      "requires": {
-        "@nivo/annotations": "0.99.0",
-        "@nivo/axes": "0.99.0",
-        "@nivo/canvas": "0.99.0",
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/legends": "0.99.0",
-        "@nivo/scales": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@nivo/tooltip": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-shape": "^3.1.6",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.2.0",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        }
-      }
-    },
-    "@nivo/canvas": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/canvas/-/canvas-0.99.0.tgz",
-      "integrity": "sha512-UxA8zb+NPwqmNm81hoyUZSMAikgjU1ukLf4KybVNyV8ejcJM+BUFXsb8DxTcLdt4nmCFHqM56GaJQv2hnAHmzg=="
-    },
-    "@nivo/colors": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
-      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
-      "requires": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@types/d3-color": "^3.0.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-scale-chromatic": "^3.0.0",
-        "d3-color": "^3.1.0",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "@nivo/core": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
-      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
-      "requires": {
-        "@nivo/theming": "0.99.0",
-        "@nivo/tooltip": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "react-virtualized-auto-sizer": "^1.0.26",
-        "use-debounce": "^10.0.4"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        },
-        "react-virtualized-auto-sizer": {
-          "version": "1.0.26",
-          "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
-          "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
-          "requires": {}
-        }
-      }
-    },
-    "@nivo/legends": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
-      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
-      "requires": {
-        "@nivo/colors": "0.99.0",
-        "@nivo/core": "0.99.0",
-        "@nivo/text": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@types/d3-scale": "^4.0.8",
-        "d3-scale": "^4.0.2"
-      }
-    },
-    "@nivo/scales": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
-      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
-      "requires": {
-        "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-time": "^1.1.1",
-        "@types/d3-time-format": "^3.0.0",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-time": "^1.0.11",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@types/d3-time-format": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
-          "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
-        }
-      }
-    },
-    "@nivo/text": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
-      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
-      "requires": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        }
-      }
-    },
-    "@nivo/theming": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
-      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
-      "requires": {
-        "lodash": "^4.17.21"
-      }
-    },
-    "@nivo/tooltip": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
-      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
-      "requires": {
-        "@nivo/core": "0.99.0",
-        "@nivo/theming": "0.99.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
-      },
-      "dependencies": {
-        "@react-spring/web": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
-          "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
-          "requires": {
-            "@react-spring/animated": "~10.0.3",
-            "@react-spring/core": "~10.0.3",
-            "@react-spring/shared": "~10.0.3",
-            "@react-spring/types": "~10.0.3"
-          }
-        }
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4886,43 +4501,25 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
-    "@react-spring/animated": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.3.tgz",
-      "integrity": "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==",
+    "@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
       "requires": {
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+          "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="
+        }
       }
-    },
-    "@react-spring/core": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.3.tgz",
-      "integrity": "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==",
-      "requires": {
-        "@react-spring/animated": "~10.0.3",
-        "@react-spring/shared": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      }
-    },
-    "@react-spring/rafz": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.3.tgz",
-      "integrity": "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg=="
-    },
-    "@react-spring/shared": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.3.tgz",
-      "integrity": "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==",
-      "requires": {
-        "@react-spring/rafz": "~10.0.3",
-        "@react-spring/types": "~10.0.3"
-      }
-    },
-    "@react-spring/types": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.3.tgz",
-      "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ=="
     },
     "@restart/context": {
       "version": "2.1.4",
@@ -4938,15 +4535,30 @@
         "dequal": "^2.0.2"
       }
     },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
+    "@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
     "@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
-    "@types/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA=="
+    "@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "@types/d3-interpolate": {
       "version": "3.0.4",
@@ -4969,11 +4581,6 @@
         "@types/d3-time": "*"
       }
     },
-    "@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="
-    },
     "@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
@@ -4983,14 +4590,14 @@
       }
     },
     "@types/d3-time": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
-      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
-    "@types/d3-time-format": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
-      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg=="
+    "@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "@types/invariant": {
       "version": "2.2.35",
@@ -5003,13 +4610,11 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
+      "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "@types/react-transition-group": {
@@ -5020,10 +4625,10 @@
         "@types/react": "*"
       }
     },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    "@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -5103,7 +4708,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
       "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
-      "peer": true,
       "requires": {}
     },
     "bootstrap-select": {
@@ -5135,7 +4739,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
       "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -5147,7 +4750,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
       "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "camelcase-css": {
       "version": "2.0.1",
@@ -5202,6 +4806,11 @@
         "tiny-emitter": "^2.0.0"
       }
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5221,7 +4830,8 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "commander": {
       "version": "4.1.1",
@@ -5253,79 +4863,24 @@
       "dev": true
     },
     "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
-    },
-    "d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "requires": {
-        "internmap": "1 - 2"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
     "d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
       "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
-    },
-    "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "requires": {
-        "d3-color": "1 - 3"
-      }
-    },
-    "d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
-    },
-    "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "dependencies": {
-        "d3-time": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-          "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-          "requires": {
-            "d3-array": "2 - 3"
-          }
-        }
-      }
-    },
-    "d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "requires": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      }
-    },
-    "d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "requires": {
-        "d3-path": "^3.1.0"
-      }
     },
     "d3-time": {
       "version": "1.1.0",
@@ -5340,10 +4895,20 @@
         "d3-time": "1 - 2"
       }
     },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
     "date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "delegate": {
       "version": "3.2.0",
@@ -5410,12 +4975,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="
+    },
     "esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
       "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.25.0",
         "@esbuild/android-arm": "0.25.0",
@@ -5471,6 +5040,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -5631,6 +5205,11 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
+    "immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="
+    },
     "immutable": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
@@ -5736,8 +5315,7 @@
     "jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "peer": true
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6031,7 +5609,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -6105,7 +5682,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6131,7 +5707,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -6164,7 +5739,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6193,6 +5767,15 @@
         "prop-types": "^15.7.2",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
+      }
+    },
+    "react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "requires": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "react-spinners": {
@@ -6230,6 +5813,40 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "requires": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      }
+    },
+    "redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "requires": {}
+    },
+    "reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
+    },
     "resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -6261,6 +5878,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -6305,6 +5923,7 @@
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.83.4.tgz",
       "integrity": "sha512-Hf2burRA/y5PGxsg6jB9UpoK/xZ6g/pgrkOcdl6j+rRg1Zj8XhGKZ1MTysZGtTPUUmiiErqzkP5+Kzp95yv9GQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@bufbuild/protobuf": "^2.0.0",
         "buffer-builder": "^0.2.0",
@@ -6341,6 +5960,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -6352,140 +5972,160 @@
       "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.83.4.tgz",
       "integrity": "sha512-9Z4pJAOgEkXa3VDY/o+U6l5XvV0mZTJcSl0l/mSPHihjAHSpLYnOW6+KOWeM8dxqrsqTYcd6COzhanI/a++5Gw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-android-arm64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.83.4.tgz",
       "integrity": "sha512-tgX4FzmbVqnQmD67ZxQDvI+qFNABrboOQgwsG05E5bA/US42zGajW9AxpECJYiMXVOHmg+d81ICbjb0fsVHskw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-android-ia32": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.83.4.tgz",
       "integrity": "sha512-RsFOziFqPcfZXdFRULC4Ayzy9aK6R6FwQ411broCjlOBX+b0gurjRadkue3cfUEUR5mmy0KeCbp7zVKPLTK+5Q==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-android-riscv64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.83.4.tgz",
       "integrity": "sha512-EHwh0nmQarBBrMRU928eTZkFGx19k/XW2YwbPR4gBVdWLkbTgCA5aGe8hTE6/1zStyx++3nDGvTZ78+b/VvvLg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-android-x64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.83.4.tgz",
       "integrity": "sha512-0PgQNuPWYy1jEOEPDVsV89KfqOsMLIp9CSbjBY7jRcwRhyVAcigqrUG6bDeNtojHUYKA1kU+Eh/85WxOHUOgBw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-darwin-arm64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.83.4.tgz",
       "integrity": "sha512-rp2ywymWc3nymnSnAFG5R/8hvxWCsuhK3wOnD10IDlmNB7o4rzKby1c+2ZfpQGowlYGWsWWTgz8FW2qzmZsQRw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-darwin-x64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.83.4.tgz",
       "integrity": "sha512-kLkN2lXz9PCgGfDS8Ev5YVcl/V2173L6379en/CaFuJJi7WiyPgBymW7hOmfCt4uO4R1y7CP2Uc08DRtZsBlAA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-arm": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.83.4.tgz",
       "integrity": "sha512-nL90ryxX2lNmFucr9jYUyHHx21AoAgdCL1O5Ltx2rKg2xTdytAGHYo2MT5S0LIeKLa/yKP/hjuSvrbICYNDvtA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-arm64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.83.4.tgz",
       "integrity": "sha512-E0zjsZX2HgESwyqw31EHtI39DKa7RgK7nvIhIRco1d0QEw227WnoR9pjH3M/ZQy4gQj3GKilOFHM5Krs/omeIA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-ia32": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.83.4.tgz",
       "integrity": "sha512-ew5HpchSzgAYbQoriRh8QhlWn5Kw2nQ2jHoV9YLwGKe3fwwOWA0KDedssvDv7FWnY/FCqXyymhLd6Bxae4Xquw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-musl-arm": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.83.4.tgz",
       "integrity": "sha512-0RrJRwMrmm+gG0VOB5b5Cjs7Sd+lhqpQJa6EJNEaZHljJokEfpE5GejZsGMRMIQLxEvVphZnnxl6sonCGFE/QQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-musl-arm64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.83.4.tgz",
       "integrity": "sha512-IzMgalf6MZOxgp4AVCgsaWAFDP/IVWOrgVXxkyhw29fyAEoSWBJH4k87wyPhEtxSuzVHLxKNbc8k3UzdWmlBFg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-musl-ia32": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.83.4.tgz",
       "integrity": "sha512-LLb4lYbcxPzX4UaJymYXC+WwokxUlfTJEFUv5VF0OTuSsHAGNRs/rslPtzVBTvMeG9TtlOQDhku1F7G6iaDotA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-musl-riscv64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.83.4.tgz",
       "integrity": "sha512-zoKlPzD5Z13HKin1UGR74QkEy+kZEk2AkGX5RelRG494mi+IWwRuWCppXIovor9+BQb9eDWPYPoMVahwN5F7VA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-musl-x64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.83.4.tgz",
       "integrity": "sha512-hB8+/PYhfEf2zTIcidO5Bpof9trK6WJjZ4T8g2MrxQh8REVtdPcgIkoxczRynqybf9+fbqbUwzXtiUao2GV+vQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-riscv64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.83.4.tgz",
       "integrity": "sha512-83fL4n+oeDJ0Y4KjASmZ9jHS1Vl9ESVQYHMhJE0i4xDi/P3BNarm2rsKljq/QtrwGpbqwn8ujzOu7DsNCMDSHA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-linux-x64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.83.4.tgz",
       "integrity": "sha512-NlnGdvCmTD5PK+LKXlK3sAuxOgbRIEoZfnHvxd157imCm/s2SYF/R28D0DAAjEViyI8DovIWghgbcqwuertXsA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-win32-arm64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.83.4.tgz",
       "integrity": "sha512-J2BFKrEaeSrVazU2qTjyQdAk+MvbzJeTuCET0uAJEXSKtvQ3AzxvzndS7LqkDPbF32eXAHLw8GVpwcBwKbB3Uw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-win32-ia32": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.83.4.tgz",
       "integrity": "sha512-uPAe9T/5sANFhJS5dcfAOhOJy8/l2TRYG4r+UO3Wp4yhqbN7bggPvY9c7zMYS0OC8tU/bCvfYUDFHYMCl91FgA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "sass-embedded-win32-x64": {
       "version": "1.83.4",
       "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.83.4.tgz",
       "integrity": "sha512-C9fkDY0jKITdJFij4UbfPFswxoXN9O/Dr79v17fJnstVwtUojzVJWKHUXvF0Zg2LIR7TCc4ju3adejKFxj7ueA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "scheduler": {
       "version": "0.23.2",
@@ -6674,6 +6314,7 @@
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "sync-message-port": "^1.0.0"
       }
@@ -6682,7 +6323,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz",
       "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "tailwindcss": {
       "version": "3.4.10",
@@ -6748,6 +6390,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6767,7 +6414,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uncontrollable": {
       "version": "7.2.1",
@@ -6796,10 +6444,10 @@
         "picocolors": "^1.0.0"
       }
     },
-    "use-debounce": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
-      "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "requires": {}
     },
     "util-deprecate": {
@@ -6812,7 +6460,80 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "dev": true
+      "dev": true,
+      "peer": true
+    },
+    "victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "requires": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+          "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        },
+        "d3-interpolate": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+          "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+          "requires": {
+            "d3-color": "1 - 3"
+          }
+        },
+        "d3-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+          "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+        },
+        "d3-scale": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+          "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+          "requires": {
+            "d3-array": "2.10.0 - 3",
+            "d3-format": "1 - 3",
+            "d3-interpolate": "1.2.0 - 3",
+            "d3-time": "2.1.1 - 3",
+            "d3-time-format": "2 - 4"
+          }
+        },
+        "d3-shape": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+          "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+          "requires": {
+            "d3-path": "^3.1.0"
+          }
+        },
+        "d3-time": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+          "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+          "requires": {
+            "d3-array": "2 - 3"
+          }
+        }
+      }
     },
     "warning": {
       "version": "4.0.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,8 +7,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.8.2",
-    "@nivo/bar": "^0.99.0",
-    "@nivo/core": "^0.99.0",
     "bootstrap": "^4.6.0",
     "bootstrap-select": "^1.13.12",
     "clipboard": "^2.0.4",
@@ -27,7 +25,8 @@
     "react": "^18.00.0",
     "react-bootstrap": "^1.6.6",
     "react-dom": "^18.00.0",
-    "react-spinners": "^0.17.0"
+    "react-spinners": "^0.17.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -11,7 +11,7 @@ defmodule LogflareWeb.AdminController do
 
   require Logger
 
-  @page_size 5
+  @page_size 50
   @accounts_sort_options [
     :inserted_at,
     :updated_at

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -11,7 +11,7 @@ defmodule LogflareWeb.AdminController do
 
   require Logger
 
-  @page_size 50
+  @page_size 5
   @accounts_sort_options [
     :inserted_at,
     :updated_at


### PR DESCRIPTION
Replaces nivo with recharts for rendering search page charts. 

I've attempted to match the design of the existing charts as much as possible but there are minor differences.

https://github.com/user-attachments/assets/bb0c3ec7-37b2-4466-bd29-e14eca2647e5


## Fixes toast (tooltip) notifications cut off (ANL-1136)

This also fixes a bug where tooltips on the right edge of the chart would be rendered outside the browser frame.

### Before

<img width="586" height="940" alt="CleanShot 2026-01-22 at 11 46 23@2x" src="https://github.com/user-attachments/assets/b2304754-edbd-4504-a2b7-098800264b52" />

### After

<img width="930" height="810" alt="CleanShot 2026-01-22 at 11 42 08@2x" src="https://github.com/user-attachments/assets/85791074-f998-494f-ab68-a9ba598b76e4" />

---

Follows on from #3019 


