### PR TITLE
feat: default LQL rules for source

### DIFF
--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -134,6 +134,7 @@ defmodule Logflare.Sources.Source do
     field :validate_schema, :boolean, default: true
     field :drop_lql_filters, Ecto.LqlRules, default: []
     field :drop_lql_string, :string
+    field :default_search_lql, :string, default: nil
     field :disable_tailing, :boolean, default: false
     field :suggested_keys, :string, default: ""
     field :retention_days, :integer, virtual: true
@@ -198,6 +199,7 @@ defmodule Logflare.Sources.Source do
       :validate_schema,
       :drop_lql_filters,
       :drop_lql_string,
+      :default_search_lql,
       :suggested_keys,
       :retention_days,
       :transform_copy_fields,
@@ -232,6 +234,7 @@ defmodule Logflare.Sources.Source do
       :validate_schema,
       :drop_lql_filters,
       :drop_lql_string,
+      :default_search_lql,
       :suggested_keys,
       :retention_days,
       :transform_copy_fields,

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -323,12 +323,13 @@ defmodule LogflareWeb.SourceController do
 
   def update(
         %{assigns: %{source: source, user: _user, plan: _plan}} = conn,
-        %{"source" => %{"default_search_lql" => lqlstring} = params}
+        %{"source" => %{"default_search_lql" => lqlstring} = _params}
       ) do
     schema = get_bigquery_schema(source)
 
     with {:ok, _lql_rules} <- Lql.Parser.parse(lqlstring, schema),
-         {:ok, _changeset} <- Sources.update_source_by_user(source, %{"default_search_lql" => lqlstring}) do
+         {:ok, _changeset} <-
+           Sources.update_source_by_user(source, %{"default_search_lql" => lqlstring}) do
       conn
       |> put_flash(:info, "Source updated!")
       |> redirect(to: Routes.source_path(conn, :edit, source.id))

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -328,7 +328,7 @@ defmodule LogflareWeb.SourceController do
     schema = get_bigquery_schema(source)
 
     with {:ok, _lql_rules} <- Lql.Parser.parse(lqlstring, schema),
-         {:ok, _changeset} <- Sources.update_source_by_user(source, params) do
+         {:ok, _changeset} <- Sources.update_source_by_user(source, %{"default_search_lql" => lqlstring}) do
       conn
       |> put_flash(:info, "Source updated!")
       |> redirect(to: Routes.source_path(conn, :edit, source.id))

--- a/lib/logflare_web/controllers/source_controller.ex
+++ b/lib/logflare_web/controllers/source_controller.ex
@@ -322,6 +322,48 @@ defmodule LogflareWeb.SourceController do
   end
 
   def update(
+        %{assigns: %{source: source, user: _user, plan: _plan}} = conn,
+        %{"source" => %{"default_search_lql" => lqlstring} = params}
+      ) do
+    schema = get_bigquery_schema(source)
+
+    with {:ok, _lql_rules} <- Lql.Parser.parse(lqlstring, schema),
+         {:ok, _changeset} <- Sources.update_source_by_user(source, params) do
+      conn
+      |> put_flash(:info, "Source updated!")
+      |> redirect(to: Routes.source_path(conn, :edit, source.id))
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(406)
+        |> put_flash(:error, "Something went wrong!")
+        |> render(
+          "edit.html",
+          changeset: changeset,
+          source: source,
+          notifications_opts: notifications_options()
+        )
+
+      {:error, :field_not_found, _suggested_querystring, error} ->
+        conn
+        |> put_flash(:error, error)
+        |> redirect(to: Routes.source_path(conn, :edit, source.id))
+
+      {:error, error} when is_binary(error) ->
+        conn
+        |> put_flash(:error, "Default search LQL: #{error}")
+        |> redirect(to: Routes.source_path(conn, :edit, source.id))
+
+      e ->
+        Logger.error("Error updating default search LQL.", error_string: inspect(e))
+
+        conn
+        |> put_flash(:error, "Something else went wrong. Contact support if this continues.")
+        |> redirect(to: Routes.source_path(conn, :edit, source.id))
+    end
+  end
+
+  def update(
         %{assigns: %{source: source, user: _user, plan: plan}} = conn,
         %{"source" => %{"notifications_every" => _freq} = params}
       ) do

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -102,7 +102,7 @@ defmodule LogflareWeb.Source.SearchLV do
       uri: nil,
       lql_rules: [],
       saved_searches: saved_searches(source),
