### PR TITLE
Fix authentication bypass in node shutdown endpoint

### DIFF
--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -2,6 +2,7 @@ defmodule LogflareWeb.AdminController do
   use LogflareWeb, :controller
 
   import Ecto.Query, only: [from: 2]
+  import Logflare.Utils.Guards, only: [is_non_empty_binary: 1]
 
   alias Logflare.Admin
   alias Logflare.Repo
@@ -18,16 +19,17 @@ defmodule LogflareWeb.AdminController do
   ]
   defp env_node_shutdown_code, do: Application.get_env(:logflare, :node_shutdown_code)
 
-  defp valid_shutdown_code?(provided) do
-    configured = env_node_shutdown_code()
+  defp valid_shutdown_code?(provided) when is_non_empty_binary(provided) do
+    case env_node_shutdown_code() do
+      configured when is_non_empty_binary(configured) ->
+        Plug.Crypto.secure_compare(configured, provided)
 
-    case {configured, provided} do
-      {nil, _} -> false
-      {"", _} -> false
-      {_, provided} when provided in [nil, ""] -> false
-      _ -> Plug.Crypto.secure_compare(configured, provided)
+      _ ->
+        false
     end
   end
+
+  defp valid_shutdown_code?(_provided), do: false
 
   def dashboard(conn, _params) do
     conn

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -24,7 +24,7 @@ defmodule LogflareWeb.AdminController do
     case {configured, provided} do
       {nil, _} -> false
       {"", _} -> false
-      {_, nil} -> false
+      {_, provided} when provided in [nil, ""] -> false
       _ -> Plug.Crypto.secure_compare(configured, provided)
     end
   end

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -18,6 +18,17 @@ defmodule LogflareWeb.AdminController do
   ]
   defp env_node_shutdown_code, do: Application.get_env(:logflare, :node_shutdown_code)
 
+  defp valid_shutdown_code?(conn) do
+    configured = env_node_shutdown_code()
+
+    case {configured, get_req_header(conn, "x-logflare-shutdown-code")} do
+      {nil, _} -> false
+      {"", _} -> false
+      {_, []} -> false
+      {_, [provided | _]} -> Plug.Crypto.secure_compare(configured, provided)
+    end
+  end
+
   def dashboard(conn, _params) do
     conn
     |> render("dashboard.html")
@@ -73,7 +84,7 @@ defmodule LogflareWeb.AdminController do
   end
 
   def shutdown_node(conn, params) do
-    if Map.get(params, "code") == env_node_shutdown_code() do
+    if valid_shutdown_code?(conn) do
       do_authorized_code_shutdown(conn, params)
     else
       do_unauthorized_code_shutdown(conn, params)

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -105,6 +105,7 @@ defmodule LogflareWeb.AdminController do
           Atom.to_string(nn) == node
         end)
 
+      Logger.info("Node shutdown initialized")
       Admin.shutdown(node_name)
 
       conn
@@ -124,6 +125,7 @@ defmodule LogflareWeb.AdminController do
   end
 
   defp do_authorized_code_shutdown(conn, _params) do
+    Logger.info("Node shutdown initialized")
     Admin.shutdown()
 
     conn

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -18,14 +18,14 @@ defmodule LogflareWeb.AdminController do
   ]
   defp env_node_shutdown_code, do: Application.get_env(:logflare, :node_shutdown_code)
 
-  defp valid_shutdown_code?(conn) do
+  defp valid_shutdown_code?(provided) do
     configured = env_node_shutdown_code()
 
-    case {configured, get_req_header(conn, "x-logflare-shutdown-code")} do
+    case {configured, provided} do
       {nil, _} -> false
       {"", _} -> false
-      {_, []} -> false
-      {_, [provided | _]} -> Plug.Crypto.secure_compare(configured, provided)
+      {_, nil} -> false
+      _ -> Plug.Crypto.secure_compare(configured, provided)
     end
   end
 
@@ -84,7 +84,9 @@ defmodule LogflareWeb.AdminController do
   end
 
   def shutdown_node(conn, params) do
-    if valid_shutdown_code?(conn) do
+    provided = conn |> get_req_header("lf-shutdown-code") |> List.first()
+
+    if valid_shutdown_code?(provided) do
       do_authorized_code_shutdown(conn, params)
     else
       do_unauthorized_code_shutdown(conn, params)

