### PR TITLE
feature: detect log type

### DIFF
--- a/lib/logflare/logs/log_event/type_detection.ex
+++ b/lib/logflare/logs/log_event/type_detection.ex
@@ -1,0 +1,69 @@
+defmodule Logflare.LogEvent.TypeDetection do
+  @moduledoc """
+  Determine whether raw ingestion params represent a log, metric, or trace."
+  """
+
+  import Logflare.Utils.Guards, only: [is_non_empty_binary: 1]
+
+  @type log_type :: :log | :metric | :trace
+
+  @doc """
+  Determines the log type from raw ingestion params.
+
+  Checks `metadata.type` first (set by OTEL processors), then falls back
+  to heuristic key detection for raw JSON payloads. Defaults to `:log`.
+  """
+  @spec detect(map()) :: log_type()
+  def detect(%{"metadata" => %{"type" => "span"}}), do: :trace
+  def detect(%{"metadata" => %{"type" => "metric"}}), do: :metric
+  def detect(%{"metadata" => %{"type" => "event"}}), do: :log
+  def detect(%{"metadata" => %{"type" => "otel_log"}}), do: :log
+
+  def detect(params) when is_map(params) do
+    cond do
+      trace?(params) -> :trace
+      metric?(params) -> :metric
+      true -> :log
+    end
+  end
+
+  defp trace?(params) do
+    has_trace_id?(params) and has_span_id?(params) and has_span_field?(params)
+  end
+
+  defp has_trace_id?(params) do
+    is_non_empty_binary(params["trace_id"]) or
+      is_non_empty_binary(params["traceId"]) or
+      is_non_empty_binary(params["otel_trace_id"])
+  end
+
+  defp has_span_id?(params) do
+    is_non_empty_binary(params["span_id"]) or
+      is_non_empty_binary(params["spanId"]) or
+      is_non_empty_binary(params["otel_span_id"])
+  end
+
+  defp has_span_field?(params) do
+    is_non_empty_binary(params["parent_span_id"]) or
+      is_non_empty_binary(params["parentSpanId"]) or
+      is_non_empty_binary(params["start_time"]) or
+      is_non_empty_binary(params["end_time"]) or
+      is_non_empty_binary(params["duration"]) or
+      is_non_empty_binary(params["duration_ms"]) or
+      is_non_empty_binary(params["duration_ns"])
+  end
+
+  defp metric?(params) do
+    has_metric_name?(params) and has_metric_value?(params)
+  end
+
+  defp has_metric_name?(params) do
+    is_non_empty_binary(params["metric_type"]) or
+      is_non_empty_binary(params["metric"])
+  end
+
+  defp has_metric_value?(params) do
+    value = params["value"] || params["gauge"] || params["count"] || params["sum"]
+    value != nil
+  end
+end

