### PR TITLE
feat: Support dot key filtering for map columns in ClickHouse LQL

### DIFF
--- a/lib/logflare/lql/backend_transformer/clickhouse.ex
+++ b/lib/logflare/lql/backend_transformer/clickhouse.ex
@@ -533,7 +533,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
   @spec negated?(map()) :: boolean()
   defp negated?(modifiers), do: Map.get(modifiers, :negate)
 
-  @spec field_expr(String.t()) :: Macro.t()
+  @spec field_expr(String.t()) :: Ecto.Query.dynamic_expr()
   defp field_expr(field_path) do
     case split_map_path(field_path) do
       {:map_access, column, key} ->

--- a/lib/logflare/lql/backend_transformer/clickhouse.ex
+++ b/lib/logflare/lql/backend_transformer/clickhouse.ex
@@ -17,6 +17,9 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
 
   @special_top_level ~w(event_message timestamp id)
 
+  # ClickHouse Map(String, String) columns that require bracket access syntax.
+  @map_columns ~w(log_attributes resource_attributes scope_attributes attributes span_attributes)
+
   # macros used for generating Ecto query fragments
   defmacrop ch_interval_second(ts_field) do
     quote do: fragment("toStartOfInterval(?, INTERVAL 1 second)", unquote(ts_field))
@@ -79,6 +82,16 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     end)
   end
 
+  @doc false
+  @spec split_map_path(String.t()) ::
+          {:map_access, String.t(), String.t()} | {:column, String.t()}
+  def split_map_path(field_path) do
+    case String.split(field_path, ".", parts: 2) do
+      [column, key] when column in @map_columns -> {:map_access, column, key}
+      _ -> {:column, field_path}
+    end
+  end
+
   @impl true
   def handle_nested_field_access(query, _field_path) do
     # ClickHouse handles nested fields natively without joins
@@ -87,18 +100,17 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
 
   @impl true
   def transform_filter_rule(filter_rule, _transformation_data) do
-    field_path = filter_rule.path
-
     if not is_nil(filter_rule.values) and filter_rule.operator == :range do
       [lvalue, rvalue] = filter_rule.values
+      field = field_expr(filter_rule.path)
 
       dynamic(
         [l],
-        fragment("? BETWEEN ? AND ?", field(l, ^field_path), ^lvalue, ^rvalue)
+        fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue)
       )
     else
       dynamic_where_filter_rule(
-        field_path,
+        filter_rule.path,
         filter_rule.operator,
         filter_rule.value,
         filter_rule.modifiers
@@ -453,8 +465,8 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
   defp where_match_filter_rule(query, rule) do
     if not is_nil(rule.values) and rule.operator == :range do
       [lvalue, rvalue] = rule.values
-      field_path = rule.path
-      where(query, [l], fragment("? BETWEEN ? AND ?", field(l, ^field_path), ^lvalue, ^rvalue))
+      field = field_expr(rule.path)
+      where(query, [l], fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue))
     else
       where(
         query,
@@ -470,50 +482,48 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
           modifiers :: map()
         ) :: Query.dynamic_expr()
   defp dynamic_where_filter_rule(field_path, operator, value, modifiers) do
+    field = field_expr(field_path)
+
     clause =
       case operator do
         :> ->
-          dynamic([l], field(l, ^field_path) > ^value)
+          dynamic([l], ^field > ^value)
 
         :>= ->
-          dynamic([l], field(l, ^field_path) >= ^value)
+          dynamic([l], ^field >= ^value)
 
         :< ->
-          dynamic([l], field(l, ^field_path) < ^value)
+          dynamic([l], ^field < ^value)
 
         :<= ->
-          dynamic([l], field(l, ^field_path) <= ^value)
+          dynamic([l], ^field <= ^value)
 
         := ->
           case value do
