### PR TITLE
fix: enforce auth before syslog body parsing and remove log injection

### DIFF
--- a/lib/logflare_web/controllers/plugs/ndjson_parser.ex
+++ b/lib/logflare_web/controllers/plugs/ndjson_parser.ex
@@ -69,6 +69,4 @@ defmodule LogflareWeb.NdjsonParser do
   # don't log either of those, only the offset.
   defp redact_decode_error(%Jason.DecodeError{position: position}),
     do: "decode error at position #{position}"
-
-  defp redact_decode_error(_), do: "decode error"
 end

--- a/lib/logflare_web/controllers/plugs/ndjson_parser.ex
+++ b/lib/logflare_web/controllers/plugs/ndjson_parser.ex
@@ -40,7 +40,7 @@ defmodule LogflareWeb.NdjsonParser do
             }
 
           {:error, error} ->
-            Logger.error("NDJSON parser error: " <> inspect(error))
+            Logger.error("NDJSON parser error: #{redact_decode_error(error)}")
 
             nil
         end
@@ -64,4 +64,11 @@ defmodule LogflareWeb.NdjsonParser do
   def decode({:error, _}) do
     raise Plug.BadRequestError
   end
+
+  # Jason.DecodeError carries the raw failing input in :data and :token —
+  # don't log either of those, only the offset.
+  defp redact_decode_error(%Jason.DecodeError{position: position}),
+    do: "decode error at position #{position}"
+
+  defp redact_decode_error(_), do: "decode error"
 end

--- a/lib/logflare_web/controllers/plugs/syslog_parser.ex
+++ b/lib/logflare_web/controllers/plugs/syslog_parser.ex
@@ -47,9 +47,7 @@ defmodule LogflareWeb.SyslogParser do
             to_log_params(syslog_message)
 
           {:error, error} ->
-            Logger.error(
-              "Syslog message parsing error: #{error}, message: |#{syslog_message_string}|, source: #{conn.params["source"]}"
-            )
+            Logger.error("Syslog message parsing error: #{error}")
 
             nil
         end

--- a/lib/logflare_web/controllers/plugs/verify_api_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_api_access.ex
@@ -20,7 +20,13 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
   def init(args), do: args |> Enum.into(%{})
 
   def call(conn, opts) do
-    opts = Enum.into(opts, %{scopes: []})
+    # The plug may run before Plug.Parsers on ingest pipelines (so that
+    # unauthenticated requests cannot reach the parsers), in which case
+    # conn.params is unfetched. Make sure at least query params are available
+    # so legacy `?api_key=` clients still authenticate.
+    conn = fetch_query_params(conn)
+
+    opts = Enum.into(opts, %{scopes: [], require_token: false})
     resource_type = Map.get(conn.assigns, :resource_type)
 
     impersonate_user_token = get_req_header(conn, "x-lf-partner-user") |> List.first()
@@ -57,7 +63,10 @@ defmodule LogflareWeb.Plugs.VerifyApiAccess do
         # either nil or %OauthAccessToken{}
         |> assign(:access_token, token)
 
-      {:error, :no_token} when resource_type != nil ->
+      # Public-endpoint queries (enable_auth: false) reach VerifyResourceAccess
+      # without a token; let those through. Ingest pipelines pass
+      # require_token: true so the 401 happens here, before Plug.Parsers.
+      {:error, :no_token} when resource_type != nil and not opts.require_token ->
         conn
 
       _ ->

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -76,6 +76,7 @@ defmodule LogflareWeb.Router do
   pipeline :api do
     plug(Plug.RequestId)
     plug(LogflareWeb.Plugs.MaybeContentTypeToJson)
