### PR TITLE
Update stale inspect_fun docs and extend redaction property tests

### DIFF
--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -11,6 +11,8 @@ defmodule Logflare.Utils do
   import Cachex.Spec
   import Logflare.Utils.Guards, only: [is_atom_value: 1]
 
+  @sensitive_header_names ["authorization", "x-api-key", "Authorization", "X-API-Key"]
+
   @doc """
   Checks if a feature flag is enabled.
   If SDK key is not set, will always return false.
@@ -357,7 +359,7 @@ defmodule Logflare.Utils do
       fn
         {[key | _], value}
         when is_binary(value) and
-               key in ["authorization", "x-api-key", "Authorization", "X-API-Key"] ->
+               key in @sensitive_header_names ->
           "REDACTED"
 
         self ->
@@ -370,8 +372,15 @@ defmodule Logflare.Utils do
   end
 
   @doc """
-  Receives the previous inspect function and performs redaction if it is a Tesla.Env.
-  Does nothing if it is not a Tesla.Env or Tesla.Client.
+  Receives the previous inspect function and redacts sensitive fields
+  before inspect output for the following structs:
+
+    - `Tesla.Env` or `Tesla.Client` - HTTP request/response data
+    - `Backend` - strips `:config` and `:config_encrypted`
+    - `User` - strips `:api_key` and `:old_api_key`
+    - `OauthAccessToken` or `PartnerOauthAccessToken` - strips OAuth tokens
+
+  Redaction is skipped in `:test` and `:dev` environments.
   """
   def inspect_fun(prev_fun, value, opts)
       when is_struct(value, Tesla.Env) or is_struct(value, Tesla.Client) or
@@ -433,8 +442,6 @@ defmodule Logflare.Utils do
   defp redact_struct_for_inspect(value) do
     redact_sensitive_headers(value)
   end
-
-  @sensitive_header_names ["authorization", "x-api-key", "Authorization", "X-API-Key"]
 
   defp redact_header_list(headers) do
     Enum.map(headers, fn

--- a/test/logflare/utils_test.exs
+++ b/test/logflare/utils_test.exs
@@ -408,6 +408,19 @@ defmodule Logflare.UtilsSyncTest do
               constant(%Tesla.Env{opts: opts ++ [req_headers: headers], headers: headers})
             end)
           end),
+          bind(headers_gen, fn headers ->
+            constant(%Tesla.Client{pre: [{Tesla.Middleware.Headers, :call, [headers]}]})
+          end),
+          bind(headers_gen, fn env_headers ->
+            bind(headers_gen, fn client_headers ->
+              constant(%Tesla.Env{
+                headers: env_headers,
+                __client__: %Tesla.Client{
+                  pre: [{Tesla.Middleware.Headers, :call, [client_headers]}]
+                }
+              })
+            end)
+          end),
           bind(string(:alphanumeric, min_length: 3), fn email ->
             constant(%User{api_key: @secret, old_api_key: @secret, email: email})
           end),


### PR DESCRIPTION
This PR provides the three minor improvements for the `Logflare.Utils.inspect_fun/3` and private API it uses:

1. The stale docstring is updated with the mentioning all redacted structures.

2. Extended the property test struct generator with `Tesla.Client` and `Tesla.Env` with a nested `__client__`, covering the missing redaction paths in property tests.

3. The @sensitive_header_names attribute was re-used everywhere where possible.