### PR TITLE
fix: stop running chromium and all browsers that already include chromium

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -66,10 +66,6 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: npx playwright test
 
-    - name: Run Playwright tests (only Chromium)
-      if: ${{ github.event_name == 'pull_request' }}
-      run: npx playwright test --project chromium
-
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:


### PR DESCRIPTION
Avoid re-running chrome twice. We did this before, so the report is related to chrome, however, that is taking extra time of our CI, and I am not sure if we are getting any benefit. 