### PR TITLE
feat: quick search inputs for suggested and clustered fields

### DIFF
--- a/assets/css/source_log_search.scss
+++ b/assets/css/source_log_search.scss
@@ -17,7 +17,6 @@
     & .source-name {
       text-align: left;
     }
-    margin-top: 20px;
   }
 
   & .alert {

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -403,8 +403,8 @@ defmodule Logflare.Logs.SearchOperations do
   end
 
   # converts "m.user_id" to "s:m.user_id@user_id"
-  # strips trailing "!" which marks required keys in suggested_keys config
   defp recommended_field_to_lql_query(field) when is_binary(field) do
+    field = Sources.Source.query_field_name(field)
     field_name = field |> String.split(".") |> List.last()
 
     "s:#{field}@#{field_name}"

--- a/lib/logflare/lql/rules.ex
+++ b/lib/logflare/lql/rules.ex
@@ -244,6 +244,26 @@ defmodule Logflare.Lql.Rules do
   end
 
   @doc """
+  Replaces all `FilterRule` structs that match provided path. Preserves index
+  position of the first matching rule.
+
+  Appends when no match exists.
+  """
+  @spec upsert_filter_rule_by_path(lql_rules(), FilterRule.t()) :: lql_rules()
+  def upsert_filter_rule_by_path(lql_rules, %FilterRule{path: path} = filter_rule)
+      when is_list(lql_rules) do
+    case Enum.find_index(lql_rules, &match?(%FilterRule{path: ^path}, &1)) do
+      nil ->
+        lql_rules ++ [filter_rule]
+
+      index ->
+        lql_rules
+        |> Enum.reject(&match?(%FilterRule{path: ^path}, &1))
+        |> List.insert_at(index, filter_rule)
+    end
+  end
+
+  @doc """
   Updates timestamp rules in the LQL rule collection with new timestamp rules.
 
   Removes all existing timestamp filters and replaces them with the provided new rules.

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -409,7 +409,7 @@ defmodule Logflare.Sources.Source do
 
       iex> source = %Source{bigquery_clustering_fields: "id,timestamp", suggested_keys: "m.user_id!,status"}
       iex> recommended_query_fields(source)
-      ["id", "timestamp", "m.user_id", "status"]
+      ["id", "timestamp", "m.user_id!", "status"]
 
 
       iex> source = %Source{bigquery_clustering_fields: nil, suggested_keys: ""}
@@ -425,8 +425,22 @@ defmodule Logflare.Sources.Source do
     suggested_keys =
       (source.suggested_keys || "")
       |> String.split(",", trim: true)
-      |> Enum.map(fn key -> key |> String.trim() |> String.trim_trailing("!") end)
+      |> Enum.map(&String.trim/1)
 
     clustering_fields ++ suggested_keys
+  end
+
+  @spec required_query_field?(String.t()) :: boolean()
+  def required_query_field?(field) when is_binary(field) do
+    field
+    |> String.trim()
+    |> String.ends_with?("!")
+  end
+
+  @spec query_field_name(String.t()) :: String.t()
+  def query_field_name(field) when is_binary(field) do
+    field
+    |> String.trim()
+    |> String.trim_trailing("!")
   end
 end

--- a/lib/logflare_web/live/search_live/event_context_component.ex
+++ b/lib/logflare_web/live/search_live/event_context_component.ex
@@ -60,7 +60,10 @@ defmodule LogflareWeb.SearchLive.EventContextComponent do
         ]
       )
 
-    required_fields = Source.recommended_query_fields(source)
+    required_fields =
+      source
+      |> Source.recommended_query_fields()
+      |> Enum.map(&Source.query_field_name/1)
 
     lql_rules
     |> Logflare.Lql.Rules.get_filter_rules()

--- a/lib/logflare_web/live/search_live/form_components.ex
+++ b/lib/logflare_web/live/search_live/form_components.ex
@@ -8,6 +8,7 @@ defmodule LogflareWeb.SearchLive.FormComponents do
   use Phoenix.Component
 
   alias Logflare.Lql.Rules
+  alias Logflare.Sources.Source
   alias LogflareWeb.Utils
 
   attr :form, Phoenix.HTML.Form, required: true
@@ -73,6 +74,60 @@ defmodule LogflareWeb.SearchLive.FormComponents do
     """
   end
 
+  attr :fields, :list, required: true
+  attr :id_prefix, :string, default: "recommended-field"
+
+  def recommended_field_inputs(assigns) do
+    assigns =
+      assigns
+      |> assign(:fields, format_recommended_fields(assigns.fields))
+
+    ~H"""
+    <div :if={Enum.any?(@fields)} class="form-text" id="recommended_fields" phx-update="ignore">
+      <div class="d-flex flex-wrap">
+        <div :for={field <- @fields} class="pr-2 pt-1 pb-1">
+          <div class="tw-flex tw-justify-between tw-items-baseline">
+            <label for={"#{@id_prefix}-#{field.name}"} class="tw-mb-0 tw-text-xs tw-text-gray-300 tw-block">{field.name}</label>
+            <span :if={field.required?} class="required-field-indicator tw-text-gray-500 tw-block tw-text-right tw-text-xs">
+              required
+            </span>
+          </div>
+          <input id={"#{@id_prefix}-#{field.name}"} name={input_name(:fields, field.name)} class="form-control form-control-sm tw-text-xs " type="text" />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp format_recommended_fields(fields) do
+    {order, required_map} =
+      Enum.reduce(fields, {[], %{}}, fn field, {order, required_map} ->
+        case Source.query_field_name(field) do
+          "" ->
+            {order, required_map}
+
+          name ->
+            required? = Source.required_query_field?(field)
+            merged_required? = Map.get(required_map, name, false) or required?
+            order = maybe_prepend_name(order, required_map, name)
+
+            {order, Map.put(required_map, name, merged_required?)}
+        end
+      end)
+
+    order
+    |> Enum.reverse()
+    |> Enum.map(&%{name: &1, required?: required_map[&1]})
+  end
+
+  defp maybe_prepend_name(order, required_map, name) do
+    if Map.has_key?(required_map, name) do
+      order
+    else
+      [name | order]
+    end
+  end
+
   attr :search_form, :any, required: true
   attr :querystring, :string, required: true
   attr :search_history, :list, required: true
@@ -90,14 +145,16 @@ defmodule LogflareWeb.SearchLive.FormComponents do
 
   def search_controls(assigns) do
     ~H"""
-    <div class="search-control" id="source-logs-search-control" phx-hook="SourceLogsSearch">
+    <div class="search-control tw-mt-1" id="source-logs-search-control" phx-hook="SourceLogsSearch">
       <.form :let={f} for={@search_form} action="#" phx-submit="start_search" phx-change="form_update" class="form-group">
+        <.recommended_field_inputs fields={Source.recommended_query_fields(@source)} id_prefix="search-field" />
+
         <div class="form-group form-text">
           {text_input(f, :querystring,
             phx_focus: :form_focus,
             phx_blur: :form_blur,
             value: @querystring,
-            class: "form-control form-control-margin",
+            class: "form-control form-control-margin tw-mt-1",
             list: "matches"
           )}
           {text_input(f, :search_timezone,

--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -87,7 +87,11 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   @spec lql_with_recommended_fields(Lql.Rules.lql_rules(), Logflare.LogEvent.t(), Source.t()) ::
           String.t()
   def lql_with_recommended_fields(lql_rules, event, source) do
-    fields = Source.recommended_query_fields(source)
+    fields =
+      source
+      |> Source.recommended_query_fields()
+      |> Enum.map(&Source.query_field_name/1)
+      |> Enum.uniq()
 
     existing_filter_paths =
       lql_rules
@@ -111,8 +115,10 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
     |> Lql.encode!()
   end
 
-  defp strip_meta("metadata." <> k), do: k
-  defp strip_meta(k), do: k
+  defp strip_meta(field), do: field |> Source.query_field_name() |> strip_metadata_prefix()
+
+  defp strip_metadata_prefix("metadata." <> key), do: key
+  defp strip_metadata_prefix(key), do: key
 
   def formatted_for_clipboard(log, search_op) do
     select_fields =

--- a/lib/logflare_web/templates/source/show.html.heex
+++ b/lib/logflare_web/templates/source/show.html.heex
@@ -60,8 +60,9 @@
 <div class="container mx-auto">
   <div>
     <%= form_for @conn, Routes.live_path(@conn, LogflareWeb.Source.SearchLV, @source), [method: :get], fn f -> %>
+      <LogflareWeb.SearchLive.FormComponents.recommended_field_inputs fields={Logflare.Sources.Source.recommended_query_fields(@source)} id_prefix="recent-logs-field" />
       <div class="form-group form-text">
-        {text_input(f, :querystring, placeholder: "404", class: "form-control form-control-margin", autofocus: true)}
+        {text_input(f, :querystring, placeholder: "404", class: "form-control tw-mt-1", autofocus: true)}
         {hidden_input(f, :tailing?, value: "true")}
         <%= if @team do %>
           {hidden_input(f, :t, value: @team.id)}

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -27,6 +27,29 @@ defmodule Logflare.SourcesTest do
     end
   end
 
+  describe "recommended_query_fields/1" do
+    test "preserves required marker in suggested keys" do
+      source =
+        build(:source,
+          bigquery_clustering_fields: "session_id",
+          suggested_keys: "metadata.level!,m.user_id"
+        )
+
+      assert Source.recommended_query_fields(source) == [
+               "session_id",
+               "metadata.level!",
+               "m.user_id"
+             ]
+    end
+
+    test "query_field_name/1 and required_query_field?/1 normalize correctly" do
+      assert Source.query_field_name("metadata.level!") == "metadata.level"
+      assert Source.query_field_name("metadata.level") == "metadata.level"
+      assert Source.required_query_field?("metadata.level!")
+      refute Source.required_query_field?("metadata.level")
+    end
+  end
+
   describe "create_source/2" do
     setup do
       user = insert(:user)

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -128,7 +128,7 @@ defmodule LogflareWeb.SourceControllerTest do
       team = insert(:team, user: user)
       source = insert(:source, user: user)
       user = Repo.preload(user, :sources)
-      [source: source, team: team, conn: login_user(conn, user)]
+      [user: user, source: source, team: team, conn: login_user(conn, user)]
     end
 
     test "show source", %{conn: conn, source: source} do
@@ -151,6 +151,28 @@ defmodule LogflareWeb.SourceControllerTest do
       |> assert_has("pre > code",
         text: Logflare.JSON.encode!(le.body["event_message"], pretty: true)
       )
+    end
+
+    test "renders inputs for recommended query fields", %{
+      conn: conn,
+      user: user
+    } do
+      source =
+        insert(:source,
+          user: user,
+          suggested_keys: "metadata.level!,m.user_id",
+          bigquery_clustering_fields: "session_id"
+        )
+
+      conn
+      |> visit(~p"/sources/#{source}")
+      |> assert_has("label", text: "session_id")
+      |> assert_has("label", text: "metadata.level")
+      |> assert_has("label", text: "m.user_id")
+      |> assert_has(".required-field-indicator", text: "required")
+      |> assert_has("input.form-control-sm[id='recent-logs-field-session_id']")
+      |> assert_has("input.form-control-sm[id='recent-logs-field-metadata.level']")
+      |> assert_has("input.form-control-sm[id='recent-logs-field-m.user_id']")
     end
 
     test "invalid source", %{conn: conn, source: source} do

--- a/test/logflare_web/live/search_live/event_context_component_test.exs
+++ b/test/logflare_web/live/search_live/event_context_component_test.exs
@@ -133,6 +133,29 @@ defmodule LogflareWeb.SearchLive.EventContextComponentTest do
                EventContextComponent.prepare_lql_rules(source, "event_message:sign_in", timestamp)
     end
 
+    test "prepare_lql_rules/1 handles required marker in suggested_keys", %{
+      user: user,
+      schema: schema,
+      timestamp: timestamp
+    } do
+      source = insert(:source, user: user, suggested_keys: "event_message!")
+      insert(:source_schema, source: source, bigquery_schema: schema)
+
+      assert [
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "event_message",
+                 operator: :=,
+                 value: "sign_in"
+               },
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~U[2025-08-19 02:33:51Z], ~U[2025-08-21 02:33:51Z]]
+               }
+             ] =
+               EventContextComponent.prepare_lql_rules(source, "event_message:sign_in", timestamp)
+    end
+
     test "prepare_lql_rules/1 includes clustering_fields", %{
       user: user,
       schema: schema,

--- a/test/logflare_web/live/search_live/form_components_test.exs
+++ b/test/logflare_web/live/search_live/form_components_test.exs
@@ -1,0 +1,42 @@
+defmodule LogflareWeb.SearchLive.FormComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias LogflareWeb.SearchLive.FormComponents
+
+  describe "recommended_field_inputs/1" do
+    test "dedupes fields, preserves first-seen order, and merges required flag" do
+      html =
+        render_component(&FormComponents.recommended_field_inputs/1, %{
+          fields: [" session_id ", "metadata.level", "metadata.level!", "", "event_message"],
+          id_prefix: "search-field"
+        })
+
+      document = Floki.parse_document!(html)
+
+      field_blocks = Floki.find(document, "div.pr-2.pt-1.pb-1")
+
+      fields =
+        Enum.map(field_blocks, fn block ->
+          label = block |> Floki.find("label") |> Floki.text()
+          required_indicators = block |> Floki.find(".required-field-indicator") |> length()
+
+          {label, required_indicators}
+        end)
+
+      assert fields == [{"session_id", 0}, {"metadata.level", 1}, {"event_message", 0}]
+    end
+
+    test "renders nothing when all fields resolve to empty names" do
+      html =
+        render_component(&FormComponents.recommended_field_inputs/1, %{
+          fields: ["", "   ", "!"],
+          id_prefix: "search-field"
+        })
+
+      refute html =~ "search-field["
+      assert html |> Floki.parse_document!() |> Floki.find("input") == []
+    end
+  end
+end


### PR DESCRIPTION
Add quick search fields for each suggested field or clustered key ('recommended fields')

Values in the quick search fields are appended to the search query. Any filter rules already included in the search query are replaced.

Closes ANL-1298

<img width="2520" height="868" alt="CleanShot 2026-02-20 at 16 07 48@2x" src="https://github.com/user-attachments/assets/9e2c5533-5a91-4940-b3f3-3fadb78a08c4" />

## Demo


https://github.com/user-attachments/assets/8eca6898-4598-448c-8a5e-1cfaf4b6b06f



## Mobile layout
<img width="708" height="1526" alt="CleanShot 2026-02-24 at 11 24 58@2x" src="https://github.com/user-attachments/assets/c248774a-cfbf-4b29-a356-015029ab9902" />

