### PR TITLE
fix: left outer join for metadata

### DIFF
--- a/lib/logflare/lql/backend_transformer/bigquery.ex
+++ b/lib/logflare/lql/backend_transformer/bigquery.ex
@@ -601,7 +601,7 @@ defmodule Logflare.Lql.BackendTransformer.BigQuery do
     name = if is_binary(alias), do: alias, else: String.replace(path, ".", "_")
 
     query
-    |> handle_nested_field_access(path)
+    |> unnest_and_join_nested_columns(:left, path)
     |> select_merge([..., t], %{
       ^name => fragment("? AS ?", field(t, ^field_name), identifier(^name))
     })

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -80,7 +80,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
 
         {:ok, {sql, _}} = BigQueryAdaptor.ecto_to_sql(so.query, [])
 
-        assert sql =~ "UNNEST(t0.metadata)"
+        assert sql =~ "LEFT OUTER JOIN UNNEST(t0.metadata)"
       end)
     end
   end


### PR DESCRIPTION
Fixes an issue where a search on a  source with a schema  that includes `metadata.level` would only return events that include a metadata field.

Part of O11Y-1717