### PR TITLE
feat: coerce ClickHouse map field values for numeric and boolean LQL filters

### DIFF
--- a/lib/logflare/lql/backend_transformer/clickhouse.ex
+++ b/lib/logflare/lql/backend_transformer/clickhouse.ex
@@ -535,24 +535,17 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
   @spec negated?(map()) :: boolean()
   defp negated?(modifiers), do: Map.get(modifiers, :negate)
 
-  @spec field_expr(String.t()) :: Ecto.Query.dynamic_expr()
-  defp field_expr(field_path) do
-    case split_map_path(field_path) do
-      {:map_access, column, key} ->
-        dynamic([l], fragment("?[?]", field(l, ^column), ^key))
-
-      {:column, column} ->
-        dynamic([l], field(l, ^column))
-    end
-  end
+  @numeric_comparison_operators [:>, :<, :>=, :<=, :=]
 
   @spec coerced_field_expr(String.t(), atom(), any()) :: Ecto.Query.dynamic_expr()
   defp coerced_field_expr(field_path, operator, value) do
-    base = field_expr(field_path)
-
     case split_map_path(field_path) do
-      {:map_access, _column, _key} -> maybe_coerce_map_value(base, operator, value)
-      {:column, _column} -> base
+      {:map_access, column, key} ->
+        base = dynamic([l], fragment("?[?]", field(l, ^column), ^key))
+        maybe_coerce_map_value(base, operator, value)
+
+      {:column, column} ->
+        dynamic([l], field(l, ^column))
     end
   end
 
@@ -562,7 +555,8 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
     dynamic([l], fragment("toFloat64OrNull(?)", ^base))
   end
 
-  defp maybe_coerce_map_value(base, _operator, value) when is_number(value) do
+  defp maybe_coerce_map_value(base, operator, value)
+       when operator in @numeric_comparison_operators and is_number(value) do
     dynamic([l], fragment("toFloat64OrNull(?)", ^base))
   end
 

--- a/lib/logflare/lql/backend_transformer/clickhouse.ex
+++ b/lib/logflare/lql/backend_transformer/clickhouse.ex
@@ -99,23 +99,25 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
   end
 
   @impl true
-  def transform_filter_rule(filter_rule, _transformation_data) do
-    if not is_nil(filter_rule.values) and filter_rule.operator == :range do
-      [lvalue, rvalue] = filter_rule.values
-      field = field_expr(filter_rule.path)
+  def transform_filter_rule(
+        %{operator: :range, values: [lvalue, rvalue], path: path},
+        _transformation_data
+      ) do
+    field = coerced_field_expr(path, :range, lvalue)
 
