### PR TITLE
adds `allowed_values` option to Logflare.Mapper

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -13,9 +13,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
   alias Logflare.Mapper.MappingConfig.InferCondition
   alias Logflare.Mapper.MappingConfig.InferRule
 
-  @log_config_id "00000000-0000-0000-0000-000000000001"
-  @metric_config_id "00000000-0000-0000-0000-000000000002"
-  @trace_config_id "00000000-0000-0000-0000-000000000003"
+  @log_config_id "00000000-0000-0000-0001-000000000002"
+  @metric_config_id "00000000-0000-0000-0002-000000000001"
+  @trace_config_id "00000000-0000-0000-0003-000000000001"
 
   @spec config_id(TypeDetection.log_type()) :: String.t()
   def config_id(:log), do: @log_config_id
@@ -62,7 +62,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           "$.metadata.parsed.error_severity"
         ],
         default: "INFO",
-        transform: "upcase"
+        transform: "upcase",
+        allowed_values:
+          ~w(TRACE DEBUG INFO NOTICE WARN WARNING ERROR FATAL CRITICAL EMERGENCY ALERT LOG PANIC)
       ),
       Field.uint8("severity_number_alt",
         paths: ["$.severity_number", "$.severityNumber"],
@@ -74,6 +76,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           "TRACE" => 1,
           "DEBUG" => 5,
           "INFO" => 9,
+          "NOTICE" => 11,
           "WARN" => 13,
           "WARNING" => 13,
           "ERROR" => 17,
@@ -81,6 +84,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           "FATAL" => 21,
           "CRITICAL" => 21,
           "EMERGENCY" => 21,
+          "ALERT" => 21,
           "PANIC" => 21
         },
         default: 0

--- a/lib/logflare/mapper/mapping_config.ex
+++ b/lib/logflare/mapper/mapping_config.ex
@@ -13,7 +13,8 @@ defmodule Logflare.Mapper.MappingConfig do
 
       config = MappingConfig.new([
         Field.string("trace_id", paths: ["$.trace_id", "$.traceId"], default: ""),
-        Field.string("severity_text", paths: ["$.level"], transform: "upcase"),
+        Field.string("severity_text", paths: ["$.level"], transform: "upcase",
+          default: "INFO", allowed_values: ~w(INFO WARN ERROR)),
         Field.uint8("severity_number", from_output: "severity_text",
           value_map: %{"INFO" => 9, "ERROR" => 17}, default: 0),
         Field.datetime64("timestamp", path: "$.timestamp"),
@@ -81,6 +82,7 @@ defmodule Logflare.Mapper.MappingConfig do
     |> maybe_add("default", encode_nif_default(f))
     |> maybe_add("precision", f.precision)
     |> maybe_add("transform", f.transform)
+    |> maybe_add("allowed_values", f.allowed_values)
     |> maybe_add("from_output", f.from_output)
     |> maybe_add("value_map", f.value_map)
     |> maybe_add("enum_values", f.enum_values)

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -22,6 +22,9 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   ### `string/2`
 
     * `:transform` — `"upcase"` or `"downcase"`, applied after resolution
+    * `:allowed_values` — list of permitted string values. After transform is applied,
+      if the value is not in this list it is replaced with the field's default. Useful for
+      `LowCardinality(String)` columns where arbitrary strings would pollute the index.
 
   ### `datetime64/2`
 
@@ -104,6 +107,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     field(:default, :string)
     field(:precision, :integer)
     field(:transform, :string)
+    field(:allowed_values, {:array, :string})
     field(:from_output, :string)
     field(:value_map, :map)
     field(:enum_values, :map)
@@ -126,6 +130,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
         :default,
         :precision,
         :transform,
+        :allowed_values,
         :from_output,
         :value_map,
         :enum_values,
@@ -143,7 +148,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
 
   @spec string(String.t(), keyword()) :: t()
   def string(name, opts \\ []) do
-    build(name, "string", opts, [:transform])
+    build(name, "string", opts, [:transform, :allowed_values])
   end
 
   @spec uint8(String.t(), keyword()) :: t()

--- a/test/profiling/mapper_bench.exs
+++ b/test/profiling/mapper_bench.exs
@@ -296,7 +296,9 @@ logs_mapping =
     Field.string("severity_text",
       paths: ["$.severity_text", "$.severityText", "$.metadata.level", "$.level"],
       default: "INFO",
-      transform: "upcase"
+      transform: "upcase",
+      allowed_values:
+        ~w(TRACE DEBUG INFO NOTICE WARN WARNING ERROR FATAL CRITICAL EMERGENCY ALERT LOG PANIC)
     ),
     Field.uint8("severity_number",
       from_output: "severity_text",
@@ -479,7 +481,9 @@ hybrid_mapping =
     Field.string("severity_text",
       paths: ["$.severity_text", "$.severityText", "$.metadata.level", "$.level"],
       default: "INFO",
-      transform: "upcase"
+      transform: "upcase",
+      allowed_values:
+        ~w(TRACE DEBUG INFO NOTICE WARN WARNING ERROR FATAL CRITICAL EMERGENCY ALERT LOG PANIC)
     ),
     Field.uint8("severity_number",
       from_output: "severity_text",


### PR DESCRIPTION
Adds a new `allowed_values` feature to the `Logflare.Mapper` (_and bumps the config ids_).

```
Field.string("severity_text",
  paths: [
    "$.severity_text",
    "$.severityText",
    "$.metadata.level",
    "$.level",
    "$.metadata.parsed.error_severity"
  ],
  default: "INFO",
  transform: "upcase",
  allowed_values:
    ~w(TRACE DEBUG INFO NOTICE WARN WARNING ERROR FATAL CRITICAL EMERGENCY ALERT LOG PANIC)
)
```

This avoids us messing up a low cardinality column in ClickHouse due to malformed logs.

Benchmarks show no loss on IPS, memory, or reductions after adding this feature.