### PR TITLE
test: stabilize and instrument Supabase E2E logs.spec.ts

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -107,6 +107,10 @@ jobs:
           docker logs --timestamps "$c" > "container-logs/${c}.log" 2>&1 || true
         done
 
+    - name: Generate failure summary
+      if: failure()
+      run: bash ./ci-failure-summary.sh >> "$GITHUB_STEP_SUMMARY"
+
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -101,6 +101,6 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: playwright-report
-        path: playwright-report/
+        name: playwright-report-${{ matrix.browsers.project }}
+        path: test/e2e/supabase/playwright-report/
         retention-days: 30

--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -98,9 +98,25 @@ jobs:
     - name: Run Playwright tests (only ${{ matrix.browsers.name }})
       run: npx playwright test --project ${{ matrix.browsers.project }}
 
+    - name: Capture container logs
+      if: failure()
+      run: |
+        mkdir -p container-logs
+        docker ps -a --format '{{.Names}}\t{{.Image}}\t{{.Status}}' > container-logs/_containers.txt
+        for c in $(docker ps -a --format '{{.Names}}'); do
+          docker logs --timestamps "$c" > "container-logs/${c}.log" 2>&1 || true
+        done
+
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
         name: playwright-report-${{ matrix.browsers.project }}
         path: test/e2e/supabase/playwright-report/
+        retention-days: 30
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: container-logs-${{ matrix.browsers.project }}
+        path: test/e2e/supabase/container-logs/
         retention-days: 30

--- a/scripts/debug-flaky-action.sh
+++ b/scripts/debug-flaky-action.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+#
+# Debug flaky GitHub Actions runs by repeatedly rerunning a workflow run
+# until it fails (repro mode) or until a sample size is reached
+# (sample mode), then surfacing artifacts and a desktop notification.
+#
+# Two modes:
+#
+#   repro  (default) — rerun until any matching job fails, then stop.
+#                      Downloads run artifacts to ARTIFACT_ROOT/attempt-<N>.
+#   sample           — rerun N times regardless of outcome, report pass/fail
+#                      counts at the end. Useful for quantifying flake rate.
+#
+# Requires: gh (authenticated), jq.
+#
+# Usage:
+#   scripts/debug-flaky-action.sh [run-id] [options]
+#
+# Examples:
+#   # Loop the most recent run on the current branch, stop on any failure
+#   scripts/debug-flaky-action.sh
+#
+#   # Loop a specific run, only counting failures whose job name matches "Playwright"
+#   scripts/debug-flaky-action.sh 25466632470 --job-pattern Playwright
+#
+#   # Quantify flake rate across 30 attempts (don't stop on failure)
+#   scripts/debug-flaky-action.sh --mode sample --cap 30
+#
+# Flags:
+#   --cap N             Max attempts (default 10)
+#   --poll-interval S   Seconds between polls of in-progress runs (default 30)
+#   --job-pattern STR   Substring to match job names (default: any job)
+#   --mode MODE         repro | sample (default: repro)
+#   --artifact-root DIR Where to download artifacts (default $TMPDIR/repro-artifacts)
+#   --no-notify         Disable desktop notifications (terminal bell still rings)
+#   -h | --help         This help text
+
+set -euo pipefail
+
+# ---------- argument parsing ----------
+
+CAP=10
+POLL_INTERVAL=30
+JOB_PATTERN=""
+MODE="repro"
+ARTIFACT_ROOT="${TMPDIR:-/tmp}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT%/}/repro-artifacts"
+NOTIFY=1
+RUN_ID=""
+
+print_help() {
+  # Print the leading comment block (everything from "Debug flaky" until the
+  # first non-comment line) with the leading "# " stripped.
+  awk '/^# Debug flaky/{p=1} p{if(!/^#/) exit; sub(/^# ?/, ""); print}' "$0"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cap) CAP="$2"; shift 2 ;;
+    --poll-interval) POLL_INTERVAL="$2"; shift 2 ;;
+    --job-pattern) JOB_PATTERN="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --artifact-root) ARTIFACT_ROOT="$2"; shift 2 ;;
+    --no-notify) NOTIFY=0; shift ;;
+    -h|--help) print_help; exit 0 ;;
+    --) shift; break ;;
+    -*)
+      echo "Unknown flag: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 2
+      ;;
+    *)
+      if [ -z "$RUN_ID" ]; then
+        RUN_ID="$1"
+      else
+        echo "Unexpected positional arg: $1" >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+case "$MODE" in
+  repro|sample) ;;
+  *) echo "Invalid --mode: $MODE (expected repro|sample)" >&2; exit 2 ;;
+esac
+
+# ---------- dependency checks ----------
+
+for tool in gh jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Missing required tool: $tool" >&2
+    exit 1
+  fi
+done
+
+# ---------- auto-detect run id ----------
+
+if [ -z "$RUN_ID" ]; then
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ -z "$branch" ]; then
+    echo "Could not determine current branch and no run-id provided." >&2
+    exit 1
+  fi
+  RUN_ID=$(gh run list --branch "$branch" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+  if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+    echo "No runs found for branch '$branch'. Push a commit or pass a run id." >&2
+    exit 1
+  fi
+fi
+
+# ---------- helpers ----------
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+notify() {
+  local title="$1"
+  local message="$2"
+  printf '\a'
+  [ "$NOTIFY" = "0" ] && return
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"$message\" with title \"$title\"" >/dev/null 2>&1 || true
+  elif command -v notify-send >/dev/null 2>&1; then
+    notify-send "$title" "$message" >/dev/null 2>&1 || true
+  fi
+}
+
+fetch_jobs() {
+  gh run view "$RUN_ID" --json jobs -q '[.jobs[] | {name, status, conclusion}]'
+}
+
+# Returns: "running", "passed", "failed"
+# When --job-pattern is set, only failures from matching jobs count as "failed".
+# Non-matching failures (e.g., unrelated infrastructure jobs) are treated as "passed"
+# for the purpose of the loop's stop condition.
+classify() {
+  local jobs="$1"
+  local pattern="$2"
+  local n_in_progress n_failed
+  n_in_progress=$(printf '%s' "$jobs" | jq '[.[] | select(.status != "completed")] | length')
+  if [ "$n_in_progress" -gt 0 ]; then
+    echo "running"
+    return
+  fi
+  if [ -n "$pattern" ]; then
+    n_failed=$(printf '%s' "$jobs" | jq --arg p "$pattern" '[.[] | select(.conclusion == "failure" and (.name | contains($p)))] | length')
+  else
+    n_failed=$(printf '%s' "$jobs" | jq '[.[] | select(.conclusion == "failure")] | length')
+  fi
+  if [ "$n_failed" -gt 0 ]; then
+    echo "failed"
+  else
+    echo "passed"
+  fi
+}
+
+summarize() {
+  printf '%s' "$1" | jq -r '[.[] | "\(.name)=\(.conclusion // .status)"] | join(" | ")'
+}
+
+fmt_elapsed() { local s="$1"; printf '%d:%02d' "$((s / 60))" "$((s % 60))"; }
+
+# ---------- main loop ----------
+
+log "==== debug-flaky-action ===="
+log "  RUN_ID=$RUN_ID  CAP=$CAP  MODE=$MODE  POLL_INTERVAL=${POLL_INTERVAL}s"
+log "  JOB_PATTERN='${JOB_PATTERN:-<any>}'  ARTIFACT_ROOT=$ARTIFACT_ROOT"
+
+PASS=0
+FAIL=0
+N=1
+
+while [ "$N" -le "$CAP" ]; do
+  ATTEMPT_START=$(date +%s)
+  POLL_COUNT=0
+  log "---- attempt $N/$CAP — polling run $RUN_ID ----"
+
+  while true; do
+    POLL_COUNT=$((POLL_COUNT + 1))
+    if ! JOBS=$(fetch_jobs 2>&1); then
+      log "  poll #$POLL_COUNT — gh fetch FAILED:"
+      printf '%s\n' "$JOBS" | sed 's/^/    /'
+      log "  retrying after ${POLL_INTERVAL}s"
+      sleep "$POLL_INTERVAL"
+      continue
+    fi
+    ELAPSED=$(fmt_elapsed $(($(date +%s) - ATTEMPT_START)))
+    STATE=$(classify "$JOBS" "$JOB_PATTERN")
+    log "  poll #$POLL_COUNT [elapsed $ELAPSED] state=$STATE  $(summarize "$JOBS")"
+
+    case "$STATE" in
+      running)
+        sleep "$POLL_INTERVAL"
+        ;;
+      passed)
+        PASS=$((PASS + 1))
+        log "attempt $N PASSED ($ELAPSED, $POLL_COUNT polls)"
+        break
+        ;;
+      failed)
+        FAIL=$((FAIL + 1))
+        log "attempt $N FAILED ($ELAPSED, $POLL_COUNT polls)"
+        printf '%s' "$JOBS" | jq -r '.[] | select(.conclusion == "failure") | "  \(.name): \(.conclusion)"'
+        DEST="$ARTIFACT_ROOT/attempt-$N"
+        mkdir -p "$DEST"
+        log "downloading artifacts to $DEST"
+        if gh run download "$RUN_ID" --dir "$DEST" 2>/dev/null; then
+          file_count=$(find "$DEST" -type f | wc -l | tr -d ' ')
+          log "downloaded $file_count files"
+        else
+          log "no artifacts available or download failed"
+        fi
+        if [ "$MODE" = "repro" ]; then
+          notify "CI Flake Repro" "Failure on attempt $N — artifacts at $DEST"
+          log "==== repro mode: stopping on first failure ===="
+          exit 0
+        fi
+        break
+        ;;
+    esac
+  done
+
+  if [ "$N" -ge "$CAP" ]; then
+    break
+  fi
+
+  N=$((N + 1))
+  log "triggering rerun → attempt $N/$CAP"
+  if ! gh run rerun "$RUN_ID" 2>&1; then
+    log "gh run rerun failed — exiting"
+    exit 1
+  fi
+  sleep 30  # let the rerun register before polling
+done
+
+# ---------- summary ----------
+
+TOTAL=$((PASS + FAIL))
+log "==== final: $PASS passed, $FAIL failed of $TOTAL ===="
+if [ "$MODE" = "sample" ] && [ "$TOTAL" -gt 0 ]; then
+  rate=$(awk "BEGIN { printf \"%.1f\", ($FAIL / $TOTAL) * 100 }")
+  log "flake rate: ${rate}%"
+fi
+notify "CI Flake Repro" "Done: $PASS passed, $FAIL failed of $TOTAL"

