### PR TITLE
chore: remove warnings related to distinct types for compile time config vars

### DIFF
--- a/priv/repo/migrations/20210322193905_rename_columns_for_mnesia_compatibility.exs
+++ b/priv/repo/migrations/20210322193905_rename_columns_for_mnesia_compatibility.exs
@@ -1,8 +1,6 @@
 defmodule Logflare.Repo.Migrations.RenameColumnsForMnesiaCompatibility do
   use Ecto.Migration
 
-  @env Application.compile_env(:logflare, :env)
-
   def change do
     alter table(:users) do
       add :billing_enabled, :boolean, null: false, default: false
@@ -10,7 +8,7 @@ defmodule Logflare.Repo.Migrations.RenameColumnsForMnesiaCompatibility do
 
     execute(~s|UPDATE users SET billing_enabled = "billing_enabled?"|)
 
-    if @env in [:dev, :test] do
+    if env() in [:dev, :test] do
       alter table(:users) do
         remove :billing_enabled?, :boolean, null: false, default: false
       end
@@ -22,7 +20,7 @@ defmodule Logflare.Repo.Migrations.RenameColumnsForMnesiaCompatibility do
 
     execute(~s|UPDATE saved_searches SET tailing = "tailing?"|)
 
-    if @env in [:dev, :test] do
+    if env() in [:dev, :test] do
       alter table(:saved_searches) do
         remove :tailing?, :boolean, null: false, default: true
       end
@@ -35,11 +33,14 @@ defmodule Logflare.Repo.Migrations.RenameColumnsForMnesiaCompatibility do
     execute(~s|UPDATE billing_accounts SET lifetime_plan = "lifetime_plan?"|)
 
 
-    if @env in [:dev, :test] do
+    if env() in [:dev, :test] do
       alter table(:billing_accounts) do
         remove :lifetime_plan?, :boolean, null: false, default: false
       end
     end
+  end
 
+  defp env do
+    Application.get_env(:logflare, :env)
   end
 end

--- a/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
+++ b/priv/repo/migrations/20210729161959_subscribe_to_postgres.exs
@@ -14,11 +14,11 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
   """
 
   use Ecto.Migration
+
   @disable_ddl_transaction true
   @disable_migration_lock true
   @username Application.compile_env(:logflare, Logflare.Repo)[:username]
   @slot Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:replication_slot]
-  @env Application.compile_env(:logflare, :env)
   @publications Application.compile_env(:logflare, Logflare.ContextCache.CacheBuster)[:publications]
   @publication_tables [
     "billing_accounts",
@@ -30,7 +30,7 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
   ]
 
   def up do
-    if @env in [:dev, :test] do
+    if env() in [:dev, :test] do
       execute("ALTER SYSTEM SET wal_level = 'logical';")
       execute("ALTER USER #{@username} WITH REPLICATION;")
     end
@@ -56,9 +56,13 @@ defmodule Logflare.Repo.Migrations.SubscribeToPostgres do
     # This is happening in `20210810182003_set_rules_to_replica_identity_full.exs`
     # execute("alter table rules replica identity default")
 
-    if @env in [:dev, :test] do
+    if env() in [:dev, :test] do
       execute("ALTER USER #{@username} WITH NOREPLICATION;")
       execute("ALTER SYSTEM RESET wal_level;")
     end
+  end
+
+  defp env do
+    Application.get_env(:logflare, :env)
   end
 end


### PR DESCRIPTION
These were happening because the type checker can validate the values at compile time and finds them always false. However, that is not true at other environments (other than dev and test).

In the last version of mix (1.19.5) the do task now requires `+` instead of `,`. Read more [here](https://hexdocs.pm/mix/Mix.Tasks.Do.html).