### PR TITLE
fix: Fix detecting IP version from host names

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,17 +28,6 @@ filter_nil_kv_pairs = fn pairs when is_list(pairs) ->
   Enum.filter(pairs, fn {_k, v} -> v !== nil end)
 end
 
-detect_ip_version = fn host ->
-  host = String.to_charlist(host)
-
-  cond do
-    match?([], host) -> {:ok, nil}
-    match?({:ok, _}, :inet6_tcp.getaddr(host)) -> {:ok, :inet6}
-    match?({:ok, _}, :inet.gethostbyname(host)) -> {:ok, :inet}
-    true -> {:error, :nxdomain}
-  end
-end
-
 logflare_metadata =
   [cluster: System.get_env("LOGFLARE_METADATA_CLUSTER")]
   |> filter_nil_kv_pairs.()
@@ -159,10 +148,10 @@ config :logflare,
          password: System.get_env("DB_PASSWORD"),
          username: System.get_env("DB_USERNAME"),
          socket_options:
-           case detect_ip_version.(System.get_env("DB_HOSTNAME", "")) do
-             {:ok, nil} -> []
-             {:ok, version} -> [version]
-             {:error, reason} -> raise "Failed to detect IP version for DB_HOSTNAME: #{reason}"
+           case Utils.ip_version(System.get_env("DB_HOSTNAME", "")) do
+             nil -> []
+             version when version in [:inet, :inet6] -> [version]
+             error -> raise "Failed to detect IP version for DB_HOSTNAME: #{error}"
            end,
          after_connect:
            if(System.get_env("DB_SCHEMA"),
@@ -295,15 +284,10 @@ socket_options_for_url = fn
   url when is_binary(url) ->
     case URI.parse(url) do
       %URI{host: host} ->
-        case detect_ip_version.(host) do
-          {:ok, nil} ->
-            []
-
-          {:ok, version} ->
-            [version]
-
-          {:error, reason} ->
-            raise "Failed to detect IP version for URL host: #{host}, reason: #{reason}"
+        case Utils.ip_version(host) do
+          nil -> []
+          version when version in [:inet, :inet6] -> [version]
+          reason -> raise "Failed to detect IP version for URL host: #{host}, reason: #{reason}"
         end
 
       _ ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -32,6 +32,7 @@ detect_ip_version = fn host ->
   host = String.to_charlist(host)
 
   cond do
+    match?([], host) -> {:ok, nil}
     match?({:ok, _}, :inet6_tcp.getaddr(host)) -> {:ok, :inet6}
     match?({:ok, _}, :inet.gethostbyname(host)) -> {:ok, :inet}
     true -> {:error, :nxdomain}
@@ -158,9 +159,10 @@ config :logflare,
          password: System.get_env("DB_PASSWORD"),
          username: System.get_env("DB_USERNAME"),
          socket_options:
-           case Utils.ip_version(System.get_env("DB_HOSTNAME", "")) do
-             nil -> []
-             version -> [version]
+           case detect_ip_version.(System.get_env("DB_HOSTNAME", "")) do
+             {:ok, nil} -> []
+             {:ok, version} -> [version]
+             {:error, reason} -> raise "Failed to detect IP version for DB_HOSTNAME: #{reason}"
            end,
          after_connect:
            if(System.get_env("DB_SCHEMA"),
@@ -293,9 +295,15 @@ socket_options_for_url = fn
   url when is_binary(url) ->
     case URI.parse(url) do
       %URI{host: host} ->
-        case Utils.ip_version(host) do
-          nil -> []
-          version -> [version]
+        case detect_ip_version.(host) do
+          {:ok, nil} ->
+            []
+
+          {:ok, version} ->
+            [version]
+
+          {:error, reason} ->
+            raise "Failed to detect IP version for URL host: #{host}, reason: #{reason}"
         end
 
       _ ->

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -306,18 +306,27 @@ defmodule Logflare.Utils do
   end
 
   @doc """
-  Determines the IP version of an address.
+  Determines the IP version of a host or IP address.
 
   iex> ip_version("127.0.0.1")
   :inet
 
   iex> ip_version("127.0.0.1:8222")
-  nil
+  :nxdomain
 
   iex> ip_version("1467:f4e1:7a77:756a:896c:dff5:ca48:cf3c")
   :inet6
 
+  iex> ip_version("supabase.com")
+  :inet
+
+  iex> ip_version("ipv6.google.com")
+  :inet6
+
   iex> ip_version("not_an_address")
+  :nxdomain
+
+  iex> ip_version("")
   nil
 
   iex> ip_version(nil)
@@ -325,10 +334,13 @@ defmodule Logflare.Utils do
   """
   @spec ip_version(String.t() | nil) :: :inet | :inet6 | nil
   def ip_version(address) when is_binary(address) do
-    case :inet.parse_address(String.to_charlist(address)) do
-      {:ok, {_, _, _, _}} -> :inet
-      {:ok, {_, _, _, _, _, _, _, _}} -> :inet6
-      {:error, _} -> nil
+    address = String.to_charlist(address)
+
+    cond do
+      match?([], address) -> nil
+      match?({:ok, _}, :inet.gethostbyname(address)) -> :inet
+      match?({:ok, _}, :inet6_tcp.getaddr(address)) -> :inet6
+      true -> :nxdomain
     end
   end
 


### PR DESCRIPTION
Because `Utils.ip_version` does not resolve host names but only checks IP-address strings, instead use the existing `detect_ip_version` function (again) that in fact resolves host names.
(After all, it makes sense to resolve names when you check `DB_HOSTNAME` or the host part of a URL.)