--- a/test/e2e/supabase/ci-failure-summary.sh
+++ b/test/e2e/supabase/ci-failure-summary.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Emit a Markdown failure summary suitable for $GITHUB_STEP_SUMMARY.
+#
+# Reads test-results/results.json (Playwright json reporter output) and
+# prints, for each failed test:
+#   - test title, file:line, classification
+#   - the error message (collapsed)
+#   - for `polling timeout` failures, the last N lines of the relevant
+#     container logs from container-logs/<container>.log (also collapsed)
+#
+# Inputs (env / cwd):
+#   - working dir must contain test-results/results.json (Playwright output)
+#   - container-logs/ optional; populated by the workflow's "Capture
+#     container logs" step on failure
+#
+# Output:
+#   - Markdown to stdout. The workflow redirects this to $GITHUB_STEP_SUMMARY.
+
+set -uo pipefail
+
+RESULTS_JSON="test-results/results.json"
+LOGS_DIR="container-logs"
+LOG_TAIL_LINES=50
+
+if [ ! -f "$RESULTS_JSON" ]; then
+  echo "## Test run summary"
+  echo
+  echo "_No \`results.json\` produced — Playwright did not finish writing reports._"
+  exit 0
+fi
+
+# Recursively walk suites/specs, emit one JSON object per failed result.
+mapfile -t failures < <(jq -c '
+  [ .. | objects | select(has("specs"))
+    | .specs[]
+    | { file, line, title } as $loc
+    | .tests[]?
+    | .results[]?
+    | select(.status == "failed")
+    | $loc + { error: (.error.message // "") }
+  ]
+  | unique_by(.file + "|" + (.line|tostring) + "|" + .title)
+  | .[]
+' "$RESULTS_JSON")
+
+echo "## Test failures (${#failures[@]})"
+echo
+
+if [ "${#failures[@]}" -eq 0 ]; then
+  echo "_Job failed but no individual test failures were recorded — likely a setup/install error before tests ran._"
+  exit 0
+fi
+
+# Strip ANSI escapes (Playwright includes color codes in error.message).
+strip_ansi() { sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g'; }
+
+classify() {
+  local err="$1"
+  if [[ "$err" == *"waitForLogs("*"timed out"* ]]; then
+    local table
+    table=$(printf '%s\n' "$err" | sed -nE 's/.*waitForLogs\(([a-z_]+),.*/\1/p' | head -1)
+    echo "polling timeout (\`$table\`)"
+  elif [[ "$err" == *"toContainText"* ]] && [[ "$err" == *"Timeout"* ]]; then
+    echo "assertion race"
+  elif [[ "$err" == *"failed:"* ]] || [[ "$err" == *"throw"* ]]; then
+    echo "setup error"
+  else
+    echo "other"
+  fi
+}
+
+# Map a logs table name to substrings of the container names whose logs are
+# most likely to explain a polling timeout.
+table_to_containers() {
+  case "$1" in
+    storage_logs)   echo "storage vector" ;;
+    postgrest_logs) echo "rest vector" ;;
+    realtime_logs)  echo "realtime vector" ;;
+    edge_logs)      echo "edge-functions vector kong" ;;
+    auth_logs)      echo "auth vector" ;;
+    *)              echo "vector" ;;
+  esac
+}
+
+extract_table() {
+  printf '%s\n' "$1" | sed -nE 's/.*polling timeout \(`([a-z_]+)`\).*/\1/p'
+}
+
+for f in "${failures[@]}"; do
+  title=$(printf '%s' "$f" | jq -r '.title')
+  file=$(printf '%s' "$f" | jq -r '.file')
+  line=$(printf '%s' "$f" | jq -r '.line // "?"')
+  error=$(printf '%s' "$f" | jq -r '.error' | strip_ansi)
+  classification=$(classify "$error")
+
+  echo "### $title"
+  echo
+  echo "**Location**: \`$file:$line\`  "
+  echo "**Classification**: $classification"
+  echo
+  echo "<details><summary>Error</summary>"
+  echo
+  echo '```'
+  printf '%s\n' "$error" | head -40
+  echo '```'
+  echo
+  echo "</details>"
+  echo
+
+  if [[ "$classification" == polling\ timeout* ]]; then
+    table=$(extract_table "$classification")
+    if [ -n "$table" ] && [ -d "$LOGS_DIR" ]; then
+      echo "#### Container log tails (last $LOG_TAIL_LINES lines)"
+      echo
+      for pattern in $(table_to_containers "$table"); do
+        for log in "$LOGS_DIR"/*"$pattern"*.log; do
+          [ -f "$log" ] || continue
+          name=$(basename "$log")
+          echo "<details><summary><code>$name</code></summary>"
+          echo
+          echo '```'
+          tail -n "$LOG_TAIL_LINES" "$log"
+          echo '```'
+          echo
+          echo "</details>"
+          echo
+        done
+      done
+    fi
+  fi
+done
+
+echo "---"
+echo
+echo "Full reports are in this run's artifacts: \`playwright-report-<browser>\` and \`container-logs-<browser>\`."

--- a/test/e2e/supabase/docker-compose.e2e.yml
+++ b/test/e2e/supabase/docker-compose.e2e.yml
@@ -7,3 +7,22 @@ services:
       tags:
         - "supabase/logflare:local"
     pull_policy: never
+    # Upstream healthcheck omits curl --fail, so a 503 from /health (returned
+    # while supabase-mode seeding is still in progress) is reported as healthy.
+    # Adding --fail makes docker actually wait for the 200 from /health, which
+    # in supabase mode requires startup_tasks seeding to complete.
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:4000/health"]
+      timeout: 5s
+      interval: 5s
+      retries: 10
+
+  # Gate Vector on analytics being fully seeded. Without this, Vector starts in
+  # parallel with analytics and POSTs into the seeding window — its first POST
+  # for a not-yet-seeded source returns 401, which Vector marks as not retriable
+  # and drops the events. Combined with the analytics healthcheck fix above,
+  # this closes the race.
+  vector:
+    depends_on:
+      analytics:
+        condition: service_healthy

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -1,6 +1,40 @@
-import { test, expect, type Request } from '@playwright/test';
+import { test, expect, type APIRequestContext, type Request } from '@playwright/test';
 import { searchLogs } from '../lib/utils';
 import supabase from '../lib/supabase';
+
+// Poll the logs.all endpoint until at least one row matches `pattern` in `table`.
+// Replaces a fixed sleep that was racy when CI ingestion was slow. The endpoint
+// runs the supplied SQL through Logflare via Studio's BFF; `regexp_contains` is
+// used because `LIKE` returns 500 against this backend.
+async function waitForLogs(
+  request: APIRequestContext,
+  table: string,
+  pattern: string,
+  { timeoutMs = 90_000, intervalMs = 1_000 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<void> {
+  const sql = `select count(*) as c from ${table} where regexp_contains(event_message, '${pattern}')`;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | undefined;
+
+  while (Date.now() < deadline) {
+    const start = new Date(Date.now() - 3_600_000).toISOString();
+    const end = new Date(Date.now() + 3_600_000).toISOString();
+    const resp = await request.get('/api/platform/projects/default/analytics/endpoints/logs.all', {
+      params: { iso_timestamp_start: start, iso_timestamp_end: end, sql },
+    });
+    if (resp.ok()) {
+      const data = await resp.json().catch(() => null);
+      const count = data?.result?.[0]?.c ?? 0;
+      if (count > 0) return;
+      lastError = undefined;
+    } else {
+      lastError = `${resp.status()} ${await resp.text().catch(() => '')}`;
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  const suffix = lastError ? ` last response: ${lastError}` : '';
+  throw new Error(`waitForLogs(${table}, "${pattern}") timed out after ${timeoutMs}ms.${suffix}`);
+}
 
 let uniqueId = '';
 
@@ -136,7 +170,9 @@ test.afterEach(async ({ page }, testInfo) => {
 });
 
 test.beforeAll(async ({ request, browserName }) => {
-  test.setTimeout(60_000);
+  // The polling below can take up to ~90s in worst case; bump the hook timeout
+  // to give it headroom on top of the synchronous setup work above.
+  test.setTimeout(180_000);
 
   uniqueId = `${Date.now()}_${browserName}`;
 
@@ -171,7 +207,22 @@ test.beforeAll(async ({ request, browserName }) => {
     query: `select cron.schedule('test_cron_${uniqueId}', '5 seconds', $$SELECT auth.email()$$);`
   }});
 
-  await new Promise(r => setTimeout(r, 30_000))
+  // Wait for ingestion of THIS test's setup events, in parallel. These are
+  // uniqueId-tagged so we can confirm our specific data made it through the
+  // (Vector → Logflare → backend → searchable) path before the test bodies
+  // run their searches. Replaces a fixed 30s sleep that was racy on slow CI
+  // runners.
+  //
+  // The other pipelines (postgrest "Config reloaded", realtime "Billing
+  // metrics", edge functions /home/deno/functions/hello, cron job)
+  // emit periodically or on infra events independent of our setup; the test
+  // bodies' date-windowed searches reliably hit historical entries, so we
+  // don't need to poll those in beforeAll.
+  await Promise.all([
+    waitForLogs(request, 'edge_logs', `function_${uniqueId}`),
+    waitForLogs(request, 'auth_logs', `example_${uniqueId}`),
+    waitForLogs(request, 'storage_logs', `avatars_${uniqueId}`),
+  ]);
 });
 
 test.afterAll(async ({ request }) => {

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -1,6 +1,67 @@
 import { test, expect, type APIRequestContext, type Page, type Request, type TestInfo } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { searchLogs } from '../lib/utils';
 import supabase from '../lib/supabase';
+
+const execFileP = promisify(execFile);
+
+// Mapping from logs.all CTE alias to the underlying Logflare source name.
+// Kept in sync with priv/supabase/endpoints/logs.all.sql — the SQL there
+// aliases each `from \`<source.name>\`` block, and tests below pass those
+// aliases through waitForLogs. Only used by sampleFromPostgres.
+const SOURCE_NAME_BY_TABLE: Record<string, string> = {
+  edge_logs: 'cloudflare.logs.prod',
+  postgres_logs: 'postgres.logs',
+  function_edge_logs: 'deno-relay-logs',
+  function_logs: 'deno-subhosting-events',
+  auth_logs: 'gotrue.logs.prod',
+  realtime_logs: 'realtime.logs.prod',
+  storage_logs: 'storage.logs.prod.2',
+  postgrest_logs: 'postgREST.logs.prod',
+  pgbouncer_logs: 'pgbouncer.logs.prod',
+};
+
+// Fetch the last `limit` event_messages directly from the analytics Postgres
+// backend via `docker exec`. Bypasses Logflare's HTTP/SQL endpoint stack so
+// the diagnostic still works when those layers are themselves the failure
+// mode (e.g. logs.all returning 5xx or hanging). Best-effort — returns an
+// empty array on any error, since this only runs on the unhappy path.
+async function sampleFromPostgres(table: string, limit = 5): Promise<string[]> {
+  const sourceName = SOURCE_NAME_BY_TABLE[table];
+  const password = process.env.POSTGRES_PASSWORD;
+  if (!sourceName || !password) return [];
+
+  const psql = async (sql: string) => {
+    const { stdout } = await execFileP(
+      'docker',
+      [
+        'exec',
+        '-e', `PGPASSWORD=${password}`,
+        'supabase-db',
+        'psql', '-U', 'supabase_admin', '-d', '_supabase',
+        '-t', '-A', '-c', sql,
+      ],
+      { timeout: 5_000 },
+    );
+    return stdout;
+  };
+
+  try {
+    const tokenOut = await psql(
+      `select token from _analytics.sources where name = '${sourceName}' limit 1`,
+    );
+    const token = tokenOut.trim();
+    if (!token) return [];
+    const physicalTable = `log_events_${token.replace(/-/g, '_')}`;
+    const sampleOut = await psql(
+      `select event_message from _analytics.${physicalTable} order by timestamp desc limit ${limit}`,
+    );
+    return sampleOut.split('\n').filter(Boolean).map(l => l.slice(0, 300));
+  } catch {
+    return [];
+  }
+}
 
 // Poll the logs.all endpoint until at least one row matches `pattern` in `table`.
 // Replaces a fixed sleep that was racy when CI ingestion was slow. The endpoint
@@ -38,22 +99,13 @@ async function waitForLogs(
     await new Promise(r => setTimeout(r, intervalMs));
   }
 
-  // Timed out — fetch a sample of recent rows from the table for forensic context,
-  // and log via console.error so the diagnostic surfaces in CI logs (Playwright's
+  // Timed out — fetch a sample of recent rows directly from the analytics
+  // Postgres backend for forensic context. Going via psql (rather than the
+  // same logs.all endpoint the polling loop just exhausted) means this still
+  // surfaces useful data when the endpoint itself is the failure mode.
+  // Logged via console.error so the diagnostic surfaces in CI logs (Playwright's
   // hook failures don't fire afterEach, so testInfo.attach isn't available here).
-  let sample: string[] = [];
-  try {
-    const start = new Date(Date.now() - 3_600_000).toISOString();
-    const end = new Date(Date.now() + 3_600_000).toISOString();
-    const sampleSql = `select event_message from ${table} order by timestamp desc limit 5`;
-    const resp = await request.get('/api/platform/projects/default/analytics/endpoints/logs.all', {
-      params: { iso_timestamp_start: start, iso_timestamp_end: end, sql: sampleSql },
-    });
-    if (resp.ok()) {
-      const data = await resp.json().catch(() => null);
-      sample = (data?.result ?? []).map((r: { event_message?: string }) => (r.event_message ?? '').slice(0, 300));
-    }
-  } catch (_) { /* ignore — diagnostic only */ }
+  const sample = await sampleFromPostgres(table);
 
   const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
   const summary = [

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -184,20 +184,20 @@ test.beforeAll(async ({ request, browserName }) => {
   uniqueId = `${Date.now()}_${browserName}`;
 
   // The Supabase JS SDK returns { data, error } and never throws on HTTP
-  // failures. Surface those errors here so a failing setup call produces an
-  // informative failure instead of an opaque 180s waitForLogs timeout when the
-  // expected logs never arrive.
+  // failures. Log SDK errors as forensic context but don't fail the hook on
+  // them: some errors (e.g. auth's "Error sending confirmation email") are
+  // downstream of the request that produces the log we care about, so the
+  // waitForLogs polls below remain the source of truth on whether setup
+  // actually populated the index.
   const { error: signUpErr } = await supabase.auth.signUp({ email: `example_${uniqueId}@email.com`, password: 'example-password' })
-  if (signUpErr) throw new Error(`auth.signUp failed: ${signUpErr.message}`)
+  if (signUpErr) console.warn(`auth.signUp returned error (continuing): ${signUpErr.message}`)
 
   const { error: createBucketErr } = await supabase.storage.createBucket(`avatars_${uniqueId}`)
-  if (createBucketErr) throw new Error(`storage.createBucket failed: ${createBucketErr.message}`)
+  if (createBucketErr) console.warn(`storage.createBucket returned error (continuing): ${createBucketErr.message}`)
 
   const { error: deleteBucketErr } = await supabase.storage.deleteBucket(`avatars_${uniqueId}`)
-  if (deleteBucketErr) throw new Error(`storage.deleteBucket failed: ${deleteBucketErr.message}`)
+  if (deleteBucketErr) console.warn(`storage.deleteBucket returned error (continuing): ${deleteBucketErr.message}`)
 
-  // function_<uniqueId> doesn't exist; the test asserts on the resulting 404
-  // log line, so don't throw on its error. The 'hello' function does exist.
   await supabase.functions.invoke(`function_${uniqueId}`)
   await supabase.functions.invoke('hello')
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type APIRequestContext, type Request } from '@playwright/test';
+import { test, expect, type APIRequestContext, type Page, type Request, type TestInfo } from '@playwright/test';
 import { searchLogs } from '../lib/utils';
 import supabase from '../lib/supabase';
 
@@ -77,12 +77,11 @@ type NetworkEntry = {
   status: number;
   contentType: string;
   durationMs?: number;
-  bodyPreview?: string;
   ts: string;
 };
+type Diagnostics = { console: ConsoleEntry[]; network: NetworkEntry[] };
 
-const consoleByTest = new Map<string, ConsoleEntry[]>();
-const networkByTest = new Map<string, NetworkEntry[]>();
+const diagnosticsByTest = new Map<string, Diagnostics>();
 
 const RELEVANT_URL_PATTERNS = [
   /\/api\/platform\//,
@@ -95,100 +94,79 @@ const RELEVANT_URL_PATTERNS = [
   /\/pg-meta\//,
 ];
 const isRelevantUrl = (url: string) => RELEVANT_URL_PATTERNS.some(re => re.test(url));
-const MAX_BODY_PREVIEW = 4_000;
+
+async function captureTable(page: Page, testInfo: TestInfo, kind: 'html' | 'text') {
+  const filename = kind === 'html' ? 'table.html' : 'table.txt';
+  const contentType = kind === 'html' ? 'text/html' : 'text/plain';
+  try {
+    const locator = page.getByRole('table');
+    const body = kind === 'html'
+      ? await locator.innerHTML({ timeout: 1_000 })
+      : (await locator.textContent({ timeout: 1_000 })) ?? '';
+    await testInfo.attach(filename, { body, contentType });
+  } catch (e) {
+    await testInfo.attach(`${filename}.error.txt`, {
+      body: `Failed to capture table ${kind}: ${(e as Error).message}`,
+      contentType: 'text/plain',
+    });
+  }
+}
 
 test.beforeEach(async ({ page }, testInfo) => {
-  const messages: ConsoleEntry[] = [];
-  consoleByTest.set(testInfo.testId, messages);
+  const consoleEntries: ConsoleEntry[] = [];
+  const network: NetworkEntry[] = [];
+  diagnosticsByTest.set(testInfo.testId, { console: consoleEntries, network });
 
   page.on('console', msg => {
-    messages.push({ type: msg.type(), text: msg.text(), ts: new Date().toISOString() });
+    consoleEntries.push({ type: msg.type(), text: msg.text(), ts: new Date().toISOString() });
   });
   page.on('pageerror', err => {
-    messages.push({
+    consoleEntries.push({
       type: 'pageerror',
       text: `${err.name}: ${err.message}${err.stack ? '\n' + err.stack : ''}`,
       ts: new Date().toISOString(),
     });
   });
 
-  const network: NetworkEntry[] = [];
-  networkByTest.set(testInfo.testId, network);
   const requestStart = new WeakMap<Request, number>();
 
   page.on('request', req => {
     if (isRelevantUrl(req.url())) requestStart.set(req, Date.now());
   });
 
-  page.on('response', async resp => {
+  page.on('response', resp => {
     const url = resp.url();
     if (!isRelevantUrl(url)) return;
     const req = resp.request();
     const startedAt = requestStart.get(req);
-    const contentType = resp.headers()['content-type'] ?? '';
-
-    let bodyPreview: string | undefined;
-    if (contentType.includes('json') || contentType.includes('text')) {
-      try {
-        const body = await resp.text();
-        bodyPreview = body.length > MAX_BODY_PREVIEW
-          ? body.slice(0, MAX_BODY_PREVIEW) + `…[truncated ${body.length - MAX_BODY_PREVIEW} chars]`
-          : body;
-      } catch {
-        bodyPreview = '<unable to read body>';
-      }
-    }
 
     network.push({
       method: req.method(),
       url,
       status: resp.status(),
-      contentType,
+      contentType: resp.headers()['content-type'] ?? '',
       durationMs: startedAt ? Date.now() - startedAt : undefined,
-      bodyPreview,
       ts: new Date().toISOString(),
     });
   });
 });
 
 test.afterEach(async ({ page }, testInfo) => {
-  const messages = consoleByTest.get(testInfo.testId) ?? [];
-  const network = networkByTest.get(testInfo.testId) ?? [];
-  consoleByTest.delete(testInfo.testId);
-  networkByTest.delete(testInfo.testId);
+  const diag = diagnosticsByTest.get(testInfo.testId) ?? { console: [], network: [] };
+  diagnosticsByTest.delete(testInfo.testId);
 
   if (testInfo.status === testInfo.expectedStatus) return;
 
-  try {
-    const tableHtml = await page.getByRole('table').innerHTML({ timeout: 1_000 });
-    await testInfo.attach('table.html', { body: tableHtml, contentType: 'text/html' });
-  } catch (e) {
-    await testInfo.attach('table-error.txt', {
-      body: `Failed to capture table HTML: ${(e as Error).message}`,
-      contentType: 'text/plain',
-    });
-  }
-
-  try {
-    const tableText = await page.getByRole('table').textContent({ timeout: 1_000 });
-    await testInfo.attach('table.txt', {
-      body: tableText ?? '',
-      contentType: 'text/plain',
-    });
-  } catch (e) {
-    await testInfo.attach('table-text-error.txt', {
-      body: `Failed to capture table text: ${(e as Error).message}`,
-      contentType: 'text/plain',
-    });
-  }
+  await captureTable(page, testInfo, 'html');
+  await captureTable(page, testInfo, 'text');
 
   await testInfo.attach('browser-console.json', {
-    body: JSON.stringify(messages, null, 2),
+    body: JSON.stringify(diag.console, null, 2),
     contentType: 'application/json',
   });
 
   await testInfo.attach('network.json', {
-    body: JSON.stringify(network, null, 2),
+    body: JSON.stringify(diag.network, null, 2),
     contentType: 'application/json',
   });
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -183,11 +183,21 @@ test.beforeAll(async ({ request, browserName }) => {
 
   uniqueId = `${Date.now()}_${browserName}`;
 
-  await supabase.auth.signUp({ email: `example_${uniqueId}@email.com`, password: 'example-password' })
+  // The Supabase JS SDK returns { data, error } and never throws on HTTP
+  // failures. Surface those errors here so a failing setup call produces an
+  // informative failure instead of an opaque 180s waitForLogs timeout when the
+  // expected logs never arrive.
+  const { error: signUpErr } = await supabase.auth.signUp({ email: `example_${uniqueId}@email.com`, password: 'example-password' })
+  if (signUpErr) throw new Error(`auth.signUp failed: ${signUpErr.message}`)
 
-  await supabase.storage.createBucket(`avatars_${uniqueId}`)
-  await supabase.storage.deleteBucket(`avatars_${uniqueId}`)
+  const { error: createBucketErr } = await supabase.storage.createBucket(`avatars_${uniqueId}`)
+  if (createBucketErr) throw new Error(`storage.createBucket failed: ${createBucketErr.message}`)
 
+  const { error: deleteBucketErr } = await supabase.storage.deleteBucket(`avatars_${uniqueId}`)
+  if (deleteBucketErr) throw new Error(`storage.deleteBucket failed: ${deleteBucketErr.message}`)
+
+  // function_<uniqueId> doesn't exist; the test asserts on the resulting 404
+  // log line, so don't throw on its error. The 'hello' function does exist.
   await supabase.functions.invoke(`function_${uniqueId}`)
   await supabase.functions.invoke('hello')
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Request } from '@playwright/test';
 import { searchLogs } from '../lib/utils';
 import supabase from '../lib/supabase';
 
@@ -8,7 +8,31 @@ test.setTimeout(60_000);
 expect.configure({ timeout: 15_000 });
 
 type ConsoleEntry = { type: string; text: string; ts: string };
+type NetworkEntry = {
+  method: string;
+  url: string;
+  status: number;
+  contentType: string;
+  durationMs?: number;
+  bodyPreview?: string;
+  ts: string;
+};
+
 const consoleByTest = new Map<string, ConsoleEntry[]>();
+const networkByTest = new Map<string, NetworkEntry[]>();
+
+const RELEVANT_URL_PATTERNS = [
+  /\/api\/platform\//,
+  /\/logs\b/,
+  /\/functions\/v1\//,
+  /\/auth\/v1\//,
+  /\/storage\/v1\//,
+  /\/realtime\/v1\//,
+  /\/rest\/v1\//,
+  /\/pg-meta\//,
+];
+const isRelevantUrl = (url: string) => RELEVANT_URL_PATTERNS.some(re => re.test(url));
+const MAX_BODY_PREVIEW = 4_000;
 
 test.beforeEach(async ({ page }, testInfo) => {
   const messages: ConsoleEntry[] = [];
@@ -24,11 +48,51 @@ test.beforeEach(async ({ page }, testInfo) => {
       ts: new Date().toISOString(),
     });
   });
+
+  const network: NetworkEntry[] = [];
+  networkByTest.set(testInfo.testId, network);
+  const requestStart = new WeakMap<Request, number>();
+
+  page.on('request', req => {
+    if (isRelevantUrl(req.url())) requestStart.set(req, Date.now());
+  });
+
+  page.on('response', async resp => {
+    const url = resp.url();
+    if (!isRelevantUrl(url)) return;
+    const req = resp.request();
+    const startedAt = requestStart.get(req);
+    const contentType = resp.headers()['content-type'] ?? '';
+
+    let bodyPreview: string | undefined;
+    if (contentType.includes('json') || contentType.includes('text')) {
+      try {
+        const body = await resp.text();
+        bodyPreview = body.length > MAX_BODY_PREVIEW
+          ? body.slice(0, MAX_BODY_PREVIEW) + `…[truncated ${body.length - MAX_BODY_PREVIEW} chars]`
+          : body;
+      } catch {
+        bodyPreview = '<unable to read body>';
+      }
+    }
+
+    network.push({
+      method: req.method(),
+      url,
+      status: resp.status(),
+      contentType,
+      durationMs: startedAt ? Date.now() - startedAt : undefined,
+      bodyPreview,
+      ts: new Date().toISOString(),
+    });
+  });
 });
 
 test.afterEach(async ({ page }, testInfo) => {
   const messages = consoleByTest.get(testInfo.testId) ?? [];
+  const network = networkByTest.get(testInfo.testId) ?? [];
   consoleByTest.delete(testInfo.testId);
+  networkByTest.delete(testInfo.testId);
 
   if (testInfo.status === testInfo.expectedStatus) return;
 
@@ -42,8 +106,26 @@ test.afterEach(async ({ page }, testInfo) => {
     });
   }
 
+  try {
+    const tableText = await page.getByRole('table').textContent({ timeout: 1_000 });
+    await testInfo.attach('table.txt', {
+      body: tableText ?? '',
+      contentType: 'text/plain',
+    });
+  } catch (e) {
+    await testInfo.attach('table-text-error.txt', {
+      body: `Failed to capture table text: ${(e as Error).message}`,
+      contentType: 'text/plain',
+    });
+  }
+
   await testInfo.attach('browser-console.json', {
     body: JSON.stringify(messages, null, 2),
+    contentType: 'application/json',
+  });
+
+  await testInfo.attach('network.json', {
+    body: JSON.stringify(network, null, 2),
     contentType: 'application/json',
   });
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -69,7 +69,6 @@ async function waitForLogs(
 let uniqueId = '';
 
 test.setTimeout(60_000);
-expect.configure({ timeout: 15_000 });
 
 type ConsoleEntry = { type: string; text: string; ts: string };
 type NetworkEntry = {
@@ -237,21 +236,25 @@ test.beforeAll(async ({ request, browserName }) => {
     query: `select cron.schedule('test_cron_${uniqueId}', '5 seconds', $$SELECT auth.email()$$);`
   }});
 
-  // Wait for ingestion of THIS test's setup events, in parallel. These are
-  // uniqueId-tagged so we can confirm our specific data made it through the
-  // (Vector → Logflare → backend → searchable) path before the test bodies
+  // Wait for ingestion of test setup events in parallel before the test bodies
   // run their searches. Replaces a fixed 30s sleep that was racy on slow CI
   // runners.
   //
-  // The other pipelines (postgrest "Config reloaded", realtime "Billing
-  // metrics", edge functions /home/deno/functions/hello, cron job)
-  // emit periodically or on infra events independent of our setup; the test
-  // bodies' date-windowed searches reliably hit historical entries, so we
-  // don't need to poll those in beforeAll.
+  // - edge_logs / auth_logs / storage_logs poll for uniqueId-tagged events from
+  //   the setup above.
+  // - realtime_logs polls for "Billing", a periodic infra emission. The test
+  //   body asserts on "Billing metrics" with a 15s expect timeout, but the
+  //   emission cadence is ~1 minute, so without this wait the test races a gap
+  //   between emissions.
+  //
+  // The remaining pipelines (postgrest "Config reloaded", edge functions
+  // /home/deno/functions/hello, cron job) reliably hit historical entries via
+  // the test bodies' date-windowed searches, so we don't poll those here.
   await Promise.all([
     waitForLogs(request, 'edge_logs', `function_${uniqueId}`),
     waitForLogs(request, 'auth_logs', `example_${uniqueId}`),
     waitForLogs(request, 'storage_logs', `avatars_${uniqueId}`),
+    waitForLogs(request, 'realtime_logs', 'Billing'),
   ]);
 });
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -230,19 +230,20 @@ test.beforeAll(async ({ request, browserName }) => {
   //
   // - edge_logs / auth_logs / storage_logs poll for uniqueId-tagged events from
   //   the setup above.
-  // - realtime_logs polls for "Billing", a periodic infra emission. The test
-  //   body asserts on "Billing metrics" with a 15s expect timeout, but the
-  //   emission cadence is ~1 minute, so without this wait the test races a gap
-  //   between emissions.
+  // - realtime_logs / postgrest_logs poll for periodic infra emissions
+  //   ("Billing" and "Config reloaded"). The corresponding test bodies assert
+  //   on those strings with a 15s expect timeout, but the emissions are
+  //   sparse, so without this wait the tests race the gap between emissions.
   //
-  // The remaining pipelines (postgrest "Config reloaded", edge functions
-  // /home/deno/functions/hello, cron job) reliably hit historical entries via
-  // the test bodies' date-windowed searches, so we don't poll those here.
+  // edge functions /home/deno/functions/hello and the cron job reliably hit
+  // historical entries via the test bodies' date-windowed searches, so we
+  // don't poll those here.
   await Promise.all([
     waitForLogs(request, 'edge_logs', `function_${uniqueId}`),
     waitForLogs(request, 'auth_logs', `example_${uniqueId}`),
     waitForLogs(request, 'storage_logs', `avatars_${uniqueId}`),
     waitForLogs(request, 'realtime_logs', 'Billing'),
+    waitForLogs(request, 'postgrest_logs', 'Config reloaded'),
   ]);
 });
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -10,21 +10,26 @@ async function waitForLogs(
   request: APIRequestContext,
   table: string,
   pattern: string,
-  { timeoutMs = 90_000, intervalMs = 1_000 }: { timeoutMs?: number; intervalMs?: number } = {}
+  { timeoutMs = 180_000, intervalMs = 1_000 }: { timeoutMs?: number; intervalMs?: number } = {}
 ): Promise<void> {
-  const sql = `select count(*) as c from ${table} where regexp_contains(event_message, '${pattern}')`;
+  const countSql = `select count(*) as c from ${table} where regexp_contains(event_message, '${pattern}')`;
   const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+  let polls = 0;
+  let lastCount: number | undefined;
   let lastError: string | undefined;
 
   while (Date.now() < deadline) {
+    polls++;
     const start = new Date(Date.now() - 3_600_000).toISOString();
     const end = new Date(Date.now() + 3_600_000).toISOString();
     const resp = await request.get('/api/platform/projects/default/analytics/endpoints/logs.all', {
-      params: { iso_timestamp_start: start, iso_timestamp_end: end, sql },
+      params: { iso_timestamp_start: start, iso_timestamp_end: end, sql: countSql },
     });
     if (resp.ok()) {
       const data = await resp.json().catch(() => null);
       const count = data?.result?.[0]?.c ?? 0;
+      lastCount = count;
       if (count > 0) return;
       lastError = undefined;
     } else {
@@ -32,8 +37,33 @@ async function waitForLogs(
     }
     await new Promise(r => setTimeout(r, intervalMs));
   }
-  const suffix = lastError ? ` last response: ${lastError}` : '';
-  throw new Error(`waitForLogs(${table}, "${pattern}") timed out after ${timeoutMs}ms.${suffix}`);
+
+  // Timed out — fetch a sample of recent rows from the table for forensic context,
+  // and log via console.error so the diagnostic surfaces in CI logs (Playwright's
+  // hook failures don't fire afterEach, so testInfo.attach isn't available here).
+  let sample: string[] = [];
+  try {
+    const start = new Date(Date.now() - 3_600_000).toISOString();
+    const end = new Date(Date.now() + 3_600_000).toISOString();
+    const sampleSql = `select event_message from ${table} order by timestamp desc limit 5`;
+    const resp = await request.get('/api/platform/projects/default/analytics/endpoints/logs.all', {
+      params: { iso_timestamp_start: start, iso_timestamp_end: end, sql: sampleSql },
+    });
+    if (resp.ok()) {
+      const data = await resp.json().catch(() => null);
+      sample = (data?.result ?? []).map((r: { event_message?: string }) => (r.event_message ?? '').slice(0, 300));
+    }
+  } catch (_) { /* ignore — diagnostic only */ }
+
+  const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+  const summary = [
+    `waitForLogs(${table}, "${pattern}") timed out after ${timeoutMs}ms`,
+    `  elapsed=${elapsedSec}s, polls=${polls}, last count=${lastCount ?? 'n/a'}, last response error=${lastError ?? 'none'}`,
+    `  recent ${table} event_messages (${sample.length} rows):`,
+    ...sample.map((m, i) => `    [${i}] ${m}`),
+  ].join('\n');
+  console.error(summary);
+  throw new Error(summary);
 }
 
 let uniqueId = '';
@@ -170,9 +200,9 @@ test.afterEach(async ({ page }, testInfo) => {
 });
 
 test.beforeAll(async ({ request, browserName }) => {
-  // The polling below can take up to ~90s in worst case; bump the hook timeout
+  // The polling below can take up to ~180s in worst case; bump the hook timeout
   // to give it headroom on top of the synchronous setup work above.
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
 
   uniqueId = `${Date.now()}_${browserName}`;
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -7,6 +7,52 @@ let uniqueId = '';
 test.setTimeout(60_000);
 expect.configure({ timeout: 15_000 });
 
+type ConsoleEntry = { type: string; text: string; ts: string };
+const consoleByTest = new Map<string, ConsoleEntry[]>();
+
+test.beforeEach(async ({ page }, testInfo) => {
+  const messages: ConsoleEntry[] = [];
+  consoleByTest.set(testInfo.testId, messages);
+
+  page.on('console', msg => {
+    messages.push({ type: msg.type(), text: msg.text(), ts: new Date().toISOString() });
+  });
+  page.on('pageerror', err => {
+    messages.push({
+      type: 'pageerror',
+      text: `${err.name}: ${err.message}${err.stack ? '\n' + err.stack : ''}`,
+      ts: new Date().toISOString(),
+    });
+  });
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  const messages = consoleByTest.get(testInfo.testId) ?? [];
+  consoleByTest.delete(testInfo.testId);
+
+  if (testInfo.status === testInfo.expectedStatus) return;
+
+  try {
+    const tableHtml = await page.getByRole('table').innerHTML({ timeout: 1_000 });
+    await testInfo.attach('table.html', { body: tableHtml, contentType: 'text/html' });
+  } catch (e) {
+    await testInfo.attach('table-error.txt', {
+      body: `Failed to capture table HTML: ${(e as Error).message}`,
+      contentType: 'text/plain',
+    });
+  }
+
+  await testInfo.attach('browser-console.json', {
+    body: JSON.stringify(messages, null, 2),
+    contentType: 'application/json',
+  });
+
+  await testInfo.attach('page-url.txt', {
+    body: page.url(),
+    contentType: 'text/plain',
+  });
+});
+
 test.beforeAll(async ({ request, browserName }) => {
   test.setTimeout(60_000);
 

--- a/test/e2e/supabase/playwright.config.ts
+++ b/test/e2e/supabase/playwright.config.ts
@@ -21,8 +21,18 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters
+   * On CI we add:
+   *   - 'github': inline error annotations on the PR diff view
+   *   - 'json':   structured results consumed by ci-failure-summary.sh to
+   *               populate $GITHUB_STEP_SUMMARY on failure */
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['github'],
+        ['json', { outputFile: 'test-results/results.json' }],
+      ]
+    : 'html',
   /* Default timeout for expect() assertions. Bumped from the 5s default so
    * `toContainText` can ride out brief UI/ingestion latency. */
   expect: { timeout: 15_000 },

--- a/test/e2e/supabase/playwright.config.ts
+++ b/test/e2e/supabase/playwright.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  /* Default timeout for expect() assertions. Bumped from the 5s default so
+   * `toContainText` can ride out brief UI/ingestion latency. */
+  expect: { timeout: 15_000 },
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: process.env.SUPABASE_PUBLIC_URL,

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -89,7 +89,13 @@ log "Waiting for Logflare to seed all sources..."
 # lib/logflare/single_tenant.ex. A POST that lands in the seeding window
 # returns 401, which Vector's HTTP sink marks as "not retriable" and drops —
 # leading to flaky empty-table failures in the E2E suite (notably storage_logs).
+#
 # Probe each source until ingestion succeeds before declaring the stack ready.
+# This only triggers a check, not re-seeding. If startup_tasks never finishes
+# seeding a source (we have evidence of persistent 401 across full test runs;
+# mechanism not yet proven), the probe times out at the deadline below and
+# dumps the analytics tail. Strictly better than a silent flake; not a fix
+# for the underlying issue, which is tracked separately.
 set -a
 # shellcheck disable=SC1091
 source "$BASE_DIR/$SUPABASE_DIR/$SPARSE_PATH/.env"

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -96,13 +96,18 @@ log "Waiting for Logflare to seed all sources..."
 # mechanism not yet proven), the probe times out at the deadline below and
 # dumps the analytics tail. Strictly better than a silent flake; not a fix
 # for the underlying issue, which is tracked separately.
-set -a
-# shellcheck disable=SC1091
-source "$BASE_DIR/$SUPABASE_DIR/$SPARSE_PATH/.env"
-set +a
+ENV_FILE="$BASE_DIR/$SUPABASE_DIR/$SPARSE_PATH/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  error "Cannot find .env at $ENV_FILE"
+  exit 1
+fi
+
+# Don't `source` the .env file: docker-compose's .env format permits
+# unquoted values with spaces, which bash interprets as commands.
+LOGFLARE_PUBLIC_ACCESS_TOKEN=$(grep -E '^LOGFLARE_PUBLIC_ACCESS_TOKEN=' "$ENV_FILE" | head -1 | cut -d= -f2-)
 
 if [ -z "${LOGFLARE_PUBLIC_ACCESS_TOKEN:-}" ]; then
-  error "LOGFLARE_PUBLIC_ACCESS_TOKEN not set after sourcing .env"
+  error "LOGFLARE_PUBLIC_ACCESS_TOKEN not found in $ENV_FILE"
   exit 1
 fi
 

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -82,5 +82,68 @@ if ! compose up -d --wait --wait-timeout 180; then
 fi
 endgroup
 
+log "Waiting for Logflare to seed all sources..."
+
+# Logflare's HTTP endpoint accepts requests as soon as Bandit binds, which
+# happens before startup_tasks finishes seeding the supabase sources defined in
+# lib/logflare/single_tenant.ex. A POST that lands in the seeding window
+# returns 401, which Vector's HTTP sink marks as "not retriable" and drops —
+# leading to flaky empty-table failures in the E2E suite (notably storage_logs).
+# Probe each source until ingestion succeeds before declaring the stack ready.
+set -a
+# shellcheck disable=SC1091
+source "$BASE_DIR/$SUPABASE_DIR/$SPARSE_PATH/.env"
+set +a
+
+if [ -z "${LOGFLARE_PUBLIC_ACCESS_TOKEN:-}" ]; then
+  error "LOGFLARE_PUBLIC_ACCESS_TOKEN not set after sourcing .env"
+  exit 1
+fi
+
+SOURCES=(
+  "cloudflare.logs.prod"
+  "postgres.logs"
+  "deno-relay-logs"
+  "deno-subhosting-events"
+  "gotrue.logs.prod"
+  "realtime.logs.prod"
+  "storage.logs.prod.2"
+  "postgREST.logs.prod"
+  "pgbouncer.logs.prod"
+)
+
+probe_source() {
+  local name="$1"
+  local out
+  out=$(docker exec supabase-analytics curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "http://127.0.0.1:4000/api/logs?source_name=$name" \
+    -H "x-api-key: $LOGFLARE_PUBLIC_ACCESS_TOKEN" \
+    -H "content-type: application/json" \
+    --data '{"event_message":"stack-readiness-probe"}' 2>/dev/null) || out="000"
+  echo "$out"
+}
+
+DEADLINE=$((SECONDS + 60))
+for source in "${SOURCES[@]}"; do
+  last_code=""
+  while true; do
+    last_code=$(probe_source "$source")
+    case "$last_code" in
+      2*) break ;;
+    esac
+    if [ "$SECONDS" -gt "$DEADLINE" ]; then
+      error "Source '$source' not ready after 60s (last status: $last_code)."
+      warn  "This usually means Logflare's startup_tasks crashed during seeding."
+      warn  "Last 50 lines of analytics log:"
+      compose logs --no-log-prefix --tail 50 analytics
+      exit 1
+    fi
+    sleep 1
+  done
+done
+
+log "All ${#SOURCES[@]} Logflare sources seeded and accepting events."
+endgroup
+
 log "Supabase stack is up! Access Supabase studio via ${CYAN}http://localhost:8000${RESET}"
 log "Run E2E tests with '${GREEN}npm run playwright:test${RESET}'"


### PR DESCRIPTION
## Summary

Stabilize the intermittent failures in `test/e2e/supabase/features/logs.spec.ts`. Post-fix flake rate measured at **0/30** across 30 sequential reruns (was regularly failing across browsers).

## Root cause

Logflare's startup in supabase mode seeds the predefined sources (`storage.logs.prod.2`, `gotrue.logs.prod`, `postgres.logs`, `cloudflare.logs.prod`, etc. — see `lib/logflare/single_tenant.ex`) inside `startup_tasks`. Bandit binds the HTTP port *before* that seeding completes. POSTs that land in the seeding window get HTTP 401, because the source isn't installed yet.

Vector's HTTP sink classifies 401 as non-retriable and **drops the events permanently** — no retry, no error visible to the test, no entry in the Logflare table. Two adjacent issues stacked on top to produce the observed empty-table flake (most often on `storage_logs`, occasionally elsewhere):

1. The upstream `analytics` Docker healthcheck used `curl http://localhost:4000/health` without `--fail`. `/health` returns 503 while `startup_tasks` is still seeding, but `curl` exits 0 on a non-2xx response unless `--fail` is set — so the container reported "healthy" while seeding was in progress.
2. With analytics reporting healthy too early, Vector started in parallel with seeding. Its first POST to a not-yet-seeded source got 401 and dropped the event.
3. The original `beforeAll` 30s blanket sleep masked this on fast runners most of the time (the seeding window is short relative to 30s) but couldn't recover events that had already been dropped at the Vector → Logflare boundary.

The original PR description on this branch hypothesized that "the 30s sleep isn't enough for the ingestion path to complete on slow CI runners." That hypothesis was wrong. The captured CI failure showed a fully-loaded page rendering an empty-state table, no console errors, and the correct uniqueId in the search URL — i.e. ingestion had completed before the search ran, but the relevant events never arrived. The path wasn't slow; events had been dropped on the floor before Logflare ever saw them. The diagnostic harness shipped earlier in this branch is what made it possible to falsify that hypothesis and find the real one.

The flake didn't reproduce locally even under torture (50/50 with `--repeat-each 50`, 20/20 with shell loop + 4-CPU pressure). Likely because the local Logflare image and seeded state were already warm, so the seeding window was effectively zero by the time Vector started posting. CI cold-starts hit the race window.

The two upstream compose-stack bugs (curl healthcheck without `--fail`, and `vector` not gating on analytics health) are filed at supabase/supabase#45738. Once that lands the overlay below becomes redundant and can be removed.

## Fix

In decreasing order of load-bearingness:

- **`test/e2e/supabase/docker-compose.e2e.yml` overlay** — override the `analytics` healthcheck to use `curl --fail`, so 503-during-seeding actually fails the check. Add `depends_on: analytics: service_healthy` to `vector`. Together these stop Vector from posting into the seeding window. This is the actual race fix. Temporary workaround pending the upstream compose fix tracked in supabase/supabase#45738 — when that ships, this overlay can be deleted.
- **`setup-supabase-services.sh` source-readiness probe** — after `docker compose up`, POST a probe event to each Supabase source until 2xx, with a 60s deadline. Belt-and-suspenders for the test phase. If a source never seeds, the probe times out and dumps the analytics log tail rather than failing silently 30s later as "No results found".
- **`logs.spec.ts` `beforeAll`** — replace the 30s blanket sleep with parallel per-pipeline polling against the same `/api/platform/projects/default/analytics/endpoints/logs.all` endpoint Studio's UI uses. Hygiene rather than a root-cause fix: when the seeding race is open, polling cannot recover dropped events. With the seeding race closed, polling provides faster feedback (typically <1s vs. blanket 30s) and a clean timeout when a pipeline genuinely doesn't deliver.

## Diagnostic harness (separately useful)

The diagnostic infrastructure shipped earlier on this branch is what made the root-cause investigation tractable, and stays in for future flakes:

- `beforeEach`/`afterEach` in `logs.spec.ts` attach the following to the Playwright report on test failure (no-op on success):
  - `table.html` — rendered HTML of the search-results table at the failure moment.
  - `table.txt` — text content of the same table, easier to compare against `expect.toContainText` assertions.
  - `browser-console.json` — captured `console` and `pageerror` events for the test, with timestamps.
  - `network.json` — request/response pairs filtered to relevant URL patterns (`/api/platform/`, `/logs`, `/functions/v1/`, `/auth/v1/`, `/storage/v1/`, `/realtime/v1/`, `/rest/v1/`, `/pg-meta/`). Method, status, content-type, duration, and the first 4 KB of response body. Asset traffic filtered out.
  - `page-url.txt` — the current URL.
- The workflow now also captures `docker logs` for every running container into per-browser `container-logs-*` artifacts on failure.
- `playwright.config.ts` adds the `github` reporter (inline PR annotations) and the `json` reporter (consumed by `ci-failure-summary.sh` to populate `$GITHUB_STEP_SUMMARY`). `expect` timeout bumped 5s → 15s to ride out brief UI/ingestion latency.
- `ci-failure-summary.sh` reads the JSON results and writes a Markdown summary to the GitHub Actions UI on failure, so the failure surface is visible without downloading artifacts.

## Workflow infra

- The pre-existing `actions/upload-artifact@v4` step had two bugs preventing retrieval: the `path` was relative to the repo root rather than `test/e2e/supabase/`, and all three matrix browsers uploaded under the same artifact name (v4 enforces unique names). Both fixed; each browser now produces a separately-named artifact.
- New `scripts/debug-flaky-action.sh` — general-purpose CLI for quantifying flake rate or repro-ing transient failures on any workflow in this repo. `repro` mode reruns until any matching job fails (downloads artifacts, notifies). `sample` mode runs N attempts regardless of outcome and reports the pass/fail rate. Run id is auto-detected from the current branch when not passed; job-name pattern filtering scopes which failures count. See `scripts/debug-flaky-action.sh --help`.

## Verification

- [x] Local: all 7 tests in `logs.spec.ts` pass on chromium in 20.5s with the polling fix in place (vs ~50–70s with the previous 30s blanket sleep). Polling typically completes in <1s on a healthy stack.
- [x] Workflow fix verified: a CI run on this branch produced three uploaded artifacts (`playwright-report-chromium`, `-firefox`, `-webkit`) at ~200 KB each, vs. the previous "No files were found" warning.
- [x] Diagnostic verified end-to-end: the captured Chromium failure that drove the root-cause investigation surfaced `table.html`, `table.txt`, `browser-console.json`, `network.json`, and `page-url.txt` as expected.
- [x] Post-fix flake rate measured via `scripts/debug-flaky-action.sh --mode sample --cap 30` against the `Integration Tests with Supabase` workflow on commit `531de768`: **30/30 success** ([run 25600358994](https://github.com/Logflare/logflare/actions/runs/25600358994), attempts 1–30 spanning 11:46–16:30 UTC on 2026-05-09, ~9–11 min each).

## Out of scope

- The `searchLogs` helper rewrite (`test/e2e/supabase/lib/utils.ts`). Cosmetic now that the seeding race is closed; defensible as a separate "test infra hygiene" change later.
- Splitting the shared `beforeAll` into per-test setup so one slow pipeline doesn't cascade.
- Browser-specific retries / timeouts in `playwright.config.ts`.
- Investigating whether `startup_tasks` ever fails to finish seeding entirely. There is a comment in `setup-supabase-services.sh` flagging evidence of persistent 401 across full test runs in some prior state; the mechanism is unproven. With the probe in place this would now surface as a clean timeout with the analytics log tail dumped, rather than a silent flake.
