### PR TITLE
fix: don't adjust shorthand timestamps timezone

### DIFF
--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -461,7 +461,7 @@ defmodule Logflare.Logs.SearchOperations do
     lql_ts_filters =
       so.lql_ts_filters
       |> Enum.map(fn
-        %{path: "timestamp", modifiers: %{explicit_timezone: true}} = pvo ->
+        %{path: "timestamp", modifiers: %{timestamp_origin: :absolute}} = pvo ->
           pvo
 
         %{path: "timestamp", values: values, operator: :range} = pvo ->

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -541,6 +541,10 @@ defmodule Logflare.Lql.Parser.Helpers do
     {lvalue, lmodifiers} = unwrap_value_modifiers(lvalue)
     {rvalue, rmodifiers} = unwrap_value_modifiers(rvalue)
 
+    if lmodifiers[:timestamp_origin] != rmodifiers[:timestamp_origin] do
+      throw("Timestamp range cannot mix timestamps with and without timezone offsets")
+    end
+
     {{:range_operator, [lvalue, rvalue]}, Map.merge(lmodifiers, rmodifiers)}
   end
 

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -559,12 +559,9 @@ defmodule Logflare.Lql.Parser.Helpers do
     Enum.map(values, &set_timestamp_origin(&1, origin))
   end
 
-  defp set_timestamp_origin(value, origin) do
-    modifiers =
-      if origin,
-        do: %{timestamp_origin: :absolute},
-        else: %{timestamp_origin: :local}
+  defp set_timestamp_origin(value, true),
+    do: {:with_modifiers, value, %{timestamp_origin: :absolute}}
 
-    {:with_modifiers, value, modifiers}
-  end
+  defp set_timestamp_origin(value, false),
+    do: {:with_modifiers, value, %{timestamp_origin: :local}}
 end

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -173,9 +173,12 @@ defmodule Logflare.Lql.Parser.Helpers do
   # ============================================================================
 
   @spec parse_date_or_datetime_with_range(list()) ::
-          [Date.t() | NaiveDateTime.t() | {:with_modifiers, NaiveDateTime.t(), map()}]
+          [
+            {:with_modifiers, Date.t() | NaiveDateTime.t(),
+             %{timestamp_origin: :absolute | :local}}
+          ]
   def parse_date_or_datetime_with_range(result) when is_list(result) do
-    explicit_timezone =
+    absolute_timestamp =
       Enum.any?(result, fn
         {:timezone, _timezone} -> true
         _ -> false
@@ -197,7 +200,7 @@ defmodule Logflare.Lql.Parser.Helpers do
           [Map.put(lacc, k, lv), Map.put(racc, k, rv)]
       end)
       |> Enum.map(&build_date_or_datetime_from_parts/1)
-      |> maybe_mark_explicit_timezone(explicit_timezone)
+      |> set_timestamp_origin(absolute_timestamp)
 
     if lv == rv do
       [lv]
@@ -210,15 +213,10 @@ defmodule Logflare.Lql.Parser.Helpers do
   def parse_date_or_datetime([{tag, result}]), do: parse_iso8601_value!(tag, result)
 
   @spec parse_timestamp_datetime([{:datetime | :datetime_tz, String.t()}]) ::
-          NaiveDateTime.t() | {:with_modifiers, NaiveDateTime.t(), map()}
+          {:with_modifiers, NaiveDateTime.t(), map()}
   def parse_timestamp_datetime([{tag, result}]) when tag in [:datetime, :datetime_tz] do
-    value = parse_iso8601_value!(:datetime, result)
-
-    if tag == :datetime_tz do
-      {:with_modifiers, value, %{explicit_timezone: true}}
-    else
-      value
-    end
+    parse_iso8601_value!(:datetime, result)
+    |> set_timestamp_origin(tag == :datetime_tz)
   end
 
   @spec parse_datetime_literal(term()) :: {:ok, Date.t() | NaiveDateTime.t()} | {:error, term()}
@@ -254,7 +252,7 @@ defmodule Logflare.Lql.Parser.Helpers do
   def parse_unix_timestamp_literal([value]) do
     case parse_unix_timestamp(value) do
       {:ok, parsed} ->
-        {:with_modifiers, parsed, %{explicit_timezone: true}}
+        set_timestamp_origin(parsed, true)
 
       {:error, :invalid_format} ->
         throw(
@@ -271,19 +269,24 @@ defmodule Logflare.Lql.Parser.Helpers do
           value: term()
         }
   def timestamp_shorthand_to_value(["now"]) do
-    %{value: %{Timex.now() | microsecond: {0, 0}}, shorthand: "now"}
+    value = %{Timex.now() | microsecond: {0, 0}} |> set_timestamp_origin(true)
+    %{value: value, shorthand: "now"}
   end
 
   def timestamp_shorthand_to_value(["today"]) do
     dt = Timex.today() |> Timex.to_datetime()
-    value = {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)]}
+
+    value =
+      {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)] |> set_timestamp_origin(true)}
 
     %{value: value, shorthand: "today"}
   end
 
   def timestamp_shorthand_to_value(["yesterday"]) do
     dt = Timex.today() |> Timex.shift(days: -1) |> Timex.to_datetime()