-            :NULL -> dynamic([l], fragment("? IS NULL", field(l, ^field_path)))
-            _ -> dynamic([l], field(l, ^field_path) == ^value)
+            :NULL -> dynamic([l], fragment("? IS NULL", ^field))
+            _ -> dynamic([l], ^field == ^value)
           end
 
         :"~" ->
-          # ClickHouse uses match() function for regex
-          dynamic([l], fragment("match(?, ?)", field(l, ^field_path), ^value))
+          dynamic([l], fragment("match(?, ?)", ^field, ^value))
 
         :string_contains ->
-          # ClickHouse uses position() function for string search
-          dynamic([l], fragment("position(?, ?) > 0", field(l, ^field_path), ^value))
+          dynamic([l], fragment("position(?, ?) > 0", ^field, ^value))
 
         :list_includes ->
-          # ClickHouse uses has() function for array membership
-          dynamic([l], fragment("has(?, ?)", field(l, ^field_path), ^value))
+          dynamic([l], fragment("has(?, ?)", ^field, ^value))
 
         :list_includes_regexp ->
-          # ClickHouse uses arrayExists with lambda for regex matching in arrays
           dynamic(
             [l],
-            fragment("arrayExists(x -> match(x, ?), ?)", ^value, field(l, ^field_path))
+            fragment("arrayExists(x -> match(x, ?), ?)", ^value, ^field)
           )
       end
 
     if negated?(modifiers) do
       case {operator, value} do
         {:=, :NULL} -> dynamic([l], not (^clause))
-        {_, _} -> dynamic([l], fragment("? IS NULL", field(l, ^field_path)) or not (^clause))
+        {_, _} -> dynamic([l], fragment("? IS NULL", ^field) or not (^clause))
       end
     else
       clause
@@ -523,11 +533,31 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
   @spec negated?(map()) :: boolean()
   defp negated?(modifiers), do: Map.get(modifiers, :negate)
 
+  @spec field_expr(String.t()) :: Macro.t()
+  defp field_expr(field_path) do
+    case split_map_path(field_path) do
+      {:map_access, column, key} ->
+        dynamic([l], fragment("?[?]", field(l, ^column), ^key))
+
+      {:column, column} ->
+        dynamic([l], field(l, ^column))
+    end
+  end
+
   @spec build_combined_select(Query.t(), select_rules :: [map()]) :: Query.t()
   defp build_combined_select(query, select_rules) do
     Enum.reduce(select_rules, query, fn %{path: path, alias: alias}, acc_query ->
       path_or_alias = if is_binary(alias), do: alias, else: String.replace(path, ".", "_")
-      select_merge(acc_query, [l], %{^path_or_alias => field(l, ^path)})
+
+      case split_map_path(path) do
+        {:map_access, column, key} ->
+          select_merge(acc_query, [l], %{
+            ^path_or_alias => fragment("?[?]", field(l, ^column), ^key)
+          })
+
+        {:column, _column} ->
+          select_merge(acc_query, [l], %{^path_or_alias => field(l, ^path)})
+      end
     end)
   end
 end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -16,6 +16,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends.Backend
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.Adaptor.QueryResult
+  alias Logflare.Lql.BackendTransformer.ClickHouse, as: ClickHouseLQLTransformer
+  alias Logflare.Lql.Rules.FilterRule
 
   doctest ClickHouseAdaptor
 
@@ -560,6 +562,64 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
         assert [%{"count" => 1}] = query_result
       end
