### PR TITLE
feature: add config option to enable/disable async inserts for clickhouse

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -116,7 +116,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
        password: :string,
        database: :string,
        port: :integer,
-       pool_size: :integer
+       pool_size: :integer,
+       async_insert: :boolean
      }}
     |> Changeset.cast(params, [
       :url,
@@ -124,8 +125,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       :password,
       :database,
       :port,
-      :pool_size
+      :pool_size,
+      :async_insert
     ])
+    |> Logflare.Utils.default_field_value(:async_insert, false)
   end
 
   @doc false

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -227,6 +227,10 @@
             {label(f_config, :port, "Connection pool size")}
             {text_input(f_config, :pool_size, class: "form-control", value: 1)}
           </div>
+          <div class="form-group">
+            {label(f_config, :async_insert, "Async Inserts")}
+            {checkbox(f_config, :async_insert, id: "async_insert")}
+          </div>
         <% "incidentio" -> %>
           <div class="form-group">
             {label(f_config, :api_token, "API Token")}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -86,6 +86,49 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  describe "cast_config/1" do
+    test "casts async_insert as boolean" do
+      params = %{
+        "url" => "http://localhost",
+        "database" => "test",
+        "port" => 8123,
+        "async_insert" => true
+      }
+
+      changeset = ClickHouseAdaptor.cast_config(params)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :async_insert) == true
+    end
+
+    test "defaults async_insert to false when not provided" do
+      params = %{
+        "url" => "http://localhost",
+        "database" => "test",
+        "port" => 8123
+      }
+
+      changeset = ClickHouseAdaptor.cast_config(params)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :async_insert) == false
+    end
+
+    test "casts string async_insert value" do
+      params = %{
+        "url" => "http://localhost",
+        "database" => "test",
+        "port" => 8123,
+        "async_insert" => "true"
+      }
+
+      changeset = ClickHouseAdaptor.cast_config(params)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :async_insert) == true
+    end
+  end
+
   describe "log event insertion and retrieval" do
     setup do
       insert(:plan, name: "Free")
@@ -97,6 +140,35 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert {:ok, _} = ClickHouseAdaptor.provision_ingest_table(backend)
 
       [source: source, backend: backend]
+    end
+
+    test "can insert log events with async_insert enabled", %{source: source, backend: backend} do
+      backend_with_async = %{backend | config: Map.put(backend.config, :async_insert, true)}
+
+      log_events = [
+        build(:log_event,
+          id: "660e8400-e29b-41d4-a716-446655440001",
+          source: source,
+          message: "Async test message",
+          metadata: %{"level" => "info"}
+        )
+      ]
+
+      result = ClickHouseAdaptor.insert_log_events(backend_with_async, log_events)
+      assert :ok = result
+
+      Process.sleep(500)
+
+      table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend)
+
+      query_result =
+        ClickHouseAdaptor.execute_ch_query(
+          backend,
+          "SELECT id FROM #{table_name} WHERE id = '660e8400-e29b-41d4-a716-446655440001'"
+        )
+
+      assert {:ok, rows} = query_result
+      assert length(rows) == 1
     end
 
     test "can insert and retrieve log events", %{source: source, backend: backend} do

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -283,6 +283,47 @@ defmodule LogflareWeb.BackendsLiveTest do
 
       assert_redirect(view, ~p"/backends")
     end
+
+    test "clickhouse form shows async inserts checkbox", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/backends/new")
+
+      html =
+        view
+        |> element("select#type")
+        |> render_change(%{backend: %{type: "clickhouse"}})
+
+      assert html =~ "Async Inserts"
+      assert html =~ "async_insert"
+    end
+
+    test "can create clickhouse backend with async_insert enabled", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/backends/new")
+
+      view
+      |> element("select#type")
+      |> render_change(%{backend: %{type: "clickhouse"}})
+
+      html =
+        view
+        |> form("form", %{
+          backend: %{
+            name: "my clickhouse",
+            type: "clickhouse",
+            config: %{
+              url: "http://localhost",
+              database: "test_db",
+              port: 8123,
+              username: "user",
+              password: "pass",
+              async_insert: true
+            }
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Successfully created backend"
+      assert html =~ "my clickhouse"
+    end
   end
 
   describe "edit" do


### PR DESCRIPTION
Add boolean config option for ClickHouse backends to enable/disable async inserts. Default behavior is to do synchronous inserts.