### PR TITLE
feat: bigquery results pagination

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -14,7 +14,6 @@ defmodule Logflare.Alerting do
   alias Logflare.Backends.Adaptor.WebhookAdaptor
   alias Logflare.Cluster
   alias Logflare.Endpoints
-  alias Logflare.Google.BigQuery.GenUtils
   alias Logflare.Repo
   alias Logflare.Teams
   alias Logflare.TeamUsers.TeamUser
@@ -465,7 +464,7 @@ defmodule Logflare.Alerting do
              },
              {transformed_query, []},
              parameterMode: "NAMED",
-             maxResults: 1000,
+             maxResults: alert_query.max_limit || 1000,
              location: alert_query.user.bigquery_dataset_location,
              use_query_cache: use_query_cache,
              labels: %{

--- a/lib/logflare/alerting/alert_query.ex
+++ b/lib/logflare/alerting/alert_query.ex
@@ -16,7 +16,8 @@ defmodule Logflare.Alerting.AlertQuery do
              :language,
              :query,
              :webhook_notification_url,
-             :slack_hook_url
+             :slack_hook_url,
+             :max_limit
            ]}
   typed_schema "alert_queries" do
     field :name, :string
@@ -28,6 +29,7 @@ defmodule Logflare.Alerting.AlertQuery do
     field :token, Ecto.UUID, autogenerate: true
     field :slack_hook_url, :string
     field :webhook_notification_url, :string
+    field :max_limit, :integer, default: 1_000
 
     belongs_to :user, Logflare.User
 
@@ -48,9 +50,11 @@ defmodule Logflare.Alerting.AlertQuery do
       :query,
       :cron,
       :slack_hook_url,
-      :webhook_notification_url
+      :webhook_notification_url,
+      :max_limit
     ])
     |> validate_required([:name, :query, :cron, :language])
+    |> validate_number(:max_limit, greater_than: 0, less_than: 10_001)
     |> validate_change(:cron, fn :cron, cron ->
       with {:ok, expr} <- Crontab.CronExpression.Parser.parse(cron),
            [first, second] <- Crontab.Scheduler.get_next_run_dates(expr) |> Enum.take(2),

--- a/lib/logflare_web/live/alerts/components/alert_form.html.heex
+++ b/lib/logflare_web/live/alerts/components/alert_form.html.heex
@@ -36,6 +36,21 @@
         <.live_component module={LogflareWeb.MonacoEditorComponent} id="alert_query_editor" field={f[:query]} endpoints={@endpoints} alerts={@alerts} sources={@sources} />
       </div>
 
+      <.header_with_anchor text="Max Row Limit" />
+      <div class="form-group">
+        <p>
+          Maximum number of rows to return across all pages. Defaults to 1,000.
+        </p>
+        {label(f, :max_limit, "Max Row Limit")}
+        {number_input(f, :max_limit,
+          min: 1,
+          max: 10000,
+          placeholder: "1000",
+          class: "form-control"
+        )}
+        {error_tag(f, :max_limit)}
+      </div>
+
       <.header_with_anchor text="Query Schedule" />
       <div class="form-group">
         <p>

--- a/priv/repo/migrations/20260214000000_add_max_limit_to_alert_queries_and_fetch_queries.exs
+++ b/priv/repo/migrations/20260214000000_add_max_limit_to_alert_queries_and_fetch_queries.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddMaxLimitToAlertQueriesAndFetchQueries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:alert_queries) do
+      add :max_limit, :integer, default: 1_000
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -380,7 +380,8 @@ defmodule Logflare.Factory do
       slack_hook_url: "some slack_hook_url",
       source_mapping: %{},
       webhook_notification_url: "some webhook_notification_url",
-      language: :bq_sql
+      language: :bq_sql,
+      max_limit: 1_000
     }
   end
 


### PR DESCRIPTION
This PR adds in support for fully fetching all results of an alert from BigQuery.
This is achieved through paginating through the results of the BigQuery query executed. This should not increase slots used much as there is no additional job created and we are essentially fetching data from the query cache.

Todos:
- [ ] implement stream-based pagination
- [ ] paginate based on a `:paginate` option
- [ ] docs on new `:max_limit` option for alerts and how BQ pagination works
- [ ] manual test