### PR TITLE
fix: correctly build base image logflare

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -44,4 +44,7 @@ RUN cargo version
 # pre-fetch cargo dependencies for layer caching
 COPY Cargo.toml Cargo.lock ./
 COPY --parents native/*/Cargo.toml ./
+# TODO: Instead of creating an empty src/lib.rs, replace `cargo fetch --locked` with `cargo build --dependencies-only`
+# once https://github.com/rust-lang/cargo/issues/2644 is resolved.
+RUN for dir in native/*/; do mkdir -p "$dir/src" && touch "$dir/src/lib.rs"; done
 RUN cargo fetch --locked


### PR DESCRIPTION
`cargo fetch --locked` fails during the Docker base image build because Cargo requires that every workspace member listed in `Cargo.toml` has a valid crate structure — at minimum a `src/lib.rs` (or `src/main.rs`). See https://github.com/rust-lang/cargo/issues/2644#issuecomment-3819570767.

The only alternative other than this, was to start using [cargo-chef](https://github.com/LukeMathWalker/cargo-chef). See how it would work [here](https://lpalmieri.com/posts/fast-rust-docker-builds/).
