### PR TITLE
feat: render standard event fields first

### DIFF
--- a/lib/logflare_web/components/json_viewer_component.ex
+++ b/lib/logflare_web/components/json_viewer_component.ex
@@ -15,27 +15,63 @@ defmodule LogflareWeb.JSONViewerComponent do
   attr :data, :any, required: true, doc: "List or map to render as a tree"
   attr :class, :string, default: "", doc: "Additional CSS classes"
   attr :id, :string, default: nil, doc: "Optional prefix for DOM ids"
+
+  attr :promoted_fields, :list,
+    default: ~w(id timestamp event_message),
+    doc: "Top-level fields to render first, in the given order"
+
   attr :rest, :global, doc: "Global attributes"
 
   slot :action
 
   def json_viewer(assigns) do
-    data =
+    {promoted_entries, remaining_entries} =
       case assigns.data do
         list when is_list(list) ->
-          Enum.with_index(list, fn v, index -> {to_string(index), v} end)
+          {[], Enum.with_index(list, fn v, index -> {to_string(index), v} end)}
 
         map when is_map(map) ->
-          map
+          partition_promoted_fields(map, assigns.promoted_fields)
       end
 
-    assigns = assign(assigns, :data, data)
+    assigns =
+      assigns
+      |> assign(:promoted_entries, promoted_entries)
+      |> assign(:remaining_entries, remaining_entries)
 
     ~H"""
     <div id={@id} class={["tw-font-mono tw-text-sm", @class]} {@rest}>
-      <.tree_node :for={{k, v} <- @data} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
+      <.tree_node :for={{k, v} <- @promoted_entries} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
+      <.tree_node :for={{k, v} <- @remaining_entries} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
     </div>
     """
+  end
+
+  @spec partition_promoted_fields(map(), [String.t()]) ::
+          {[{String.t(), any()}], [{any(), any()}]}
+  defp partition_promoted_fields(map, promoted_fields)
+       when is_map(map) and is_list(promoted_fields) do
+    {promoted_lookup, remaining_entries} =
+      map
+      |> Map.to_list()
+      |> Enum.reduce({%{}, []}, fn {key, value}, {promoted, remaining} ->
+        if key in promoted_fields do
+          {Map.put(promoted, key, value), remaining}
+        else
+          {promoted, [{key, value} | remaining]}
+        end
+      end)
+
+    promoted_entries =
+      promoted_fields
+      |> Enum.flat_map(fn field ->
+        case Map.fetch(promoted_lookup, field) do
+          {:ok, value} -> [{field, value}]
+          :error -> []
+        end
+      end)
+
+    {promoted_entries, Enum.reverse(remaining_entries)}
   end
 
   defp tree_node(%{value: _value, kind: _kind, path: path, key: _key} = assigns) do

--- a/lib/logflare_web/components/json_viewer_component.ex
+++ b/lib/logflare_web/components/json_viewer_component.ex
@@ -6,6 +6,12 @@ defmodule LogflareWeb.JSONViewerComponent do
 
   alias Phoenix.LiveView.JS
 
+  @promoted_fields %{
+    "id" => 0,
+    "timestamp" => 1,
+    "event_message" => 2
+  }
+
   @doc """
   ## Examples
 
@@ -15,63 +21,33 @@ defmodule LogflareWeb.JSONViewerComponent do
   attr :data, :any, required: true, doc: "List or map to render as a tree"
   attr :class, :string, default: "", doc: "Additional CSS classes"
   attr :id, :string, default: nil, doc: "Optional prefix for DOM ids"
-
-  attr :promoted_fields, :list,
-    default: ~w(id timestamp event_message),
-    doc: "Top-level fields to render first, in the given order"
-
   attr :rest, :global, doc: "Global attributes"
 
   slot :action
 
   def json_viewer(assigns) do
-    {promoted_entries, remaining_entries} =
+    data =
       case assigns.data do
         list when is_list(list) ->
-          {[], Enum.with_index(list, fn v, index -> {to_string(index), v} end)}
+          Enum.with_index(list, fn v, index -> {to_string(index), v} end)
 
         map when is_map(map) ->
-          partition_promoted_fields(map, assigns.promoted_fields)
+          last = @promoted_fields |> Map.keys() |> length
+
+          map
+          |> Enum.sort_by(fn {key, _value} ->
+            key = to_string(key)
+            {Map.get(@promoted_fields, key, last), key}
+          end)
       end
 
-    assigns =
-      assigns
-      |> assign(:promoted_entries, promoted_entries)
-      |> assign(:remaining_entries, remaining_entries)
+    assigns = assigns |> assign(:data, data)
 
     ~H"""
     <div id={@id} class={["tw-font-mono tw-text-sm", @class]} {@rest}>
