### PR TITLE
chore: remove useless observer metrics

### DIFF
--- a/lib/logflare/system_metrics/observer.ex
+++ b/lib/logflare/system_metrics/observer.ex
@@ -26,9 +26,6 @@ defmodule Logflare.SystemMetrics.Observer do
       io_output: output,
       logical_processors: to_integer(:erlang.system_info(:logical_processors)),
       logical_processors_online: to_integer(:erlang.system_info(:logical_processors_online)),
-      logical_processors_available:
-        to_integer(:erlang.system_info(:logical_processors_available)),
-      schedulers: :erlang.system_info(:schedulers),
       schedulers_online: :erlang.system_info(:schedulers_online),
       otp_release: :erlang.system_info(:otp_release) |> List.to_integer(),
       atom_limit: :erlang.system_info(:atom_limit),

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -113,8 +113,6 @@ defmodule Logflare.Telemetry do
       last_value("logflare.system.observer.metrics.io_output", unit: {:byte, :kilobyte}),
       last_value("logflare.system.observer.metrics.logical_processors"),
       last_value("logflare.system.observer.metrics.logical_processors_online"),
-      last_value("logflare.system.observer.metrics.logical_processors_available"),
-      last_value("logflare.system.observer.metrics.schedulers"),
       last_value("logflare.system.observer.metrics.schedulers_online"),
       last_value("logflare.system.observer.metrics.otp_release"),
       last_value("logflare.system.observer.metrics.atom_limit"),

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -87,7 +87,6 @@ defmodule Logflare.TelemetryTest do
              :io_input,
              :io_output,
              :logical_processors,
-             :logical_processors_available,
              :logical_processors_online,
              :otp_release,
              :port_count,
@@ -95,7 +94,6 @@ defmodule Logflare.TelemetryTest do
              :process_count,
              :process_limit,
              :run_queue,
-             :schedulers,
              :schedulers_online,
              :total_active_tasks,
              :uptime


### PR DESCRIPTION
## Summary

- Drop two BEAM telemetry measurements from `Logflare.SystemMetrics.Observer` and the corresponding registrations in `Logflare.Telemetry`:
  - `logical_processors_available` — returns `:unknown` on most containerized hosts (cgroup CPU affinity isn't visible to the BEAM), where the existing `to_integer/1` helper coerces it to `0`. The metric is actively misleading in that environment rather than informative.
  - `schedulers` — the configured normal scheduler count, set by the VM's `+S` flag at startup and never mutated afterwards. A flat-line time series with no diagnostic value.
- The `_online` siblings (`logical_processors_online`, `schedulers_online`) remain and cover the operationally interesting signals.

## Test plan

- [x] `mix test test/logflare/telemetry_test.exs` — 8/8 pass; assertion
  of the expected emitted keys is updated alongside.
- [x] `mix test` on telemetry-adjacent files
  (`system_metrics/cluster_test.exs`, `opentelemetry_test.exs`,
  `open_telemetry_sampler_test.exs`) — 21/21 pass.
- [x] CI green.