### PR TITLE
feat: LQL timestamp support for unix timestamps and ISO8601

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/lql/index.md
+++ b/docs/docs.logflare.com/docs/concepts/lql/index.md
@@ -31,7 +31,7 @@ You can use data in metadata fields to limit your search. Reference your schema 
 | Field    | Filter                                  | Syntax                                                                      | Example                                                                                                           |
 | -------- | --------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Metadata | exact match                             | `path:value`                                                                | `m.response.status_code:500`                                                                                      |
-| Metadata | match float, integer or datetime values | `path:>=value` <br/> `path:>value` <br/> `path:<=value` <br/> `path:<value` | `m.response.status_code:>300` <br/> `m.response.status_code:<=400` <br/> `m.user.created_at:>2019-07-01T00:15:00` |
+| Metadata | match float, integer or datetime values | `path:>=value` <br/> `path:>value` <br/> `path:<=value` <br/> `path:<value` | `m.response.status_code:>300` <br/> `m.response.status_code:<=400` <br/> `m.user.created_at:>2019-07-01T00:15:00` <br/> `m.user.created_at:>=2026-03-17T14:47:02.000Z` <br/> `m.user.created_at:>=2026-03-17T14:47:02+02:00` <br/> `m.user.created_at:>=1710683222000` |
 | Metadata | match regex                             | `path:~regex`                                                               | `m.browser:~"Firefox 5\d"`                                                                                        |
 | Metadata | match regex or                          | <code>path:~"value1&#124;value2&#124;value3"</code>                         | <code>m.url:~"jpg$&#124;jpeg$&#124;png$"</code>                                                                   |
 | Metadata | match array includes                    | `path:@>value`                                                              | `m.user.roles:@>"new" subscriber"`                                                                                |
@@ -54,6 +54,9 @@ Timestamps will be automatically converted to UTC if Logflare is set to display 
 | Timestamp | date range                     | `t:2022-04-{07..09}`                                            |
 | Timestamp | datetime range                 | `t:2022-04-{07..09}T00:{00..40}:00`                             |
 | Timestamp | datetime range with subseconds | `t:2022-04-{07..09}T00:{00..40}:00.{001..314}`                  |
+| Timestamp | UTC ISO 8601 datetime          | `t:>2026-03-17T14:47:02.000Z`                                   |
+| Timestamp | offset ISO 8601 datetime       | `t:>2026-03-17T14:47:02+02:00` <br/> `t:<2026-03-17T14:47:02-02:00` |
+| Timestamp | Unix timestamp                 | `t:1710683222..1710684222` <br/> `t:1710683222000..1710684222000` <br/> `t:1710683222000000` _(microseconds are truncated to milliseconds; only 10, 13, and 16 digit Unix timestamps are accepted)_ |
 
 #### Chart Aggregations
 

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -461,6 +461,9 @@ defmodule Logflare.Logs.SearchOperations do
     lql_ts_filters =
       so.lql_ts_filters
       |> Enum.map(fn
+        %{path: "timestamp", modifiers: %{explicit_timezone: true}} = pvo ->
+          pvo
+
         %{path: "timestamp", values: values, operator: :range} = pvo ->
           values =
             for value <- values do

--- a/lib/logflare/lql/encoder.ex
+++ b/lib/logflare/lql/encoder.ex
@@ -94,13 +94,7 @@ defmodule Logflare.Lql.Encoder do
     do: "t:#{op}#{v}"
 
   defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: v}) do
