### PR TITLE
feat: Error handling in BigQuery Storage Write API

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,7 +89,8 @@ config :logflare,
          metadata: logflare_metadata,
          health: logflare_health,
          http_connection_pools: http_connection_pools,
-         bq_write_api_pool_size: System.get_env("LOGFLARE_BQ_WRITE_API_POOL_SIZE")
+         bq_write_api_pool_size:
+           System.get_env("LOGFLARE_BQ_WRITE_API_POOL_SIZE", "10") |> String.to_integer()
        ]
        |> filter_nil_kv_pairs.()
 

--- a/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
@@ -95,22 +95,20 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient do
   end
 
   defp send_requests(requests, channel) do
-    try do
-      stream = BigQueryWrite.Stub.append_rows(channel)
+    stream = BigQueryWrite.Stub.append_rows(channel)
 
-      stream =
-        Enum.reduce(
-          requests,
-          stream,
-          fn request, stream ->
-            GRPC.Stub.send_request(stream, request)
-          end
-        )
+    stream =
+      Enum.reduce(
+        requests,
+        stream,
+        fn request, stream ->
+          GRPC.Stub.send_request(stream, request)
+        end
+      )
 
-      {:ok, GRPC.Stub.end_stream(stream)}
-    catch
-      :exit, reason -> {:error, Exception.format_exit(reason)}
-    end
+    {:ok, GRPC.Stub.end_stream(stream)}
+  catch
+    :exit, reason -> {:error, Exception.format_exit(reason)}
   end
 
   defp retry_call(requests, retry_attempt) do

--- a/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
@@ -65,12 +65,24 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient do
   end
 
   defp try_call(requests, retry_attempt \\ 0) do
-    with {:ok, channel} <- GrpcPool.get_channel(connetion_pool_name()),
-         {:ok, stream} <- send_requests(requests, channel),
-         {:ok, responses} <- GRPC.Stub.recv(stream),
-         [] <- handle_responses(requests, responses) do
-      :ok
-    else
+    OpenTelemetry.Tracer.with_span "ingest.call_attempt", %{
+      attributes: %{retry_attempt: retry_attempt}
+    } do
+      with {:ok, channel} <- GrpcPool.get_channel(connetion_pool_name()),
+           {:ok, stream} <- send_requests(requests, channel),
+           {:ok, responses} <- GRPC.Stub.recv(stream),
+           [] <- handle_responses(requests, responses) do
+        :ok
+      else
+        err ->
+          OpenTelemetry.Tracer.set_status(:error, inspect(err))
+          err
+      end
+    end
+    |> case do
+      :ok ->
+        :ok
+
       failed_reqs when is_list(failed_reqs) and retry_attempt < 5 ->
         retry_call(failed_reqs, retry_attempt)
 
@@ -127,7 +139,9 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient do
 
       {_request, {:ok, %AppendRowsResponse{row_errors: errors}}}, acc when is_list(errors) ->
         Logger.warning("Storage Write API AppendRows row errors - #{inspect(errors)}")
-        # TODO: Maybe set telemetry attribute with error count
+        OpenTelemetry.Tracer.set_attribute("row_errors_present", true)
+        # TODO: This will override previous, but most of the time there's only one request
+        OpenTelemetry.Tracer.set_attribute("row_errors_count", length(errors))
         acc
     end)
   end

--- a/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor/google_api_client.ex
@@ -51,62 +51,90 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient do
     project = context[:project_id]
     dataset = context[:dataset_id]
 
-    with {:ok, channel} <- GrpcPool.get_channel(connetion_pool_name()) do
+    requests =
+      Enum.map(arrow_rows, fn rows_batch ->
+        %AppendRowsRequest{
+          write_stream:
+            "projects/#{project}/datasets/#{dataset}/tables/#{table}/streams/_default",
+          rows: {:arrow_rows, rows_batch},
+          default_missing_value_interpretation: :NULL_VALUE
+        }
+      end)
+
+    try_call(requests)
+  end
+
+  defp try_call(requests, retry_attempt \\ 0) do
+    with {:ok, channel} <- GrpcPool.get_channel(connetion_pool_name()),
+         {:ok, stream} <- send_requests(requests, channel),
+         {:ok, responses} <- GRPC.Stub.recv(stream),
+         [] <- handle_responses(requests, responses) do
+      :ok
+    else
+      failed_reqs when is_list(failed_reqs) and retry_attempt < 5 ->
+        retry_call(failed_reqs, retry_attempt)
+
+      _err when retry_attempt < 5 ->
+        retry_call(requests, retry_attempt)
+
+      err ->
+        err
+    end
+  end
+
+  defp send_requests(requests, channel) do
+    try do
       stream = BigQueryWrite.Stub.append_rows(channel)
 
       stream =
         Enum.reduce(
-          arrow_rows,
+          requests,
           stream,
-          fn arrow_data, stream ->
-            request =
-              %AppendRowsRequest{
-                write_stream:
-                  "projects/#{project}/datasets/#{dataset}/tables/#{table}/streams/_default",
-                rows: {:arrow_rows, arrow_data}
-              }
-
+          fn request, stream ->
             GRPC.Stub.send_request(stream, request)
           end
         )
 
