### PR TITLE
test: remove unecessary timer.sleep

### DIFF
--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -264,8 +264,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
 
       assert {:ok, _} = Backends.ingest_logs([%{"message" => "test webhook egress"}], source)
 
-      :timer.sleep(2500)
-
       assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 15_000
 
       rows = for row <- rows, do: row.json


### PR DESCRIPTION
In this [PR](https://github.com/Logflare/logflare/pull/3368/changes#r3121672642) the `assert_receive` was increased to `15_000`, so the `:timer.sleep(2500)` is no longer necessary.