### PR TITLE
fix: include recommended query fields for 'view' event modal

### DIFF
--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -42,7 +42,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
                    title="Log Event"
                    phx-value-log-event-id={log.id}
                    phx-value-log-event-timestamp={log.body["timestamp"]}
-                   phx-value-lql={@querystring}
+                   phx-value-lql={lql_with_recommended_fields(@search_op.lql_rules, log, @search_op.source)}
                  >
                    <span>view</span>
                  </.modal_link>


### PR DESCRIPTION
This is an attempt to fix a reported bug that would result in the event modal showing "not found" while the permalink works correctly.  I haven't been able to reproduce the bug so this is a speculative fix. 

Both code paths call `LogEvents.get_event_with_fallback` so I don't think the issue is related to the cache. 
One difference was the 'view' link wasn't including recommended fields. It's possible the user was working with a BigQuery table that required a field to be selected that wasn't.

I haven't included tests for this change, but can if requested. It would simply be a regex on the event anchor element.

ANL-1368