--- a/test/logflare/log_event/type_detection_test.exs
+++ b/test/logflare/log_event/type_detection_test.exs
@@ -1,0 +1,204 @@
+defmodule Logflare.LogEvent.TypeDetectionTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.LogEvent.TypeDetection
+
+  describe "detect/1 with metadata.type (OTEL processor fast path)" do
+    test "span -> :trace" do
+      assert TypeDetection.detect(%{"metadata" => %{"type" => "span"}}) == :trace
+    end
+
+    test "metric -> :metric" do
+      assert TypeDetection.detect(%{"metadata" => %{"type" => "metric"}}) == :metric
+    end
+
+    test "event -> :log" do
+      assert TypeDetection.detect(%{"metadata" => %{"type" => "event"}}) == :log
+    end
+
+    test "otel_log -> :log" do
+      assert TypeDetection.detect(%{"metadata" => %{"type" => "otel_log"}}) == :log
+    end
+
+    test "unknown metadata.type falls through to heuristics" do
+      assert TypeDetection.detect(%{"metadata" => %{"type" => "unknown"}}) == :log
+    end
+  end
+
+  describe "detect/1 trace heuristic" do
+    test "trace_id + span_id + start_time" do
+      params = %{
+        "trace_id" => "abc123",
+        "span_id" => "def456",
+        "start_time" => "2025-12-22T20:04:25.369201Z"
+      }
+
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "traceId + spanId + end_time (camelCase variants)" do
+      params = %{
+        "traceId" => "abc123",
+        "spanId" => "def456",
+        "end_time" => "2025-12-22T20:04:25.511409Z"
+      }
+
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "otel_trace_id + otel_span_id + parent_span_id" do
+      params = %{
+        "otel_trace_id" => "abc123",
+        "otel_span_id" => "def456",
+        "parent_span_id" => "789ghi"
+      }
+
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "parentSpanId (camelCase) satisfies span field requirement" do
+      params = %{
+        "trace_id" => "abc123",
+        "span_id" => "def456",
+        "parentSpanId" => "789ghi"
+      }
+
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "duration satisfies span field requirement" do
+      params = %{"trace_id" => "abc123", "span_id" => "def456", "duration" => "142ms"}
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "duration_ms satisfies span field requirement" do
+      params = %{"trace_id" => "abc123", "span_id" => "def456", "duration_ms" => "142"}
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "duration_ns satisfies span field requirement" do
+      params = %{"trace_id" => "abc123", "span_id" => "def456", "duration_ns" => "142000000"}
+      assert TypeDetection.detect(params) == :trace
+    end
+
+    test "missing span_id -> :log" do
+      params = %{
+        "trace_id" => "abc123",
+        "start_time" => "2025-12-22T20:04:25.369201Z"
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "missing trace_id -> :log" do
+      params = %{
+        "span_id" => "def456",
+        "start_time" => "2025-12-22T20:04:25.369201Z"
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "trace_id + span_id without span-specific field -> :log" do
+      params = %{"trace_id" => "abc123", "span_id" => "def456"}
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "empty string trace_id -> :log" do
+      params = %{
+        "trace_id" => "",
+        "span_id" => "def456",
+        "start_time" => "2025-12-22T20:04:25.369201Z"
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "empty string span_id -> :log" do
+      params = %{
+        "trace_id" => "abc123",
+        "span_id" => "",
+        "start_time" => "2025-12-22T20:04:25.369201Z"
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+  end
+
+  describe "detect/1 metric heuristic" do
+    test "metric_type + value" do
+      params = %{"metric_type" => "sum", "value" => 25_607_364}
+      assert TypeDetection.detect(params) == :metric
+    end
+
+    test "metric_type + gauge" do
+      params = %{"metric_type" => "gauge", "gauge" => 42.5}
+      assert TypeDetection.detect(params) == :metric
+    end
+
+    test "metric_type + count" do
+      params = %{"metric_type" => "histogram", "count" => 1509}
+      assert TypeDetection.detect(params) == :metric
+    end
+
+    test "metric_type + sum" do
+      params = %{"metric_type" => "histogram", "sum" => 1000.0}
+      assert TypeDetection.detect(params) == :metric
+    end
+
+    test "metric (name) + value" do
+      params = %{"metric" => "http.request.duration", "value" => 142}
+      assert TypeDetection.detect(params) == :metric
+    end
+
+    test "metric_type without value -> :log" do
+      params = %{"metric_type" => "sum"}
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "value without metric_type -> :log" do
+      params = %{"value" => 42}
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "empty string metric_type -> :log" do
+      params = %{"metric_type" => "", "value" => 42}
+      assert TypeDetection.detect(params) == :log
+    end
+  end
+
+  describe "detect/1 log (default fallback)" do
+    test "plain log message" do
+      params = %{"event_message" => "Hello world"}
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "empty map" do
+      assert TypeDetection.detect(%{}) == :log
+    end
+
+    test "log with metadata but no type indicator" do
+      params = %{
+        "event_message" => "Sent 202 in 23ms",
+        "metadata" => %{
+          "level" => "info",
+          "otel_trace_id" => "abc123",
+          "otel_span_id" => "def456"
+        }
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+
+    test "log with nested metadata.req.traceId" do
+      params = %{
+        "event_message" => "GET /storage/v1/object",
+        "metadata" => %{
+          "req" => %{"traceId" => "8ff10a03a3b2144e-SJC"}
+        }
+      }
+
+      assert TypeDetection.detect(params) == :log
+    end
+  end
+end

--- a/test/profiling/log_event_make_type_detection_bench.exs
+++ b/test/profiling/log_event_make_type_detection_bench.exs
@@ -153,7 +153,7 @@ defmodule PayloadGenerator do
           "processes" => 9148,
           "processes_used" => 9138,
           "system" => 1863,
-          "total" => 11012
+          "total" => 11_012
         },
         "observer_metrics" => %{
           "atom_count" => 119_531,
@@ -168,7 +168,7 @@ defmodule PayloadGenerator do
           "otp_release" => "27",
           "port_count" => 2307,
           "port_limit" => 1_048_576,
-          "process_count" => 82914,
+          "process_count" => 82_914,
           "process_limit" => 8_388_608,
           "run_queue" => 0,
           "schedulers" => 32,
@@ -231,7 +231,7 @@ defmodule PayloadGenerator do
         "_net_host_name" => "auth.supabase.io",
         "_net_protocol_version" => "1.1",
         "_net_sock_peer_addr" => random_ip(),
-        "_net_sock_peer_port" => 36196,
+        "_net_sock_peer_port" => 36_196,
         "_user_agent_original" => "stripped"
       },
       "end_time" => "2025-12-22T20:04:25.511409Z",
@@ -263,7 +263,7 @@ defmodule PayloadGenerator do
         "_http_route" => "/functions/v1/*path",
         "_http_status_code" => 404,
         "_network_peer_address" => random_ip(),
-        "_network_peer_port" => 57785,
+        "_network_peer_port" => 57_785,
         "_network_protocol_version" => "1.1",
         "_server_address" => "supabase-api-gateway",
         "_url_path" => "/functions/v1/stripe-worker",
@@ -300,7 +300,7 @@ defmodule PayloadGenerator do
         "_http_response_status_code" => 202,
         "_http_route" => "/api/broadcast",
         "_network_peer_address" => "::ffff:99.14.9.22",
-        "_network_peer_port" => 36686,
+        "_network_peer_port" => 36_686,
         "_network_protocol_version" => "1.1",
         "_phoenix_action" => "broadcast",
         "_phoenix_plug" => "Elixir.RealtimeWeb.BroadcastController",
@@ -415,7 +415,7 @@ Benchee.run(
 )
 
 # ============================================================================
-# Baseline results (2026-02-06, Apple M4, 10 cores, 32 GB, OTP 27, Elixir 1.19)
+# Baseline results before log type detection (2026-02-06, Apple M4, 10 cores, 32 GB, OTP 27, Elixir 1.19)
 # ============================================================================
 #
 # Input                       ips        average    memory


### PR DESCRIPTION
Part of the effort around routing for the sake of ClickHouse ingestion.

**_90% of the lines added in this are the benchmark script and the tests. I do plan to drop the benchmark script after the larger effort is complete._**

Detects the log type within `LogEvent.make/2` using pattern matching and some heuristics to known paths we have seen resulting in an atom of `:log`, `:metric`, or `:trace`.

I isolated this logic into its own module knowing it will be a case where we'll need to add additional matches down the road.

I include a new benchmark script for the sake of avoiding a negative impact to this part of the ingestion cycle. This script includes realistic payload examples to push on the evaluation a bit harder. Baseline numbers were established _before_ the detection logic. Subsequent runs show no major changes after adding the detection.

While I did consider moving this closer to ingestion, it seemed like the logic would need to be invoked from multiple places doing that. `LogEvent.make` seemed to be the most logical place.