-    value = {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)]}
+
+    value =
+      {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)] |> set_timestamp_origin(true)}
 
     %{value: value, shorthand: "yesterday"}
   end
@@ -313,7 +316,8 @@ defmodule Logflare.Lql.Parser.Helpers do
           Timex.beginning_of_year(today_ndt)
       end
 
-    value = {:range_operator, [lvalue, now_ndt]}
+    value = {:range_operator, [lvalue, now_ndt] |> set_timestamp_origin(true)}
+
     %{value: value, shorthand: "this@#{period}"}
   end
 
@@ -347,7 +351,9 @@ defmodule Logflare.Lql.Parser.Helpers do
       end
 
     lvalue = Timex.shift(truncated, [{period, amount}])
-    value = {:range_operator, [lvalue, now_ndt]}
+
+    value = {:range_operator, [lvalue, now_ndt] |> set_timestamp_origin(true)}
+
     %{value: value, shorthand: "last@#{if amount < 0, do: -amount, else: amount}#{period}"}
   end
 
@@ -549,9 +555,16 @@ defmodule Logflare.Lql.Parser.Helpers do
     |> then(fn {values, modifiers} -> {Enum.reverse(values), modifiers} end)
   end
 
-  defp maybe_mark_explicit_timezone(values, true) when is_list(values) do
-    Enum.map(values, &{:with_modifiers, &1, %{explicit_timezone: true}})
+  defp set_timestamp_origin(values, origin) when is_list(values) do
+    Enum.map(values, &set_timestamp_origin(&1, origin))
   end
 
-  defp maybe_mark_explicit_timezone(values, false), do: values
+  defp set_timestamp_origin(value, origin) do
+    modifiers =
+      if origin,
+        do: %{timestamp_origin: :absolute},
+        else: %{timestamp_origin: :local}
+
+    {:with_modifiers, value, modifiers}
+  end
 end

--- a/lib/logflare/lql/parser/helpers.ex
+++ b/lib/logflare/lql/parser/helpers.ex
@@ -269,26 +269,22 @@ defmodule Logflare.Lql.Parser.Helpers do
           value: term()
         }
   def timestamp_shorthand_to_value(["now"]) do
-    value = %{Timex.now() | microsecond: {0, 0}} |> set_timestamp_origin(true)
+    value = set_timestamp_origin(%{Timex.now() | microsecond: {0, 0}}, true)
     %{value: value, shorthand: "now"}
   end
 
   def timestamp_shorthand_to_value(["today"]) do
     dt = Timex.today() |> Timex.to_datetime()
+    range = set_timestamp_origin([dt, Timex.shift(dt, days: 1, seconds: -1)], true)
 