-    dtstring =
-      v
-      |> DateTime.from_naive!("Etc/UTC")
-      |> Timex.format!("{ISO:Extended:Z}")
-      |> String.trim_trailing("Z")
-
-    "t:#{op}#{dtstring}"
+    "t:#{op}#{format_filter_value(v)}"
   end
 
   defp to_fragment(%FilterRule{
@@ -127,7 +121,7 @@ defmodule Logflare.Lql.Encoder do
   defp to_fragment(%FilterRule{path: "event_message", value: v, operator: :"~"}), do: "~#{v}"
 
   defp to_fragment(%FilterRule{path: path, operator: :range, values: values}) do
-    "#{path}:#{Enum.join(values, "..")}"
+    "#{path}:#{Enum.map_join(values, "..", &format_generic_filter_value/1)}"
     |> String.replace_leading("timestamp:", "t:")
     |> String.replace_leading("metadata.", "m.")
   end
@@ -144,7 +138,7 @@ defmodule Logflare.Lql.Encoder do
   end
 
   defp to_fragment(%FilterRule{path: path, operator: :=, value: v}) do
-    value = maybe_quote(v)
+    value = format_generic_filter_value(v)
 
     "#{path}:#{value}"
     |> String.replace_leading("timestamp:", "t:")
@@ -163,7 +157,7 @@ defmodule Logflare.Lql.Encoder do
   end
 
   defp to_fragment(%FilterRule{path: path, operator: :list_includes, value: v}) do
-    value = maybe_quote(v)
+    value = format_generic_filter_value(v)
 
     "#{path}:@>#{value}"
     |> String.replace_leading("timestamp:", "t:")
@@ -182,7 +176,7 @@ defmodule Logflare.Lql.Encoder do
   end
 
   defp to_fragment(%FilterRule{path: path, operator: :list_includes_regexp, value: v}) do
-    value = maybe_quote(v)
+    value = format_generic_filter_value(v)
 
     "#{path}:@>~#{value}"
     |> String.replace_leading("timestamp:", "t:")
@@ -201,7 +195,7 @@ defmodule Logflare.Lql.Encoder do
   end
 
   defp to_fragment(%FilterRule{path: path, operator: op, value: v}) do
-    value = maybe_quote(v)
+    value = format_generic_filter_value(v)
 
     "#{path}:#{op}#{value}"
     |> String.replace_leading("timestamp:", "t:")
@@ -234,6 +228,25 @@ defmodule Logflare.Lql.Encoder do
   end
 
   defp maybe_quote(v), do: to_string(v)
+
+  defp format_generic_filter_value(value) when is_valid_date_or_datetime(value),
+    do: format_filter_value(value)
+
+  defp format_generic_filter_value(value), do: maybe_quote(value)
+
+  defp format_filter_value(%Date{} = value), do: Date.to_iso8601(value)
+
+  defp format_filter_value(%DateTime{} = value) do
+    value
+    |> DateTime.shift_zone!("Etc/UTC")
+    |> DateTime.to_naive()
+    |> format_filter_value()
+  end
+
+  defp format_filter_value(%NaiveDateTime{microsecond: {0, _}} = value),
+    do: NaiveDateTime.to_iso8601(%{value | microsecond: {0, 0}})
+
+  defp format_filter_value(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
 
   def to_datetime_with_range(%Date{} = ldt, %Date{} = rdt) do
     mapper_fn = fn period -> timestamp_mapper(ldt, rdt, period) end

--- a/lib/logflare/lql/parser.ex
+++ b/lib/logflare/lql/parser.ex
@@ -310,9 +310,16 @@ defmodule Logflare.Lql.Parser do
   end
 
   defp maybe_cast_value(c, :string), do: c
-  defp maybe_cast_value(c, :datetime), do: c
-  # questionable if this can be reached
-  defp maybe_cast_value(c, :naive_datetime), do: c
+
+  defp maybe_cast_value(%{value: value} = c, type) when type in [:datetime, :naive_datetime] do
+    case parse_datetime_literal(value) do
+      {:ok, parsed_value} ->
+        %{c | value: parsed_value}
+
+      {:error, _reason} ->
+        throw("Query syntax error: expected datetime for #{c.path}, got: '#{value}'")
+    end
+  end
 
   # also questionable if this can be reached
   defp maybe_cast_value(c, nil) do

--- a/lib/logflare/lql/parser/combinators.ex
+++ b/lib/logflare/lql/parser/combinators.ex
@@ -373,7 +373,7 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> reduce(:parse_date_or_datetime)
   end
 
-  defp iso_datetime_string do
+  defp iso_datetime_parts do
     iso_date_string()
     |> string("T")
     |> ascii_string([?0..?9], 2)
@@ -385,7 +385,20 @@ defmodule Logflare.Lql.Parser.Combinators do
       string(".")
       |> ascii_string([?0..?9], min: 1, max: 6)
     )
-    |> optional(timezone())
+  end
+
+  defp iso_datetime_string_with_timezone do
+    iso_datetime_parts()
+    |> concat(timezone())
+    |> reduce({Enum, :join, [""]})
+  end
+
+  defp iso_datetime_string do
+    choice([
+      iso_datetime_string_with_timezone(),
+      iso_datetime_parts()
+      |> reduce({Enum, :join, [""]})
+    ])
     |> reduce({Enum, :join, [""]})
   end
 
@@ -399,6 +412,18 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> unwrap_and_tag(:datetime)
     |> label("ISO8601 datetime")
     |> reduce(:parse_date_or_datetime)
+  end
+
+  def timestamp_datetime do
+    choice([
+      iso_datetime_string_with_timezone()
+      |> unwrap_and_tag(:datetime_tz),
+      iso_datetime_parts()
+      |> reduce({Enum, :join, [""]})
+      |> unwrap_and_tag(:datetime)
+    ])
+    |> label("ISO8601 datetime")
+    |> reduce(:parse_timestamp_datetime)
   end
 
   def timezone do
@@ -513,6 +538,12 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> label("date, datetime, or Unix timestamp value")
   end
 
+  def timestamp_date_or_datetime_or_unix do
+    [timestamp_datetime(), date(), unix_timestamp()]
+    |> choice()
+    |> label("date, datetime, or Unix timestamp value")
+  end
+
   def timestamp_shorthand_value do
     choice([
       string("now"),
@@ -531,9 +562,9 @@ defmodule Logflare.Lql.Parser.Combinators do
 
   def timestamp_value do
     choice([
-      range_operator(date_or_datetime_or_unix()),
+      range_operator(timestamp_date_or_datetime_or_unix()),
       datetime_with_range(),
-      date_or_datetime_or_unix(),
+      timestamp_date_or_datetime_or_unix(),
       timestamp_shorthand_value(),
       invalid_match_all_value()
     ])

--- a/lib/logflare/lql/parser/combinators.ex
+++ b/lib/logflare/lql/parser/combinators.ex
@@ -157,6 +157,8 @@ defmodule Logflare.Lql.Parser.Combinators do
 
   def field_value do
     choice([
+      range_operator(date_or_datetime_literal()),
+      date_or_datetime_literal(),
       range_operator(number()),
       number(),
       null(),
@@ -350,20 +352,29 @@ defmodule Logflare.Lql.Parser.Combinators do
     ])
   end
 
-  def date do
+  defp iso_date_string do
     ascii_string([?0..?9], 4)
     |> string("-")
     |> ascii_string([?0..?9], 2)
     |> string("-")
     |> ascii_string([?0..?9], 2)
     |> reduce({Enum, :join, [""]})
+  end
+
+  def date_literal_string do
+    iso_date_string()
+    |> label("ISO8601 date")
+  end
+
+  def date do
+    iso_date_string()
     |> unwrap_and_tag(:date)
     |> label("ISO8601 date")
     |> reduce(:parse_date_or_datetime)
   end
 
-  def datetime do
-    date()
+  defp iso_datetime_string do
+    iso_date_string()
     |> string("T")
     |> ascii_string([?0..?9], 2)
     |> string(":")
@@ -372,21 +383,44 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> ascii_string([?0..?9], 2)
     |> optional(
       string(".")
-      |> ascii_string([?0..?9], 6)
+      |> ascii_string([?0..?9], min: 1, max: 6)
     )
-    |> optional(
-      choice([
-        string("Z"),
-        string("+")
-        |> ascii_string([?0..?9], 2)
-        |> string(":")
-        |> ascii_string([?0..?9], 2)
-      ])
-    )
+    |> optional(timezone())
     |> reduce({Enum, :join, [""]})
+  end
+
+  def datetime_literal_string do
+    iso_datetime_string()
+    |> label("ISO8601 datetime")
+  end
+
+  def datetime do
+    iso_datetime_string()
     |> unwrap_and_tag(:datetime)
     |> label("ISO8601 datetime")
     |> reduce(:parse_date_or_datetime)
+  end
+
+  def timezone do
+    choice([
+      string("Z") |> replace("Z"),
+      choice([string("+"), string("-")])
+      |> concat(ascii_string([?0..?9], 2))
+      |> concat(string(":"))
+      |> concat(ascii_string([?0..?9], 2))
+      |> reduce({Enum, :join, [""]})
+    ])
+  end
+
+  def unix_timestamp do
+    choice([
+      ascii_string([?0..?9], 16),
+      ascii_string([?0..?9], 13),
+      ascii_string([?0..?9], 10)
+    ])
+    |> lookahead_not(ascii_char([?0..?9]))
+    |> label("Unix timestamp")
+    |> reduce(:parse_unix_timestamp_literal)
   end
 
   def integer_with_range(combinator \\ empty(), number) do
@@ -455,14 +489,8 @@ defmodule Logflare.Lql.Parser.Combinators do
     |> lookahead_not(string(".."))
     |> concat(
       optional(
-        choice([
-          ignore(string("Z")),
-          string("+")
-          |> ascii_string([?0..?9], 2)
-          |> string(":")
-          |> ascii_string([?0..?9], 2)
-        ])
-        # |> tag(:timezone)
+        timezone()
+        |> unwrap_and_tag(:timezone)
       )
     )
   end
@@ -471,6 +499,18 @@ defmodule Logflare.Lql.Parser.Combinators do
     [datetime(), date()]
     |> choice()
     |> label("date or datetime value")
+  end
+
+  def date_or_datetime_literal do
+    [datetime_literal_string(), date_literal_string()]
+    |> choice()
+    |> label("date or datetime literal")
+  end
+
+  def date_or_datetime_or_unix do
+    [datetime(), date(), unix_timestamp()]
+    |> choice()
+    |> label("date, datetime, or Unix timestamp value")
   end
 
   def timestamp_shorthand_value do
@@ -491,9 +531,9 @@ defmodule Logflare.Lql.Parser.Combinators do
 
   def timestamp_value do
     choice([
-      range_operator(date_or_datetime()),
+      range_operator(date_or_datetime_or_unix()),
       datetime_with_range(),
-      date_or_datetime(),
+      date_or_datetime_or_unix(),
       timestamp_shorthand_value(),
       invalid_match_all_value()
     ])

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -85,7 +85,11 @@ defmodule Logflare.Lql.Parser.Helpers do
   end
 
   def to_rule(args, :filter) when is_list(args) do
-    filter = struct!(FilterRule, Map.new(args))
+    filter =
+      args
+      |> Map.new()
+      |> then(&struct!(FilterRule, &1))
+      |> maybe_merge_value_modifiers()
 
     cond do
       match?({:quoted, _}, filter.value) ->
@@ -100,10 +104,19 @@ defmodule Logflare.Lql.Parser.Helpers do
 
         case value do
           [[_, _] = v] ->
-            %{filter | value: nil, values: v, operator: :range}
+            {values, modifiers} = unwrap_values_modifiers(v)
+
+            %{
+              filter
+              | value: nil,
+                values: values,
+                operator: :range,
+                modifiers: Map.merge(filter.modifiers, modifiers)
+            }
 
           [[v]] ->
-            %{filter | value: v}
+            {value, modifiers} = unwrap_value_modifiers(v)
+            %{filter | value: value, modifiers: Map.merge(filter.modifiers, modifiers)}
         end
 
       true ->
@@ -159,8 +172,15 @@ defmodule Logflare.Lql.Parser.Helpers do
   # DateTime Helper Functions
   # ============================================================================
 
-  @spec parse_date_or_datetime_with_range(list()) :: [Date.t() | NaiveDateTime.t()]
+  @spec parse_date_or_datetime_with_range(list()) ::
+          [Date.t() | NaiveDateTime.t() | {:with_modifiers, NaiveDateTime.t(), map()}]
   def parse_date_or_datetime_with_range(result) when is_list(result) do
+    explicit_timezone =
+      Enum.any?(result, fn
+        {:timezone, _timezone} -> true
+        _ -> false
+      end)
+
     [lv, rv] =
       result
       |> Enum.reduce([%{}, %{}], fn
@@ -177,6 +197,7 @@ defmodule Logflare.Lql.Parser.Helpers do
           [Map.put(lacc, k, lv), Map.put(racc, k, rv)]
       end)
       |> Enum.map(&build_date_or_datetime_from_parts/1)
+      |> maybe_mark_explicit_timezone(explicit_timezone)
 
     if lv == rv do
       [lv]
@@ -187,6 +208,18 @@ defmodule Logflare.Lql.Parser.Helpers do
 
   @spec parse_date_or_datetime([{:date | :datetime, String.t()}]) :: Date.t() | NaiveDateTime.t()
   def parse_date_or_datetime([{tag, result}]), do: parse_iso8601_value!(tag, result)
+
+  @spec parse_timestamp_datetime([{:datetime | :datetime_tz, String.t()}]) ::
+          NaiveDateTime.t() | {:with_modifiers, NaiveDateTime.t(), map()}
+  def parse_timestamp_datetime([{tag, result}]) when tag in [:datetime, :datetime_tz] do
+    value = parse_iso8601_value!(:datetime, result)
+
+    if tag == :datetime_tz do
+      {:with_modifiers, value, %{explicit_timezone: true}}
+    else
+      value
+    end
+  end
 
   @spec parse_datetime_literal(term()) :: {:ok, Date.t() | NaiveDateTime.t()} | {:error, term()}
   def parse_datetime_literal(%Date{} = value), do: {:ok, value}
@@ -217,11 +250,11 @@ defmodule Logflare.Lql.Parser.Helpers do
 
   def parse_datetime_literal(_value), do: {:error, :invalid_format}
 
-  @spec parse_unix_timestamp_literal([String.t()]) :: NaiveDateTime.t()
+  @spec parse_unix_timestamp_literal([String.t()]) :: {:with_modifiers, NaiveDateTime.t(), map()}
   def parse_unix_timestamp_literal([value]) do
     case parse_unix_timestamp(value) do
       {:ok, parsed} ->
-        parsed
+        {:with_modifiers, parsed, %{explicit_timezone: true}}
 
       {:error, :invalid_format} ->
         throw(
@@ -485,4 +518,40 @@ defmodule Logflare.Lql.Parser.Helpers do
         {:error, :invalid_format}
     end
   end
+
+  defp maybe_merge_value_modifiers(%FilterRule{} = rule) do
+    {value, modifiers} = unwrap_value_modifiers(rule.value)
+
+    %{
+      rule
+      | value: value,
+        modifiers: Map.merge(rule.modifiers, modifiers)
+    }
+  end
+
+  defp unwrap_value_modifiers({:with_modifiers, value, modifiers}),
+    do: {value, modifiers}
+
+  defp unwrap_value_modifiers({:range_operator, [lvalue, rvalue]}) do
+    {lvalue, lmodifiers} = unwrap_value_modifiers(lvalue)
+    {rvalue, rmodifiers} = unwrap_value_modifiers(rvalue)
+
+    {{:range_operator, [lvalue, rvalue]}, Map.merge(lmodifiers, rmodifiers)}
+  end
+
+  defp unwrap_value_modifiers(value), do: {value, %{}}
+
+  defp unwrap_values_modifiers(values) when is_list(values) do
+    Enum.reduce(values, {[], %{}}, fn value, {acc, modifiers} ->
+      {value, value_modifiers} = unwrap_value_modifiers(value)
+      {[value | acc], Map.merge(modifiers, value_modifiers)}
+    end)
+    |> then(fn {values, modifiers} -> {Enum.reverse(values), modifiers} end)
+  end
+
+  defp maybe_mark_explicit_timezone(values, true) when is_list(values) do
+    Enum.map(values, &{:with_modifiers, &1, %{explicit_timezone: true}})
+  end
+
+  defp maybe_mark_explicit_timezone(values, false), do: values
 end

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -164,6 +164,9 @@ defmodule Logflare.Lql.Parser.Helpers do
     [lv, rv] =
       result
       |> Enum.reduce([%{}, %{}], fn
+        {:timezone, timezone}, [lacc, racc] ->
+          [Map.put(lacc, :timezone, timezone), Map.put(racc, :timezone, timezone)]
+
         {k, v}, [lacc, racc] ->
           [lv, rv] =
             case v do
@@ -173,20 +176,7 @@ defmodule Logflare.Lql.Parser.Helpers do
 
           [Map.put(lacc, k, lv), Map.put(racc, k, rv)]
       end)
-      |> Enum.map(fn
-        %{second: _, minute: _, hour: _} = dt ->
-          dt =
-            Map.update(dt, :microsecond, {0, 0}, fn us ->
-              {float, ""} = Float.parse("0." <> us)
-
-              {round(float * 1_000_000), 6}
-            end)
-
-          struct!(NaiveDateTime, dt)
-
-        d ->
-          struct!(Date, d)
-      end)
+      |> Enum.map(&build_date_or_datetime_from_parts/1)
 
     if lv == rv do
       [lv]
@@ -196,27 +186,50 @@ defmodule Logflare.Lql.Parser.Helpers do
   end
 
   @spec parse_date_or_datetime([{:date | :datetime, String.t()}]) :: Date.t() | NaiveDateTime.t()
-  def parse_date_or_datetime([{tag, result}]) do
-    mod =
-      case tag do
-        :date -> Date
-        :datetime -> NaiveDateTime
-      end
+  def parse_date_or_datetime([{tag, result}]), do: parse_iso8601_value!(tag, result)
 
-    case mod.from_iso8601(result) do
-      {:ok, dt, _offset} ->
-        dt
+  @spec parse_datetime_literal(term()) :: {:ok, Date.t() | NaiveDateTime.t()} | {:error, term()}
+  def parse_datetime_literal(%Date{} = value), do: {:ok, value}
+  def parse_datetime_literal(%NaiveDateTime{} = value), do: {:ok, value}
 
-      {:ok, dt} ->
-        dt
+  def parse_datetime_literal(%DateTime{} = value) do
+    {:ok, value |> DateTime.shift_zone!("Etc/UTC") |> DateTime.to_naive()}
+  end
+
+  def parse_datetime_literal(value) when is_integer(value) do
+    value
+    |> Integer.to_string()
+    |> parse_unix_timestamp()
+  end
+
+  def parse_datetime_literal(value) when is_binary(value) do
+    cond do
+      String.match?(value, ~r/^\d+$/) ->
+        parse_unix_timestamp(value)
+
+      String.contains?(value, "T") ->
+        parse_iso8601_datetime(value)
+
+      true ->
+        parse_iso8601_date(value)
+    end
+  end
+
+  def parse_datetime_literal(_value), do: {:error, :invalid_format}
+
+  @spec parse_unix_timestamp_literal([String.t()]) :: NaiveDateTime.t()
+  def parse_unix_timestamp_literal([value]) do
+    case parse_unix_timestamp(value) do
+      {:ok, parsed} ->
+        parsed
 
       {:error, :invalid_format} ->
         throw(
-          "Error while parsing timestamp #{tag} value: expected ISO8601 string, got '#{result}'"
+          "Error while parsing timestamp: '#{value}' is not a valid Unix timestamp (expected 10, 13, or 16 digits)"
         )
 
-      {:error, e} ->
-        throw(e)
+      {:error, error} ->
+        throw(error)
     end
   end
 
@@ -316,7 +329,7 @@ defmodule Logflare.Lql.Parser.Helpers do
         :timestamp
       ) do
     throw(
-      "Error while parsing timestamp filter value: expected ISO8601 string or range or shorthand, got '#{v}'"
+      "Error while parsing timestamp filter value: expected ISO8601 string, Unix timestamp, range or shorthand, got '#{v}'"
     )
   end
 
@@ -338,4 +351,138 @@ defmodule Logflare.Lql.Parser.Helpers do
   end
 
   def check_for_invalid_blank_select_alias(args), do: args
+
+  defp build_date_or_datetime_from_parts(%{second: _, minute: _, hour: _} = dt) do
+    {timezone, dt} = Map.pop(dt, :timezone)
+    microseconds = Map.get(dt, :microsecond)
+
+    if is_binary(timezone) do
+      dt
+      |> datetime_parts_to_iso8601(microseconds, timezone)
+      |> then(&parse_iso8601_value!(:datetime, &1))
+    else
+      dt =
+        Map.update(dt, :microsecond, {0, 0}, fn us ->
+          {float, ""} = Float.parse("0." <> us)
+
+          {round(float * 1_000_000), 6}
+        end)
+
+      struct!(NaiveDateTime, dt)
+    end
+  end
+
+  defp build_date_or_datetime_from_parts(d), do: struct!(Date, d)
+
+  defp datetime_parts_to_iso8601(dt, microseconds, timezone) do
+    datetime =
+      "#{dt.year}-#{pad_int(dt.month)}-#{pad_int(dt.day)}T#{pad_int(dt.hour)}:#{pad_int(dt.minute)}:#{pad_int(dt.second)}"
+
+    case microseconds do
+      nil ->
+        datetime <> timezone
+
+      us ->
+        datetime <> "." <> us <> timezone
+    end
+  end
+
+  defp pad_int(value), do: String.pad_leading(to_string(value), 2, "0")
+
+  defp parse_iso8601_value!(:date, value) do
+    case parse_iso8601_date(value) do
+      {:ok, parsed} ->
+        parsed
+
+      {:error, :invalid_format} ->
+        throw("Error while parsing timestamp date value: expected ISO8601 string, got '#{value}'")
+
+      {:error, error} ->
+        throw(error)
+    end
+  end
+
+  defp parse_iso8601_value!(:datetime, value) do
+    case parse_iso8601_datetime(value) do
+      {:ok, parsed} ->
+        parsed
+
+      {:error, :invalid_format} ->
+        throw(
+          "Error while parsing timestamp datetime value: expected ISO8601 string, got '#{value}'"
+        )
+
+      {:error, error} ->
+        throw(error)
+    end
+  end
+
+  defp parse_iso8601_date(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> {:ok, date}
+      {:error, :invalid_format} -> {:error, :invalid_format}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp parse_iso8601_datetime(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} ->
+        {:ok, DateTime.to_naive(datetime)}
+
+      {:error, :missing_offset} ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, datetime} -> {:ok, datetime}
+          {:error, :invalid_format} -> {:error, :invalid_format}
+          {:error, error} -> {:error, error}
+        end
+
+      {:error, :invalid_format} ->
+        {:error, :invalid_format}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp parse_unix_timestamp(value) when is_binary(value) do
+    case normalize_unix_timestamp(value) do
+      {timestamp, unit} when is_integer(timestamp) ->
+        case DateTime.from_unix(timestamp, unit) do
+          {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
+          {:error, error} -> {:error, error}
+        end
+
+      :error ->
+        {:error, :invalid_format}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp normalize_unix_timestamp(value) do
+    case byte_size(value) do
+      10 ->
+        case Integer.parse(value) do
+          {timestamp, ""} -> {timestamp, :second}
+          _ -> :error
+        end
+
+      13 ->
+        case Integer.parse(value) do
+          {timestamp, ""} -> {timestamp, :millisecond}
+          _ -> :error
+        end
+
+      16 ->
+        case Integer.parse(value) do
+          {timestamp, ""} -> {div(timestamp, 1_000), :millisecond}
+          _ -> :error
+        end
+
+      _ ->
+        {:error, :invalid_format}
+    end
+  end
 end

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -319,6 +319,42 @@ defmodule Logflare.Logs.SearchOperationsTest do
     end
   end
 
+  describe "apply_local_timestamp_correction/1" do
+    test "skips timestamp filters with explicit timezone modifiers" do
+      value = ~N[2026-03-17 14:47:02]
+      range_start = ~N[2026-03-17 14:47:02]
+      range_end = ~N[2026-03-17 15:47:02]
+
+      so =
+        %SO{
+          partition_by: :timestamp,
+          querystring: "",
+          tailing?: false,
+          chart_data_shape_id: nil,
+          lql_ts_filters: [
+            %FilterRule{
+              path: "timestamp",
+              operator: :>,
+              value: value,
+              modifiers: %{explicit_timezone: true}
+            },
+            %FilterRule{
+              path: "timestamp",
+              operator: :range,
+              value: nil,
+              values: [range_start, range_end],
+              modifiers: %{explicit_timezone: true}
+            }
+          ],
+          search_timezone: "Australia/Brisbane"
+        }
+
+      corrected = SearchOperations.apply_local_timestamp_correction(so)
+
+      assert corrected.lql_ts_filters == so.lql_ts_filters
+    end
+  end
+
   describe "postgres timestamp filter rules" do
     setup_single_tenant(backend_type: :postgres)
 

--- a/test/logflare/lql/encoder_test.exs
+++ b/test/logflare/lql/encoder_test.exs
@@ -95,6 +95,32 @@ defmodule Logflare.Lql.EncoderTest do
       assert result == "t:2020-01-01T{10..11}:{30..45}:00"
     end
 
+    test "drops zero milliseconds in timestamp" do
+      lql_rules = [
+        %FilterRule{
+          operator: :>=,
+          path: "timestamp",
+          value: NaiveDateTime.from_iso8601!("2026-03-17T12:47:02.000")
+        }
+      ]
+
+      result = Encoder.to_querystring(lql_rules)
+      assert result == "t:>=2026-03-17T12:47:02"
+    end
+
+    test "formats milliseconds in timestamp" do
+      lql_rules = [
+        %FilterRule{
+          operator: :>=,
+          path: "timestamp",
+          value: NaiveDateTime.from_iso8601!("2026-03-17T12:47:02.123")
+        }
+      ]
+
+      result = Encoder.to_querystring(lql_rules)
+      assert result == "t:>=2026-03-17T12:47:02.123"
+    end
+
     test "encodes quoted string filter" do
       lql_rules = [
         %FilterRule{

--- a/test/logflare/lql/parser/combinators_test.exs
+++ b/test/logflare/lql/parser/combinators_test.exs
@@ -25,6 +25,7 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
   defparsec(:test_datetime_abbreviations, Combinators.datetime_abbreviations())
   defparsec(:test_date, Combinators.date())
   defparsec(:test_datetime, Combinators.datetime())
+  defparsec(:test_timestamp_datetime, Combinators.timestamp_datetime())
   defparsec(:test_timestamp_shorthand_value, Combinators.timestamp_shorthand_value())
   defparsec(:test_timestamp_value, Combinators.timestamp_value())
 
@@ -163,10 +164,24 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
       assert match?({:ok, [value: %{shorthand: "now"}], "", _, _, _}, result)
 
       result = test_timestamp_value("1710683222000")
-      assert match?({:ok, [value: ~N[2024-03-17 13:47:02.000]], "", _, _, _}, result)
+
+      assert {:ok,
+              [value: {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{explicit_timezone: true}}],
+              "", _, _, _} = result
 
       result = test_timestamp_value("1710683222000000")
-      assert match?({:ok, [value: ~N[2024-03-17 13:47:02.000]], "", _, _, _}, result)
+
+      assert {:ok,
+              [value: {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{explicit_timezone: true}}],
+              "", _, _, _} = result
+    end
+
+    test "timestamp datetime parser distinguishes timezone-bearing datetimes" do
+      assert {:ok, [{:with_modifiers, ~N[2023-01-15 10:00:00], %{explicit_timezone: true}}], "",
+              _, _, _} = test_timestamp_datetime("2023-01-15T10:00:00Z")
+
+      assert {:ok, [~N[2023-01-15 10:00:00]], "", _, _, _} =
+               test_timestamp_datetime("2023-01-15T10:00:00")
     end
   end
 
@@ -176,10 +191,15 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
       assert match?({:ok, [%{path: "timestamp"}], "", _, _, _}, result)
 
       result = test_timestamp_clause("t:>2023-01-15T10:00:00Z")
-      assert match?({:ok, [%{path: "timestamp", operator: :>}], "", _, _, _}, result)
+
+      assert {:ok, [%{path: "timestamp", operator: :>, modifiers: %{explicit_timezone: true}}],
+              "", _, _, _} = result
 
       result = test_timestamp_clause("t:1710683222..1710684222")
-      assert match?({:ok, [%{path: "timestamp", operator: :range}], "", _, _, _}, result)
+
+      assert {:ok,
+              [%{path: "timestamp", operator: :range, modifiers: %{explicit_timezone: true}}], "",
+              _, _, _} = result
     end
 
     test "metadata clause parser" do

--- a/test/logflare/lql/parser/combinators_test.exs
+++ b/test/logflare/lql/parser/combinators_test.exs
@@ -131,6 +131,12 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
     test "datetime parser" do
       result = test_datetime("2023-01-15T10:30:00Z")
       assert match?({:ok, [~N[2023-01-15 10:30:00]], "", _, _, _}, result)
+
+      result = test_datetime("2023-01-15T10:30:00.1234+02:00")
+      assert match?({:ok, [~N[2023-01-15 08:30:00.1234]], "", _, _, _}, result)
+
+      result = test_datetime("2023-01-15T10:30:00-02:00")
+      assert match?({:ok, [~N[2023-01-15 12:30:00]], "", _, _, _}, result)
     end
 
     test "timestamp shorthand value parser" do
@@ -155,6 +161,12 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
 
       result = test_timestamp_value("now")
       assert match?({:ok, [value: %{shorthand: "now"}], "", _, _, _}, result)
+
+      result = test_timestamp_value("1710683222000")
+      assert match?({:ok, [value: ~N[2024-03-17 13:47:02.000]], "", _, _, _}, result)
+
+      result = test_timestamp_value("1710683222000000")
+      assert match?({:ok, [value: ~N[2024-03-17 13:47:02.000]], "", _, _, _}, result)
     end
   end
 
@@ -165,6 +177,9 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
 
       result = test_timestamp_clause("t:>2023-01-15T10:00:00Z")
       assert match?({:ok, [%{path: "timestamp", operator: :>}], "", _, _, _}, result)
+
+      result = test_timestamp_clause("t:1710683222..1710684222")
+      assert match?({:ok, [%{path: "timestamp", operator: :range}], "", _, _, _}, result)
     end
 
     test "metadata clause parser" do

--- a/test/logflare/lql/parser/helpers_test.exs
+++ b/test/logflare/lql/parser/helpers_test.exs
@@ -268,6 +268,51 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert result == ~N[2023-01-15 10:30:00]
     end
 
+    test "parse_date_or_datetime normalizes UTC offsets" do
+      result = Helpers.parse_date_or_datetime([{:datetime, "2023-01-15T10:30:00+02:00"}])
+      assert result == ~N[2023-01-15 08:30:00]
+    end
+
+    test "parse_datetime_literal handles Unix timestamps in seconds and milliseconds" do
+      assert {:ok, ~N[2024-03-17 13:47:02]} = Helpers.parse_datetime_literal("1710683222")
+      assert {:ok, ~N[2024-03-17 13:47:02.000]} = Helpers.parse_datetime_literal("1710683222000")
+    end
+
+    test "parse_datetime_literal truncates Unix microseconds to milliseconds" do
+      assert {:ok, ~N[2024-03-17 13:47:02.000]} =
+               Helpers.parse_datetime_literal("1710683222000001")
+    end
+
+    test "parse_datetime_literal rejects unsupported Unix widths" do
+      assert {:error, :invalid_format} = Helpers.parse_datetime_literal("171068322200")
+      assert {:error, :invalid_format} = Helpers.parse_datetime_literal("17106832220000")
+      assert {:error, :invalid_format} = Helpers.parse_datetime_literal("171068322200000")
+    end
+
+    test "parse_datetime_literal rejects invalid formats" do
+      assert {:error, :invalid_format} = Helpers.parse_datetime_literal(:bad_format)
+    end
+
+    test "parse_unix_timestamp_literal raises for unsupported widths" do
+      assert catch_throw(Helpers.parse_unix_timestamp_literal(["17106832220000"])) ==
+               "Error while parsing timestamp: '17106832220000' is not a valid Unix timestamp (expected 10, 13, or 16 digits)"
+    end
+
+    test "parse_date_or_datetime_with_range normalizes timezone-bearing values" do
+      result =
+        Helpers.parse_date_or_datetime_with_range(
+          year: [2023],
+          month: [1],
+          day: [15],
+          hour: [10],
+          minute: [30],
+          second: [0],
+          timezone: "+02:00"
+        )
+
+      assert result == [~N[2023-01-15 08:30:00]]
+    end
+
     test "timestamp_shorthand_to_value handles 'now'" do
       result = Helpers.timestamp_shorthand_to_value(["now"])
       assert result.shorthand == "now"
@@ -323,8 +368,6 @@ defmodule Logflare.Lql.Parser.HelpersTest do
 
   describe "ISO8601 parsing error handling" do
     test "handles ISO8601 parsing with timezone offset" do
-      stub(Date, :from_iso8601, fn _ -> {:ok, ~D[2023-01-01], "+00:00"} end)
-
       result = Helpers.parse_date_or_datetime([{:date, "2023-01-01"}])
       assert result == ~D[2023-01-01]
     end
@@ -336,7 +379,7 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert error =~ "Error while parsing timestamp date value: expected ISO8601 string, got"
     end
 
-    test "handles generic ISO8601 error" do
+    test "handles generic ISO8601 errors" do
       stub(Date, :from_iso8601, fn _ -> {:error, "custom error"} end)
 
       error = catch_throw(Helpers.parse_date_or_datetime([{:date, "2023-01-01"}]))

--- a/test/logflare/lql/parser/helpers_test.exs
+++ b/test/logflare/lql/parser/helpers_test.exs
@@ -123,6 +123,19 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert result.value == ~N[2023-01-01 12:00:00]
       assert is_nil(result.shorthand)
     end
+
+    test "merges explicit timezone modifier for timestamp datetime values" do
+      args = [
+        path: "timestamp",
+        operator: :=,
+        value: {:with_modifiers, ~N[2023-01-01 12:00:00], %{explicit_timezone: true}}
+      ]
+
+      result = Helpers.to_rule(args, :filter)
+
+      assert result.value == ~N[2023-01-01 12:00:00]
+      assert result.modifiers == %{explicit_timezone: true}
+    end
   end
 
   describe "to_rule/1 for metadata_level_clause" do
@@ -273,9 +286,29 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert result == ~N[2023-01-15 08:30:00]
     end
 
+    test "parse_timestamp_datetime preserves explicit timezone modifier for Z suffixes" do
+      assert {:with_modifiers, ~N[2023-01-15 10:30:00], %{explicit_timezone: true}} =
+               Helpers.parse_timestamp_datetime([{:datetime_tz, "2023-01-15T10:30:00Z"}])
+    end
+
+    test "parse_timestamp_datetime preserves explicit timezone modifier for UTC offsets" do
+      assert {:with_modifiers, ~N[2023-01-15 08:30:00], %{explicit_timezone: true}} =
+               Helpers.parse_timestamp_datetime([{:datetime_tz, "2023-01-15T10:30:00+02:00"}])
+    end
+
+    test "parse_timestamp_datetime leaves naive datetimes unmodified" do
+      assert ~N[2023-01-15 10:30:00] =
+               Helpers.parse_timestamp_datetime([{:datetime, "2023-01-15T10:30:00"}])
+    end
+
     test "parse_datetime_literal handles Unix timestamps in seconds and milliseconds" do
       assert {:ok, ~N[2024-03-17 13:47:02]} = Helpers.parse_datetime_literal("1710683222")
       assert {:ok, ~N[2024-03-17 13:47:02.000]} = Helpers.parse_datetime_literal("1710683222000")
+    end
+
+    test "parse_unix_timestamp_literal marks Unix timestamps as explicit timezone" do
+      assert {:with_modifiers, ~N[2024-03-17 13:47:02], %{explicit_timezone: true}} =
+               Helpers.parse_unix_timestamp_literal(["1710683222"])
     end
 
     test "parse_datetime_literal truncates Unix microseconds to milliseconds" do
@@ -310,7 +343,9 @@ defmodule Logflare.Lql.Parser.HelpersTest do
           timezone: "+02:00"
         )
 
-      assert result == [~N[2023-01-15 08:30:00]]
+      assert result == [
+               {:with_modifiers, ~N[2023-01-15 08:30:00], %{explicit_timezone: true}}
+             ]
     end
 
     test "timestamp_shorthand_to_value handles 'now'" do

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -327,6 +327,15 @@ defmodule Logflare.Lql.ParserTest do
                nil
              ]
 
+      assert Enum.map(rules, & &1.modifiers) == [
+               %{explicit_timezone: true},
+               %{explicit_timezone: true},
+               %{explicit_timezone: true},
+               %{explicit_timezone: true},
+               %{explicit_timezone: true},
+               %{explicit_timezone: true}
+             ]
+
       assert Lql.encode!(result) ==
                "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02 t:<=2024-03-17T13:47:02"
     end

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -296,6 +296,51 @@ defmodule Logflare.Lql.ParserTest do
                |> String.trim()
     end
 
+    test "timestamp filters support UTC offsets, Z suffixes, and Unix timestamps" do
+      qs = ~S|
+      t:>2026-03-17T14:47:02.000Z
+      t:>=2026-03-17T14:47:02+02:00
+      t:<2026-03-17T14:47:02-02:00
+      t:1710683222..1710683822
+      t:1710683222000..1710683822000
+      t:<=1710683222000000
+      |
+
+      {:ok, result} = Parser.parse(qs, @default_schema)
+      rules = Enum.filter(result, &(&1.path == "timestamp"))
+
+      assert Enum.map(rules, & &1.value) == [
+               ~N[2026-03-17 14:47:02.000],
+               ~N[2026-03-17 12:47:02],
+               ~N[2026-03-17 16:47:02],
+               nil,
+               nil,
+               ~N[2024-03-17 13:47:02.000]
+             ]
+
+      assert Enum.map(rules, & &1.values) == [
+               nil,
+               nil,
+               nil,
+               [~N[2024-03-17 13:47:02], ~N[2024-03-17 13:57:02]],
+               [~N[2024-03-17 13:47:02.000], ~N[2024-03-17 13:57:02.000]],
+               nil
+             ]
+
+      assert Lql.encode!(result) ==
+               "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02 t:<=2024-03-17T13:47:02"
+    end
+
+    test "timestamp filters reject ambiguous 14 and 15 digit Unix timestamps" do
+      assert {:error,
+              "Error while parsing timestamp filter value: expected ISO8601 string, Unix timestamp, range or shorthand, got '17106832220000'"} =
+               Parser.parse("t:17106832220000", @default_schema)
+
+      assert {:error,
+              "Error while parsing timestamp filter value: expected ISO8601 string, Unix timestamp, range or shorthand, got '171068322200000'"} =
+               Parser.parse("t:171068322200000", @default_schema)
+    end
+
     test "timestamp shorthands" do
       assert {:ok,
               [
@@ -308,7 +353,8 @@ defmodule Logflare.Lql.ParserTest do
               ]} = Parser.parse("timestamp:now", @default_schema)
 
       # use diff to reduce test flakiness
-      assert DateTime.diff(now_ndt(), now_out, :millisecond) |> abs() <= 150
+      assert NaiveDateTime.diff(to_naive(now_ndt()), to_naive(now_out), :millisecond) |> abs() <=
+               150
 
       for {qs, shorthand, start_value, end_value} <- [
             {"t:today", "today", today_dt(),
@@ -378,8 +424,12 @@ defmodule Logflare.Lql.ParserTest do
                 ]} = Parser.parse(qs, @default_schema)
 
         # use diff to reduce test flakiness
-        assert DateTime.diff(start_value, start_out, :millisecond) |> abs() <= 1500
-        assert DateTime.diff(end_value, end_out, :millisecond) |> abs() <= 1500
+        assert NaiveDateTime.diff(to_naive(start_value), to_naive(start_out), :millisecond)
+               |> abs() <=
+                 1500
+
+        assert NaiveDateTime.diff(to_naive(end_value), to_naive(end_out), :millisecond) |> abs() <=
+                 1500
       end
     end
 
@@ -621,7 +671,7 @@ defmodule Logflare.Lql.ParserTest do
                Parser.parse("m.nonexistent:value", @default_schema)
     end
 
-    test "handles naive_datetime fields without casting" do
+    test "casts naive_datetime fields from ISO8601 and Unix literals" do
       schema = build_schema(%{"metadata" => %{"test_field" => "value"}})
       mocked_typemap = %{"metadata.test_field" => :naive_datetime}
 
@@ -629,8 +679,64 @@ defmodule Logflare.Lql.ParserTest do
         mocked_typemap
       end)
 
-      assert {:ok, [%FilterRule{path: "metadata.test_field", value: "test_value"}]} =
+      assert {:ok,
+              [
+                %FilterRule{
+                  path: "metadata.test_field",
+                  operator: :>=,
+                  value: ~N[2026-03-17 12:47:02]
+                },
+                %FilterRule{
+                  path: "metadata.test_field",
+                  operator: :range,
+                  values: [~N[2024-03-17 13:47:02], ~N[2024-03-17 13:57:02]]
+                },
+                %FilterRule{
+                  path: "metadata.test_field",
+                  operator: :<=,
+                  value: ~N[2024-03-17 13:47:02.000]
+                }
+              ]} =
+               Parser.parse(
+                 "m.test_field:>=2026-03-17T14:47:02+02:00 m.test_field:1710683222..1710683822 m.test_field:<=1710683222000000",
+                 schema
+               )
+    end
+
+    test "returns error for invalid naive_datetime field values" do
+      schema = build_schema(%{"metadata" => %{"test_field" => "value"}})
+      mocked_typemap = %{"metadata.test_field" => :naive_datetime}
+
+      stub(Logflare.Google.BigQuery.SchemaUtils, :bq_schema_to_flat_typemap, fn _ ->
+        mocked_typemap
+      end)
+
+      assert {:error,
+              "Query syntax error: expected datetime for metadata.test_field, got: 'test_value'"} =
                Parser.parse("m.test_field:test_value", schema)
+    end
+
+    test "casts datetime fields and encodes them canonically" do
+      schema = build_schema(%{"metadata" => %{"created_at" => "value"}})
+      mocked_typemap = %{"metadata.created_at" => :datetime}
+
+      stub(Logflare.Google.BigQuery.SchemaUtils, :bq_schema_to_flat_typemap, fn _ ->
+        mocked_typemap
+      end)
+
+      assert {:ok, rules} =
+               Parser.parse(
+                 "m.created_at:>=2026-03-17T14:47:02.000Z m.created_at:<=1710683222000",
+                 schema
+               )
+
+      assert Enum.map(rules, & &1.value) == [
+               ~N[2026-03-17 14:47:02.000],
+               ~N[2024-03-17 13:47:02.000]
+             ]
+
+      assert Lql.encode!(rules) ==
+               "m.created_at:>=2026-03-17T14:47:02 m.created_at:<=2024-03-17T13:47:02"
     end
 
     test "returns field not found error for nil type fields" do
@@ -1052,6 +1158,9 @@ defmodule Logflare.Lql.ParserTest do
   def today_dt do
     Timex.today() |> Timex.to_datetime()
   end
+
+  def to_naive(%DateTime{} = value), do: DateTime.to_naive(value)
+  def to_naive(%NaiveDateTime{} = value), do: value
 
   def now_ndt do
     %{Timex.now() | microsecond: {0, 0}}


### PR DESCRIPTION
Add support for LQL timestamp filters in these formats:

### Unix timestamp

Use Unix timestamps as 10-digit seconds, 13-digit milliseconds, or 16-digit microseconds.
Microsecond values are truncated to milliseconds.
Unix timestamps are interpreted as UTC.

Examples:
* `t:>=1710683222000`
* `t:<=1710683222000000`
* `t:1710683222..1710683822`
* `t:1710683222000..1710683822000`


### ISO8601 format
  A timestamp can be written as:
1. A datetime with a Z suffix
   This is treated as a UTC datetime.
2. A datetime with an explicit timezone offset
   This is treated using the supplied offset.


Examples:
* `t:2026-03-17..2026-03-19`
* `t:>2026-03-17T14:47:02Z`
* `t:>=2026-03-17T14:47:02.123Z`
* `t:<2026-03-17T14:47:02+02:00`
* `t:>=2026-03-17T14:47:02-02:00`
* `t:2026-03-17T14:47:02+02:00..2026-03-17T15:47:02+02:00`

https://github.com/user-attachments/assets/2ec7ba63-4f34-4821-baeb-7c60866421bd


https://github.com/user-attachments/assets/c6edb205-49e7-4677-820a-37fa9c9224ef

Closes O11Y-1586