-      querystring: Map.get(params, "querystring", @default_qs),
+      querystring: querystring_param_or_default(params, source, flat_map),
       force_query: Map.get(params, "force", "false") == "true"
     )
     |> maybe_assign_user_timezone(team_user, user)
@@ -113,6 +113,14 @@ defmodule LogflareWeb.Source.SearchLV do
     params = Map.put(params, "t", socket.assigns.team.id)
 
     mount_with_source(socket, source, params, effective_user)
+  end
+
+  defp querystring_param_or_default(params, source, schema_flatmap) do
+    qs = params |> Map.get("querystring", @default_qs)
+
+    source
+    |> append_default_search_lql(qs)
+    |> normalize_querystring(schema_flatmap)
   end
 
   defp maybe_assign_user_timezone(socket, team_user, user) do
@@ -156,8 +164,10 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, push_patch(socket, to: path, replace: true)}
   end
 
-  def handle_params(%{"querystring" => qs} = params, uri, socket) do
+  def handle_params(%{"querystring" => _qs} = params, uri, socket) do
     source = socket.assigns.source
+    qs = querystring_param_or_default(params, source, socket.assigns.source_schema_flat_map)
+    params = %{params | "querystring" => qs}
 
     tailing? = Map.get(params, "tailing?", "true") != "false" and socket.assigns.tailing?
 
@@ -227,7 +237,12 @@ defmodule LogflareWeb.Source.SearchLV do
   end
 
   def handle_params(%{"source_id" => source}, uri, socket) do
-    params = %{"source_id" => source, "querystring" => "", "tailing?" => "true"}
+    params = %{
+      "source_id" => source,
+      "querystring" => socket.assigns.querystring,
+      "tailing?" => "true"
+    }
+
     handle_params(params, uri, socket)
   end
 
@@ -1058,6 +1073,23 @@ defmodule LogflareWeb.Source.SearchLV do
       })
 
     {:noreply, socket}
+  end
+
+  defp append_default_search_lql(source, qs) do
+    "#{qs} #{source.default_search_lql}"
+    |> String.trim()
+  end
+
+  defp normalize_querystring(qs, schema_flatmap) do
+    case Lql.decode(qs, schema_flatmap) do
+      {:ok, lql_rules} ->
+        lql_rules
+        |> Rules.normalize_all_rules()
+        |> Lql.encode!()
+
+      _error ->
+        qs
+    end
   end
 
   defp check_suggested_keys(_lql_rules, _source, %{assigns: %{force_query: true}} = socket),

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -35,7 +35,6 @@ defmodule LogflareWeb.Source.SearchLV do
 
   @tail_search_interval 1000
   @user_idle_interval :timer.minutes(2)
-  @default_qs "c:count(*) c:group_by(t::minute)"
 
   on_mount LogflareWeb.AuthLive
 
@@ -102,7 +101,6 @@ defmodule LogflareWeb.Source.SearchLV do
       uri: nil,
       lql_rules: [],
       saved_searches: saved_searches(source),
-      querystring: querystring_param_or_default(params, source, flat_map),
       force_query: Map.get(params, "force", "false") == "true"
     )
     |> maybe_assign_user_timezone(team_user, user)
@@ -113,14 +111,6 @@ defmodule LogflareWeb.Source.SearchLV do
     params = Map.put(params, "t", socket.assigns.team.id)
 
     mount_with_source(socket, source, params, effective_user)
