### PR TITLE
fix: LQL chart generation syntax error

### DIFF
--- a/lib/logflare/lql/backend_transformer/clickhouse.ex
+++ b/lib/logflare/lql/backend_transformer/clickhouse.ex
@@ -339,7 +339,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     query
     |> select([t], %{
       timestamp: ch_interval_second(field(t, ^timestamp_field)),
-      count: fragment("quantile(?)(?))", ^percentile_value, field(t, ^field_path))
+      count: fragment("quantile(?)(?)", ^percentile_value, field(t, ^field_path))
     })
     |> group_by([t], ch_interval_second(field(t, ^timestamp_field)))
     |> order_by([t], ch_interval_second(field(t, ^timestamp_field)))
@@ -352,7 +352,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     query
     |> select([t], %{
       timestamp: ch_interval_minute(field(t, ^timestamp_field)),
-      count: fragment("quantile(?)(?))", ^percentile_value, field(t, ^field_path))
+      count: fragment("quantile(?)(?)", ^percentile_value, field(t, ^field_path))
     })
     |> group_by([t], ch_interval_minute(field(t, ^timestamp_field)))
     |> order_by([t], ch_interval_minute(field(t, ^timestamp_field)))
@@ -365,7 +365,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     query
     |> select([t], %{
       timestamp: ch_interval_hour(field(t, ^timestamp_field)),
-      count: fragment("quantile(?)(?))", ^percentile_value, field(t, ^field_path))
+      count: fragment("quantile(?)(?)", ^percentile_value, field(t, ^field_path))
     })
     |> group_by([t], ch_interval_hour(field(t, ^timestamp_field)))
     |> order_by([t], ch_interval_hour(field(t, ^timestamp_field)))
@@ -378,7 +378,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     query
     |> select([t], %{
       timestamp: ch_interval_day(field(t, ^timestamp_field)),
-      count: fragment("quantile(?)(?))", ^percentile_value, field(t, ^field_path))
+      count: fragment("quantile(?)(?)", ^percentile_value, field(t, ^field_path))
     })
     |> group_by([t], ch_interval_day(field(t, ^timestamp_field)))
     |> order_by([t], ch_interval_day(field(t, ^timestamp_field)))

--- a/test/logflare/lql_test.exs
+++ b/test/logflare/lql_test.exs
@@ -5,12 +5,13 @@ defmodule Logflare.LqlTest do
 
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.Lql
-  alias Logflare.Lql.Parser
+  alias Logflare.Lql.Parser, as: LqlParser
   alias Logflare.Lql.Rules.ChartRule
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Lql.Rules.FromRule
   alias Logflare.Lql.Rules.SelectRule
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
+  alias Logflare.Sql.Parser, as: SqlParser
 
   describe "apply_filter_rules/3" do
     test "applies filter rules to query using BigQuery backend transformer by default" do
@@ -369,7 +370,7 @@ defmodule Logflare.LqlTest do
       ]
 
       for {query, path, aggregate, period} <- test_cases do
-        {:ok, [rule]} = Parser.parse(query)
+        {:ok, [rule]} = LqlParser.parse(query)
         assert %ChartRule{path: ^path, aggregate: ^aggregate, period: ^period} = rule
       end
     end
@@ -377,14 +378,14 @@ defmodule Logflare.LqlTest do
 
   describe "`FromRule` decode/encode" do
     test "decodes simple `FromRule`" do
-      {:ok, rules} = Parser.parse("f:my_table")
+      {:ok, rules} = LqlParser.parse("f:my_table")
 
       assert length(rules) == 1
       assert [%FromRule{table: "my_table"}] = rules
     end
 
     test "decodes `FromRule` with filters" do
-      {:ok, rules} = Parser.parse("f:logs m.status:error")
+      {:ok, rules} = LqlParser.parse("f:logs m.status:error")
 
       assert length(rules) == 2
       assert %FromRule{table: "logs"} = Enum.find(rules, &match?(%FromRule{}, &1))
