### PR TITLE
handle additional settings for ClickHouse ingest tables

### DIFF
--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -130,6 +130,38 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  describe "clickhouse_cloud?/1" do
+    test "returns true for ClickHouse Cloud URLs" do
+      backend = %Backend{config: %{url: "https://abc123.eu-central-1.aws.clickhouse.cloud"}}
+      assert ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+
+    test "returns true for GCP Cloud URLs" do
+      backend = %Backend{config: %{url: "https://xyz.europe-west4.gcp.clickhouse.cloud"}}
+      assert ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+
+    test "returns true regardless of port in URL" do
+      backend = %Backend{config: %{url: "https://foo.clickhouse.cloud:8443"}}
+      assert ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+
+    test "returns false for self-hosted URLs" do
+      backend = %Backend{config: %{url: "http://localhost:8123"}}
+      refute ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+
+    test "returns false for similar but non-Cloud domains" do
+      backend = %Backend{config: %{url: "https://clickhouse.cloud.example.com"}}
+      refute ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+
+    test "returns false when config has no url" do
+      backend = %Backend{config: %{}}
+      refute ClickHouseAdaptor.clickhouse_cloud?(backend)
+    end
+  end
+
   describe "redact_config/1" do
     test "redacts password field" do
       config = %{password: "secret123", database: "logs"}


### PR DESCRIPTION
ClickHouse engineers have worked with us to tune our otel_logs ingest table with a number of specific settings. These settings were not previously reflected in the DDL statements generated when adding a new ClickHouse backend. Another issue is that many of these settings are specific to ClickHouse Cloud.

This PR allows those settings to be leveraged for new backends and does some checks to see if the CH instance is running on ClickHouse Cloud based on the hostname. While this will not catch every scenario, it covers our use-case in the short-term.

Some known caveats:
- Only applies the larger set of optimized settings to the _*otel_logs*_ table variants (_this can be changed in the future by changing `@apply_optimized_settings_to_all_tables` to true in `ClickHouseAdaptor.QueryTemplates`_)
- Will only apply settings if the tables do not exist already (_does not perform an ALTER or anything like that_)


**Later Improvements**

Down the road, I'd like to see some UX around the list of provisioned tables when viewing a backend's show form - and allowing for a scenario where an admin could see any settings they may be missing along with a button to allow them to make the changes through Logflare.