-    value =
-      {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)] |> set_timestamp_origin(true)}
-
-    %{value: value, shorthand: "today"}
+    %{value: {:range_operator, range}, shorthand: "today"}
   end
 
   def timestamp_shorthand_to_value(["yesterday"]) do
     dt = Timex.today() |> Timex.shift(days: -1) |> Timex.to_datetime()
+    range = set_timestamp_origin([dt, Timex.shift(dt, days: 1, seconds: -1)], true)
 
-    value =
-      {:range_operator, [dt, Timex.shift(dt, days: 1, seconds: -1)] |> set_timestamp_origin(true)}
-
-    %{value: value, shorthand: "yesterday"}
+    %{value: {:range_operator, range}, shorthand: "yesterday"}
   end
 
   def timestamp_shorthand_to_value(["this", period]) do
@@ -316,9 +312,9 @@ defmodule Logflare.Lql.Parser.Helpers do
           Timex.beginning_of_year(today_ndt)
       end
 
-    value = {:range_operator, [lvalue, now_ndt] |> set_timestamp_origin(true)}
+    range = set_timestamp_origin([lvalue, now_ndt], true)
 
-    %{value: value, shorthand: "this@#{period}"}
+    %{value: {:range_operator, range}, shorthand: "this@#{period}"}
   end
 
   def timestamp_shorthand_to_value(["last", amount, period]) do
@@ -352,9 +348,12 @@ defmodule Logflare.Lql.Parser.Helpers do
 
     lvalue = Timex.shift(truncated, [{period, amount}])
 
-    value = {:range_operator, [lvalue, now_ndt] |> set_timestamp_origin(true)}
+    range = set_timestamp_origin([lvalue, now_ndt], true)
 
-    %{value: value, shorthand: "last@#{if amount < 0, do: -amount, else: amount}#{period}"}
+    %{
+      value: {:range_operator, range},
+      shorthand: "last@#{if amount < 0, do: -amount, else: amount}#{period}"
+    }
   end
 
   # ============================================================================

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -10,6 +10,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
   alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Logs.SearchOperation, as: SO
+  alias Logflare.Lql
   alias Logflare.Logs.SearchOperations
   alias Logflare.Lql.Parser
   alias Logflare.Lql.Rules.ChartRule
@@ -320,10 +321,8 @@ defmodule Logflare.Logs.SearchOperationsTest do
   end
 
   describe "apply_local_timestamp_correction/1" do
-    test "skips timestamp filters with explicit timezone modifiers" do
+    test "skips timestamp filters with absolute timestamp origin" do
       value = ~N[2026-03-17 14:47:02]
-      range_start = ~N[2026-03-17 14:47:02]
-      range_end = ~N[2026-03-17 15:47:02]
 
       so =
         %SO{
@@ -336,20 +335,72 @@ defmodule Logflare.Logs.SearchOperationsTest do
               path: "timestamp",
               operator: :>,
               value: value,
-              modifiers: %{explicit_timezone: true}
-            },
-            %FilterRule{
-              path: "timestamp",
-              operator: :range,
-              value: nil,
-              values: [range_start, range_end],
-              modifiers: %{explicit_timezone: true}
+              modifiers: %{timestamp_origin: :absolute}
             }
           ],
           search_timezone: "Australia/Brisbane"
         }
 
       corrected = SearchOperations.apply_local_timestamp_correction(so)