+    plug(LogflareWeb.Plugs.VerifyApiAccess)
 
     plug(Plug.Parsers,
       parsers: [JsonParser, BertParser, SyslogParser, NdjsonParser],

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -76,7 +76,6 @@ defmodule LogflareWeb.Router do
   pipeline :api do
     plug(Plug.RequestId)
     plug(LogflareWeb.Plugs.MaybeContentTypeToJson)
-    plug(LogflareWeb.Plugs.VerifyApiAccess)
 
     plug(Plug.Parsers,
       parsers: [JsonParser, BertParser, SyslogParser, NdjsonParser],
@@ -90,8 +89,35 @@ defmodule LogflareWeb.Router do
     plug(OpenApiSpex.Plug.PutApiSpec, module: LogflareWeb.ApiSpec)
   end
 
-  pipeline :otlp_api do
+  # Authenticated ingest. VerifyApiAccess runs before body parsing so
+  # unauthenticated requests can never trigger the parsers. FetchResource and
+  # VerifyResourceAccess run after parsing because some clients (e.g. the
+  # BERT logger) identify the source via a body field.
+  pipeline :ingest_api do
     plug(Plug.RequestId)
+    plug(LogflareWeb.Plugs.MaybeContentTypeToJson)
+    plug(LogflareWeb.Plugs.VerifyApiAccess, require_token: true)
+
+    plug(Plug.Parsers,
+      parsers: [JsonParser, BertParser, SyslogParser, NdjsonParser],
+      json_decoder: Jason,
+      body_reader: {PlugCaisson, :read_body, []},
+      length: 12_000_000
+    )
+
+    plug(LogflareWeb.Plugs.FetchResource)
+    plug(LogflareWeb.Plugs.VerifyResourceAccess)
+    plug(:accepts, ["json", "bert"])
+    plug(LogflareWeb.Plugs.SetHeaders)
+    plug(OpenApiSpex.Plug.PutApiSpec, module: LogflareWeb.ApiSpec)
+    plug(LogflareWeb.Plugs.SetPlanFromCache)
+    plug(LogflareWeb.Plugs.RateLimiter)
+    plug(LogflareWeb.Plugs.BufferLimiter)
+  end
+
+  pipeline :ingest_otlp_api do
+    plug(Plug.RequestId)
+    plug(LogflareWeb.Plugs.VerifyApiAccess, require_token: true)
 
     plug(Plug.Parsers,
       parsers: [ProtobufParser],
@@ -100,26 +126,20 @@ defmodule LogflareWeb.Router do
       length: 12_000_000
     )
 
+    plug(LogflareWeb.Plugs.FetchResource)
+    plug(LogflareWeb.Plugs.VerifyResourceAccess)
     plug(:accepts, ["json", "protobuf"])
     plug(LogflareWeb.Plugs.SetHeaders)
     plug(LogflareWeb.Plugs.BlockSystemSource)
+    plug(LogflareWeb.Plugs.SetPlanFromCache)
+    plug(LogflareWeb.Plugs.RateLimiter)
+    plug(LogflareWeb.Plugs.BufferLimiter)
   end
 
   pipeline :require_endpoint_auth do
     plug(LogflareWeb.Plugs.VerifyApiAccess)
     plug(LogflareWeb.Plugs.FetchResource)
     plug(LogflareWeb.Plugs.VerifyResourceAccess)
-  end
-
-  pipeline :require_ingest_api_auth do
-    plug(LogflareWeb.Plugs.VerifyApiAccess)
-    plug(LogflareWeb.Plugs.FetchResource)
-    plug(LogflareWeb.Plugs.VerifyResourceAccess)
-    # We are ensuring source start in Logs.ingest
-    # plug LogflareWeb.Plugs.EnsureSourceStarted
-    plug(LogflareWeb.Plugs.SetPlanFromCache)
-    plug(LogflareWeb.Plugs.RateLimiter)
-    plug(LogflareWeb.Plugs.BufferLimiter)
   end
 
   pipeline :require_mgmt_api_auth do
@@ -514,7 +534,7 @@ defmodule LogflareWeb.Router do
   end
 
   scope "/v1", LogflareWeb, assigns: %{resource_type: :source} do
-    pipe_through([:otlp_api, :require_ingest_api_auth])
+    pipe_through([:ingest_otlp_api])
 
     post(
       "/traces",
@@ -540,7 +560,7 @@ defmodule LogflareWeb.Router do
 
   for path <- ["/logs", "/api/logs", "/api/events"] do
     scope path, LogflareWeb, assigns: %{resource_type: :source} do
-      pipe_through([:api, :require_ingest_api_auth])
+      pipe_through([:ingest_api])
 
       post("/", LogController, :create)
       options("/", LogController, :create)
@@ -568,7 +588,7 @@ defmodule LogflareWeb.Router do
 
     # logpush
     scope "#{path}/cloudflare", LogflareWeb, assigns: %{resource_type: :source} do
-      pipe_through([:logpush, :api, :require_ingest_api_auth])
+      pipe_through([:logpush, :ingest_api])
       post("/", LogController, :cloudflare)
     end
   end

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -253,6 +253,37 @@ defmodule LogflareWeb.LogControllerTest do
       refute log =~ "Syslog message parsing error"
     end
 
+    test "invalid api key on /logs/cloudflare 401s before parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/x-ndjson")
+            |> put_req_header("x-api-key", "this-key-is-not-valid")
+            |> post(~p"/logs/cloudflare", @malformed_ndjson)
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+      refute log =~ "NDJSON parser error"
+    end
+
+    test "invalid api key on /v1/logs 401s before parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/x-protobuf")
+            |> put_req_header("x-api-key", "this-key-is-not-valid")
+            |> post(~p"/v1/logs", "garbage protobuf #{@attacker_marker}")
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+    end
+
     test "authenticated /logs/logplex with malformed body does not log raw content", %{conn: conn} do
       user = insert(:user)
       source = insert(:source, user: user)

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -319,6 +319,23 @@ defmodule LogflareWeb.LogControllerTest do
       assert log =~ "NDJSON parser error"
       refute log =~ @attacker_marker
     end
+
+    test "authenticated /logs/logplex error log does not include ?source= query param",
+         %{conn: conn} do
+      user = insert(:user)
+      insert(:plan, name: "Free")
+
+      log =
+        capture_log(fn ->
+          conn
+          |> put_req_header("x-api-key", user.api_key)
+          |> put_req_header("content-type", "application/logplex-1")
+          |> post(~p"/logs/logplex?#{[source: @attacker_marker]}", @malformed_syslog)
+        end)
+
+      assert log =~ "Syslog message parsing error"
+      refute log =~ @attacker_marker
+    end
   end
 
   describe "pipeline with ?api_key= query auth" do

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule LogflareWeb.LogControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
+  import ExUnit.CaptureLog
   alias Logflare.Backends.Adaptor.WebhookAdaptor
   alias Logflare.SingleTenant
   alias Logflare.Users
@@ -182,6 +183,135 @@ defmodule LogflareWeb.LogControllerTest do
     end
   end
 
+  # The syslog Plug.Parsers parser used to run before auth, so an
+  # unauthenticated POST with a malformed payload could write attacker-supplied
+  # content to application logs via Logger.error. Auth now runs ahead of body
+  # parsing on ingest pipelines, and parser error logs no longer include the
+  # raw body either.
+  describe "ingest auth runs before parsers" do
+    @attacker_marker "MALICIOUS_LOG_INJECTION_MARKER_2026"
+    @malformed_syslog "not a valid syslog message #{@attacker_marker}\n"
+    @malformed_ndjson "{not json #{@attacker_marker}\n"
+
+    test "unauthenticated /logs/logplex returns 401 without parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/logplex-1")
+            |> post(~p"/logs/logplex", @malformed_syslog)
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+      refute log =~ "Syslog message parsing error"
+    end
+
+    test "unauthenticated /logs/cloudflare returns 401 without parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/x-ndjson")
+            |> post(~p"/logs/cloudflare", @malformed_ndjson)
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+      refute log =~ "NDJSON parser error"
+    end
+
+    test "unauthenticated /v1/logs returns 401 without parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/x-protobuf")
+            |> post(~p"/v1/logs", "garbage protobuf #{@attacker_marker}")
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+    end
+
+    test "invalid api key on /logs/logplex 401s before parsing the body", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> put_req_header("content-type", "application/logplex-1")
+            |> put_req_header("x-api-key", "this-key-is-not-valid")
+            |> post(~p"/logs/logplex", @malformed_syslog)
+
+          assert json_response(conn, 401)
+        end)
+
+      refute log =~ @attacker_marker
+      refute log =~ "Syslog message parsing error"
+    end
+
+    test "authenticated /logs/logplex with malformed body does not log raw content", %{conn: conn} do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      insert(:plan, name: "Free")
+
+      log =
+        capture_log(fn ->
+          conn
+          |> put_req_header("x-api-key", user.api_key)
+          |> put_req_header("content-type", "application/logplex-1")
+          |> post(~p"/logs/logplex?#{[source: source.token]}", @malformed_syslog)
+        end)
+
+      assert log =~ "Syslog message parsing error"
+      refute log =~ @attacker_marker
+    end
+
+    test "authenticated /logs/cloudflare with malformed body does not log raw content", %{
+      conn: conn
+    } do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      insert(:plan, name: "Free")
+
+      log =
+        capture_log(fn ->
+          conn
+          |> put_req_header("x-api-key", user.api_key)
+          |> put_req_header("content-type", "application/x-ndjson")
+          |> post(~p"/logs/cloudflare?#{[source: source.token]}", @malformed_ndjson)
+        end)
+
+      assert log =~ "NDJSON parser error"
+      refute log =~ @attacker_marker
+    end
+  end
+
+  describe "pipeline with ?api_key= query auth" do
+    setup [:pipeline_setup, :warm_caches, :reject_context_functions]
+
+    test ":create ingestion authenticates via ?api_key=", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      expect_bq_insert()
+
+      conn =
+        post(
+          conn,
+          ~p"/logs?#{[source: source.token, api_key: user.api_key]}",
+          @valid
+        )
+
+      assert_logged_successfully(conn)
+      assert_eventually_received(:inserted)
+    end
+  end
+
   describe "pipeline invalid" do
     setup [:pipeline_setup, :warm_caches, :reject_context_functions]
 
