### PR TITLE
chore: ops export script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,4 +444,13 @@ $(TELEGRAF_KEYS_SENTINEL):
 docker.multi-step:
 	docker-compose build base runner
 
-.PHONY: $(addprefix ssl.,${envs}) ssl.telegraf docker.build.multistep
+ops.sign-export:
+	@if [ -z "$(PROJECT)" ]; then \
+		echo "Error: PROJECT env variable must be set. Usage: make ops.sign-export PROJECT=your_project"; \
+		exit 1; \
+	fi
+	@CLOUDSDK_PYTHON=python3 CLOUDSDK_PYTHON_SITEPACKAGES=1 gcloud storage sign-url 'gs://supabase-log-exports-prod/$(PROJECT)-*.json.gz' \
+		--private-key-file=.log-export.gcloud.json  \
+		--duration=5d > export-dl-$(PROJECT).txt
+
+.PHONY: $(addprefix ssl.,${envs}) ssl.telegraf docker.build.multistep ops.sign-export


### PR DESCRIPTION
```bash
make ops.sign-export PROJECT=targetprojectref
```
For automating log exports.
Exports links to a `export-dl-$PROJECT.txt`
Requires service account key file at `.log-export.gcloud.json`