-      dynamic(
-        [l],
-        fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue)
-      )
-    else
-      dynamic_where_filter_rule(
-        filter_rule.path,
-        filter_rule.operator,
-        filter_rule.value,
-        filter_rule.modifiers
-      )
-    end
+    dynamic(
+      [l],
+      fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue)
+    )
+  end
+
+  def transform_filter_rule(filter_rule, _transformation_data) do
+    dynamic_where_filter_rule(
+      filter_rule.path,
+      filter_rule.operator,
+      filter_rule.value,
+      filter_rule.modifiers
+    )
   end
 
   @doc """
@@ -462,17 +464,17 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
           query :: Query.t(),
           rule :: map()
         ) :: Query.t()
+  defp where_match_filter_rule(query, %{operator: :range, values: [lvalue, rvalue], path: path}) do
+    field = coerced_field_expr(path, :range, lvalue)
+    clause = dynamic([l], fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue))
+    where(query, ^clause)
+  end
+
   defp where_match_filter_rule(query, rule) do
-    if not is_nil(rule.values) and rule.operator == :range do
-      [lvalue, rvalue] = rule.values
-      field = field_expr(rule.path)
-      where(query, [l], fragment("? BETWEEN ? AND ?", ^field, ^lvalue, ^rvalue))
-    else
-      where(
-        query,
-        ^dynamic_where_filter_rule(rule.path, rule.operator, rule.value, rule.modifiers)
-      )
-    end
+    where(
+      query,
+      ^dynamic_where_filter_rule(rule.path, rule.operator, rule.value, rule.modifiers)
+    )
   end
 
   @spec dynamic_where_filter_rule(
@@ -482,7 +484,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
           modifiers :: map()
         ) :: Query.dynamic_expr()
   defp dynamic_where_filter_rule(field_path, operator, value, modifiers) do
-    field = field_expr(field_path)
+    field = coerced_field_expr(field_path, operator, value)
 
     clause =
       case operator do
@@ -543,6 +545,32 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouse do
         dynamic([l], field(l, ^column))
     end
   end
+
+  @spec coerced_field_expr(String.t(), atom(), any()) :: Ecto.Query.dynamic_expr()
+  defp coerced_field_expr(field_path, operator, value) do
+    base = field_expr(field_path)
+
+    case split_map_path(field_path) do
+      {:map_access, _column, _key} -> maybe_coerce_map_value(base, operator, value)
+      {:column, _column} -> base
+    end
+  end
+
+  @spec maybe_coerce_map_value(Ecto.Query.dynamic_expr(), atom(), any()) ::
+          Ecto.Query.dynamic_expr()
+  defp maybe_coerce_map_value(base, :range, lvalue) when is_number(lvalue) do
+    dynamic([l], fragment("toFloat64OrNull(?)", ^base))
+  end
+
+  defp maybe_coerce_map_value(base, _operator, value) when is_number(value) do
+    dynamic([l], fragment("toFloat64OrNull(?)", ^base))
+  end
+
+  defp maybe_coerce_map_value(base, :=, value) when is_boolean(value) do
+    dynamic([l], fragment("accurateCastOrNull(?, 'Bool')", ^base))
+  end
+
+  defp maybe_coerce_map_value(base, _operator, _value), do: base
 
   @spec build_combined_select(Query.t(), select_rules :: [map()]) :: Query.t()
   defp build_combined_select(query, select_rules) do

--- a/lib/logflare/lql/parser.ex
+++ b/lib/logflare/lql/parser.ex
@@ -9,6 +9,7 @@ defmodule Logflare.Lql.Parser do
   import NimbleParsec
   import Logflare.Lql.Parser.Combinators
   import Logflare.Lql.Parser.Helpers
+  import Logflare.Utils.Guards
 
   alias GoogleApi.BigQuery.V2.Model.TableSchema, as: TS
   alias Logflare.Google.BigQuery.SchemaUtils
@@ -209,6 +210,8 @@ defmodule Logflare.Lql.Parser do
     FromRule.build(keyword_list)
   end
 
+  @spec build_chart_rule([{:chart, Keyword.t()}], schema_flat_map(), String.t()) ::
+          ChartRule.t() | nil
   defp build_chart_rule(chart_rule_tokens, typemap, querystring) do
     if not Enum.empty?(chart_rule_tokens) do
       chart_rule =
@@ -220,6 +223,8 @@ defmodule Logflare.Lql.Parser do
     end
   end
 
+  @spec get_path_type(schema_flat_map(), String.t(), String.t()) ::
+          atom() | {:list, atom()}
   defp get_path_type(typemap, path, _querystring) do
     type = Map.get(typemap, path)
 
@@ -250,26 +255,35 @@ defmodule Logflare.Lql.Parser do
   end
 
   # cast without typing, best effort
+  @spec maybe_cast_value(FilterRule.t()) :: FilterRule.t()
   defp maybe_cast_value(%{value: "true"} = c), do: %{c | value: true}
   defp maybe_cast_value(%{value: "false"} = c), do: %{c | value: false}
-  defp maybe_cast_value(%{value: nil} = c), do: c
 
-  defp maybe_cast_value(%{value: v} = c) do
-    parsed =
-      case Integer.parse(v) do
-        {num, ""} ->
-          num
-
-        _ ->
-          case Float.parse(v) do
-            {num, ""} -> num
-            _ -> v
-          end
-      end
-
-    %{c | value: parsed}
+  defp maybe_cast_value(%{value: nil, values: [_ | _] = vals} = c) do
+    %{c | values: Enum.map(vals, &cast_scalar_value/1)}
   end
 
+  defp maybe_cast_value(%{value: nil} = c), do: c
+
+  defp maybe_cast_value(%{value: v} = c), do: %{c | value: cast_scalar_value(v)}
+
+  @spec cast_scalar_value(term()) :: term()
+  defp cast_scalar_value(v) when is_non_empty_binary(v) do
+    case Integer.parse(v) do
+      {num, ""} ->
+        num
+
+      _ ->
+        case Float.parse(v) do
+          {num, ""} -> num
+          _ -> v
+        end
+    end
+  end
+
+  defp cast_scalar_value(v), do: v
+
+  @spec maybe_cast_value(map(), atom() | {:list, atom()}) :: map()
   defp maybe_cast_value(c, {:list, type}), do: maybe_cast_value(c, type)
 
   defp maybe_cast_value(%{values: values, value: nil} = c, type) when values != [] do
@@ -293,7 +307,7 @@ defmodule Logflare.Lql.Parser do
     do: throw("Query syntax error: Expected boolean for #{p}, got: '#{v}'")
 
   defp maybe_cast_value(%{value: v, path: p} = c, type)
-       when is_binary(v) and type in [:integer, :float] do
+       when is_non_empty_binary(v) and type in [:integer, :float] do
     mod =
       case type do
         :integer -> Integer

--- a/test/logflare/lql/backend_transformer/clickhouse_test.exs
+++ b/test/logflare/lql/backend_transformer/clickhouse_test.exs
@@ -293,13 +293,14 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
 
     test "does not coerce when value is string or column is non-Map" do
       cases = [
-        {"string value on Map dot-key", "log_attributes.parsed.backend_type", "client"},
-        {"numeric value on non-Map column", "severity_number", 10}
+        {"string value on Map dot-key", "log_attributes.parsed.backend_type", :=, "client"},
+        {"numeric value on non-Map column", "severity_number", :>, 10},
+        {"regex operator with numeric value", "log_attributes.foo", :"~", 5},
+        {"string_contains with numeric value", "log_attributes.foo", :string_contains, 5},
+        {"list_includes with numeric value", "log_attributes.foo", :list_includes, 5}
       ]
 
-      for {label, path, value} <- cases do
-        op = if is_binary(value), do: :=, else: :>
-
+      for {label, path, op, value} <- cases do
         filter_rule =
           FilterRule.build(path: path, operator: op, value: value, modifiers: %{})
 

--- a/test/logflare/lql/backend_transformer/clickhouse_test.exs
+++ b/test/logflare/lql/backend_transformer/clickhouse_test.exs
@@ -4,6 +4,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
   import Ecto.Query
 
   alias Ecto.Query.DynamicExpr
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Lql.BackendTransformer.ClickHouse
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Lql.Rules.SelectRule
@@ -250,6 +251,99 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
     end
   end
 
+  describe "transform_filter_rule/2 with numeric values on Map column dot-keys" do
+    test "coerces Map value with toFloat64OrNull across comparison operators and int/float values" do
+      cases = [
+        {":> int", "log_attributes.response_time", :>, 100, "> 100"},
+        {":< int", "log_attributes.response_time", :<, 500, "< 500"},
+        {":>= int", "log_attributes.retries", :>=, 5, ">= 5"},
+        {":<= int", "log_attributes.retries", :<=, 5, "<= 5"},
+        {":> float", "log_attributes.ratio", :>, 0.95, "> 0.95"},
+        {":<= float", "log_attributes.score", :<=, 99.95, "<= 99.95"},
+        {"dotted-key :>=", "span_attributes.http.status_code", :>=, 500, ">= 500"}
+      ]
+
+      for {label, path, op, value, op_fragment} <- cases do
+        filter_rule =
+          FilterRule.build(path: path, operator: op, value: value, modifiers: %{})
+
+        result = ClickHouse.transform_filter_rule(filter_rule, %{})
+        assert %DynamicExpr{} = result
+
+        sql = filter_to_sql(result)
+
+        assert sql =~ "toFloat64OrNull", "[#{label}] missing coercion\nSQL: #{sql}"
+        assert sql =~ op_fragment, "[#{label}] missing `#{op_fragment}`\nSQL: #{sql}"
+      end
+    end
+
+    test "coerces Map value for :range BETWEEN with int and float bounds" do
+      for {label, path, values, between_fragment} <- [
+            {"int bounds", "log_attributes.response_time", [100, 500], "BETWEEN 100 AND 500"},
+            {"float bounds", "log_attributes.ratio", [0.1, 0.9], "BETWEEN 0.1 AND 0.9"}
+          ] do
+        filter_rule =
+          FilterRule.build(path: path, operator: :range, values: values, modifiers: %{})
+
+        sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
+        assert sql =~ "toFloat64OrNull", "[#{label}] missing coercion\nSQL: #{sql}"
+        assert sql =~ between_fragment, "[#{label}] missing `#{between_fragment}`\nSQL: #{sql}"
+      end
+    end
+
+    test "does not coerce when value is string or column is non-Map" do
+      cases = [
+        {"string value on Map dot-key", "log_attributes.parsed.backend_type", "client"},
+        {"numeric value on non-Map column", "severity_number", 10}
+      ]
+
+      for {label, path, value} <- cases do
+        op = if is_binary(value), do: :=, else: :>
+
+        filter_rule =
+          FilterRule.build(path: path, operator: op, value: value, modifiers: %{})
+
+        sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
+        refute sql =~ "toFloat64OrNull", "[#{label}] unexpected coercion\nSQL: #{sql}"
+      end
+    end
+  end
+
+  describe "transform_filter_rule/2 with boolean values on Map column dot-keys" do
+    test "coerces Map value with toBoolOrNull for true/false, negated, and dotted keys" do
+      cases = [
+        {"true", "log_attributes.is_error", true, %{}},
+        {"false", "log_attributes.is_error", false, %{}},
+        {"negated true", "log_attributes.is_error", true, %{negate: true}},
+        {"dotted key", "span_attributes.otel.status.ok", true, %{}}
+      ]
+
+      for {label, path, value, modifiers} <- cases do
+        filter_rule =
+          FilterRule.build(path: path, operator: :=, value: value, modifiers: modifiers)
+
+        sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
+        assert sql =~ "toBoolOrNull", "[#{label}] missing coercion\nSQL: #{sql}"
+      end
+    end
+
+    test "does not coerce when value is not a boolean or column is non-Map" do
+      cases = [
+        {"non-Map Bool column", "is_monotonic", true},
+        {"quoted string on Map", "log_attributes.status", "true"},
+        {"NULL equality on Map", "log_attributes.optional_flag", :NULL}
+      ]
+
+      for {label, path, value} <- cases do
+        filter_rule =
+          FilterRule.build(path: path, operator: :=, value: value, modifiers: %{})
+
+        sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
+        refute sql =~ "toBoolOrNull", "[#{label}] unexpected coercion\nSQL: #{sql}"
+      end
+    end
+  end
+
   describe "apply_filter_rules_to_query/3 with dot-key Map paths" do
     test "applies range filter on Map column dot-key to query" do
       query = from(l in "logs")
@@ -477,5 +571,12 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
         ClickHouse.where_timestamp_ago(query, datetime, 1, "INVALID")
       end
     end
+  end
+
+  @spec filter_to_sql(Ecto.Query.dynamic_expr()) :: String.t()
+  defp filter_to_sql(dynamic_expr) do
+    query = where(from(l in "logs"), ^dynamic_expr)
+    {:ok, {sql, _params}} = ClickHouseAdaptor.ecto_to_sql(query, inline_params: true)
+    sql
   end
 end

--- a/test/logflare/lql/backend_transformer/clickhouse_test.exs
+++ b/test/logflare/lql/backend_transformer/clickhouse_test.exs
@@ -310,7 +310,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
   end
 
   describe "transform_filter_rule/2 with boolean values on Map column dot-keys" do
-    test "coerces Map value with toBoolOrNull for true/false, negated, and dotted keys" do
+    test "coerces Map value with accurateCastOrNull for true/false, negated, and dotted keys" do
       cases = [
         {"true", "log_attributes.is_error", true, %{}},
         {"false", "log_attributes.is_error", false, %{}},
@@ -323,7 +323,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
           FilterRule.build(path: path, operator: :=, value: value, modifiers: modifiers)
 
         sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
-        assert sql =~ "toBoolOrNull", "[#{label}] missing coercion\nSQL: #{sql}"
+        assert sql =~ "accurateCastOrNull", "[#{label}] missing coercion\nSQL: #{sql}"
       end
     end
 
@@ -339,7 +339,7 @@ defmodule Logflare.Lql.BackendTransformer.ClickHouseTest do
           FilterRule.build(path: path, operator: :=, value: value, modifiers: %{})
 
         sql = filter_to_sql(ClickHouse.transform_filter_rule(filter_rule, %{}))
-        refute sql =~ "toBoolOrNull", "[#{label}] unexpected coercion\nSQL: #{sql}"
+        refute sql =~ "accurateCastOrNull", "[#{label}] unexpected coercion\nSQL: #{sql}"
       end
     end
   end

--- a/test/logflare/lql_test.exs
+++ b/test/logflare/lql_test.exs
@@ -879,11 +879,11 @@ defmodule Logflare.LqlTest do
       end
     end
 
-    test "ClickHouse boolean filters on Map column dot-keys coerce values with toBoolOrNull" do
+    test "ClickHouse boolean filters on Map column dot-keys coerce values with accurateCastOrNull" do
       for {lql, expected_fragments} <- [
-            {"log_attributes.is_error:true", ["'is_error'", "toBoolOrNull"]},
-            {"log_attributes.is_error:false", ["'is_error'", "toBoolOrNull"]},
-            {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "toBoolOrNull"]}
+            {"log_attributes.is_error:true", ["'is_error'", "accurateCastOrNull"]},
+            {"log_attributes.is_error:false", ["'is_error'", "accurateCastOrNull"]},
+            {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "accurateCastOrNull"]}
           ] do
         {:ok, sql} = Lql.to_sandboxed_sql(lql, "otel_logs", :clickhouse)
 
@@ -910,7 +910,7 @@ defmodule Logflare.LqlTest do
         refute sql =~ "toFloat64OrNull",
                "[#{label}] unexpected numeric coercion for `#{lql}`\nSQL: #{sql}"
 
-        refute sql =~ "toBoolOrNull",
+        refute sql =~ "accurateCastOrNull",
                "[#{label}] unexpected boolean coercion for `#{lql}`\nSQL: #{sql}"
 
         assert {:ok, _ast} = SqlParser.parse("clickhouse", sql)

--- a/test/logflare/lql_test.exs
+++ b/test/logflare/lql_test.exs
@@ -851,6 +851,72 @@ defmodule Logflare.LqlTest do
       end
     end
 
+    test "ClickHouse numeric/range filters on Map column dot-keys coerce values with toFloat64OrNull" do
+      for {lql, expected_fragments} <- [
+            {"log_attributes.foo:>5", ["'foo'", "toFloat64OrNull", "> 5"]},
+            {"log_attributes.bla.foo:>5", ["'bla.foo'", "toFloat64OrNull", "> 5"]},
+            {"log_attributes.count:>5.5", ["'count'", "toFloat64OrNull", "> 5.5"]},
+            {"log_attributes.score:<=99.95", ["'score'", "toFloat64OrNull", "<= 99.95"]},
+            {"log_attributes.tiny:>=0.001", ["'tiny'", "toFloat64OrNull", ">= 0.001"]},
+            {"resource_attributes.latency_ms:>100",
+             ["resource_attributes", "'latency_ms'", "toFloat64OrNull", "> 100"]},
+            {"span_attributes.http.status_code:>=500",
+             ["span_attributes", "'http.status_code'", "toFloat64OrNull", ">= 500"]},
+            {"log_attributes.response_time:100..500",
+             ["'response_time'", "toFloat64OrNull", "BETWEEN 100 AND 500"]},
+            {"log_attributes.ratio:0.1..0.9",
+             ["'ratio'", "toFloat64OrNull", "BETWEEN 0.1 AND 0.9"]}
+          ] do
+        {:ok, sql} = Lql.to_sandboxed_sql(lql, "otel_logs", :clickhouse)
+
+        for fragment <- expected_fragments do
+          assert sql =~ fragment,
+                 "Missing `#{fragment}` in generated SQL for LQL `#{lql}`\nSQL: #{sql}"
+        end
+
+        assert {:ok, _ast} = SqlParser.parse("clickhouse", sql),
+               "Generated SQL failed to parse for LQL `#{lql}`\nSQL: #{sql}"
+      end
+    end
+
+    test "ClickHouse boolean filters on Map column dot-keys coerce values with toBoolOrNull" do
+      for {lql, expected_fragments} <- [
+            {"log_attributes.is_error:true", ["'is_error'", "toBoolOrNull"]},
+            {"log_attributes.is_error:false", ["'is_error'", "toBoolOrNull"]},
+            {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "toBoolOrNull"]}
+          ] do
+        {:ok, sql} = Lql.to_sandboxed_sql(lql, "otel_logs", :clickhouse)
+
+        for fragment <- expected_fragments do
+          assert sql =~ fragment,
+                 "Missing `#{fragment}` in generated SQL for LQL `#{lql}`\nSQL: #{sql}"
+        end
+
+        assert {:ok, _ast} = SqlParser.parse("clickhouse", sql),
+               "Generated SQL failed to parse for LQL `#{lql}`\nSQL: #{sql}"
+      end
+    end
+
+    test "ClickHouse filters skip coercion for non-Map columns and quoted strings" do
+      cases = [
+        {"string equality on Map", "log_attributes.parsed.backend_type:client"},
+        {"top-level numeric column", "severity_number:>10"},
+        {"top-level Bool column", "is_monotonic:true"}
+      ]
+
+      for {label, lql} <- cases do
+        {:ok, sql} = Lql.to_sandboxed_sql(lql, "otel_logs", :clickhouse)
+
+        refute sql =~ "toFloat64OrNull",
+               "[#{label}] unexpected numeric coercion for `#{lql}`\nSQL: #{sql}"
+
+        refute sql =~ "toBoolOrNull",
+               "[#{label}] unexpected boolean coercion for `#{lql}`\nSQL: #{sql}"
+
+        assert {:ok, _ast} = SqlParser.parse("clickhouse", sql)
+      end
+    end
+
     test "`FromRule` overrides `cte_table_name` parameter" do
       # When `f:second_cte` is specified, it should use `second_cte`
       # even though default `cte_table_name` parameter is "final_data"

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -580,9 +580,9 @@ defmodule Logflare.SqlTest do
         {"log_attributes.ratio:>0.75", ["'ratio'", "toFloat64OrNull", "> 0.75"]},
         {"log_attributes.ratio:0.1..0.5", ["'ratio'", "toFloat64OrNull", "BETWEEN 0.1 AND 0.5"]},
         {"log_attributes.bla.foo:>=5", ["'bla.foo'", "toFloat64OrNull", ">= 5"]},
-        {"log_attributes.is_error:true", ["'is_error'", "toBoolOrNull"]},
-        {"log_attributes.is_error:false", ["'is_error'", "toBoolOrNull"]},
-        {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "toBoolOrNull"]}
+        {"log_attributes.is_error:true", ["'is_error'", "accurateCastOrNull"]},
+        {"log_attributes.is_error:false", ["'is_error'", "accurateCastOrNull"]},
+        {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "accurateCastOrNull"]}
       ]
 
       for {lql, expected_fragments} <- cases do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -565,6 +565,42 @@ defmodule Logflare.SqlTest do
       end
     end
 
+    test "sandboxed queries preserve Map column coercion for ClickHouse LQL filters" do
+      user = insert(:user)
+      source = insert(:source, user: user, name: "my_ch_table")
+      _backend = insert(:backend, type: :clickhouse, user: user, sources: [source])
+
+      cte_query =
+        "with src as (select timestamp, event_message, log_attributes from my_ch_table) select timestamp, event_message, log_attributes from src"
+
+      cases = [
+        {"log_attributes.response_time:>100", ["'response_time'", "toFloat64OrNull", "> 100"]},
+        {"log_attributes.response_time:100..500",
+         ["'response_time'", "toFloat64OrNull", "BETWEEN 100 AND 500"]},
+        {"log_attributes.ratio:>0.75", ["'ratio'", "toFloat64OrNull", "> 0.75"]},
+        {"log_attributes.ratio:0.1..0.5", ["'ratio'", "toFloat64OrNull", "BETWEEN 0.1 AND 0.5"]},
+        {"log_attributes.bla.foo:>=5", ["'bla.foo'", "toFloat64OrNull", ">= 5"]},
+        {"log_attributes.is_error:true", ["'is_error'", "toBoolOrNull"]},
+        {"log_attributes.is_error:false", ["'is_error'", "toBoolOrNull"]},
+        {"log_attributes.deep.nested.flag:true", ["'deep.nested.flag'", "toBoolOrNull"]}
+      ]
+
+      for {lql, expected_fragments} <- cases do
+        {:ok, consumer_sql} = Logflare.Lql.to_sandboxed_sql(lql, "src", :clickhouse)
+
+        assert {:ok, result} = Sql.transform(:ch_sql, {cte_query, consumer_sql}, user),
+               "Sql.transform failed for LQL: #{lql}\nConsumer SQL: #{consumer_sql}"
+
+        assert String.downcase(result) =~ "with src as"
+        assert String.downcase(result) =~ "where"
+
+        for fragment <- expected_fragments do
+          assert result =~ fragment,
+                 "Missing `#{fragment}` in transformed result for LQL: #{lql}\nResult: #{result}"
+        end
+      end
+    end
+
     test "sandboxed queries cannot access sources/tables outside of CTE scope" do
       user = insert(:user)
       source = insert(:source, user: user, name: "my_ch_table")

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -892,28 +892,68 @@ defmodule LogflareWeb.EndpointsLiveTest do
       log_events = [
         build_mapped_log_event(
           source: edge_source,
-          message: "edge error",
-          body: %{"metadata" => %{"level" => "error"}}
+          message: "edge error event",
+          body: %{
+            "metadata" => %{
+              "level" => "error",
+              "response_time" => "500",
+              "http.status_code" => "500",
+              "is_error" => "true",
+              "ratio" => "1.5"
+            }
+          }
         ),
         build_mapped_log_event(
           source: edge_source,
-          message: "edge info",
-          body: %{"metadata" => %{"level" => "info"}}
+          message: "edge info event",
+          body: %{
+            "metadata" => %{
+              "level" => "info",
+              "response_time" => "150",
+              "http.status_code" => "200",
+              "is_error" => "false",
+              "ratio" => "0.75"
+            }
+          }
         ),
         build_mapped_log_event(
           source: edge_source,
-          message: "edge debug",
-          body: %{"metadata" => %{"level" => "debug"}}
+          message: "edge debug event",
+          body: %{
+            "metadata" => %{
+              "level" => "debug",
+              "response_time" => "50",
+              "http.status_code" => "200",
+              "is_error" => "false",
+              "ratio" => "0.1"
+            }
+          }
         ),
         build_mapped_log_event(
           source: other_source,
-          message: "postgres error",
-          body: %{"metadata" => %{"level" => "error"}}
+          message: "postgres error event",
+          body: %{
+            "metadata" => %{
+              "level" => "error",
+              "response_time" => "400",
+              "http.status_code" => "500",
+              "is_error" => "true",
+              "ratio" => "0.5"
+            }
+          }
         ),
         build_mapped_log_event(
           source: other_source,
-          message: "postgres info",
-          body: %{"metadata" => %{"level" => "info"}}
+          message: "postgres info event",
+          body: %{
+            "metadata" => %{
+              "level" => "info",
+              "response_time" => "100",
+              "http.status_code" => "200",
+              "is_error" => "false",
+              "ratio" => "0.25"
+            }
+          }
         )
       ]
 
@@ -930,10 +970,10 @@ defmodule LogflareWeb.EndpointsLiveTest do
           sandboxable: true,
           query: """
           WITH src AS (
-            SELECT timestamp, event_message, severity_text, source_name
+            SELECT timestamp, event_message, severity_text, source_name, log_attributes
             FROM #{table_name}
           )