@@ -290,6 +420,58 @@ defmodule LogflareWeb.LogControllerTest do
                "message" => "Logged!"
              }
 
+      assert_eventually_received(:inserted)
+    end
+
+    test ":elixir_logger ingestion with source_name in BERT body", %{conn: conn, source: source} do
+      expect_bq_insert()
+
+      body =
+        Bertex.encode(%{
+          "source_name" => source.name,
+          "batch" => [
+            %{
+              "level" => "info",
+              "message" => "bert body source_name test",
+              "metadata" => %{},
+              "timestamp" => "2026-05-14T17:00:00Z"
+            }
+          ]
+        })
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/bert")
+        |> post(~p"/logs/elixir/logger", body)
+
+      assert_logged_successfully(conn)
+      assert_eventually_received(:inserted)
+    end
+
+    test ":create ingestion with source token in JSON body", %{conn: conn, source: source} do
+      expect_bq_insert()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/logs",
+          Jason.encode!(%{"source" => Atom.to_string(source.token), "event_message" => "x"})
+        )
+
+      assert_logged_successfully(conn)
+      assert_eventually_received(:inserted)
+    end
+
+    test ":create ingestion with source_name in JSON body", %{conn: conn, source: source} do
+      expect_bq_insert()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/logs", Jason.encode!(%{"source_name" => source.name, "event_message" => "x"}))
+
+      assert_logged_successfully(conn)
       assert_eventually_received(:inserted)
     end
   end