-  end
-
-  defp querystring_param_or_default(params, source, schema_flatmap) do
-    qs = params |> Map.get("querystring", @default_qs)
-
-    source
-    |> append_default_search_lql(qs)
-    |> normalize_querystring(schema_flatmap)
   end
 
   defp maybe_assign_user_timezone(socket, team_user, user) do
@@ -164,10 +154,10 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, push_patch(socket, to: path, replace: true)}
   end
 
-  def handle_params(%{"querystring" => _qs} = params, uri, socket) do
+  def handle_params(%{"querystring" => qs} = params, uri, socket) do
     source = socket.assigns.source
-    qs = querystring_param_or_default(params, source, socket.assigns.source_schema_flat_map)
-    params = %{params | "querystring" => qs}
+
+    qs = querystring_or_default(qs, source)
 
     tailing? = Map.get(params, "tailing?", "true") != "false" and socket.assigns.tailing?
 
@@ -177,6 +167,7 @@ defmodule LogflareWeb.Source.SearchLV do
       |> assign(:tailing?, tailing?)
       |> assign(uri: URI.parse(uri))
       |> assign(uri_params: params)
+      |> assign(querystring: qs)
 
     socket =
       if team_user = socket.assigns[:team_user],
@@ -237,19 +228,8 @@ defmodule LogflareWeb.Source.SearchLV do
   end
 
   def handle_params(%{"source_id" => source}, uri, socket) do
-    params = %{
-      "source_id" => source,
-      "querystring" => socket.assigns.querystring,
-      "tailing?" => "true"
-    }
-
+    params = %{"source_id" => source, "querystring" => "", "tailing?" => "true"}
     handle_params(params, uri, socket)
-  end
-
-  def handle_params(_params, _uri, socket) do
-    source = socket.assigns.source
-    socket = assign(socket, :page_title, source.name)
-    {:noreply, socket}
   end
 
   def render(assigns) do
@@ -1075,23 +1055,6 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, socket}
   end
 
-  defp append_default_search_lql(source, qs) do
-    "#{qs} #{source.default_search_lql}"
-    |> String.trim()
-  end
-
-  defp normalize_querystring(qs, schema_flatmap) do
-    case Lql.decode(qs, schema_flatmap) do
-      {:ok, lql_rules} ->
-        lql_rules
-        |> Rules.normalize_all_rules()
-        |> Lql.encode!()
-
-      _error ->
-        qs
-    end
-  end
-
   defp check_suggested_keys(_lql_rules, _source, %{assigns: %{force_query: true}} = socket),
     do: {:ok, socket}
 
@@ -1195,6 +1158,10 @@ defmodule LogflareWeb.Source.SearchLV do
       class: "tw-block tw-pt-3"
     )
   end
+
+  @spec querystring_or_default(String.t(), Logflare.Sources.Source.t()) :: String.t()
+  defp querystring_or_default("", source), do: source.default_search_lql || ""
+  defp querystring_or_default(qs, _source), do: qs
 
   @spec lql_schema_flat_map(Logflare.Sources.Source.t()) :: map()
   defp lql_schema_flat_map(source) do

--- a/lib/logflare_web/templates/source/edit.html.eex
+++ b/lib/logflare_web/templates/source/edit.html.eex
@@ -334,6 +334,19 @@
     <%= submit "Save", class: "btn btn-primary form-button" %>
   <% end %>
 
+  <%= section_header("Default Search LQL") %>
+  <p>Set LQL to be included in the initial search query for this source.</p>
+  <%= form_for @changeset, Routes.source_path(@conn, :update, @source),fn f -> %>
+    <div class="form-group">
+      <%= text_input f, :default_search_lql, class: "form-control form-control-margin" %>
+      <%= error_tag f, :default_search_lql %>
+      <small class="form-text text-muted">
+        For example: <code>s:m.parsed.parsed s:m.level</code>.
+      </small>
+    </div>
+    <%= submit "Save", class: "btn btn-primary form-button" %>
+  <% end %>
+
 
   <%= if @user.system_monitoring do %>
     <%= section_header("Monitoring Labels") %>

