### PR TITLE
Fix specs for some public API in Logflare.Utils

### DIFF
--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -334,7 +334,7 @@ defmodule Logflare.Utils do
   iex> ip_version(nil)
   nil
   """
-  @spec ip_version(String.t() | nil) :: :inet | :inet6 | nil
+  @spec ip_version(String.t() | nil) :: :inet | :inet6 | :nxdomain | nil
   def ip_version(address) when is_binary(address) do
     address = String.to_charlist(address)
 
@@ -351,7 +351,7 @@ defmodule Logflare.Utils do
   @doc """
   Redacts sensitive headers from a list of Tesla.Env headers. Used for automatic redaction.
   """
-  @spec redact_sensitive_headers(map()) :: list(tuple())
+  @spec redact_sensitive_headers(map()) :: map()
   def redact_sensitive_headers(%{} = value) do
     # iteraptor does not handle structs as the main Enum, we need to wrap it
     List.wrap(value)
@@ -484,7 +484,7 @@ defmodule Logflare.Utils do
   @doc """
   Tries to stop a process gracefully. If it fails, it sends a signal to the process.
   """
-  @spec try_to_stop_process(pid(), atom()) :: :ok | :noop
+  @spec try_to_stop_process(pid(), term(), term()) :: :ok | :noop
   def try_to_stop_process(pid, signal \\ :shutdown, force_signal \\ :kill) do
     GenServer.stop(pid, signal, 5_000)
     :ok


### PR DESCRIPTION
This PR provides minor fixes for the specs for some public APIs from `Logflare.Utils`:

1. Added missing `:nxdomain` as a possible return value to the `ip_version/1`

2. Fixed return type of the `redact_sensitive_headers/1`

3. Added missing parameter to the `try_to_stop_process/3`. Since this function marks the last two parameters as optional, it is worth adding the full list of parameters to avoid ambiguity. In addition the second parameter type is also changed from `atom()` to `term()`, as `GenServer.stop/3` accepts any `term()` as a reason.