### PR TITLE
fix: get_event_with_fallback uses consistent timestamp precision

### DIFF
--- a/lib/logflare/logs/log_events.ex
+++ b/lib/logflare/logs/log_events.ex
@@ -144,7 +144,7 @@ defmodule Logflare.Logs.LogEvents do
   defp calculate_partition_range(opts) when is_list(opts) do
     cond do
       timestamp = Keyword.get(opts, :timestamp) ->
-        [Timex.shift(timestamp, hours: -1), Timex.shift(timestamp, hours: 1)]
+        calculate_partition_range_from_timestamp(timestamp)
 
       source = Keyword.get(opts, :source) ->
         user = Keyword.get(opts, :user)
@@ -157,5 +157,14 @@ defmodule Logflare.Logs.LogEvents do
       true ->
         raise ArgumentError, "Either :timestamp or both :source and :user must be provided"
     end
+  end
+
+  @spec calculate_partition_range_from_timestamp(DateTime.t()) :: [DateTime.t()]
+  defp calculate_partition_range_from_timestamp(timestamp) when is_second_precision(timestamp) do
+    [Timex.shift(timestamp, hours: -1), Timex.shift(timestamp, hours: 1)]
+  end
+
+  defp calculate_partition_range_from_timestamp(%DateTime{}) do
+    raise ArgumentError, "timestamp must be second precision"
   end
 end

--- a/lib/logflare/utils/guards.ex
+++ b/lib/logflare/utils/guards.ex
@@ -42,6 +42,11 @@ defmodule Logflare.Utils.Guards do
   defguard is_datetime(value) when is_struct(value, DateTime)
 
   @doc """
+  Guard that indicates if the value is a `DateTime` struct with second precision.
+  """
+  defguard is_second_precision(value) when is_datetime(value) and value.microsecond == {0, 0}
+
+  @doc """
   Guard that indicates if the value is a `NaiveDateTime` struct.
   """
   defguard is_naive_datetime(value) when is_struct(value, NaiveDateTime)

--- a/lib/logflare_web/live/log_event_live.ex
+++ b/lib/logflare_web/live/log_event_live.ex
@@ -58,5 +58,7 @@ defmodule LogflareWeb.LogEventLive do
 
   @spec maybe_put_timestamp(Keyword.t(), DateTime.t() | nil) :: Keyword.t()
   defp maybe_put_timestamp(opts, nil), do: opts
-  defp maybe_put_timestamp(opts, timestamp), do: Keyword.put(opts, :timestamp, timestamp)
+
+  defp maybe_put_timestamp(opts, timestamp),
+    do: Keyword.put(opts, :timestamp, DateTime.truncate(timestamp, :second))
 end

--- a/lib/logflare_web/live/log_event_live/search_log_event_viewer_component.ex
+++ b/lib/logflare_web/live/log_event_live/search_log_event_viewer_component.ex
@@ -143,5 +143,5 @@ defmodule LogflareWeb.Search.LogEventViewerComponent do
   defp maybe_put_timestamp(opts, nil) when is_list(opts), do: opts
 
   defp maybe_put_timestamp(opts, timestamp) when is_list(opts),
-    do: Keyword.put(opts, :timestamp, timestamp)
+    do: Keyword.put(opts, :timestamp, DateTime.truncate(timestamp, :second))
 end

--- a/test/logflare/log_events_test.exs
+++ b/test/logflare/log_events_test.exs
@@ -65,4 +65,12 @@ defmodule Logflare.LogEventsTest do
     assert query =~ "_PARTITIONTIME"
     assert query =~ ".id ="
   end
+
+  test "get_event_with_fallback/3 requires second precision timestamp" do
+    timestamp = DateTime.from_naive!(~N[2026-01-01 00:00:00.123456], "Etc/UTC")
+
+    assert_raise ArgumentError, "timestamp must be second precision", fn ->
+      LogEvents.get_event_with_fallback(:source_token, "log_id", timestamp: timestamp)
+    end
+  end
 end


### PR DESCRIPTION
This PR enforces timestamps with second precision when loading an event through `get_event_with_fallback`

Previously some UI element would call this with different timestamp precision which may have caused inconsistent results in fetching an event. These are now truncated by the LiveView components. A timestamp with microsecond precision will raise an Argument error. The existing LiveView tests cover this.

Closes ANL-1368