--- a/lib/logflare_web/controllers/admin_controller.ex
+++ b/lib/logflare_web/controllers/admin_controller.ex
@@ -22,7 +22,10 @@ defmodule LogflareWeb.AdminController do
   defp valid_shutdown_code?(provided) when is_non_empty_binary(provided) do
     case env_node_shutdown_code() do
       configured when is_non_empty_binary(configured) ->
-        Plug.Crypto.secure_compare(configured, provided)
+        Plug.Crypto.secure_compare(
+          :crypto.hash(:sha256, configured),
+          :crypto.hash(:sha256, provided)
+        )
 
       _ ->
         false

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -2,6 +2,67 @@ defmodule LogflareWeb.AdminControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  describe "shutdown_node/2" do
+    setup do
+      insert(:plan)
+      :ok
+    end
+
+    test "returns 401 when shutdown code is not configured", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, nil)
+      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
+
+      conn =
+        conn
+        |> put_req_header("x-logflare-shutdown-code", "anything")
+        |> put(~p"/admin/shutdown")
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 401 when shutdown code env is empty string", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, "")
+      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
+
+      conn =
+        conn
+        |> put_req_header("x-logflare-shutdown-code", "")
+        |> put(~p"/admin/shutdown")
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 401 when header is absent", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, "secret")
+      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
+
+      conn = put(conn, ~p"/admin/shutdown")
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 401 when provided code does not match", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, "correct-secret")
+      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
+
+      conn =
+        conn
+        |> put_req_header("x-logflare-shutdown-code", "wrong-secret")
+        |> put(~p"/admin/shutdown")
+
+      assert json_response(conn, 401)
+    end
+
+    test "nil code in query param no longer bypasses auth when env var is unset", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, nil)
+      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
+
+      conn = put(conn, ~p"/admin/shutdown")
+
+      assert json_response(conn, 401)
+    end
+  end
+
   describe "Admin controller" do
     setup do
       insert(:plan)

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -2,6 +2,8 @@ defmodule LogflareWeb.AdminControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  import ExUnit.CaptureLog
+
   setup do
     prior = Application.get_env(:logflare, :node_shutdown_code)
     Application.delete_env(:logflare, :node_shutdown_code)
@@ -64,11 +66,17 @@ defmodule LogflareWeb.AdminControllerTest do
     test "shuts down node when secret matches header", %{conn: conn} do
       Application.put_env(:logflare, :node_shutdown_code, "correct-secret")
 
-      expect(Logflare.Admin, :shutdown, fn -> :ok end)
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("lf-shutdown-code", "correct-secret")
+            |> put(~p"/admin/shutdown")
 
-      conn
-      |> put_req_header("lf-shutdown-code", "correct-secret")
-      |> put(~p"/admin/shutdown")
+          assert json_response(conn, 200)
+        end)
+
+      assert log =~ "Node shutdown initialized"
     end
   end
 

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -54,7 +54,7 @@ defmodule LogflareWeb.AdminControllerTest do
       assert json_response(conn, 401)
     end
 
-    test "nil code in query param no longer bypasses auth when env var is unset", %{conn: conn} do
+    test "returns 401 when env is unset and no header sent", %{conn: conn} do
       conn = put(conn, ~p"/admin/shutdown")
 
       assert json_response(conn, 401)

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -2,6 +2,13 @@ defmodule LogflareWeb.AdminControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  setup do
+    prior = Application.get_env(:logflare, :node_shutdown_code)
+    Application.delete_env(:logflare, :node_shutdown_code)
+    on_exit(fn -> Application.put_env(:logflare, :node_shutdown_code, prior) end)
+    :ok
+  end
+
   describe "shutdown_node/2" do
     setup do
       insert(:plan)
@@ -9,9 +16,6 @@ defmodule LogflareWeb.AdminControllerTest do
     end
 
     test "returns 401 when shutdown code is not configured", %{conn: conn} do
-      Application.put_env(:logflare, :node_shutdown_code, nil)
-      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
-
       conn =
         conn
         |> put_req_header("lf-shutdown-code", "anything")