+    end
+  end
+
+  describe "LQL query integration" do
+    setup do
+      insert(:plan, name: "Free")
+
+      {source, backend} =
+        setup_clickhouse_test()
+
+      start_supervised!({ClickHouseAdaptor, backend})
+      assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+
+      [source: source, backend: backend]
+    end
+
+    test "dot-key filter produces valid ClickHouse Map access query", %{
+      source: source,
+      backend: backend
+    } do
+      log_events = [
+        build_mapped_log_event(
+          source: source,
+          message: "dot-key match",
+          body: %{"metadata" => %{"parsed.backend_type" => "client"}}
+        ),
+        build_mapped_log_event(
+          source: source,
+          message: "dot-key no match",
+          body: %{"metadata" => %{"parsed.backend_type" => "server"}}
+        )
+      ]
+
+      :ok = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
+      Process.sleep(100)
+
+      table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
+
+      filter_rule =
+        FilterRule.build(
+          path: "log_attributes.parsed.backend_type",
+          operator: :=,
+          value: "client",
+          modifiers: %{}
+        )
+
+      query =
+        from(l in table_name,
+          select: l.event_message
+        )
+        |> ClickHouseLQLTransformer.apply_filter_rules_to_query(
+          [filter_rule],
+          []
+        )
+
+      {:ok, %QueryResult{rows: rows}} = ClickHouseAdaptor.execute_query(backend, query, [])
+
+      assert [%{"event_message" => "dot-key match"}] = rows
     end
   end
 

--- a/test/logflare/lql/backend_transformer/clickhouse_test.exs
+++ b/test/logflare/lql/backend_transformer/clickhouse_test.exs
@@ -175,6 +175,124 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
     end
   end
 
+  describe "split_map_path/1" do
+    test "returns map_access for known Map column with dot key" do
+      assert {:map_access, "log_attributes", "parsed.backend_type"} =
+               ClickHouse.split_map_path("log_attributes.parsed.backend_type")
+    end
+
+    test "returns map_access for all known Map columns" do
+      for col <-
+            ~w(log_attributes resource_attributes scope_attributes attributes span_attributes) do
+        assert {:map_access, ^col, "key"} = ClickHouse.split_map_path("#{col}.key")
+      end
+    end
+
+    test "returns column for non-Map column" do
+      assert {:column, "event_message"} = ClickHouse.split_map_path("event_message")
+    end
+
+    test "returns column for unknown dotted path" do
+      assert {:column, "unknown_col.field"} = ClickHouse.split_map_path("unknown_col.field")
+    end
+  end
+
+  describe "transform_filter_rule/2 with dot-key Map paths" do
+    test "transforms equality filter on Map column dot-key" do
+      filter_rule =
+        FilterRule.build(
+          path: "log_attributes.parsed.backend_type",
+          operator: :=,
+          value: "client",
+          modifiers: %{}
+        )
+
+      result = ClickHouse.transform_filter_rule(filter_rule, %{})
+      assert %DynamicExpr{} = result
+
+      query = from(l in "logs")
+      query_with_filter = where(query, ^result)
+      assert %Ecto.Query{wheres: [_where_clause]} = query_with_filter
+    end
+
+    test "transforms range filter on Map column dot-key" do
+      filter_rule =
+        FilterRule.build(
+          path: "log_attributes.response_time",
+          operator: :range,
+          values: [100, 500],
+          modifiers: %{}
+        )
+
+      result = ClickHouse.transform_filter_rule(filter_rule, %{})
+      assert %DynamicExpr{} = result
+
+      query = from(l in "logs")
+      query_with_filter = where(query, ^result)
+      assert %Ecto.Query{wheres: [_where_clause]} = query_with_filter
+    end
+
+    test "transforms negated filter on Map column dot-key" do
+      filter_rule =
+        FilterRule.build(
+          path: "log_attributes.parsed.backend_type",
+          operator: :=,
+          value: "client",
+          modifiers: %{negate: true}
+        )
+
+      result = ClickHouse.transform_filter_rule(filter_rule, %{})
+      assert %DynamicExpr{} = result
+
+      query = from(l in "logs")
+      query_with_filter = where(query, ^result)
+      assert %Ecto.Query{wheres: [_where_clause]} = query_with_filter
+    end
+  end
+
+  describe "apply_filter_rules_to_query/3 with dot-key Map paths" do
+    test "applies range filter on Map column dot-key to query" do
+      query = from(l in "logs")
+
+      filter_rule =
+        FilterRule.build(
+          path: "log_attributes.response_time",
+          operator: :range,
+          values: [100, 500],
+          modifiers: %{}
+        )
+
+      result = ClickHouse.apply_filter_rules_to_query(query, [filter_rule], [])
+      assert %Ecto.Query{wheres: [_where_clause]} = result
+    end
+  end
+
+  describe "apply_select_rules_to_query/3 with dot-key Map paths" do
+    test "applies select rule for Map column dot-key" do
+      query = from(l in "logs")
+      select_rule = %SelectRule{path: "log_attributes.parsed.backend_type"}
+
+      result = ClickHouse.apply_select_rules_to_query(query, [select_rule], [])
+
+      assert %Ecto.Query{select: %{expr: expr}} = result
+      assert Macro.to_string(expr) =~ "log_attributes_parsed_backend_type"
+    end
+
+    test "applies select rule for Map column dot-key with alias" do
+      query = from(l in "logs")
+
+      select_rule = %SelectRule{
+        path: "log_attributes.parsed.backend_type",
+        alias: "backend_type"
+      }
+
+      result = ClickHouse.apply_select_rules_to_query(query, [select_rule], [])
+
+      assert %Ecto.Query{select: %{expr: expr}} = result
+      assert Macro.to_string(expr) =~ "backend_type"
+    end
+  end
+
   describe "transform_chart_rule/5" do
     setup do
       base_query = from("logs")
