### PR TITLE
chore: reorder columns in `otel_traces_*` schema

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -199,8 +199,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates do
         `scope_version` String CODEC(ZSTD(1)),
         `resource_attributes` JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
         `span_attributes` JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
-        `mapping_config_id` UUID,
-        `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
         `events.timestamp` Array(DateTime64(9)) CODEC(ZSTD(1)),
         `events.name` Array(LowCardinality(String)) CODEC(ZSTD(1)),
         `events.attributes` Array(JSON(max_dynamic_paths=0, max_dynamic_types=1)) CODEC(ZSTD(1)),
@@ -208,6 +206,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates do
         `links.span_id` Array(String) CODEC(ZSTD(1)),
         `links.trace_state` Array(String) CODEC(ZSTD(1)),
         `links.attributes` Array(JSON(max_dynamic_paths=0, max_dynamic_types=1)) CODEC(ZSTD(1)),
+        `mapping_config_id` UUID,
+        `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
         INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
         INDEX idx_duration duration TYPE minmax GRANULARITY 1
       )


### PR DESCRIPTION
moves `mapping_config_id` and `timestamp` columns to the end of the `otel_traces_*` table