### PR TITLE
perf: on every pull request, run playwright tests only on chromium

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -1,24 +1,10 @@
 name: Integration Tests with Supabase
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'config/**'
-      - 'assets/**'
-      - 'lib/**'
-      - 'priv/**'
-      - 'mix.exs'
-      - 'mix.lock'
-      - 'Dockerfile'
-      - 'run.sh'
-      - 'test/e2e/supabase/**'
-      - '.github/workflows/integration-supabase.yml'
   pull_request:
     branches:
       - main
-    paths:
+    paths: &watched_paths
       - 'config/**'
       - 'assets/**'
       - 'lib/**'
@@ -29,6 +15,11 @@ on:
       - 'run.sh'
       - 'test/e2e/supabase/**'
       - '.github/workflows/integration-supabase.yml'
+  # TODO: turn on when all browsers job take less than 15 minutes to run
+  # push:
+  #   branches:
+  #     - main
+  #   paths: *watched_paths
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:
@@ -91,12 +82,21 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+    # TODO: Find a way to make it take less than 15 minutes to reactive it on main
+    # - name: Install Playwright Browsers
+    #   if: ${{ github.event_name != 'pull_request' }}
+    #   run: npx playwright install chromium --with-deps
+    # - name: Run Playwright tests (all browsers)
+    #   if: ${{ github.event_name != 'pull_request' }}
+    #   run: npx playwright test
 
-    - name: Run Playwright tests (all browsers)
-      if: ${{ github.event_name != 'pull_request' }}
-      run: npx playwright test
+    - name: Install Playwright Chromium Browser
+      if: ${{ github.event_name == 'pull_request' }}
+      run: npx playwright install chromium --with-deps
+
+    - name: Run Playwright tests (only Chromium)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: npx playwright test --project chromium
 
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}


### PR DESCRIPTION
The all browsers playwright tests are taking longer than 15 minutes, for that reason it is cancelling the pipeline on every push in main branch. Even with the cache optimization done previously. So this PR reactivates only chromium on pull request and stops this workflow to run on every push (I think it could be beneficial long term but I think it is not worth it atm).


See the example [below](https://github.com/Logflare/logflare/actions/runs/21991706284/job/63540342501).
<img width="1850" height="1037" alt="image" src="https://github.com/user-attachments/assets/af7f4df3-8c60-46ae-aca5-af83b869c70a" />