--- a/test/logflare_web/controllers/plugs/verify_api_access_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_api_access_test.exs
@@ -177,6 +177,38 @@ defmodule LogflareWeb.Plugs.VerifyApiAccessTest do
     end
   end
 
+  describe "require_token option" do
+    setup do
+      conn =
+        build_conn(:post, "/logs", %{})
+        |> assign(:resource_type, :source)
+
+      {:ok, conn: conn}
+    end
+
+    test "default opts pass through with resource_type and no token (preserves public endpoints)",
+         %{conn: conn} do
+      conn = VerifyApiAccess.call(conn, %{})
+      assert conn.halted == false
+      assert Map.get(conn.assigns, :user) == nil
+    end
+
+    test "require_token: true halts with 401 when no token is present", %{conn: conn} do
+      conn
+      |> VerifyApiAccess.call(%{require_token: true})
+      |> assert_unauthorized()
+    end
+
+    test "require_token: true still accepts ?api_key= query auth", %{conn: conn, user: user} do
+      new_params = Map.merge(conn.params, %{"api_key" => user.api_key})
+
+      conn
+      |> Map.put(:params, new_params)
+      |> VerifyApiAccess.call(%{require_token: true})
+      |> assert_authorized(user)
+    end
+  end
+
   test "private scope", %{user: user} do
     {:ok, access_token} = Logflare.Auth.create_access_token(user, %{scopes: "private"})
 


