### PR TITLE
chore: optimize pipeline by caching docker image layers

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -47,6 +47,38 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Cache Docker layers
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build and cache Logflare image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        tags: supabase/logflare:local
+        load: true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        pull: true
+
+    - name: Move Docker cache
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      working-directory: .
+
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -36,7 +36,7 @@ log "Cloning Supabase repository..."
 if [ -d "$SUPABASE_DIR" ]; then
   warn "Directory '$SUPABASE_DIR' exists. Removing..."
   cd "$SUPABASE_DIR/$SPARSE_PATH"
-  docker compose down -v
+  compose down -v
   cd ../..
   sudo rm -rf "$SUPABASE_DIR"
 fi
@@ -64,9 +64,7 @@ fi
 cp .env.example .env
 endgroup
 
-log "Build logflare image..."
-compose build analytics
-endgroup
+[ ! "$GITHUB_ACTIONS" = "true" ] && log "Build logflare image..." && compose build analytics
 
 log "Pulling docker images..."
 compose pull


### PR DESCRIPTION
I have considered using this [action](https://github.com/marketplace/actions/docker-layer-caching), I discarded it because it is not from the official docker team.

This [guide](https://www.blacksmith.sh/blog/cache-is-king-a-guide-for-docker-layer-caching-in-github-actions) gives a good overview on how to accomplish this and explains why caching images from the docker registry is in practice worse than just pulling.

I am essentially following this [approach](https://cicube.io/blog/optimize-docker-builds-github-actions-cache/).


## Performance Comparison

Previously, this was taken ~9 minutes to setup the supabase services.

<img width="1846" height="831" alt="image" src="https://github.com/user-attachments/assets/ddd36192-f7bc-41c5-827c-c64be6dc6df8" />

Now, it is taking around ~7 minutes by caching the layers of the image build.

<img width="1846" height="831" alt="image" src="https://github.com/user-attachments/assets/67cc3fa2-53cc-4c41-93dc-7c7502d1304a" />