@@ -22,7 +26,6 @@ defmodule LogflareWeb.AdminControllerTest do
 
     test "returns 401 when shutdown code env is empty string", %{conn: conn} do
       Application.put_env(:logflare, :node_shutdown_code, "")
-      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
 
       conn =
         conn
@@ -34,7 +37,6 @@ defmodule LogflareWeb.AdminControllerTest do
 
     test "returns 401 when header is absent", %{conn: conn} do
       Application.put_env(:logflare, :node_shutdown_code, "secret")
-      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
 
       conn = put(conn, ~p"/admin/shutdown")
 
@@ -43,7 +45,6 @@ defmodule LogflareWeb.AdminControllerTest do
 
     test "returns 401 when provided code does not match", %{conn: conn} do
       Application.put_env(:logflare, :node_shutdown_code, "correct-secret")
-      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
 
       conn =
         conn
@@ -54,9 +55,6 @@ defmodule LogflareWeb.AdminControllerTest do
     end
 
     test "nil code in query param no longer bypasses auth when env var is unset", %{conn: conn} do
-      Application.put_env(:logflare, :node_shutdown_code, nil)
-      on_exit(fn -> Application.delete_env(:logflare, :node_shutdown_code) end)
-
       conn = put(conn, ~p"/admin/shutdown")
 
       assert json_response(conn, 401)

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -66,12 +66,9 @@ defmodule LogflareWeb.AdminControllerTest do
 
       expect(Logflare.Admin, :shutdown, fn -> :ok end)
 
-      conn =
-        conn
-        |> put_req_header("lf-shutdown-code", "correct-secret")
-        |> put(~p"/admin/shutdown")
-
-      assert json_response(conn, 200)
+      conn
+      |> put_req_header("lf-shutdown-code", "correct-secret")
+      |> put(~p"/admin/shutdown")
     end
   end
 

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -12,6 +12,7 @@ defmodule LogflareWeb.AdminControllerTest do
   describe "shutdown_node/2" do
     setup do
       insert(:plan)
+      stub(Logflare.Admin, :shutdown, fn -> :ok end)
       :ok
     end
 
@@ -58,6 +59,19 @@ defmodule LogflareWeb.AdminControllerTest do
       conn = put(conn, ~p"/admin/shutdown")
 
       assert json_response(conn, 401)
+    end
+
+    test "shuts down node when secret matches header", %{conn: conn} do
+      Application.put_env(:logflare, :node_shutdown_code, "correct-secret")
+
+      expect(Logflare.Admin, :shutdown, fn -> :ok end)
+
+      conn =
+        conn
+        |> put_req_header("lf-shutdown-code", "correct-secret")
+        |> put(~p"/admin/shutdown")
+
+      assert json_response(conn, 200)
     end
   end
 

--- a/test/logflare_web/controllers/admin_controller_test.exs
+++ b/test/logflare_web/controllers/admin_controller_test.exs
@@ -14,7 +14,7 @@ defmodule LogflareWeb.AdminControllerTest do
 
       conn =
         conn
-        |> put_req_header("x-logflare-shutdown-code", "anything")
+        |> put_req_header("lf-shutdown-code", "anything")
         |> put(~p"/admin/shutdown")
 
       assert json_response(conn, 401)
@@ -26,7 +26,7 @@ defmodule LogflareWeb.AdminControllerTest do
 
       conn =
         conn
-        |> put_req_header("x-logflare-shutdown-code", "")
+        |> put_req_header("lf-shutdown-code", "")
         |> put(~p"/admin/shutdown")
 
       assert json_response(conn, 401)
@@ -47,7 +47,7 @@ defmodule LogflareWeb.AdminControllerTest do
 
       conn =
         conn
-        |> put_req_header("x-logflare-shutdown-code", "wrong-secret")
+        |> put_req_header("lf-shutdown-code", "wrong-secret")
         |> put(~p"/admin/shutdown")
 
       assert json_response(conn, 401)


### PR DESCRIPTION
This PR tightens security around the LOGFLARE_NODE_SHUTDOWN_CODE, using a header verification instead of query parameter, and also preventing shutdown via the API if code is not set.
Timing attack prevention has also been added. 

Closes PRODSEC-44

https://claude.ai/code/session_01FTArwTBUZpCbanBxaViw8i
