### PR TITLE
adds `use_simple_schemas` config option to whitelist so value is displayed in the UI

### DIFF
--- a/lib/logflare_web/live/display_helpers.ex
+++ b/lib/logflare_web/live/display_helpers.ex
@@ -15,7 +15,7 @@ defmodule LogflareWeb.Live.DisplayHelpers do
   """
   def sanitize_backend_config(config) when is_map(config) do
     allowed_keys =
-      ~w(async_insert batch_timeout database hostname insert_protocol native_pool_size native_port pool_size port project_id read_only_url region s3_bucket schema storage_region table url)a
+      ~w(async_insert batch_timeout database hostname insert_protocol native_pool_size native_port pool_size port project_id read_only_url region s3_bucket schema storage_region table url use_simple_schemas)a
 
     config
     |> Enum.map(fn {key, value} ->

--- a/test/logflare_web/live/display_helpers_test.exs
+++ b/test/logflare_web/live/display_helpers_test.exs
@@ -21,7 +21,8 @@ defmodule LogflareWeb.Live.DisplayHelpersTest do
         schema: "public",
         storage_region: "eu-west-1",
         table: "log_events",
-        url: "https://api.example.com"
+        url: "https://api.example.com",
+        use_simple_schemas: true
       }
 
       check all key <- atom(:alphanumeric), key not in Map.keys(config) do
@@ -41,7 +42,8 @@ defmodule LogflareWeb.Live.DisplayHelpersTest do
                  schema: "public",
                  storage_region: "eu-west-1",
                  table: "log_events",
-                 url: "https://api.example.com"
+                 url: "https://api.example.com",
+                 use_simple_schemas: true
                }
       end
     end


### PR DESCRIPTION
Forgot to add this into #3207 

Just adds the `use_simple_schemas` config option for CH backends to the list of fields that are allowed to show their value.