@@ -301,11 +419,9 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
       result = ClickHouse.apply_select_rules_to_query(query, [select_rule], [])
 
       assert %Ecto.Query{select: %{expr: expr}} = result
-      assert expr |> Macro.to_string() =~ "metadata_user_id"
+      assert Macro.to_string(expr) =~ "metadata_user_id"
     end
-  end
 
-  describe "apply_select_rules_to_query/3 with aliases" do
     test "applies top-level field with alias" do
       query = from(l in "logs")
       select_rule = %SelectRule{path: "event_message", alias: "msg"}
@@ -313,7 +429,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
       result = ClickHouse.apply_select_rules_to_query(query, [select_rule], [])
 
       assert %Ecto.Query{select: %{expr: expr}} = result
-      assert expr |> Macro.to_string() =~ "msg"
+      assert Macro.to_string(expr) =~ "msg"
     end
 
     test "applies nested field with alias" do
@@ -324,7 +440,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
       result = ClickHouse.apply_select_rules_to_query(query, [select_rule], [])
 
       assert %Ecto.Query{select: %{expr: expr}} = result
-      assert expr |> Macro.to_string() =~ "user_id"
+      assert Macro.to_string(expr) =~ "user_id"
     end
   end
 


### PR DESCRIPTION
Adds support for dot-key filtering on ClickHouse Map columns in LQL. Previously, a query like `log_attributes.parsed.backend_type:~"client"` would fail because the ClickHouse transformer treated the entire dotted path as a column name (`l0."log_attributes.parsed.backend_type"`) instead of using Map bracket access (`l0."log_attributes"['parsed.backend_type']`).

**Key Changes:**
  - `lib/logflare/lql/backend_transformer/clickhouse.ex` — Added `split_map_path/1` to detect when a field path starts with a known ClickHouse Map column and splits it into column + map key.
  - `test/logflare/lql/backend_transformer/clickhouse_test.exs` — Added unit tests for `split_map_path/1` and dot-key filter/select rules (_equality, range, negation, select with alias_). Consolidated some old describe blocks. Fixed pipe-style `Macro.to_string` assertions throughout to improve readability.
  - `test/logflare/backends/adaptor/clickhouse_adaptor_test.exs` — Added "LQL query integration" describe block with a round-trip test: inserts events with dotted map keys into ClickHouse, queries them back using an LQL filter rule, and validates correct row filtering.