-          SELECT timestamp, event_message, severity_text, source_name FROM src
+          SELECT timestamp, event_message, severity_text, source_name, log_attributes FROM src
           """
         )
 
@@ -1036,6 +1076,51 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
       refute html =~ ~r/&quot;source_name&quot;:\s*&quot;postgres_logs&quot;/,
              "postgres_logs rows leaked through source_name:edge_function_logs filter"
+    end
+
+    test "Map column LQL filters coerce values and run against live ClickHouse", %{
+      conn: conn,
+      endpoint: endpoint
+    } do
+      cases = [
+        {"numeric >", "log_attributes.response_time:>200",
+         ["edge error event", "postgres error event"],
+         ["edge info event", "edge debug event", "postgres info event"]},
+        {"numeric range", "log_attributes.response_time:100..300",
+         ["edge info event", "postgres info event"],
+         ["edge error event", "edge debug event", "postgres error event"]},
+        {"dotted numeric >=", "log_attributes.http.status_code:>=500",
+         ["edge error event", "postgres error event"],
+         ["edge info event", "edge debug event", "postgres info event"]},
+        {"float >", "log_attributes.ratio:>1.0", ["edge error event"],
+         ["edge info event", "edge debug event", "postgres error event", "postgres info event"]},
+        {"float range", "log_attributes.ratio:0.1..0.5",
+         ["edge debug event", "postgres error event", "postgres info event"],
+         ["edge error event", "edge info event"]},
+        {"boolean true", "log_attributes.is_error:true",
+         ["edge error event", "postgres error event"],
+         ["edge info event", "edge debug event", "postgres info event"]},
+        {"boolean false", "log_attributes.is_error:false",
+         ["edge info event", "edge debug event", "postgres info event"],
+         ["edge error event", "postgres error event"]}
+      ]
+
+      for {label, lql, expected, refuted} <- cases do
+        html = submit_sandbox_lql(conn, endpoint, lql)
+
+        refute html =~ "Error occurred when running sandbox query",
+               "[#{label}] expected `#{lql}` to succeed against live ClickHouse"
+
+        assert html =~ "Ran sandbox query successfully"
+
+        for msg <- expected do
+          assert html =~ msg, "[#{label}] missing `#{msg}` for `#{lql}`"
+        end
+
+        for msg <- refuted do
+          refute html =~ msg, "[#{label}] `#{msg}` leaked through `#{lql}`"
+        end
+      end
     end
   end
 
@@ -1171,5 +1256,24 @@ defmodule LogflareWeb.EndpointsLiveTest do
         assert html =~ ~r/#{path}[^"<]*t=#{team_user.team_id}/
       end
     end
+  end
+
+  @spec submit_sandbox_lql(Plug.Conn.t(), struct(), String.t()) :: String.t()
+  defp submit_sandbox_lql(conn, endpoint, lql) do
+    {:ok, view, initial_html} = live(conn, "/endpoints/#{endpoint.id}")
+    assert initial_html =~ "ClickHouse SQL"
+
+    view
+    |> element("form", "Test Sandbox Query")
+    |> render_submit(%{
+      sandbox_form: %{
+        query_mode: "lql",
+        sandbox_query: "#{lql} s:event_message s:log_attributes",
+        params: %{},
+        show_transformed: "true"
+      }
+    })
+
+    render(view)
   end
 end


### PR DESCRIPTION
LQL numeric and boolean filters against ClickHouse `Map(String, String)` columns now coerce the stored string value during SQL generation so comparisons evaluate correctly instead of erroring on type mismatch.

### What's Coerced

- Numeric comparisons and ranges
  - `log_attributes.response_time:>200` -> `toFloat64OrNull(log_attributes['response_time']) > 200`
- Operators: `:>`, `:<`, `:>=`, `:<=`, `:=`, and `:range` with numeric bounds
- Boolean equality
  - `log_attributes.is_error:true` -> `accurateCastOrNull(log_attributes['is_error'], 'Bool') = true`
  - Handles `"true"/"false"/"1"/"0"/"yes"/"on"` variants (_case-insensitive_)


### Not Coerced By Design

- Top-level typed columns
- Quoted string values (_e.g. `log_attributes.foo:"true"` stays as string compare_)
- `:NULL` equality
- String-oriented operators (`:~`, `:string_contains`, `:list_includes`, `:list_includes_regexp`) - even if the value parses as numeric


### Existing Bugs Fixed

- Range filters on map columns previously raised due to pinning a dynamic inside a raw `where/3` macro. Now wrapped in `dynamic/2`.
- LQL parser now casts numeric-string range bounds to int/float so they render as typed SQL literals instead of quoted strings.
