### PR TITLE
Prevent XSS in Monaco editor completions by escaping HTML

### DIFF
--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -84,7 +84,7 @@ defmodule LogflareWeb.MonacoEditorComponent do
           hook.pushEventTo(ev.target, "format-query", { value: value });
         })
 
-        const completions = <%= Jason.encode!(@completions) |> raw() %>
+        const completions = <%= Jason.encode!(@completions, escape: :html_safe) |> raw() %>
 
         if (completions.length == 0) { return; }
 

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -39,7 +39,7 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
     end
 
     test "escapes </script> in completion names to prevent XSS", %{assigns: assigns} do
-      xss_name = ~s(</script><script>alert(document.domain)</script>)
+      xss_name = ~s|<script>alert(document.domain)</script>|
 
       html =
         render_component(MonacoEditorComponent, %{

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -38,6 +38,22 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
       assert html =~ ~s(const completions = ["Source 1","Endpoint 1"])
     end
 
+    test "escapes </script> in completion names to prevent XSS", %{assigns: assigns} do
+      xss_name = ~s(</script><script>alert(document.domain)</script>)
+
+      html =
+        render_component(MonacoEditorComponent, %{
+          id: "test-editor",
+          field: assigns.form[:query],
+          endpoints: [],
+          sources: [%{id: "source1", name: xss_name}],
+          alerts: []
+        })
+
+      refute html =~ "</script><script>"
+      assert html =~ "\\u003c"
+    end
+
     test "renders with parser error message set", %{assigns: assigns} do
       html =
         render_component(MonacoEditorComponent, %{

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -51,7 +51,7 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
         })
 
       refute html =~ "</script><script>"
-      assert html =~ "\\u003c"
+      assert html =~ "\\u003Cscript>alert(document.domain)\\u003C\\/script>"
     end
 
     test "renders with parser error message set", %{assigns: assigns} do


### PR DESCRIPTION
This PR fixes a potential XSS vulnerability in the Monaco editor component by properly escaping HTML characters in completion names before rendering them in JavaScript.

Completion names (from sources and endpoints) were being JSON-encoded but not HTML-escaped before being embedded directly into a JavaScript string literal. An attacker could inject a completion name like `</script><script>alert(document.domain)</script>` which would break out of the string and execute arbitrary JavaScript.

Closes PRODSEC-42

https://claude.ai/code/session_013Fn6xnMTBQCf8P9ddUNLQE