### PR TITLE
fix: custom aggreate path chart rendering

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -127,6 +127,7 @@ const chartSettings = (type) => {
           level_alert: alertColor,
           level_emergency: emergencyColor,
           other: brandGray,
+          value: brandGray,
         },
         keys: [
           "level_info",
@@ -138,6 +139,7 @@ const chartSettings = (type) => {
           "level_error",
           "level_warn",
           "other",
+          "value",
         ],
       };
 
@@ -152,6 +154,7 @@ const chartSettings = (type) => {
           status_2xx: infoColor,
           status_1xx: debugColor,
           other: brandGray,
+          value: brandGray,
         },
         keys: [
           "status_2xx",
@@ -160,6 +163,7 @@ const chartSettings = (type) => {
           "status_4xx",
           "status_5xx",
           "other",
+          "value",
         ],
       };
 


### PR DESCRIPTION
Renders aggregate results that use a 'value' key.

O11Y-1483

<img width="1856" height="2034" alt="CleanShot 2026-02-25 at 14 14 23@2x" src="https://github.com/user-attachments/assets/20e96b53-6c0f-405d-80ac-6ec675531bd1" />