--- a/lib/logflare_web/templates/source/show.html.heex
+++ b/lib/logflare_web/templates/source/show.html.heex
@@ -66,6 +66,8 @@
           <LogflareWeb.SearchLive.FormComponents.recommended_field_inputs fields={Logflare.Sources.Source.recommended_query_fields(@source)} id_prefix="recent-logs-field" />
           <div class="tw-order-2 tw-basis-full tw-min-w-0 sm:tw-min-w-[20rem] sm:tw-basis-0 sm:tw-flex-1">
             {text_input(f, :querystring,
+              id: "source-search-querystring",
+              value: if(@source.default_search_lql, do: @source.default_search_lql <> " "),
               placeholder: "404",
               class: "form-control tw-mt-0 tw-border-[#282c34] tw-text-sm tw-h-8 tw-min-h-8 tw-max-h-8 tw-py-[3px] tw-bg-[#282c34] tw-font-mono tw-text-[#c4cad6] placeholder:tw-text-[#8c92a3] focus:tw-border-[#3e4451] focus:tw-bg-[#282c34] focus:tw-text-[#c4cad6]",
               autofocus: true
@@ -110,6 +112,12 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", async () => {
+      const searchInput = document.getElementById("source-search-querystring")
+      if (searchInput && searchInput.value !== "") {
+        searchInput.focus()
+        searchInput.setSelectionRange(searchInput.value.length, searchInput.value.length)
+      }
+
       await Source.main({scrollTracker: true}, {avgEventsPerSecond: <%= @source.metrics.avg %>})
     })
 </script>

--- a/priv/repo/migrations/20260505000000_add_default_search_lql_to_sources.exs
+++ b/priv/repo/migrations/20260505000000_add_default_search_lql_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddDefaultSearchLqlToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :default_search_lql, :text
+    end
+  end
+end

--- a/test/logflare/sources/source_test.exs
+++ b/test/logflare/sources/source_test.exs
@@ -12,6 +12,17 @@ defmodule Logflare.Sources.SourceTest do
     :ok
   end
 
+  describe "default_search_lql" do
+    test "allows clearing default search LQL" do
+      source = %Source{name: "Test Source", default_search_lql: "s:m.level"}
+
+      changeset = Source.update_by_user_changeset(source, %{"default_search_lql" => ""})
+
+      assert changeset.valid?
+      assert apply_changes(changeset).default_search_lql == nil
+    end
+  end
+
   describe "Source" do
     test "generate_bq_table_id/1" do
       u = insert(:user)

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -1040,6 +1040,56 @@ defmodule LogflareWeb.SourceControllerTest do
     end
   end
 
+  describe "default_search_lql" do
+    setup [:create_plan]
+
+    setup %{conn: conn} do
+      user = insert(:user)
+      insert(:team, user: user)
+      source = insert(:source, user: user)
+      insert(:source_schema, source: source)
+
+      [conn: login_user(conn, user), user: user, source: source]
+    end
+
+    test "updates default search LQL successfully", %{conn: conn, source: source} do
+      conn =
+        patch(conn, ~p"/sources/#{source}", %{
+          "source" => %{"default_search_lql" => "s:m.level"}
+        })
+
+      assert redirected_to(conn, 302) =~ ~p"/sources/#{source}/edit"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Source updated!"
+      assert Repo.reload(source).default_search_lql == "s:m.level"
+    end
+
+    test "allows clearing default search LQL", %{conn: conn, user: user} do
+      source = insert(:source, user: user, default_search_lql: "s:m.level")
+
+      conn =
+        patch(conn, ~p"/sources/#{source}", %{
+          "source" => %{"default_search_lql" => ""}
+        })
+
+      assert redirected_to(conn, 302) =~ ~p"/sources/#{source}/edit"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Source updated!"
+      assert Repo.reload(source).default_search_lql == nil
+    end
+
+    test "shows error for unknown field in default search LQL", %{conn: conn, source: source} do
+      conn =
+        patch(conn, ~p"/sources/#{source}", %{
+          "source" => %{"default_search_lql" => "nonexistent_field:value"}
+        })
+
+      assert redirected_to(conn, 302) =~ ~p"/sources/#{source}/edit"
+
+      [flash | _] = Phoenix.Flash.get(conn.assigns.flash, :error)
+
+      assert flash =~ "LQL parser error: path `nonexistent_field`"
+    end
+  end
+
   describe "create with session params" do
     setup [:create_plan]
 

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -145,6 +145,18 @@ defmodule LogflareWeb.SourceControllerTest do
       |> assert_has("button > span", text: "Search", exact: true)
     end
 
