### PR TITLE
perf: reduce reconciliation queries

### DIFF
--- a/lib/logflare/backends/source_sup_worker.ex
+++ b/lib/logflare/backends/source_sup_worker.ex
@@ -8,7 +8,7 @@ defmodule Logflare.Backends.SourceSupWorker do
   alias Logflare.Rules
   alias Logflare.Backends.SourceSup
 
-  @default_interval 30_000
+  @default_interval :timer.minutes(10)
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)


### PR DESCRIPTION
Increases time between each reconciliation attempt. This is just a safety measure and does not need to run so often.