@@ -394,7 +395,7 @@ defmodule Logflare.LqlTest do
     end
 
     test "decodes `FromRule` with select rules" do
-      {:ok, rules} = Parser.parse("f:events s:timestamp s:event_message")
+      {:ok, rules} = LqlParser.parse("f:events s:timestamp s:event_message")
 
       assert length(rules) == 3
       assert %FromRule{table: "events"} = Enum.find(rules, &match?(%FromRule{}, &1))
@@ -403,7 +404,7 @@ defmodule Logflare.LqlTest do
     end
 
     test "decodes `FromRule` with chart rule" do
-      {:ok, rules} = Parser.parse("f:metrics c:count(*) c:group_by(t::minute)")
+      {:ok, rules} = LqlParser.parse("f:metrics c:count(*) c:group_by(t::minute)")
 
       assert length(rules) == 2
       assert %FromRule{table: "metrics"} = Enum.find(rules, &match?(%FromRule{}, &1))
@@ -444,11 +445,11 @@ defmodule Logflare.LqlTest do
 
     test "round-trip decode/encode preserves from rule" do
       original = "f:my_source m.level:error s:event_message"
-      {:ok, rules} = Parser.parse(original)
+      {:ok, rules} = LqlParser.parse(original)
       {:ok, encoded} = Lql.encode(rules)
 
       # Re-parse to verify structure is preserved
-      {:ok, rules2} = Parser.parse(encoded)
+      {:ok, rules2} = LqlParser.parse(encoded)
 
       assert length(rules) == length(rules2)
       assert Enum.find(rules, &match?(%FromRule{table: "my_source"}, &1))
@@ -638,6 +639,96 @@ defmodule Logflare.LqlTest do
 
       assert String.downcase(sql) =~ "count(distinct"
       assert String.downcase(sql) =~ "group by"
+    end
+
+    test "converts chart count aggregation to ClickHouse SQL" do
+      lql = "c:count(*) c:group_by(t::hour)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "events", :clickhouse)
+
+      assert String.downcase(sql) =~ "select"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "count"
+      assert String.downcase(sql) =~ "group by"
+      assert String.downcase(sql) =~ "order by"
+      assert String.downcase(sql) =~ ~s|from "events"|
+    end
+
+    test "converts chart avg aggregation to ClickHouse SQL" do
+      lql = "c:avg(m.latency) c:group_by(t::hour)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "metrics", :clickhouse)
+
+      assert String.downcase(sql) =~ "avg"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "group by"
+      assert String.downcase(sql) =~ "hour"
+    end
+
+    test "converts chart sum aggregation to ClickHouse SQL" do
+      lql = "c:sum(m.bytes) c:group_by(t::day)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "traffic", :clickhouse)
+
+      assert String.downcase(sql) =~ "sum"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "group by"
+    end
+
+    test "converts chart max aggregation to ClickHouse SQL" do
+      lql = "c:max(m.response_time) c:group_by(t::second)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "requests", :clickhouse)
+
+      assert String.downcase(sql) =~ "max"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "second"
+    end
+
+    test "converts chart p50 percentile to ClickHouse SQL" do
+      lql = "c:p50(m.duration) c:group_by(t::minute)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "traces", :clickhouse)
+
+      assert String.downcase(sql) =~ "quantile"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "group by"
+    end
+
+    test "converts chart p95 percentile to ClickHouse SQL" do
+      lql = "c:p95(m.duration) c:group_by(t::minute)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "traces", :clickhouse)
+
+      assert String.downcase(sql) =~ "quantile"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "group by"
+    end
+
+    test "converts chart p99 percentile to ClickHouse SQL" do
+      lql = "c:p99(m.duration) c:group_by(t::minute)"
+      {:ok, sql} = Lql.to_sandboxed_sql(lql, "traces", :clickhouse)
+
+      assert String.downcase(sql) =~ "quantile"
+      assert String.downcase(sql) =~ "tostartofinterval"
+      assert String.downcase(sql) =~ "group by"
+    end
+
+    test "ClickHouse chart SQL round-trips through Rust parser" do
+      for {lql, aggregate_check} <- [
+            {"c:count(*) c:group_by(t::hour)", "count"},
+            {"c:avg(m.latency) c:group_by(t::minute)", "avg"},
+            {"c:sum(m.bytes) c:group_by(t::day)", "sum"},
+            {"c:max(m.response_time) c:group_by(t::second)", "max"},
+            {"c:p50(m.duration) c:group_by(t::minute)", "quantile"},
+            {"c:p95(m.duration) c:group_by(t::hour)", "quantile"},
+            {"c:p99(m.duration) c:group_by(t::day)", "quantile"}
+          ] do
+        {:ok, sql} = Lql.to_sandboxed_sql(lql, "events", :clickhouse)
+
+        assert {:ok, ast} = SqlParser.parse("clickhouse", sql),
+               "Failed to parse generated SQL for: #{lql}\nSQL: #{sql}"
+
+        assert {:ok, round_tripped} = SqlParser.to_string(ast),
+               "Failed to round-trip SQL for: #{lql}"
+
+        assert String.downcase(round_tripped) =~ aggregate_check,
+               "Round-tripped SQL missing #{aggregate_check} for: #{lql}\nSQL: #{round_tripped}"
+      end
     end
 
     test "converts chart avg query to Postgres SQL" do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -587,6 +587,44 @@ defmodule Logflare.SqlTest do
       assert String.downcase(err) =~ "table not found in cte"
     end
 