+    test "show source uses default search LQL as search input value", %{conn: conn, user: user} do
+      source = insert(:source, user: user, default_search_lql: "level:error")
+
+      html =
+        conn
+        |> get(~p"/sources/#{source}")
+        |> html_response(200)
+
+      assert html =~ ~s|id="source-search-querystring"|
+      assert html =~ ~s|value="level:error "|
+    end
+
     test "show source's recent logs", %{conn: conn, source: source} do
       start_supervised!({SourceSup, source})
       le = build(:log_event, level: "debug", source: source)
@@ -1061,19 +1073,6 @@ defmodule LogflareWeb.SourceControllerTest do
       assert redirected_to(conn, 302) =~ ~p"/sources/#{source}/edit"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Source updated!"
       assert Repo.reload(source).default_search_lql == "s:m.level"
-    end
-
-    test "allows clearing default search LQL", %{conn: conn, user: user} do
-      source = insert(:source, user: user, default_search_lql: "s:m.level")
-
-      conn =
-        patch(conn, ~p"/sources/#{source}", %{
-          "source" => %{"default_search_lql" => ""}
-        })
-
-      assert redirected_to(conn, 302) =~ ~p"/sources/#{source}/edit"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Source updated!"
-      assert Repo.reload(source).default_search_lql == nil
     end
 
     test "shows error for unknown field in default search LQL", %{conn: conn, source: source} do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -328,9 +328,14 @@ defmodule LogflareWeb.Source.SearchLVTest do
   end
 
   describe "search tasks" do
-    setup do
+    setup context do
       user = insert(:user)
-      source = insert(:source, user: user, bigquery_clustering_fields: "user_id")
+
+      source_attrs =
+        [user: user, bigquery_clustering_fields: "user_id"]
+        |> Keyword.merge(Map.get(context, :source_attrs, []))
+
+      source = insert(:source, source_attrs)
       plan = insert(:plan)
 
       bq_schema = TestUtils.build_bq_schema(%{"user_id" => "some_value"})
@@ -496,6 +501,61 @@ defmodule LogflareWeb.Source.SearchLVTest do
       querystring = find_querystring(html)
 
       assert querystring =~ "c:count(*) c:group_by(t::minute)"
