### PR TITLE
feat: copy log events copy clipboard

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -102,6 +102,24 @@ document.addEventListener("DOMContentLoaded", (e) => {
   initLiveReact();
 });
 
+const buildLogListClipboardText = (selector) => {
+  return Array.from(document.querySelectorAll(selector))
+    .map((node) => {
+      const timestamp =
+        node.querySelector("[data-timestamp]").textContent?.trim() || "";
+      const message = Array.from(node.childNodes).reduce((acc, node) => {
+        if (node.nodeType == Node.TEXT_NODE) {
+          return acc + " " + node.textContent.trim();
+        }
+        return acc;
+      }, timestamp);
+
+      return message.trim();
+    })
+    .reverse()
+    .join("\n");
+};
+
 // Use `:text` on the `:detail` optoin to pass values to event listener
 window.addEventListener("logflare:copy-to-clipboard", (event) => {
   if ("clipboard" in navigator) {
@@ -120,6 +138,23 @@ window.addEventListener("logflare:copy-to-clipboard", (event) => {
   } else {
     console.error("Your browser does not support clipboard copy.");
   }
+});
+
+window.addEventListener("logflare:copy-logs-list", (event) => {
+  const selector = event.detail.selector;
+  if (!selector) {
+    console.error("No selector provided for log list copy")
+    return;
+  }
+
+  const text = buildLogListClipboardText(selector);
+
+  event.target.dispatchEvent(
+    new CustomEvent("logflare:copy-to-clipboard", {
+      bubbles: true,
+      detail: {text},
+    })
+  );
 });
 
 window.addEventListener("phx:page-loading-stop", (_info) => {

--- a/lib/logflare_web/live/search_live/subhead_components.ex
+++ b/lib/logflare_web/live/search_live/subhead_components.ex
@@ -9,6 +9,7 @@ defmodule LogflareWeb.SearchLive.SubheadComponents do
   import LogflareWeb.LqlHelpers
   import LogflareWeb.ModalLiveHelpers, only: [modal_link: 1]
   alias Logflare.DateTimeUtils
+  alias Phoenix.LiveView.JS
 
   attr :user, Logflare.User, required: true
   attr :source, Logflare.Sources.Source, required: true
@@ -22,6 +23,12 @@ defmodule LogflareWeb.SearchLive.SubheadComponents do
     <div class="log-settings tw-justify-between tw-mt-2 tw-grow">
       <.timezone user_preferences={@user.preferences} search_timezone={@search_timezone} />
       <ul>
+        <li class={disabled_if_no_events(@search_op_log_events)}>
+          <.link href="#" phx-click={JS.dispatch("logflare:copy-logs-list", detail: %{selector: "#logs-list li"})} data-log-list-selector="#logs-list" data-toggle="tooltip" title="Copy events to clipboard" class="logflare-tooltip">
+            <i class="fas fa-copy"></i>
+            <span class="hide-on-mobile tw-pl-1">copy</span>
+          </.link>
+        </li>
         <li>
           <a href="javascript:Source.scrollOverflowBottom();">
             <span id="scroll-down"><i class="fas fa-chevron-circle-down"></i></span>
@@ -106,6 +113,9 @@ defmodule LogflareWeb.SearchLive.SubheadComponents do
   def show_checkbox?(%{user_preferences: preferences, search_timezone: search_timezone}) do
     search_timezone != user_timezone(preferences)
   end
+
+  defp disabled_if_no_events(%{rows: rows}) when is_list(rows) and rows != [], do: nil
+  defp disabled_if_no_events(_), do: "tw-opacity-50 tw-pointer-events-none"
 
   defp user_timezone(preferences), do: preferences && Map.get(preferences, :timezone)
 


### PR DESCRIPTION
Add a copy log events to clipboard button. 

* Copies timestamp and event message in plain text
* Copies directly from DOM to avoid extra page weight or network round trip.

Closes O11Y-1560

<img width="2764" height="1538" alt="CleanShot 2026-04-14 at 13 24 27@2x" src="https://github.com/user-attachments/assets/cf0b7a0d-c994-4259-b6b9-c8846c28914f" />


## Tests

No tests but after #3239 is merged I could add a E2E feature test with PlaywrightEx

## Demo



https://github.com/user-attachments/assets/178cf08e-bfde-42ed-ade8-65af25c371ee