-      GRPC.Stub.end_stream(stream)
-
-      GRPC.Stub.recv(stream)
-      |> case do
-        {:ok, responses} ->
-          insert_error_count =
-            Enum.reduce(responses, 0, fn
-              {:error, response}, acc ->
-                Logger.warning(
-                  "Storage Write API AppendRows response error - #{inspect(response)}"
-                )
-
-                acc
-
-              {:ok, %AppendRowsResponse{response: {:error, %{message: msg}}}}, acc ->
-                Logger.warning(
-                  "Storage Write API AppendRows response with error msg - #{inspect(msg)}"
-                )
-
-                acc
-
-              {:ok, %AppendRowsResponse{row_errors: []}}, acc ->
-                acc
-
-              {:ok, %AppendRowsResponse{row_errors: errors}}, acc when is_list(errors) ->
-                Logger.warning("Storage Write API AppendRows row errors - #{inspect(errors)}")
-                length(errors) + acc
-            end)
-
-          OpenTelemetry.Tracer.set_attribute(:insert_error_count, insert_error_count)
-
-          :ok
-
-        {:error, response} = err ->
-          Logger.warning("Storage Write API AppendRows error - #{inspect(response)}")
-          err
-      end
+      {:ok, GRPC.Stub.end_stream(stream)}
+    catch
+      :exit, reason -> {:error, Exception.format_exit(reason)}
     end
+  end
+
+  defp retry_call(requests, retry_attempt) do
+    # 200, 400, 800, 1600, 2000, ...
+    retry_wait = min(2000, 200 * 2 ** retry_attempt)
+    sleep(retry_wait)
+    try_call(requests, retry_attempt + 1)
+  end
+
+  defp handle_responses(requests, responses) do
+    requests
+    |> Stream.zip(responses)
+    |> Enum.reduce([], fn
+      {request, {:error, response}}, acc ->
+        Logger.error("Storage Write API AppendRows response error - #{inspect(response)}")
+
+        [request | acc]
+
+      {request, {:ok, %AppendRowsResponse{response: {:error, %{message: msg}}}}}, acc ->
+        Logger.warning("Storage Write API AppendRows response with error msg - #{inspect(msg)}")
+
+        [request | acc]
+
+      {_request, {:ok, %AppendRowsResponse{row_errors: []}}}, acc ->
+        acc
+
+      {_request, {:ok, %AppendRowsResponse{row_errors: errors}}}, acc when is_list(errors) ->
+        Logger.warning("Storage Write API AppendRows row errors - #{inspect(errors)}")
+        # TODO: Maybe set telemetry attribute with error count
+        acc
+    end)
+  end
+
+  defp sleep(ms) do
+    Application.get_env(:logflare, __MODULE__, [])
+    |> Keyword.get(:sleep, &Process.sleep/1)
+    |> then(& &1.(ms))
   end
 end

--- a/lib/logflare/networking.ex
+++ b/lib/logflare/networking.ex
@@ -147,7 +147,7 @@ defmodule Logflare.Networking do
         {Logflare.Networking.GrpcPool,
          name: GoogleApiClient.connetion_pool_name(),
          url: "https://bigquerystorage.googleapis.com",
-         size: Application.get_env(:logflare, :bq_write_api_pool_size, 25)}
+         size: Application.get_env(:logflare, :bq_write_api_pool_size)}
       ]
     end
   end

--- a/lib/logflare/networking/grpc_channel_monitor.ex
+++ b/lib/logflare/networking/grpc_channel_monitor.ex
@@ -72,7 +72,15 @@ defmodule Logflare.Networking.GrpcChannelMonitor do
 
   defp handle_disconnection(%{idx: idx, registry: registry, channel: channel} = state) do
     Registry.unregister(registry, idx)
-    if channel, do: GRPC.Stub.disconnect(channel)
+
+    if channel do
+      try do
+        GRPC.Stub.disconnect(channel)
+      catch
+        :exit, {:noproc, _call} -> :ok
+      end
+    end
+
     connect_after(0)
     %{state | backoff: @min_backoff, channel: nil}
   end

