### PR TITLE
refactor: use SavedSearches.Cache to check saved search limit

### DIFF
--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -487,7 +487,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
     %Billing.Plan{limit_saved_search_limit: limit} = Billing.get_plan_by_user(user)
 
-    if SavedSearches.list_saved_searches_by_source(source.id) |> Enum.count() < limit do
+    if SavedSearches.Cache.list_saved_searches_by_source(source.id) |> length() < limit do
       case SavedSearches.save_by_user(qs, lql_rules, source, tailing?) do
         {:ok, _saved_search} ->
           socket =


### PR DESCRIPTION
As per [review](https://github.com/Logflare/logflare/pull/3079/changes/BASE..587298dd9e6896ac9565685337b703116218dcfb#r2714874075) in #3079 