+
+      assert corrected.lql_ts_filters == so.lql_ts_filters
+    end
+
+    test "shifts local timestamp filters using the search timezone" do
+      range_start = ~N[2026-03-17 14:47:02]
+      range_end = ~N[2026-03-17 15:47:02]
+
+      so =
+        %SO{
+          partition_by: :timestamp,
+          querystring: "",
+          tailing?: false,
+          chart_data_shape_id: nil,
+          lql_ts_filters: [
+            %FilterRule{
+              path: "timestamp",
+              operator: :range,
+              value: nil,
+              values: [range_start, range_end],
+              modifiers: %{timestamp_origin: :local}
+            }
+          ],
+          search_timezone: "Australia/Brisbane"
+        }
+
+      corrected = SearchOperations.apply_local_timestamp_correction(so)
+
+      assert [
+               %FilterRule{
+                 values: [~U[2026-03-17 04:47:02Z], ~U[2026-03-17 05:47:02Z]]
+               }
+             ] = corrected.lql_ts_filters
+    end
+
+    test "does not shift shorthand timestamps" do
+      querystring = "t:last@1hour"
+      schema = TestUtils.default_bq_schema()
+
+      {:ok, lql_rules} = Lql.decode(querystring, schema)
+      [timestamp_filter] = Enum.filter(lql_rules, &(&1.path == "timestamp"))
+
+      so =
+        %SO{
+          partition_by: :timestamp,
+          querystring: querystring,
+          tailing?: false,
+          chart_data_shape_id: nil,
+          lql_ts_filters: [timestamp_filter],
+          search_timezone: "Australia/Brisbane"
+        }
+
+      corrected = SearchOperations.apply_local_timestamp_correction(so)
+
+      assert %FilterRule{
+               operator: :range,
+               shorthand: "last@1hour",
+               modifiers: %{timestamp_origin: :absolute}
+             } = timestamp_filter
 
       assert corrected.lql_ts_filters == so.lql_ts_filters
     end

--- a/test/logflare/lql/parser/combinators_test.exs
+++ b/test/logflare/lql/parser/combinators_test.exs
@@ -154,33 +154,57 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
     test "timestamp value parser" do
       result = test_timestamp_value("2023-01-15")
       # The timestamp value parser can return different formats depending on which parser matches
-      assert match?({:ok, [value: ~D[2023-01-15]], "", _, _, _}, result) or
+      assert match?(
+               {:ok, [value: {:with_modifiers, ~D[2023-01-15], %{timestamp_origin: :local}}], "",
+                _, _, _},
+               result
+             ) or
                match?(
-                 {:ok, [value: {:datetime_with_range, [[~D[2023-01-15]]]}], "", _, _, _},
+                 {:ok,
+                  [
+                    value:
+                      {:datetime_with_range,
+                       [[{:with_modifiers, ~D[2023-01-15], %{timestamp_origin: :local}}]]}
+                  ], "", _, _, _},
                  result
                )
 
       result = test_timestamp_value("now")
-      assert match?({:ok, [value: %{shorthand: "now"}], "", _, _, _}, result)
+
+      assert match?(
+               {:ok,
+                [
+                  value: %{
+                    shorthand: "now",
+                    value: {:with_modifiers, _, %{timestamp_origin: :absolute}}
+                  }
+                ], "", _, _, _},
+               result
+             )
 
       result = test_timestamp_value("1710683222000")
 
       assert {:ok,
-              [value: {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{explicit_timezone: true}}],
-              "", _, _, _} = result
+              [
+                value:
+                  {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{timestamp_origin: :absolute}}
+              ], "", _, _, _} = result
 
       result = test_timestamp_value("1710683222000000")
 
       assert {:ok,
-              [value: {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{explicit_timezone: true}}],
-              "", _, _, _} = result
+              [
+                value:
+                  {:with_modifiers, ~N[2024-03-17 13:47:02.000], %{timestamp_origin: :absolute}}
+              ], "", _, _, _} = result
     end
 
     test "timestamp datetime parser distinguishes timezone-bearing datetimes" do
-      assert {:ok, [{:with_modifiers, ~N[2023-01-15 10:00:00], %{explicit_timezone: true}}], "",
-              _, _, _} = test_timestamp_datetime("2023-01-15T10:00:00Z")
+      assert {:ok, [{:with_modifiers, ~N[2023-01-15 10:00:00], %{timestamp_origin: :absolute}}],
+              "", _, _, _} = test_timestamp_datetime("2023-01-15T10:00:00Z")
 