--- a/lib/logflare/networking/grpc_pool.ex
+++ b/lib/logflare/networking/grpc_pool.ex
@@ -40,7 +40,12 @@ defmodule Logflare.Networking.GrpcPool do
 
   @spec get_channel(module()) :: {:ok, GRPC.Channel.t()} | {:error, :not_connected}
   def get_channel(name) do
-    ref = :persistent_term.get({name, :counter})
+    ref = :persistent_term.get({name, :counter}, nil)
+
+    if is_nil(ref) do
+      raise ArgumentError, "No GrpcPool started with a name #{inspect(name)}"
+    end
+
     size = :persistent_term.get({name, :size})
     idx = rem(:atomics.add_get(ref, 1, 1), size)
 

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -157,6 +157,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
           :telemetry.execute([:logflare, :backends, :ingest], metrics, metadata)
         end
     end
+
+    :ok
   end
 
   @impl Broadway

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -25,6 +25,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   alias Logflare.Utils
   require OpenTelemetry.Tracer
 
+  @behaviour Broadway.Acknowledger
+
   # BQ max is 10MB
   # https://cloud.google.com/bigquery/quotas#streaming_inserts
   @max_batch_length 6_000_000
@@ -88,6 +90,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   end
 
   # pipeline name is sharded
+  @impl Broadway
   def process_name({:via, module, {registry, identifier}}, base_name) do
     {:via, module, {registry, {identifier, base_name}}}
   end
@@ -107,6 +110,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   end
 
   # Ziinc: temporarily pass in source token until PubSubRates is refactored
+  @impl Broadway.Acknowledger
   def ack({queue, source_token}, successful, _failed) do
     # TODO: re-queue failed
     metrics = Sources.get_source_metrics_for_ingest(source_token)
@@ -155,7 +159,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     end
   end
 
-  @spec handle_message(any, Broadway.Message.t(), any) :: Broadway.Message.t()
+  @impl Broadway
   def handle_message(_processor_name, message, context) do
     Logger.metadata(
       source_id: context.source_token,
@@ -169,6 +173,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     |> Message.put_batcher(:bq)
   end
 
+  @impl Broadway
   def handle_batch(:bq, messages, batch_info, context) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],

