### PR TITLE
chore: add `.iex.exs` to formatter config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter,.dialyzer_ignore}.exs", "{config,lib}/**/*.{heex,ex,exs}"],
+  inputs: ["{mix,.formatter,.dialyzer_ignore,.iex}.exs", "{config,lib}/**/*.{heex,ex,exs}"],
   subdirectories: ["test", "priv/repo"],
   import_deps: [
     :ecto_sql,


### PR DESCRIPTION
I noticed in https://github.com/Logflare/logflare/pull/3381 it wasn't being formatted on save.