### PR TITLE
feat: store last chosen team in session

### DIFF
--- a/lib/logflare_web/controllers/auth/auth_controller.ex
+++ b/lib/logflare_web/controllers/auth/auth_controller.ex
@@ -19,7 +19,6 @@ defmodule LogflareWeb.AuthController do
     conn
     |> configure_session(drop: true)
     |> put_resp_cookie("_logflare_last_provider", "", max_age: 0)
-    |> put_resp_cookie("_logflare_last_team", "", max_age: 0)
     |> put_resp_cookie("_logflare_team_user_id", "", max_age: 0)
     |> put_resp_cookie("_logflare_user_id", "", max_age: 0)
     |> redirect(to: Routes.auth_path(conn, :login))

--- a/lib/logflare_web/controllers/plugs/set_team_context.ex
+++ b/lib/logflare_web/controllers/plugs/set_team_context.ex
@@ -16,7 +16,10 @@ defmodule LogflareWeb.Plugs.SetTeamContext do
         assign(conn, :user, nil)
 
       email ->
-        team_id = Map.get(conn.params, "t", nil)
+        team_id =
+          Map.get(conn.params, "t") ||
+            get_session(conn, :last_switched_team_id)
+
         set_team_context(conn, team_id, email)
     end
   end

--- a/lib/logflare_web/controllers/team_controller.ex
+++ b/lib/logflare_web/controllers/team_controller.ex
@@ -1,0 +1,21 @@
+defmodule LogflareWeb.TeamController do
+  use LogflareWeb, :controller
+
+  alias Logflare.Teams.TeamContext
+
+  def switch(conn, %{"team_id" => team_id, "redirect_to" => redirect_to}) do
+    email = get_session(conn, :current_email)
+
+    case TeamContext.resolve(team_id, email) do
+      {:ok, %{team: team}} ->
+        conn
+        |> put_session(:last_switched_team_id, team.id)
+        |> redirect(to: LogflareWeb.Utils.with_team_param(redirect_to, team))
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "Unable to switch to that team.")
+        |> redirect(to: redirect_to)
+    end
+  end
+end

--- a/lib/logflare_web/core_components.ex
+++ b/lib/logflare_web/core_components.ex
@@ -220,10 +220,10 @@ defmodule LogflareWeb.CoreComponents do
       </a>
       <div :if={@has_multiple_teams} class="dropdown-menu dropdown-menu-right" aria-labelledby="teamDropdown">
         <%= for team <- @teams do %>
-          <.team_link team={team} href={@current_path} class={["dropdown-item tw-flex tw-items-center tw-gap-2", @selected_class.(team.id)]}>
+          <a href={~p"/teams/switch?#{[team_id: team.id, redirect_to: @current_path]}"} class={["dropdown-item tw-flex tw-items-center tw-gap-2", @selected_class.(team.id)]}>
             <span>{team.name}</span>
             <span :if={TeamContext.home_team?(team, @team_context)} class="tw-text-sm tw-self-end">home team</span>
-          </.team_link>
+          </a>
         <% end %>
       </div>
     </li>

--- a/lib/logflare_web/live/auth_live.ex
+++ b/lib/logflare_web/live/auth_live.ex
@@ -13,8 +13,8 @@ defmodule LogflareWeb.AuthLive do
   alias Logflare.Teams.TeamContext
   require Logger
 
-  def on_mount(:default, params, %{"current_email" => email}, socket) do
-    team_id = Map.get(params, "t")
+  def on_mount(:default, params, %{"current_email" => email} = session, socket) do
+    team_id = Map.get(params, "t") || session["last_switched_team_id"]
 
     case TeamContext.resolve(team_id, email) do
       {:ok, %TeamContext{team: team, user: user, team_user: team_user}} ->

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -247,6 +247,12 @@ defmodule LogflareWeb.Router do
     get("/public/:public_token", SourceController, :public)
   end
 
+  scope "/teams", LogflareWeb do
+    pipe_through([:browser, :require_auth])
+
+    get("/switch", TeamController, :switch)
+  end
+
   scope "/sources", LogflareWeb do
     pipe_through([:browser, :require_auth])
 

--- a/test/logflare_web/components/team_switcher_test.exs
+++ b/test/logflare_web/components/team_switcher_test.exs
@@ -45,7 +45,9 @@ defmodule LogflareWeb.TeamSwitcherTest do
 
       conn
       |> visit("/account/edit?key=test")
