### PR TITLE
fix: inspect button in log event modal

### DIFF
--- a/lib/logflare_web/templates/log/log_event_body.html.heex
+++ b/lib/logflare_web/templates/log/log_event_body.html.heex
@@ -13,11 +13,8 @@
         </div>
         <div class="tw-text-xs">
           <%= if @local_timezone do %>
-            <.link to={
-              Routes.live_path(LogflareWeb.Endpoint, LogflareWeb.Source.SearchLV, @source,
-                querystring: "t:>#{Timex.format!(Timex.shift(@local_timestamp, seconds: -30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} t:<#{Timex.format!(Timex.shift(@local_timestamp, seconds: 30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} c:count(*) c:group_by(t::second)",
-                tailing?: false
-              )
+            <.link patch={
+              ~p"/sources/#{@source}/search?#{%{querystring: "t:>#{Timex.format!(Timex.shift(@local_timestamp, seconds: -30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} t:<#{Timex.format!(Timex.shift(@local_timestamp, seconds: 30), "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}")} c:count(*) c:group_by(t::second)", tailing?: false}}"
             }>
               <i class="fas fa-search tw-mr-1 tw-w-2"></i> inspect
             </.link>

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1015,6 +1015,48 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert query =~ ~r"..\.testing"
     end
 
+    test "log event modal - inspect link", %{conn: conn, user: user} do
+      schema = TestUtils.build_bq_schema(%{"testing" => "string"})
+      source = insert(:source, user: user)
+      insert(:source_schema, source: source, bigquery_schema: schema)
+
+      stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, _opts ->
+        {:ok,
+         TestUtils.gen_bq_response(%{
+           "event_message" => "some modal message",
+           "testing" => "modal123",
+           "id" => "some-uuid"
+         })}
+      end)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sources/#{source.id}/search?#{%{querystring: "testing:modal123"}}")
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      view
+      |> TestUtils.wait_for_render("li:first-of-type a[phx-value-log-event-id='some-uuid']")
+
+      view
+      |> element("li:first-of-type a[phx-value-log-event-id='some-uuid']", "view")
+      |> render_click()
+
+      TestUtils.retry_assert(fn ->
+        assert render(view) =~ "inspect"
+      end)
+
+      view
+      |> element("#log-event-viewer a", "inspect")
+      |> render_click()
+
+      to = assert_patch(view)
+
+      assert to =~ ~r|^/sources/#{source.id}/search\?querystring=|
+      assert to =~ "tailing%3F=false"
+      refute has_element?(view, "#log-event-viewer")
+    end
+
     test "log event modal - quick filter button appends filter to search", %{
       conn: conn,
       source: source


### PR DESCRIPTION
Fixes the inspect button in the log event modal.

Added test coverage. There's an opportunity to refactor some of those modal tests to reduce repeated boiler plate if we want.

Fixes O11Y-1680

https://github.com/user-attachments/assets/04aa8485-20be-41ae-952c-d2ad2a04fa77