-      assert {:ok, [~N[2023-01-15 10:00:00]], "", _, _, _} =
+      assert {:ok, [{:with_modifiers, ~N[2023-01-15 10:00:00], %{timestamp_origin: :local}}], "",
+              _, _, _} =
                test_timestamp_datetime("2023-01-15T10:00:00")
     end
   end
@@ -192,14 +216,25 @@ defmodule Logflare.Lql.Parser.CombinatorsTest do
 
       result = test_timestamp_clause("t:>2023-01-15T10:00:00Z")
 
-      assert {:ok, [%{path: "timestamp", operator: :>, modifiers: %{explicit_timezone: true}}],
-              "", _, _, _} = result
+      assert {:ok,
+              [
+                %{
+                  path: "timestamp",
+                  operator: :>,
+                  modifiers: %{timestamp_origin: :absolute}
+                }
+              ], "", _, _, _} = result
 
       result = test_timestamp_clause("t:1710683222..1710684222")
 
       assert {:ok,
-              [%{path: "timestamp", operator: :range, modifiers: %{explicit_timezone: true}}], "",
-              _, _, _} = result
+              [
+                %{
+                  path: "timestamp",
+                  operator: :range,
+                  modifiers: %{timestamp_origin: :absolute}
+                }
+              ], "", _, _, _} = result
     end
 
     test "metadata clause parser" do

--- a/test/logflare/lql/parser/helpers_test.exs
+++ b/test/logflare/lql/parser/helpers_test.exs
@@ -124,17 +124,17 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert is_nil(result.shorthand)
     end
 
-    test "merges explicit timezone modifier for timestamp datetime values" do
+    test "merges timestamp origin modifier for timestamp datetime values" do
       args = [
         path: "timestamp",
         operator: :=,
-        value: {:with_modifiers, ~N[2023-01-01 12:00:00], %{explicit_timezone: true}}
+        value: {:with_modifiers, ~N[2023-01-01 12:00:00], %{timestamp_origin: :absolute}}
       ]
 
       result = Helpers.to_rule(args, :filter)
 
       assert result.value == ~N[2023-01-01 12:00:00]
-      assert result.modifiers == %{explicit_timezone: true}
+      assert result.modifiers == %{timestamp_origin: :absolute}
     end
   end
 
@@ -286,18 +286,18 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert result == ~N[2023-01-15 08:30:00]
     end
 
-    test "parse_timestamp_datetime preserves explicit timezone modifier for Z suffixes" do
-      assert {:with_modifiers, ~N[2023-01-15 10:30:00], %{explicit_timezone: true}} =
+    test "parse_timestamp_datetime marks Z suffixes as absolute" do
+      assert {:with_modifiers, ~N[2023-01-15 10:30:00], %{timestamp_origin: :absolute}} =
                Helpers.parse_timestamp_datetime([{:datetime_tz, "2023-01-15T10:30:00Z"}])
     end
 
-    test "parse_timestamp_datetime preserves explicit timezone modifier for UTC offsets" do
-      assert {:with_modifiers, ~N[2023-01-15 08:30:00], %{explicit_timezone: true}} =
+    test "parse_timestamp_datetime marks UTC offsets as absolute" do
+      assert {:with_modifiers, ~N[2023-01-15 08:30:00], %{timestamp_origin: :absolute}} =
                Helpers.parse_timestamp_datetime([{:datetime_tz, "2023-01-15T10:30:00+02:00"}])
     end
 
-    test "parse_timestamp_datetime leaves naive datetimes unmodified" do
-      assert ~N[2023-01-15 10:30:00] =
+    test "parse_timestamp_datetime marks naive datetimes as local" do
+      assert {:with_modifiers, ~N[2023-01-15 10:30:00], %{timestamp_origin: :local}} =
                Helpers.parse_timestamp_datetime([{:datetime, "2023-01-15T10:30:00"}])
     end
 