-      |> assert_has(~s|#team-switcher a[href="/account/edit?key=test&t=#{team2.id}"]|)
+      |> assert_has(
+        ~s|#team-switcher a[href="/teams/switch?team_id=#{team2.id}&redirect_to=%2Faccount%2Fedit%3Fkey%3Dtest"]|
+      )
     end
   end
 end

--- a/test/logflare_web/controllers/auth/auth_controller_test.exs
+++ b/test/logflare_web/controllers/auth/auth_controller_test.exs
@@ -18,7 +18,6 @@ defmodule LogflareWeb.AuthControllerTest do
     assert redirected_to(conn, 302) == ~p"/auth/login"
     assert conn.resp_cookies["_logflare_user_id"].value == ""
     assert conn.resp_cookies["_logflare_team_user_id"].value == ""
-    assert conn.resp_cookies["_logflare_last_team"].value == ""
     assert conn.resp_cookies["_logflare_last_provider"].value == ""
   end
 end

--- a/test/logflare_web/controllers/team_controller_test.exs
+++ b/test/logflare_web/controllers/team_controller_test.exs
@@ -1,0 +1,55 @@
+defmodule LogflareWeb.TeamControllerTest do
+  use LogflareWeb.ConnCase, async: true
+
+  setup do
+    insert(:plan)
+    user = insert(:user)
+    home_team = insert(:team, user: user)
+
+    other_user = insert(:user)
+    other_team = insert(:team, user: other_user)
+    _team_user = insert(:team_user, team: other_team, email: user.email)
+
+    %{user: user, home_team: home_team, other_team: other_team}
+  end
+
+  describe "GET /teams/switch" do
+    test "stores last_switched_team_id in session and redirects with team param",
+         %{conn: conn, user: user, other_team: other_team} do
+      conn =
+        conn
+        |> login_user(user)
+        |> get(~p"/teams/switch?#{[team_id: other_team.id, redirect_to: "/dashboard"]}")
+
+      assert redirected_to(conn) =~ "/dashboard"
+      assert redirected_to(conn) =~ "t=#{other_team.id}"
+      assert get_session(conn, :last_switched_team_id) == other_team.id
+    end
+
+    test "redirects to home team without error",
+         %{conn: conn, user: user, home_team: home_team} do
+      conn =
+        conn
+        |> login_user(user)
+        |> get(~p"/teams/switch?#{[team_id: home_team.id, redirect_to: "/dashboard"]}")
+
+      assert redirected_to(conn) =~ "/dashboard"
+    end
+
+    test "shows error when switching to unauthorized team", %{conn: conn} do
+      user = insert(:user)
+      _home_team = insert(:team, user: user)
+
+      other_user = insert(:user)
+      other_team = insert(:team, user: other_user)
+
+      conn =
+        conn
+        |> login_user(user)
+        |> get(~p"/teams/switch?#{[team_id: other_team.id, redirect_to: "/dashboard"]}")
+
+      assert redirected_to(conn) == "/dashboard"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Unable to switch to that team."
+    end
+  end
+end

--- a/test/logflare_web/live/auth_live_test.exs
+++ b/test/logflare_web/live/auth_live_test.exs
@@ -4,10 +4,30 @@ defmodule LogflareWeb.AuthLiveTest do
 
   alias LogflareWeb.AuthLive
 
+  setup do
+    insert(:plan)
+    :ok
+  end
+
   test "on_mount redirects to login when session has no current_email" do
     socket = %Phoenix.LiveView.Socket{endpoint: LogflareWeb.Endpoint, router: LogflareWeb.Router}
 
     assert {:halt, socket} = AuthLive.on_mount(:default, %{}, %{}, socket)
     assert {:redirect, %{to: "/auth/login"}} = socket.redirected
+  end
+
+  test "on_mount uses last_switched_team_id from session when param absent" do
+    user = insert(:user)
+    _home_team = insert(:team, user: user)
+
+    other_user = insert(:user)
+    other_team = insert(:team, user: other_user)
+    _team_user = insert(:team_user, team: other_team, email: user.email)
+
+    socket = %Phoenix.LiveView.Socket{endpoint: LogflareWeb.Endpoint, router: LogflareWeb.Router}
+    session = %{"current_email" => user.email, "last_switched_team_id" => other_team.id}
+
+    assert {:cont, socket} = AuthLive.on_mount(:default, %{}, session, socket)
+    assert socket.assigns.team.id == other_team.id
   end
 end


### PR DESCRIPTION
Default to the last selected team when no `t=` team param is present.

* when a user selects a team from the team switcher dropdown the `last_team_id` is stored in the session
* When visiting a URL without a `t=` param the `last_team_id` is used as the current team

## Demo

This recording demonstrates moving between teams and falling back to the last selected team.

* From the dashboard of my home team  I selected another team (Happy Team `team_id=13`)
* Click through to a source. 
* Remove the `t=` param from the URL.
* click dashboard: the last selected team is preserved


https://github.com/user-attachments/assets/2a3560c9-8ce3-47e7-b3c2-a7645c9b3996



Closes ANL-1278