### PR TITLE
adds `has_sources_or_rules` filter to `Backends.list_backends/1`

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -90,6 +90,13 @@ defmodule Logflare.Backends do
       {:default_ingest?, true}, q ->
         where(q, [b], b.default_ingest? == true)
 
+      {:has_sources_or_rules, true}, q ->
+        q
+        |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
+        |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
+        |> where([b, sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
+        |> distinct([b], b.id)
+
       _, q ->
         q
     end)

--- a/lib/logflare/backends/consolidated_sup_worker.ex
+++ b/lib/logflare/backends/consolidated_sup_worker.ex
@@ -52,7 +52,7 @@ defmodule Logflare.Backends.ConsolidatedSupWorker do
   end
 
   defp list_expected_backend_ids do
-    Backends.list_backends([])
+    Backends.list_backends(has_sources_or_rules: true)
     |> Enum.filter(&Adaptor.consolidated_ingest?/1)
     |> Enum.map(& &1.id)
     |> MapSet.new()


### PR DESCRIPTION
This is to avoid trying to spin up consolidated ingest backends that have nothing to do.