+    test "sandboxed LQL chart queries transform correctly through full pipeline" do
+      user = insert(:user)
+      source = insert(:source, user: user, name: "my_ch_table")
+      _backend = insert(:backend, type: :clickhouse, user: user, sources: [source])
+
+      cte_query = "with src as (select timestamp from my_ch_table) select timestamp from src"
+
+      for {lql, expected_fragment} <- [
+            {"c:count(*) c:group_by(t::hour)", "count"},
+            {"c:count(*) c:group_by(t::minute)", "count"},
+            {"c:count(*) c:group_by(t::second)", "count"},
+            {"c:count(*) c:group_by(t::day)", "count"},
+            {"c:avg(m.latency) c:group_by(t::minute)", "avg"},
+            {"c:sum(m.bytes) c:group_by(t::day)", "sum"},
+            {"c:max(m.response_time) c:group_by(t::second)", "max"},
+            {"c:p50(m.duration) c:group_by(t::minute)", "quantile"},
+            {"c:p95(m.duration) c:group_by(t::hour)", "quantile"},
+            {"c:p99(m.duration) c:group_by(t::day)", "quantile"}
+          ] do
+        {:ok, consumer_sql} = Logflare.Lql.to_sandboxed_sql(lql, "src", :clickhouse)
+
+        assert {:ok, result} = Sql.transform(:ch_sql, {cte_query, consumer_sql}, user),
+               "Sql.transform failed for LQL: #{lql}\nConsumer SQL: #{consumer_sql}"
+
+        assert String.downcase(result) =~ "with src as",
+               "Missing CTE in transformed result for: #{lql}\nResult: #{result}"
+
+        assert String.downcase(result) =~ expected_fragment,
+               "Missing #{expected_fragment} in transformed result for: #{lql}\nResult: #{result}"
+
+        assert String.downcase(result) =~ "group by",
+               "Missing GROUP BY in transformed result for: #{lql}\nResult: #{result}"
+
+        assert String.downcase(result) =~ "order by",
+               "Missing ORDER BY in transformed result for: #{lql}\nResult: #{result}"
+      end
+    end
+
     test "sandboxed queries reject table references not in CTE" do
       user = insert(:user)
       source = insert(:source, user: user, name: "my_ch_table")


### PR DESCRIPTION
Removes a stray parenthesis in the ClickHouse quantile fragment that was producing invalid SQL and breaking chart queries.

Also adds a round-trip integration test with ClickHouse to validate the SQL generation on the query end.