### PR TITLE
test: improve SearchOperationsTest postgres coverage

### DIFF
--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -73,6 +73,8 @@ defmodule Logflare.Logs.SearchOperations do
     backend = postgres_backend(so)
 
     PostgresAdaptor.execute_query(backend, so.query, query_type: :search)
+  rescue
+    error -> {:error, error}
   end
 
   defp execute_backend_query(%SO{} = so) do

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -73,8 +73,6 @@ defmodule Logflare.Logs.SearchOperations do
     backend = postgres_backend(so)
 
     PostgresAdaptor.execute_query(backend, so.query, query_type: :search)
-  rescue
-    error -> {:error, error}
   end
 
   defp execute_backend_query(%SO{} = so) do

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -500,19 +500,24 @@ defmodule Logflare.Logs.SearchOperationsTest do
       refute result_so.error
     end
 
-    test "do_query/1 stores postgres backend errors", %{backend: backend, base_so: base_so} do
+    test "do_query/1 propagates postgres backend errors", %{backend: backend, base_so: base_so} do
       Backends
       |> expect(:get_default_backend, fn _user -> backend end)
 
       PostgresAdaptor
       |> expect(:execute_query, fn ^backend, %Ecto.Query{}, [query_type: :search] ->
         raise Postgrex.Error,
-          postgres: %{code: :invalid_sql_statement_name, message: "connection refused"}
+          postgres: %{
+            code: "26000",
+            pg_code: :invalid_sql_statement_name,
+            message: "connection refused",
+            severity: "ERROR"
+          }
       end)
 
-      result_so = SearchOperations.do_query(base_so)
-
-      assert %Postgrex.Error{} = result_so.error
+      assert_raise Postgrex.Error, fn ->
+        SearchOperations.do_query(base_so)
+      end
     end
 
     test "do_query/1 renames count to value for aggregates and process_query_result/1 adds datetime",

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
 
   import Ecto.Query
   import Logflare.Utils.Guards
+  import Logflare.TestUtils
 
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
@@ -183,10 +184,10 @@ defmodule Logflare.Logs.SearchOperationsTest do
   end
 
   describe "postgres chart aggregation" do
+    setup_single_tenant(backend_type: :postgres)
+
     setup %{user: user} do
       source = insert(:source, user: user)
-
-      stub(Backends, :get_default_backend, fn ^user -> %{type: :postgres} end)
 
       base_so =
         @postgres_search_attrs
@@ -265,10 +266,10 @@ defmodule Logflare.Logs.SearchOperationsTest do
   end
 
   describe "postgres query defaults and rules" do
+    setup_single_tenant(backend_type: :postgres)
+
     setup %{user: user} do
       source = insert(:source, user: user)
-
-      stub(Backends, :get_default_backend, fn ^user -> %{type: :postgres} end)
 
       so =
         %{@postgres_search_attrs | source: source}
@@ -319,10 +320,10 @@ defmodule Logflare.Logs.SearchOperationsTest do
   end
 
   describe "postgres timestamp filter rules" do
+    setup_single_tenant(backend_type: :postgres)
+
     setup %{user: user} do
       source = insert(:source, user: user)
-
-      stub(Backends, :get_default_backend, fn ^user -> %{type: :postgres} end)
 
       base_so =
         @postgres_search_attrs
@@ -445,13 +446,13 @@ defmodule Logflare.Logs.SearchOperationsTest do
   end
 
   describe "postgres backend adaptor integration" do
+    setup_single_tenant(backend_type: :postgres)
+
     setup %{user: user} do
       Mimic.copy(PostgresAdaptor)
 
       source = insert(:source, user: user)
       backend = build(:backend, type: :postgres)
-
-      stub(Backends, :get_default_backend, fn ^user -> backend end)
 
       base_so =
         %{@postgres_search_attrs | source: source, query: from("test_table")}
@@ -493,15 +494,8 @@ defmodule Logflare.Logs.SearchOperationsTest do
         {:ok, QueryResult.new(rows, %{total_rows: length(rows)})}
       end)
 
-      PostgresAdaptor
-      |> expect(:ecto_to_sql, fn %Ecto.Query{}, [] ->
-        {:ok, {"SELECT * FROM test_table", ["param"]}}
-      end)
-
       result_so = SearchOperations.do_query(base_so)
 
-      assert result_so.sql_string == "SELECT * FROM test_table"
-      assert result_so.sql_params == ["param"]
       assert result_so.rows == rows
       refute result_so.error
     end
@@ -512,12 +506,13 @@ defmodule Logflare.Logs.SearchOperationsTest do
 
       PostgresAdaptor
       |> expect(:execute_query, fn ^backend, %Ecto.Query{}, [query_type: :search] ->
-        {:error, :postgres_failed}
+        raise Postgrex.Error,
+          postgres: %{code: :invalid_sql_statement_name, message: "connection refused"}
       end)
 
       result_so = SearchOperations.do_query(base_so)
 
-      assert result_so.error == :postgres_failed
+      assert %Postgrex.Error{} = result_so.error
     end
 
     test "do_query/1 renames count to value for aggregates and process_query_result/1 adds datetime",
@@ -534,11 +529,6 @@ defmodule Logflare.Logs.SearchOperationsTest do
       |> expect(:execute_query, fn ^backend, %Ecto.Query{}, [query_type: :search] ->
         rows = [%{"count" => 2, "timestamp" => unix_timestamp}]
         {:ok, QueryResult.new(rows, %{total_rows: length(rows)})}
-      end)
-
-      PostgresAdaptor
-      |> expect(:ecto_to_sql, fn %Ecto.Query{}, [] ->
-        {:ok, {"SELECT count(*) FROM test_table", []}}
       end)
 
       result_so =


### PR DESCRIPTION
Implement feedback on test improvements from #3307 

* use `TestUtils.setup_single_tenant' macro
* remove unnecessary mocks
* stub exception for postgres error