-      <.tree_node :for={{k, v} <- @promoted_entries} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
-      <.tree_node :for={{k, v} <- @remaining_entries} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
+      <.tree_node :for={{k, v} <- @data} key={k} label={k} value={v} path={[]} key_path={[]} id={@id} action={@action} />
     </div>
     """
-  end
-
-  @spec partition_promoted_fields(map(), [String.t()]) ::
-          {[{String.t(), any()}], [{any(), any()}]}
-  defp partition_promoted_fields(map, promoted_fields)
-       when is_map(map) and is_list(promoted_fields) do
-    {promoted_lookup, remaining_entries} =
-      map
-      |> Map.to_list()
-      |> Enum.reduce({%{}, []}, fn {key, value}, {promoted, remaining} ->
-        if key in promoted_fields do
-          {Map.put(promoted, key, value), remaining}
-        else
-          {promoted, [{key, value} | remaining]}
-        end
-      end)
-
-    promoted_entries =
-      promoted_fields
-      |> Enum.flat_map(fn field ->
-        case Map.fetch(promoted_lookup, field) do
-          {:ok, value} -> [{field, value}]
-          :error -> []
-        end
-      end)
-
-    {promoted_entries, Enum.reverse(remaining_entries)}
   end
 
   defp tree_node(%{value: _value, kind: _kind, path: path, key: _key} = assigns) do

--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -33,7 +33,7 @@ defmodule LogflareWeb.QueryComponents do
   attr :search_params, :map, default: %{}
 
   def quick_filter(%{node: %{path: [path]}} = assigns)
-      when path in ["event_message", "timestamp"] and not is_map_key(assigns, :class) do
+      when path in ["id", "event_message", "timestamp"] and not is_map_key(assigns, :class) do
     assigns
     |> assign(:class, nil)
     |> quick_filter()

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -266,7 +266,7 @@ defmodule Logflare.Backends.UserMonitoringTest do
 
       :timer.sleep(2500)
 
-      assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 5_000
+      assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 15_000
 
       rows = for row <- rows, do: row.json
 

--- a/test/logflare_web/components/json_viewer_component_test.exs
+++ b/test/logflare_web/components/json_viewer_component_test.exs
@@ -73,6 +73,20 @@ defmodule LogflareWeb.JSONViewerComponentTest do
     |> Floki.text(sep: " ")
   end
 
+  defp extract_top_level_keys(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("div > span.tw-text-json-tree-key")
+    |> Enum.map(fn {_, _, [key]} ->
+      key
+      |> String.trim_trailing(":")
+    end)
+  end
+
+  defp enumerated_keys(map) when is_map(map) do
+    Enum.map(map, fn {key, _value} -> to_string(key) end)
+  end
+
   describe "json_viewer/1" do
     test "renders simple map with string values" do
       data = %{"user" => %{"name" => "John", "age" => "30"}}
@@ -105,6 +119,50 @@ defmodule LogflareWeb.JSONViewerComponentTest do
       assert html =~ "apple"
       assert html =~ "banana"
       assert html =~ "cherry"
+    end
+
+    test "renders top-level promoted fields first" do
+      data = %{
+        "alpha" => 1,
+        "timestamp" => 123,
+        "event_message" => "hello",
+        "beta" => true,
+        "id" => "event-123",
+        "gamma" => nil
+      }
+
+      expected_remaining_keys =
+        data
+        |> enumerated_keys()
+        |> Enum.reject(&(&1 in ~w(id timestamp event_message)))
+
+      html = render_component(&json_viewer/1, data: data, id: "json-viewer")
+
+      assert extract_top_level_keys(html) == [
+               "id",
+               "timestamp",
+               "event_message"
+               | expected_remaining_keys
+             ]
+    end
+
+    test "renders only present promoted fields first" do
+      data = %{
+        "alpha" => 1,
+        "timestamp" => 123,
+        "beta" => true
+      }
+
+      expected_remaining_keys =
+        data
+        |> enumerated_keys()
+        |> Enum.reject(&(&1 in ~w(id timestamp event_message)))
+
+      html = render_component(&json_viewer/1, data: data, id: "json-viewer")
+
+      assert extract_top_level_keys(html) == [
+               "timestamp" | expected_remaining_keys
+             ]
     end
 
     test "renders deeply nested structure (3+ levels)" do


### PR DESCRIPTION
JSON viewer will render promoted fields (`id`, `timestamp`, `event_message`) first.

Closes O11Y-1596

<img width="2278" height="1336" alt="CleanShot 2026-04-14 at 16 57 49@2x" src="https://github.com/user-attachments/assets/f0f9f976-0e20-495d-b1ba-5d54e12ac861" />