@@ -306,8 +306,8 @@ defmodule Logflare.Lql.Parser.HelpersTest do
       assert {:ok, ~N[2024-03-17 13:47:02.000]} = Helpers.parse_datetime_literal("1710683222000")
     end
 
-    test "parse_unix_timestamp_literal marks Unix timestamps as explicit timezone" do
-      assert {:with_modifiers, ~N[2024-03-17 13:47:02], %{explicit_timezone: true}} =
+    test "parse_unix_timestamp_literal marks Unix timestamps as absolute" do
+      assert {:with_modifiers, ~N[2024-03-17 13:47:02], %{timestamp_origin: :absolute}} =
                Helpers.parse_unix_timestamp_literal(["1710683222"])
     end
 
@@ -344,38 +344,70 @@ defmodule Logflare.Lql.Parser.HelpersTest do
         )
 
       assert result == [
-               {:with_modifiers, ~N[2023-01-15 08:30:00], %{explicit_timezone: true}}
+               {:with_modifiers, ~N[2023-01-15 08:30:00], %{timestamp_origin: :absolute}}
              ]
     end
 
     test "timestamp_shorthand_to_value handles 'now'" do
       result = Helpers.timestamp_shorthand_to_value(["now"])
       assert result.shorthand == "now"
-      assert %DateTime{} = result.value
+      assert {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}} = result.value
     end
 
     test "timestamp_shorthand_to_value handles 'today'" do
       result = Helpers.timestamp_shorthand_to_value(["today"])
       assert result.shorthand == "today"
-      assert match?({:range_operator, [%DateTime{}, %DateTime{}]}, result.value)
+
+      assert match?(
+               {:range_operator,
+                [
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}},
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}}
+                ]},
+               result.value
+             )
     end
 
     test "timestamp_shorthand_to_value handles 'yesterday'" do
       result = Helpers.timestamp_shorthand_to_value(["yesterday"])
       assert result.shorthand == "yesterday"
-      assert match?({:range_operator, [%DateTime{}, %DateTime{}]}, result.value)
+
+      assert match?(
+               {:range_operator,
+                [
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}},
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}}
+                ]},
+               result.value
+             )
     end
 
     test "timestamp_shorthand_to_value handles 'this@period'" do
       result = Helpers.timestamp_shorthand_to_value(["this", :hours])
       assert result.shorthand == "this@hours"
-      assert match?({:range_operator, [%DateTime{}, %DateTime{}]}, result.value)
+
+      assert match?(
+               {:range_operator,
+                [
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}},
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}}
+                ]},
+               result.value
+             )
     end
 
     test "timestamp_shorthand_to_value handles 'last@amount period'" do
       result = Helpers.timestamp_shorthand_to_value(["last", 5, :minutes])
       assert result.shorthand == "last@5minutes"
-      assert match?({:range_operator, [%DateTime{}, %DateTime{}]}, result.value)
+
+      assert match?(
+               {:range_operator,
+                [
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}},
+                  {:with_modifiers, %DateTime{}, %{timestamp_origin: :absolute}}
+                ]},
+               result.value
+             )
     end
   end
 

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -225,7 +225,7 @@ defmodule Logflare.Lql.ParserTest do
           value: "a"
         },
         %FilterRule{
-          modifiers: %{negate: true},
+          modifiers: %{negate: true, timestamp_origin: :local},
           operator: :range,
           path: "timestamp",
           values: [~N[2019-01-01 00:13:37Z], ~N[2019-02-01 00:23:34Z]]
@@ -311,22 +311,22 @@ defmodule Logflare.Lql.ParserTest do
                %FilterRule{
                  value: ~N[2026-03-17 14:47:02.000],
                  values: nil,
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                },
                %FilterRule{
                  value: ~N[2026-03-17 12:47:02],
                  values: nil,
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                },
                %FilterRule{
                  value: ~N[2026-03-17 16:47:02],
                  values: nil,
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                },
                %FilterRule{
                  value: ~N[2024-03-17 13:47:02.000],
                  values: nil,
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                }
              ] = rules
 
