### PR TITLE
chore: Stop `net_kernel` after Cache Gossip test

### DIFF
--- a/test/logflare/context_cache/gossip/distributed_test.exs
+++ b/test/logflare/context_cache/gossip/distributed_test.exs
@@ -10,8 +10,8 @@ defmodule Logflare.ContextCache.Gossip.DistributedTest do
   setup_all do
     if not Node.alive?() do
       case :net_kernel.start(:"test@127.0.0.1", %{}) do
-        {:ok, _} ->
-          on_exit(fn -> :net_kernel.stop() end)
+        {:ok, _pid} ->
+          on_exit(fn -> :ok = :net_kernel.stop() end)
 
         {:error, reason} ->
           raise """

--- a/test/logflare/context_cache/gossip/distributed_test.exs
+++ b/test/logflare/context_cache/gossip/distributed_test.exs
@@ -8,12 +8,10 @@ defmodule Logflare.ContextCache.Gossip.DistributedTest do
   @moduletag :cluster
 
   setup_all do
-    start_net_kernel? = not Node.alive?()
-
-    if start_net_kernel? do
+    if not Node.alive?() do
       case :net_kernel.start(:"test@127.0.0.1", %{}) do
         {:ok, _} ->
-          :ok
+          on_exit(fn -> :net_kernel.stop() end)
 
         {:error, reason} ->
           raise """
@@ -29,13 +27,6 @@ defmodule Logflare.ContextCache.Gossip.DistributedTest do
           """
       end
     end
-
-    on_exit(fn ->
-      # only stop net_kernel if we were the ones who started it
-      if start_net_kernel? do
-        :net_kernel.stop()
-      end
-    end)
 
     original_context_cache_gossip = Application.get_env(:logflare, :context_cache_gossip)
 

--- a/test/logflare/context_cache/gossip/distributed_test.exs
+++ b/test/logflare/context_cache/gossip/distributed_test.exs
@@ -8,7 +8,9 @@ defmodule Logflare.ContextCache.Gossip.DistributedTest do
   @moduletag :cluster
 
   setup_all do
-    if not Node.alive?() do
+    start_net_kernel? = not Node.alive?()
+
+    if start_net_kernel? do
       case :net_kernel.start(:"test@127.0.0.1", %{}) do
         {:ok, _} ->
           :ok
@@ -27,6 +29,13 @@ defmodule Logflare.ContextCache.Gossip.DistributedTest do
           """
       end
     end
+
+    on_exit(fn ->
+      # only stop net_kernel if we were the ones who started it
+      if start_net_kernel? do
+        :net_kernel.stop()
+      end
+    end)
 
     original_context_cache_gossip = Application.get_env(:logflare, :context_cache_gossip)
 


### PR DESCRIPTION
Follow-up to https://github.com/Logflare/logflare/pull/3218