### PR DESCRIPTION
## Summary

- Move `VerifyApiAccess` ahead of `Plug.Parsers` on ingest pipelines so unauthenticated callers can no longer reach the parsers. This closes the log-injection path through `SyslogParser` and prevents future parser-side bugs from leaking attacker-supplied content on the unauthenticated path.
- Introduce dedicated `:ingest_api` and `:ingest_otlp_api` pipelines for `/logs`, `/api/logs`, `/api/events`, the Cloudflare logpush scope, and `/v1/*` OTLP routes. The shared `:api` pipeline is left alone so `/health`, webhooks, OAuth, OpenAPI etc. keep working without API auth.
- `FetchResource` and `VerifyResourceAccess` still run **after** parsing because some clients (notably the BERT logger at `/logs/elixir/logger`) identify the source via a body field. Auth running first is enough to keep unauthenticated bodies away from the parsers.
- Add a `require_token: true` option to `VerifyApiAccess`. Without it the plug's existing `{:error, :no_token}` clause passes unauthenticated requests through whenever a `resource_type` assign is set — a behavior the public-endpoint query path (`enable_auth: false`) relies on, but which would otherwise silently defeat the new ordering. The ingest pipelines now pass this option; the endpoint and mgmt pipelines do not.
- `VerifyApiAccess` calls `fetch_query_params/1` at the top of `call/2` so legacy `?api_key=` clients still authenticate even when the plug runs before `Plug.Parsers` (which previously fetched them).
- Redact raw bodies from parser error logs. `SyslogParser` no longer logs the raw message string or `?source=` param. `NdjsonParser` was logging `inspect/1` of the `Jason.DecodeError`, which carries the raw failing input in `:data` and `:token` — it now logs only the decode position. Defence-in-depth on the authenticated path; auth ordering already protects the unauthenticated path.
- Add controller-level tests for malformed payloads on `/logs/logplex`, `/logs/cloudflare`, and `/v1/logs` (unauthenticated, authenticated, and invalid-key) asserting (a) parser-error log lines never appear for unauthenticated or invalid-key requests, (b) an attacker-controlled marker never appears in the captured logs even when the parser does run.
- Lock in body-sourced ingest paths against the resource-after-parsing reorder: BERT body `source_name` to `/logs/elixir/logger`, JSON body `source` token to `/logs`, JSON body `source_name` to `/logs`.
- Add plug-level coverage of the new `require_token` option in `verify_api_access_test.exs`.

## Test plan

- [x] `mix test test/logflare_web/controllers/log_controller_test.exs` (29/29)
- [x] `mix test test/logflare_web/controllers/plugs/verify_api_access_test.exs` (14/14)
- [x] `mix test test/logflare_web/controllers/endpoints_controller_test.exs test/logflare_web/controllers/api/endpoint_controller_test.exs` (38/38, 2 skipped)
- [x] `mix lint.diff` clean
- [x] Manual: unauth POST `/logs/logplex`, `/logs/cloudflare`, and `/v1/logs` with malformed bodies all return 401 with no `Syslog message parsing error` / `NDJSON parser error` line in the dev server log (parsers never run)
- [x] Manual: authenticated POST `/logs/logplex` and `/logs/cloudflare` with malformed bodies do log a redacted parser-error line and never contain the request body
- [x] Manual: legacy `?api_key=` query auth on `POST /logs?source=<token>&api_key=...` returns 200 (verifies `fetch_query_params` defensive fetch)
- [x] Manual: BERT body with `source_name` to `POST /logs/elixir/logger` returns 200 (verifies the body-sourced source-name path still works post-reorder)
- [x] Manual: `/health`, OpenAPI spec, mgmt API list/create/delete with bearer auth, mgmt API 401 without auth — all behave as before
- [x] Manual: public endpoint (`enable_auth: false`) reachable unauthenticated by UUID token (verifies the `require_token` opt-in correctly preserves the public-endpoint pathway)

Closes PRODSEC-39

https://claude.ai/code/session_0188UD1xQBYhqoM9Lt1WsPcx

---
_Generated by [Claude Code](https://claude.ai/code/session_0188UD1xQBYhqoM9Lt1WsPcx)_