@@ -347,12 +347,12 @@ defmodule Logflare.Lql.ParserTest do
                %FilterRule{
                  value: nil,
                  values: [~N[2024-03-17 13:47:02], ~N[2024-03-17 13:57:02]],
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                },
                %FilterRule{
                  value: nil,
                  values: [~N[2024-03-17 13:47:02.000], ~N[2024-03-17 13:57:02.000]],
-                 modifiers: %{explicit_timezone: true}
+                 modifiers: %{timestamp_origin: :absolute}
                }
              ] = rules
 
@@ -789,6 +789,7 @@ defmodule Logflare.Lql.ParserTest do
           ] do
         lql_rules = [
           %FilterRule{
+            modifiers: %{timestamp_origin: :local},
             operator: :range,
             path: "timestamp",
             values: [start_date, end_date]
@@ -805,6 +806,7 @@ defmodule Logflare.Lql.ParserTest do
 
       lql_rules = [
         %FilterRule{
+          modifiers: %{timestamp_origin: :local},
           operator: :>,
           path: "timestamp",
           value: ~N[2020-01-01 13:14:15.000500]
@@ -827,6 +829,7 @@ defmodule Logflare.Lql.ParserTest do
 
         lql_rules = [
           %FilterRule{
+            modifiers: %{timestamp_origin: :local},
             operator: :range,
             path: "timestamp",
             values: [
@@ -846,6 +849,7 @@ defmodule Logflare.Lql.ParserTest do
 
       lql_rules = [
         %FilterRule{
+          modifiers: %{timestamp_origin: :local},
           operator: :range,
           path: "timestamp",
           values: [

--- a/test/logflare/lql/parser_test.exs
+++ b/test/logflare/lql/parser_test.exs
@@ -360,6 +360,46 @@ defmodule Logflare.Lql.ParserTest do
                "t:2024-03-17T13:{47..57}:02 t:2024-03-17T13:{47..57}:02"
     end
 
+    test "timestamp filters support timestamp ranges with consistent timestamp origin" do
+      qs = ~S|
+      t:2024-03-01T03:23:45+02:00..2024-03-01T07:23:56-04:00
+      t:2024-03-02T01:23:45Z..2024-03-02T22:33:44Z
+      t:2024-03-03T00:11:22..2024-04-03T11:22:33
+      |
+
+      assert {:ok, result} = Parser.parse(qs, @default_schema)
+      rules = Enum.filter(result, &(&1.path == "timestamp"))
+
+      assert [
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~N[2024-03-01 01:23:45], ~N[2024-03-01 11:23:56]],
+                 modifiers: %{timestamp_origin: :absolute}
+               },
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~N[2024-03-02 01:23:45], ~N[2024-03-02 22:33:44]],
+                 modifiers: %{timestamp_origin: :absolute}
+               },
+               %Logflare.Lql.Rules.FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~N[2024-03-03 00:11:22], ~N[2024-04-03 11:22:33]],
+                 modifiers: %{timestamp_origin: :local}
+               }
+             ] = rules
+    end
+
+    test "timestamp filters reject range with mixed timestamp origin" do
+      assert {:error, "Timestamp range cannot mix timestamps with and without timezone offsets"} =
+               Parser.parse(
+                 "t:2024-03-17T13:47:02+00:00..2024-03-17T13:57:02.000",
+                 @default_schema
+               )
+    end
+
     test "timestamp filters reject ambiguous 14 and 15 digit Unix timestamps" do
       assert {:error,
               "Error while parsing timestamp filter value: expected ISO8601 string, Unix timestamp, range or shorthand, got '17106832220000'"} =

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -59,9 +59,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
   end
 
   defp setup_team_user_session(%{conn: conn, user: user, plan: plan, team_user: team_user}) do
-    _billing_account = insert(:billing_account, user: user, stripe_plan_id: plan.stripe_id)
-    user = user |> Logflare.Repo.preload(:billing_account)
-
+    [conn: conn] = setup_user_session(%{conn: conn, user: user, plan: plan})
     [conn: login_user(conn, user, team_user)]
   end
 
@@ -1489,6 +1487,83 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       assert view |> element("#logs-list-container") |> render() =~ matching_message
       refute view |> element("#logs-list-container") |> render() =~ non_matching_message
+    end
+  end
+
+  describe "single tenant postgres shorthand timestamp search" do
+    TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
+
+    setup do
+      start_supervised!(Logflare.SystemMetricsSup)
+
+      user = SingleTenant.get_default_user()
+      source = insert(:source, user: user)
+      plan = SingleTenant.get_default_plan()
+
+      insert(:source_schema,
+        source: source,
+        bigquery_schema: TestUtils.build_bq_schema(%{"event_message" => "test"})
+      )
+
+      %{user: user, source: source, plan: plan}
+    end
+
+    setup [:setup_user_session]
+
+    test "shorthand timestamp filters are not shifted by search timezone", %{
+      conn: conn,
+      source: source
+    } do
+      now = DateTime.utc_now()
+      today_start = DateTime.new!(DateTime.to_date(now), ~T[00:00:00], "Etc/UTC")
+      yesterday_start = DateTime.add(today_start, -1, :day)
+
+      cases = [
+        {"t:last@5m", :second, {DateTime.add(now, -1, :minute), DateTime.add(now, 30, :second)}},
+        {"t:this@day", :hour,
+         {DateTime.add(now, -1, :minute), DateTime.add(today_start, -1, :minute)}},
+        {"t:yesterday", :hour, {DateTime.add(yesterday_start, 12, :hour), now}}
+      ]
+
+      Enum.each(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->
+        matching_message = "included-#{System.unique_integer([:positive])}"
+        non_matching_message = "excluded-#{System.unique_integer([:positive])}"
+
+        {:ok, 2} =
+          [
+            %{
+              "event_message" => matching_message,
+              "timestamp" => included_timestamp |> DateTime.to_iso8601()
+            },
+            %{
+              "event_message" => non_matching_message,
+              "timestamp" => excluded_timestamp |> DateTime.to_iso8601()
+            }
+          ]
+          |> Backends.ingest_logs(source)
+
+        Enum.each(["UTC", "Singapore"], fn timezone ->
+          {:ok, view, _html} =
+            live(
+              conn,
+              Routes.live_path(conn, SearchLV, source.id, tailing?: false, tz: timezone)
+            )
+
+          %{executor_pid: search_executor_pid} = get_view_assigns(view)
+          allow_sandbox(search_executor_pid)
+
+          TestUtils.retry_assert(fn ->
+            render_change(view, :start_search, %{
+              "querystring" => "#{querystring} c:count(*) c:group_by(t::#{chart_period})"
+            })
+
+            html = view |> element("#logs-list-container") |> render()
+
+            assert html =~ matching_message
+            refute html =~ non_matching_message
+          end)
+        end)
+      end)
     end
   end
 


### PR DESCRIPTION
This PR corrects how local timestamps are adjusted to the search timezone.

The LQL parser sets a `timestamp_origin` modifier to `absolute` for timestamps that should not be adjusted from the search timezone to UTC. Timestamps that have a timezone suffix (eg Z or +08:00), are a unix timestamp, or a timestamp shorthand, are all treated as `:absolute` and not adjusted.

Part of O11Y-1717

## Background
In a prior reverted PR #3399 the LQL parser identified timestamps with an explicit timezone suffix (Z or a +/- offset).

However, it did not handle shorthand timestamps (`last@1day` or `today`) correctly. The parser maps these to a UTC date time but because they lacked a Z suffix in the LQL string they were then subsequently adjusted based on the search timezone. This caused incorrect search results.

This PR replaces the `explicit_timezone` modifier flag with `timestamp_origin`.