+    end
+
+    @tag source_attrs: [default_search_lql: "s:m.level"]
+    test "appends source default LQL to the initial search query", %{
+      conn: conn,
+      source: source
+    } do
+      {:ok, view, html} = live(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      querystring = find_querystring(html)
+
+      assert querystring =~ "s:m.level"
+      assert querystring =~ "c:count(*) c:group_by(t::minute)"
+    end
+
+    @tag source_attrs: [default_search_lql: "s:m.level"]
+    test "appends source default LQL to an initial querystring param", %{
+      conn: conn,
+      source: source
+    } do
+      {:ok, view, html} =
+        live(conn, Routes.live_path(conn, SearchLV, source.id, querystring: "error"))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      querystring = find_querystring(html)
+
+      assert querystring =~ "error"
+      assert querystring =~ "s:m.level"
+    end
+
+    @tag source_attrs: [default_search_lql: "s:m.level"]
+    test "preserves source default LQL when starting a new search", %{
+      conn: conn,
+      source: source
+    } do
+      {:ok, view, html} =
+        live(conn, Routes.live_path(conn, SearchLV, source.id, querystring: "error"))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      assert find_querystring(html) =~ "s:m.level"
+
+      render_change(view, :start_search, %{
+        "querystring" => "c:count(*) c:group_by(t::minute) error s:m.level"
+      })
+
+      html = render(view)
+      assert find_querystring(html) =~ "s:m.level"
+      assert find_querystring(html) =~ "error"
     end
 
     test "query field has schema fields and saved searches", %{

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -504,7 +504,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
     end
 
     @tag source_attrs: [default_search_lql: "s:m.level"]
-    test "appends source default LQL to the initial search query", %{
+    test "appends source default LQL when querystring param is absent", %{
       conn: conn,
       source: source
     } do
@@ -520,10 +520,21 @@ defmodule LogflareWeb.Source.SearchLVTest do
     end
 
     @tag source_attrs: [default_search_lql: "s:m.level"]
-    test "appends source default LQL to an initial querystring param", %{
-      conn: conn,
-      source: source
-    } do
+    test "appends source default LQL to an empty querystring", %{conn: conn, source: source} do
+      {:ok, view, html} =
+        live(conn, Routes.live_path(conn, SearchLV, source.id, querystring: ""))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      querystring = find_querystring(html)
+
+      assert querystring =~ "s:m.level"
+      assert querystring =~ "c:count(*) c:group_by(t::minute)"
+    end
+
+    @tag source_attrs: [default_search_lql: "s:m.level"]
+    test "does not append default LQL to querystring param", %{conn: conn, source: source} do
       {:ok, view, html} =
         live(conn, Routes.live_path(conn, SearchLV, source.id, querystring: "error"))
 
@@ -533,16 +544,12 @@ defmodule LogflareWeb.Source.SearchLVTest do
       querystring = find_querystring(html)
 
       assert querystring =~ "error"
-      assert querystring =~ "s:m.level"
+      refute querystring =~ "s:m.level"
     end
 
     @tag source_attrs: [default_search_lql: "s:m.level"]
-    test "preserves source default LQL when starting a new search", %{
-      conn: conn,
-      source: source
-    } do
-      {:ok, view, html} =
-        live(conn, Routes.live_path(conn, SearchLV, source.id, querystring: "error"))
+    test "does not append default LQL when removed from query", %{conn: conn, source: source} do
+      {:ok, view, html} = live(conn, Routes.live_path(conn, SearchLV, source.id))
 
       %{executor_pid: search_executor_pid} = get_view_assigns(view)
       allow_sandbox(search_executor_pid)
@@ -550,11 +557,11 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert find_querystring(html) =~ "s:m.level"
 
       render_change(view, :start_search, %{
-        "querystring" => "c:count(*) c:group_by(t::minute) error s:m.level"
+        "querystring" => "c:count(*) c:group_by(t::minute) error"
       })
 
       html = render(view)
-      assert find_querystring(html) =~ "s:m.level"
+      refute find_querystring(html) =~ "s:m.level"
       assert find_querystring(html) =~ "error"
     end
 


### PR DESCRIPTION
Adds a default LQL query setting for sources. This LQL query is appended to any new source search.

* default LQL query can be set per source.
* any valid LQL expression can be set. 
* when starting a search the default LQL query will be appended
* editing the query for an existing search will not append the default LQL, allowing the user to remove it.


### Questions

1. Currently all LQL rules (select, filter, etc) are supported. Is this correct?
2. The LQL parser only removes duplicate select rules. Do we need to handle other depublication?
3. Should the source default LQL field be available to mange through the source API? 
 


Follows on from #3432 

Closes O11Y-740


<img width="2776" height="1190" alt="CleanShot 2026-05-06 at 09 09 53@2x" src="https://github.com/user-attachments/assets/660be204-55e7-466e-a24a-e9bd97d21563" />

## Demo


https://github.com/user-attachments/assets/b0f463eb-ef07-44b7-9beb-46ded56ebdf2

