### PR TITLE
fix: treat monaco editor as uncontrolled component

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -94,7 +94,6 @@ let liveSocket = new LiveSocket("/live", Socket, {
   },
 });
 liveSocket.enableDebug()
-liveSocket.enableLatencySim(750)
 
 liveSocket.connect();
 window.initLiveReact = initLiveReact;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -94,6 +94,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
   },
 });
 liveSocket.enableDebug()
+liveSocket.enableLatencySim(750)
 
 liveSocket.connect();
 window.initLiveReact = initLiveReact;

--- a/assets/js/lql_editor_wrapper_hook.js
+++ b/assets/js/lql_editor_wrapper_hook.js
@@ -25,7 +25,7 @@ const LqlEditorWrapper = {
     this._editor = null;
     this._editorDisposables = [];
     this._pendingServerValue = null;
-    this._lastServerSetValue = null;
+    this._lastServerQuerystring = this.el.dataset.querystring ?? "";
     this._handleSubmitRequest = () => {
       this.submitSearch();
     };
@@ -67,15 +67,7 @@ const LqlEditorWrapper = {
       );
 
       this._editorDisposables = [
-        standaloneEditor.onDidChangeModelContent(() => {
-          const value = standaloneEditor.getValue();
-          if (this._lastServerSetValue !== null && value === this._lastServerSetValue) {
-            this._lastServerSetValue = null;
-            return;
-          }
-          this._lastServerSetValue = null;
-          this.pushEvent("querystring_changed", { querystring: value });
-        }),
+        standaloneEditor.onDidChangeModelContent(() => {}),
         standaloneEditor.onDidFocusEditorText(() => {
           this.pushEvent("form_focus", { value: standaloneEditor.getValue() });
         }),
@@ -94,14 +86,21 @@ const LqlEditorWrapper = {
     this._suggestedSearches = parseSuggestedSearches(
       this.el.dataset.suggestedSearchesJson
     );
-    const value = this.el.dataset.querystring ?? "";
+    const serverValue = this.el.dataset.querystring ?? "";
+
+    // Only force-update the editor if the server pushed a genuinely new value
+    // (e.g. saved search click, URL param change), not an echo of user input
+    if (serverValue === this._lastServerQuerystring) {
+      return;
+    }
+    this._lastServerQuerystring = serverValue;
 
     if (!this._editor) {
-      this._pendingServerValue = value;
+      this._pendingServerValue = serverValue;
       return;
     }
 
-    this.setEditorValue(value);
+    this.setEditorValue(serverValue);
   },
 
   applyPendingEditorValue() {
@@ -127,7 +126,6 @@ const LqlEditorWrapper = {
       "editor.contrib.suggestController"
     );
 
-    this._lastServerSetValue = value;
     this._editor.setValue(value);
 
     if (hadTextFocus && model) {

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -431,8 +431,8 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, socket}
   end
 
-  def handle_event("querystring_changed", %{"querystring" => qs}, socket) do
-    {:noreply, assign(socket, :querystring, qs)}
+  def handle_event("querystring_changed", %{"querystring" => _qs}, socket) do
+    {:noreply, socket}
   end
 
   def handle_event(

--- a/lib/logflare_web/templates/layout/root.html.heex
+++ b/lib/logflare_web/templates/layout/root.html.heex
@@ -47,6 +47,11 @@
     {@inner_content}
     <script src={Routes.static_path(@conn, "/js/app.js")}>
     </script>
+    <%= if Application.get_env(:logflare, :env) == :dev do %>
+      <script>
+        window.liveSocket.enableLatencySim(750)
+      </script>
+    <% end %>
     <%= if Application.get_env(:logflare, :env) == :prod do %>
       <script>
         window.addEventListener('load', () => {


### PR DESCRIPTION
this PR fixes race conditions when trying to treat the monaco editor as a controlled component.
 A default 750ms latency simulation has been added to the liveview socket to ensure that this gets catched at dev.

before:

https://github.com/user-attachments/assets/9acb17f0-73ab-46c9-ac48-94a2ae127ccb



now:

https://github.com/user-attachments/assets/0c6008f7-073e-45d0-a92d-cb5cebe4226d

