### PR TITLE
perf: double the export duration

### DIFF
--- a/lib/logflare/backends/user_monitoring.ex
+++ b/lib/logflare/backends/user_monitoring.ex
@@ -14,7 +14,7 @@ defmodule Logflare.Backends.UserMonitoring do
     export_period =
       case Application.get_env(:logflare, :env) do
         :test -> 100
-        _ -> :timer.minutes(4) + :rand.uniform(60_000)
+        _ -> :timer.minutes(8) + :rand.uniform(60_000 * 2)
       end
 
     otel_exporter_opts =


### PR DESCRIPTION
doubles the max of the otel metrics export duration, resulting in instances exporting metrics up to 8-10 minutes.

This should halve the amount of datapoints getting ingested for user metrics, resulting in less compute and less ingest cost.