--- a/test/logflare/backends/adaptor/bigquery_adaptor/google_api_client_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor/google_api_client_test.exs
@@ -1,0 +1,175 @@
+defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClientTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+  import Mimic
+
+  alias Google.Cloud.Bigquery.Storage.V1.AppendRowsResponse
+  alias Google.Cloud.Bigquery.Storage.V1.BigQueryWrite
+  alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
+  alias Logflare.Networking.GrpcPool
+
+  defp call_append_rows() do
+    context = [project_id: "my-project", dataset_id: "my-dataset"]
+    GoogleApiClient.append_rows({:arrow, [%{}]}, context, "my-table")
+  end
+
+  @moduletag capture_log: true
+
+  setup :verify_on_exit!
+
+  setup do
+    test_pid = self()
+
+    sleep_fn = fn ms -> send(test_pid, {:sleep, ms}) end
+    Application.put_env(:logflare, GoogleApiClient, sleep: sleep_fn)
+    on_exit(fn -> Application.put_env(:logflare, GoogleApiClient, []) end)
+
+    stub(GrpcPool, :get_channel, fn _ -> {:ok, %GRPC.Channel{}} end)
+    stub(BigQueryWrite.Stub, :append_rows, fn _ -> %GRPC.Client.Stream{} end)
+    stub(GRPC.Stub, :send_request, fn stream, _ -> stream end)
+    stub(GRPC.Stub, :end_stream, fn stream -> stream end)
+    stub(GRPC.Stub, :recv, fn _ -> {:ok, []} end)
+
+    :ok
+  end
+
+  describe "Succseeds on" do
+    test "recv empty responses" do
+      expect(GRPC.Stub, :recv, fn _ -> {:ok, []} end)
+      assert :ok = call_append_rows()
+      refute_received {:sleep, _}
+    end
+
+    test "clean response with no row errors" do
+      expect(GRPC.Stub, :recv, fn _ ->
+        {:ok, [{:ok, %AppendRowsResponse{row_errors: []}}]}
+      end)
+
+      assert :ok = call_append_rows()
+      refute_received {:sleep, _}
+    end
+
+    test "response with row_errors" do
+      row_error = %{message: "bad row"}
+
+      stub(GRPC.Stub, :recv, fn _ ->
+        {:ok, [{:ok, %AppendRowsResponse{row_errors: [row_error]}}]}
+      end)
+
+      assert {:ok, log} = with_log(fn -> call_append_rows() end)
+      assert log =~ "bad row"
+      refute_received {:sleep, _}
+    end
+  end
+
+  describe "Retry when recv returns" do
+    test "RPCError with :unavailable status is returned directly" do
+      error = %GRPC.RPCError{status: :unavailable, message: "service unavailable"}
+      expect(GRPC.Stub, :recv, fn _ -> {:error, error} end)
+      expect(GRPC.Stub, :recv, fn _ -> {:ok, []} end)
+
+      assert :ok = call_append_rows()
+
+      assert_received {:sleep, _}
+      refute_received {:sleep, _}
+    end
+
+    test "adapter string error" do
+      error = "Error occurred while receiving data: :closed"
+      expect(GRPC.Stub, :recv, fn _ -> {:error, error} end)
+      expect(GRPC.Stub, :recv, fn _ -> {:ok, []} end)
+
+      assert :ok = call_append_rows()
+
+      assert_received {:sleep, _}
+      refute_received {:sleep, _}
+    end
+
+    test "response with error field" do
+      error = {:error, %Google.Rpc.Status{message: "insert error"}}
+
+      expect(GRPC.Stub, :recv, fn _ ->
+        {:ok, [{:ok, %AppendRowsResponse{response: error}}]}
+      end)
+
+      result = {:append_result, %AppendRowsResponse.AppendResult{}}
+
+      expect(GRPC.Stub, :recv, fn _ ->
+        {:ok, [{:ok, %AppendRowsResponse{response: result}}]}
+      end)
+
+      assert :ok = call_append_rows()
+
+      assert_received {:sleep, _}
+      refute_received {:sleep, _}
+    end
+  end
+
+  describe "Retry when get_channel returns" do
+    test "transient error, then valid channel" do
+      test_pid = self()
+
+      expect(GrpcPool, :get_channel, fn _ ->
+        send(test_pid, :channel_attempt)
+        {:error, :no_channel}
+      end)
+
+      expect(GrpcPool, :get_channel, fn _ ->
+        send(test_pid, :channel_attempt)
+        {:ok, %GRPC.Channel{}}
+      end)
+
+      assert :ok = call_append_rows()
+      assert_received :channel_attempt
+      assert_received {:sleep, _}
+      assert_received :channel_attempt
+      refute_received {:sleep, _}
+    end
+  end
+
+  describe "When connection goes down" do
+    test "on send_request call" do
+      # Simulate Mint adapter call when connection process went down
+      expect(GRPC.Stub, :send_request, fn _stream, _req ->
+        GenServer.call(Invalid, {:stream_body, make_ref(), "data"})
+      end)
+
+      expect(GRPC.Stub, :send_request, fn stream, _req -> stream end)
+
+      assert :ok = call_append_rows()
+      assert_received {:sleep, _}
+      refute_received {:sleep, _}
+    end
+
+    test "on end_stream call" do
+      # Simulate Mint adapter call when connection process went down
+      expect(GRPC.Stub, :end_stream, fn _ ->
+        GenServer.call(Invalid, {:stream_body, make_ref(), :eof})
+      end)
+
+      expect(GRPC.Stub, :end_stream, fn stream -> stream end)
+
+      assert :ok = call_append_rows()
+      assert_received {:sleep, _}
+      refute_received {:sleep, _}
+    end
+  end
+
+  test "retry exhaustion after 5 retries" do
+    error = {:error, :not_connected}
+
+    for _ <- 0..5 do
+      expect(GrpcPool, :get_channel, fn _ -> error end)
+    end
+
+    assert ^error = call_append_rows()
+
+    assert_received {:sleep, 200}
+    assert_received {:sleep, 400}
+    assert_received {:sleep, 800}
+    assert_received {:sleep, 1600}
+    assert_received {:sleep, 2000}
+    refute_received {:sleep, _}
+  end
+end

--- a/test/logflare/backends/adaptor/bigquery_adaptor/google_api_client_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor/google_api_client_test.exs
@@ -9,7 +9,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClientTest do
   alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
   alias Logflare.Networking.GrpcPool
 
-  defp call_append_rows() do
+  defp call_append_rows do
     context = [project_id: "my-project", dataset_id: "my-dataset"]
     GoogleApiClient.append_rows({:arrow, [%{}]}, context, "my-table")
   end


### PR DESCRIPTION
Closes O11Y-1679

The PR introduces:
* retries on errors with exponential backoff
* tests for GoogleApiClient
* Fix for missing value errors (default missing value interpretation setting)