### PR TITLE
Revert "fix: LQL preserves timestamp Z suffix"

### DIFF
--- a/lib/logflare/lql/encoder.ex
+++ b/lib/logflare/lql/encoder.ex
@@ -85,16 +85,16 @@ defmodule Logflare.Lql.Encoder do
          path: "timestamp",
          operator: :range,
          values: [lv, rv],
-         modifiers: mods
+         modifiers: _mods
        }) do
-    "t:#{to_datetime_with_range(lv, rv, mods)}"
+    "t:#{to_datetime_with_range(lv, rv)}"
   end
 
   defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: %Date{} = v}),
     do: "t:#{op}#{v}"
 
-  defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: v, modifiers: mods}) do
-    "t:#{op}#{format_timestamp_filter_value(v, mods)}"
+  defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: v}) do
+    "t:#{op}#{format_filter_value(v)}"
   end
 
   defp to_fragment(%FilterRule{
@@ -247,18 +247,6 @@ defmodule Logflare.Lql.Encoder do
     do: NaiveDateTime.to_iso8601(%{value | microsecond: {0, 0}})
 
   defp format_filter_value(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
-
-  defp format_timestamp_filter_value(value, %{explicit_timezone: true}) do
-    format_filter_value(value) <> "Z"
-  end
-
-  defp format_timestamp_filter_value(value, _mods), do: format_filter_value(value)
-
-  def to_datetime_with_range(ldt, rdt, %{explicit_timezone: true}) do
-    to_datetime_with_range(ldt, rdt) <> "Z"
-  end
-
-  def to_datetime_with_range(ldt, rdt, _mods), do: to_datetime_with_range(ldt, rdt)
 
   def to_datetime_with_range(%Date{} = ldt, %Date{} = rdt) do
     mapper_fn = fn period -> timestamp_mapper(ldt, rdt, period) end

--- a/test/logflare/lql/encoder_test.exs
+++ b/test/logflare/lql/encoder_test.exs
@@ -121,37 +121,6 @@ defmodule Logflare.Lql.EncoderTest do
       assert result == "t:>=2026-03-17T12:47:02.123"
     end
 
-    test "preserves Z suffix for explicit UTC timestamp filters" do
-      lql_rules = [
-        %FilterRule{
-          operator: :>=,
-          path: "timestamp",
-          value: NaiveDateTime.from_iso8601!("2026-04-10T03:18:15"),
-          modifiers: %{explicit_timezone: true}
-        }
-      ]
-
-      result = Encoder.to_querystring(lql_rules)
-      assert result == "t:>=2026-04-10T03:18:15Z"
-    end
-
-    test "preserves Z suffix for explicit UTC timestamp ranges" do
-      lql_rules = [
-        %FilterRule{
-          operator: :range,
-          path: "timestamp",
-          values: [
-            NaiveDateTime.from_iso8601!("2026-04-10T03:18:15"),
-            NaiveDateTime.from_iso8601!("2026-04-10T03:19:15")
-          ],
-          modifiers: %{explicit_timezone: true}
-        }
-      ]
-
-      result = Encoder.to_querystring(lql_rules)
-      assert result == "t:2026-04-10T03:{18..19}:15Z"
-    end
-
     test "encodes quoted string filter" do
       lql_rules = [
         %FilterRule{

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -331,7 +331,7 @@ defmodule Logflare.Lql.ParserTest do
              ] = rules
 
       assert Lql.encode!(result) ==
-               "t:>2026-03-17T14:47:02Z t:>=2026-03-17T12:47:02Z t:<2026-03-17T16:47:02Z t:<=2024-03-17T13:47:02Z"
+               "t:>2026-03-17T14:47:02 t:>=2026-03-17T12:47:02 t:<2026-03-17T16:47:02 t:<=2024-03-17T13:47:02"
     end
 
     test "timestamp filters support Unix timestamp ranges" do
@@ -357,7 +357,7 @@ defmodule Logflare.Lql.ParserTest do
              ] = rules
 
       assert Lql.encode!(result) ==
-               "t:2024-03-17T13:{47..57}:02Z t:2024-03-17T13:{47..57}:02Z"
+               "t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02"
     end
 
     test "timestamp filters reject ambiguous 14 and 15 digit Unix timestamps" do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1254,27 +1254,6 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert get_view_assigns(view).querystring =~ "error"
       assert get_view_assigns(view).querystring =~ "t:2020-04-20T00:{01..02}:00"
     end
-
-    test "preserves Z suffixes from query params", %{conn: conn, source: source} do
-      {:ok, view, _html} =
-        live(
-          conn,
-          Routes.live_path(conn, SearchLV, source,
-            querystring:
-              "t:>2026-04-10T03:18:15Z t:<2026-04-10T03:19:15Z c:count(*) c:group_by(t::second)",
-            tailing?: false
-          )
-        )
-
-      querystring =
-        view
-        |> TestUtils.wait_for_render("#lql-editor-hook")
-        |> render()
-        |> find_querystring()
-
-      assert querystring =~ "t:>2026-04-10T03:18:15Z"
-      assert querystring =~ "t:<2026-04-10T03:19:15Z"
-    end
   end
 
   describe "create from query" do


### PR DESCRIPTION
Reverts Logflare/logflare#3387

Reverts Z suffix handling