### PR TITLE
chore: use `import_if_available/1` in `.iex.exs`

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,1 @@
-import Logflare.Utils.Debugging
+import_if_available Logflare.Utils.Debugging

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,1 @@
-import_if_available Logflare.Utils.Debugging
+import_if_available(Logflare.Utils.Debugging)


### PR DESCRIPTION
This allows running `iex` (without `-S mix`) without errors.