### PR TITLE
make clickhouse connection pools a bit more sane

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -10,11 +10,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   alias Logflare.LogEvent
 
   @finch_pool Logflare.FinchClickHouseIngest
-  @max_retries 3
+  @max_retries 1
   @initial_delay 500
   @max_delay 4_000
   @pool_timeout 8_000
-  @receive_timeout 15_000
+  @receive_timeout 30_000
 
   @doc """
   Inserts a list of `LogEvent` structs into ClickHouse.

--- a/lib/logflare/networking.ex
+++ b/lib/logflare/networking.ex
@@ -97,7 +97,7 @@ defmodule Logflare.Networking do
        pools: %{
          default: [
            protocols: [:http1],
-           size: max(base * 125, 150),
+           size: min(max(base * 10, 50), 100),
            count: http1_count,
            conn_max_idle_time: 9_000,
            start_pool_metrics?: true


### PR DESCRIPTION
Minor adjustments to the ClickHouse connection pool configuration and connection retry behavior to avoid a snowball effect when the CH cluster slows down.

- Changes timeout in ClickHouse ingester (Tesla/Finch) from 15s to 30s
- Reduce network-level retries from 3 to 1
- Adjust pool configuration to allow for a much smaller number of connections overall

| vCPU | Pools | Before Size | Before Total | After Size | After Total |
|------|-------|-------------|--------------|------------|-------------|
| 4    | 1     | 500         | **500**      | 50         | **50**      |
| 16   | 4     | 2,000       | **8,000**    | 100        | **400**     |
| 32   | 8     | 4,000       | **32,000**   | 100        | **800**     |

_Worth noting that production nodes are running 32 vCPUs with staging running a mix of 4 and 16 vCPUs._