### PR TITLE
fix: LQL preserves timestamp Z suffix

### DIFF
--- a/lib/logflare/lql/encoder.ex
+++ b/lib/logflare/lql/encoder.ex
@@ -85,16 +85,16 @@ defmodule Logflare.Lql.Encoder do
          path: "timestamp",
          operator: :range,
          values: [lv, rv],
-         modifiers: _mods
+         modifiers: mods
        }) do
-    "t:#{to_datetime_with_range(lv, rv)}"
+    "t:#{to_datetime_with_range(lv, rv, mods)}"
   end
 
   defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: %Date{} = v}),
     do: "t:#{op}#{v}"
 
-  defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: v}) do
-    "t:#{op}#{format_filter_value(v)}"
+  defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: v, modifiers: mods}) do
+    "t:#{op}#{format_timestamp_filter_value(v, mods)}"
   end
 
   defp to_fragment(%FilterRule{
@@ -247,6 +247,18 @@ defmodule Logflare.Lql.Encoder do
     do: NaiveDateTime.to_iso8601(%{value | microsecond: {0, 0}})
 
   defp format_filter_value(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+
+  defp format_timestamp_filter_value(value, %{explicit_timezone: true}) do
+    format_filter_value(value) <> "Z"
+  end
+
+  defp format_timestamp_filter_value(value, _mods), do: format_filter_value(value)
+
+  def to_datetime_with_range(ldt, rdt, %{explicit_timezone: true}) do
+    to_datetime_with_range(ldt, rdt) <> "Z"
+  end
+
+  def to_datetime_with_range(ldt, rdt, _mods), do: to_datetime_with_range(ldt, rdt)
 
   def to_datetime_with_range(%Date{} = ldt, %Date{} = rdt) do
     mapper_fn = fn period -> timestamp_mapper(ldt, rdt, period) end

--- a/test/logflare/lql/encoder_test.exs
+++ b/test/logflare/lql/encoder_test.exs
@@ -121,6 +121,37 @@ defmodule Logflare.Lql.EncoderTest do
       assert result == "t:>=2026-03-17T12:47:02.123"
     end
 
+    test "preserves Z suffix for explicit UTC timestamp filters" do
+      lql_rules = [
+        %FilterRule{
+          operator: :>=,
+          path: "timestamp",
+          value: NaiveDateTime.from_iso8601!("2026-04-10T03:18:15"),
+          modifiers: %{explicit_timezone: true}
+        }
+      ]
+
+      result = Encoder.to_querystring(lql_rules)
+      assert result == "t:>=2026-04-10T03:18:15Z"
+    end
+
+    test "preserves Z suffix for explicit UTC timestamp ranges" do
+      lql_rules = [
+        %FilterRule{
+          operator: :range,
+          path: "timestamp",
+          values: [
+            NaiveDateTime.from_iso8601!("2026-04-10T03:18:15"),
+            NaiveDateTime.from_iso8601!("2026-04-10T03:19:15")
+          ],
+          modifiers: %{explicit_timezone: true}
+        }
+      ]
+
+      result = Encoder.to_querystring(lql_rules)
+      assert result == "t:2026-04-10T03:{18..19}:15Z"
+    end
+
     test "encodes quoted string filter" do
       lql_rules = [
         %FilterRule{

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -331,7 +331,7 @@ defmodule Logflare.Lql.ParserTest do
              ] = rules
 
       assert Lql.encode!(result) ==
-               "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:<=2024-03-17T13:47:02"
+               "t:>2026-03-17T14:47:02Z t:>=2026-03-17T12:47:02Z t:<2026-03-17T16:47:02Z t:<=2024-03-17T13:47:02Z"
     end
 
     test "timestamp filters support Unix timestamp ranges" do
@@ -357,7 +357,7 @@ defmodule Logflare.Lql.ParserTest do
              ] = rules
 
       assert Lql.encode!(result) ==
-               "t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02"
+               "t:2024-03-17T13:{47..57}:02Z t:2024-03-17T13:{47..57}:02Z"
     end
 
     test "timestamp filters reject ambiguous 14 and 15 digit Unix timestamps" do

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -301,43 +301,63 @@ defmodule Logflare.Lql.ParserTest do
       t:>2026-03-17T14:47:02.000Z
       t:>=2026-03-17T14:47:02+02:00
       t:<2026-03-17T14:47:02-02:00
-      t:1710683222..1710683822
-      t:1710683222000..1710683822000
       t:<=1710683222000000
       |
 
       {:ok, result} = Parser.parse(qs, @default_schema)
       rules = Enum.filter(result, &(&1.path == "timestamp"))
 
-      assert Enum.map(rules, & &1.value) == [
-               ~N[2026-03-17 14:47:02.000],
-               ~N[2026-03-17 12:47:02],
-               ~N[2026-03-17 16:47:02],
-               nil,
-               nil,
-               ~N[2024-03-17 13:47:02.000]
-             ]
-
-      assert Enum.map(rules, & &1.values) == [
-               nil,
-               nil,
-               nil,
-               [~N[2024-03-17 13:47:02], ~N[2024-03-17 13:57:02]],
-               [~N[2024-03-17 13:47:02.000], ~N[2024-03-17 13:57:02.000]],
-               nil
-             ]
-
-      assert Enum.map(rules, & &1.modifiers) == [
-               %{explicit_timezone: true},
-               %{explicit_timezone: true},
-               %{explicit_timezone: true},
-               %{explicit_timezone: true},
-               %{explicit_timezone: true},
-               %{explicit_timezone: true}
-             ]
+      assert [
+               %FilterRule{
+                 value: ~N[2026-03-17 14:47:02.000],
+                 values: nil,
+                 modifiers: %{explicit_timezone: true}
+               },
+               %FilterRule{
+                 value: ~N[2026-03-17 12:47:02],
+                 values: nil,
+                 modifiers: %{explicit_timezone: true}
+               },
+               %FilterRule{
+                 value: ~N[2026-03-17 16:47:02],
+                 values: nil,
+                 modifiers: %{explicit_timezone: true}
+               },
+               %FilterRule{
+                 value: ~N[2024-03-17 13:47:02.000],
+                 values: nil,
+                 modifiers: %{explicit_timezone: true}
+               }
+             ] = rules
 
       assert Lql.encode!(result) ==
-               "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02 t:<=2024-03-17T13:47:02"
+               "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:<=2024-03-17T13:47:02"
+    end
+
+    test "timestamp filters support Unix timestamp ranges" do
+      qs = ~S|
+      t:1710683222..1710683822
+      t:1710683222000..1710683822000
+      |
+
+      {:ok, result} = Parser.parse(qs, @default_schema)
+      rules = Enum.filter(result, &(&1.path == "timestamp"))
+
+      assert [
+               %FilterRule{
+                 value: nil,
+                 values: [~N[2024-03-17 13:47:02], ~N[2024-03-17 13:57:02]],
+                 modifiers: %{explicit_timezone: true}
+               },
+               %FilterRule{
+                 value: nil,
+                 values: [~N[2024-03-17 13:47:02.000], ~N[2024-03-17 13:57:02.000]],
+                 modifiers: %{explicit_timezone: true}
+               }
+             ] = rules
+
+      assert Lql.encode!(result) ==
+               "t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02"
     end
 
     test "timestamp filters reject ambiguous 14 and 15 digit Unix timestamps" do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1212,6 +1212,27 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert get_view_assigns(view).querystring =~ "error"
       assert get_view_assigns(view).querystring =~ "t:2020-04-20T00:{01..02}:00"
     end
+
+    test "preserves Z suffixes from query params", %{conn: conn, source: source} do
+      {:ok, view, _html} =
+        live(
+          conn,
+          Routes.live_path(conn, SearchLV, source,
+            querystring:
+              "t:>2026-04-10T03:18:15Z t:<2026-04-10T03:19:15Z c:count(*) c:group_by(t::second)",
+            tailing?: false
+          )
+        )
+
+      querystring =
+        view
+        |> TestUtils.wait_for_render("#lql-editor-hook")
+        |> render()
+        |> find_querystring()
+
+      assert querystring =~ "t:>2026-04-10T03:18:15Z"
+      assert querystring =~ "t:<2026-04-10T03:19:15Z"
+    end
   end
 
   describe "create from query" do


### PR DESCRIPTION
Ensures timestamp with Z suffix is preserved by the LQL encoder. 

This fixes a bug when a user as local timezone set but performed a search with a explicit timezone in the URL query params.

Fixes O11Y-1681

Stacked on #3384 

## Demo

In this demonstration:

1. Start with a search in Singapore local time, verify results are shown.
2. Append the Z suffix in the URL. This changes the search the UTC timestamp. Verify Z is preserved in the search query, and correctly returns no results.
3. Switch back to local time: results are shown.


https://github.com/user-attachments/assets/b07763bc-21de-4083-9218-f7abc997dd3f

