### PR TITLE
ClickHouse connection pool adjustments/telemetry additions

### DIFF
--- a/lib/logflare/networking.ex
+++ b/lib/logflare/networking.ex
@@ -99,8 +99,11 @@ defmodule Logflare.Networking do
            protocols: [:http1],
            size: min(base * 2, 15),
            count: min(max(div(base, 2), 1), 4),
-           conn_max_idle_time: 9_500,
-           start_pool_metrics?: true
+           conn_max_idle_time: 5_000,
+           start_pool_metrics?: true,
+           conn_opts: [
+             transport_opts: [timeout: 10_000]
+           ]
          ]
        }}
     ]

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -228,13 +228,36 @@ defmodule Logflare.Telemetry do
       )
     ]
 
+    finch_metrics = [
+      distribution("finch.request.stop.duration",
+        tags: [:name],
+        unit: {:native, :millisecond},
+        description: "Finch end-to-end request duration"
+      ),
+      distribution("finch.connect.stop.duration",
+        tags: [:name],
+        unit: {:native, :millisecond},
+        description: "Finch TCP connection establishment duration"
+      ),
+      distribution("finch.queue.stop.duration",
+        tags: [:name],
+        unit: {:native, :millisecond},
+        description: "Finch pool checkout queue duration"
+      ),
+      counter("finch.conn_max_idle_time_exceeded.idle_time",
+        tags: [:host, :port],
+        description: "Count of connections discarded due to exceeding max idle time"
+      )
+    ]
+
     Enum.concat([
       phoenix_metrics,
       database_metrics,
       vm_metrics,
       cache_metrics,
       broadway_metrics,
-      application_metrics
+      application_metrics,
+      finch_metrics
     ])
   end
 


### PR DESCRIPTION
2-3 times per hour we see ClickHouse connection timeouts in production. Deeper investigation of these showed a nearly exact 5s timing. Discussing with @ruslandoga, he pointed me to [this code](https://github.com/sneako/finch/blob/94d427d9b011f1bfedf40b9dbb0f23d8f228761b/lib/finch.ex#L16) in Finch that has a default timeout set to 5s.

These changes increase that timeout to 10s for the ClickHouse pool. I also lower the `conn_max_idle_time` from 9.5s to 5s - to provide a safer margin below ClickHouse's 10s keep alive timeout as I suspect reuse of server-closed connections could be part of the situation. While 5s may seem a little aggressive - I don't foresee many connections going unused for that long given our volume. Open to suggestion on this though.

Lastly, I have added 4 new metrics to the telemetry we emit around Finch related to this effort.
- `finch.request.stop.duration` — end-to-end request duration, tagged by pool name
- `finch.connect.stop.duration` — TCP connection establishment time, tagged by pool name (_will show us if >5s connects occur_)
- `finch.queue.stop.duration` — pool checkout wait time, tagged by pool name
- `finch.conn_max_idle_time_exceeded` — counter of connections discarded for exceeding idle time, tagged by host/port (_will show the impact of lowering idle time from 9.5s to 5s_)

_The tag options for `finch.conn_max_idle_time_exceeded` do not include pool name, so host/port seemed to be the most logical choice on that as we can make assumptions that ports 8123 or 8443 would be ClickHouse, aside from host name_