### PR TITLE
feat: add Dynatrace adaptor for Generic Log Ingest v2

### DIFF
--- a/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
+++ b/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
@@ -1,0 +1,103 @@
+defmodule Logflare.Backends.Adaptor.DynatraceAdaptor do
+  @moduledoc """
+  Wrapper module for `Logflare.Backends.Adaptor.WebhookAdaptor` to provide API
+  for the Dynatrace Generic Log Ingest v2 endpoint.
+
+  https://docs.dynatrace.com/docs/shortlink/lma-generic-log-ingest-api
+
+  ## Configuration
+
+  - `:url` - The Dynatrace environment URL, e.g.
+    `https://<env-id>.live.dynatrace.com` for SaaS or
+    `https://<server>/e/<env-id>` for Managed/ActiveGate. The
+    `/api/v2/logs/ingest` path is appended automatically.
+  - `:api_token` - API token with the `logs.ingest` (`v2 Logs ingest`) scope.
+  """
+
+  @behaviour Logflare.Backends.Adaptor
+
+  alias Ecto.Changeset
+  alias Logflare.Backends.Adaptor.WebhookAdaptor
+  alias Logflare.Backends.Backend
+  alias Logflare.LogEvent
+  alias Logflare.Sources.Source
+
+  @log_ingest_path "/api/v2/logs/ingest"
+
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def start_link({source, backend}) do
+    backend = %{backend | config: transform_config(backend)}
+    WebhookAdaptor.start_link({source, backend})
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def transform_config(%_{config: config}) do
+    %{
+      url: ingest_url(config.url),
+      headers: %{"Authorization" => "Api-Token #{config.api_token}"},
+      http: "http2",
+      gzip: true
+    }
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def pre_ingest(source, _backend, log_events) do
+    Enum.map(log_events, &translate_event(source, &1))
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def cast_config(params, existing_config \\ %{}) do
+    {existing_config, %{url: :string, api_token: :string}}
+    |> Changeset.cast(params, [:url, :api_token])
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def validate_config(changeset) do
+    changeset
+    |> Changeset.validate_required([:url, :api_token])
+    |> Changeset.validate_format(:url, ~r/https?\:\/\/.+/)
+  end
+
+  @impl Logflare.Backends.Adaptor
+  def redact_config(config) do
+    Map.put(config, :api_token, "REDACTED")
+  end
+
+  @impl Logflare.Backends.Adaptor
+  @spec test_connection(Backend.t()) :: :ok | {:error, term()}
+  def test_connection(%Backend{} = backend) do
+    backend = %{backend | config: transform_config(backend)}
+    WebhookAdaptor.test_connection(backend, [])
+  end
+
+  defp ingest_url(url) when is_binary(url) do
+    String.trim_trailing(url, "/") <> @log_ingest_path
+  end
+
+  defp translate_event(%Source{} = source, %LogEvent{} = le) do
+    %LogEvent{
+      le
+      | body: %{
+          "timestamp" => format_timestamp(le.body["timestamp"]),
+          "content" => le.body["event_message"] || le.body["message"] || "",
+          "service" => source.service_name || source.name,
+          "log.source" => "logflare",
+          "data" => le.body
+        }
+    }
+  end
+
+  defp format_timestamp(ts) when is_integer(ts) do
+    ts |> DateTime.from_unix!(:microsecond) |> DateTime.to_iso8601()
+  end
+
+  defp format_timestamp(ts) when is_binary(ts), do: ts
+  defp format_timestamp(_), do: DateTime.utc_now() |> DateTime.to_iso8601()
+end

--- a/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
+++ b/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
@@ -62,7 +62,7 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptor do
   def validate_config(changeset) do
     changeset
     |> Changeset.validate_required([:url, :api_token])
-    |> Changeset.validate_format(:url, ~r/https\:\/\/.+/,
+    |> Changeset.validate_format(:url, ~r/\Ahttps:\/\/.+/,
       message: "must use HTTPS to protect API credentials"
     )
   end

--- a/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
+++ b/lib/logflare/backends/adaptor/dynatrace_adaptor.ex
@@ -62,7 +62,9 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptor do
   def validate_config(changeset) do
     changeset
     |> Changeset.validate_required([:url, :api_token])
-    |> Changeset.validate_format(:url, ~r/https?\:\/\/.+/)
+    |> Changeset.validate_format(:url, ~r/https\:\/\/.+/,
+      message: "must use HTTPS to protect API credentials"
+    )
   end
 
   @impl Logflare.Backends.Adaptor
@@ -78,7 +80,13 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptor do
   end
 
   defp ingest_url(url) when is_binary(url) do
-    String.trim_trailing(url, "/") <> @log_ingest_path
+    trimmed = String.trim_trailing(url, "/")
+
+    if String.ends_with?(trimmed, @log_ingest_path) do
+      trimmed
+    else
+      trimmed <> @log_ingest_path
+    end
   end
 
   defp translate_event(%Source{} = source, %LogEvent{} = le) do

--- a/lib/logflare/backends/backend.ex
+++ b/lib/logflare/backends/backend.ex
@@ -27,7 +27,8 @@ defmodule Logflare.Backends.Backend do
     axiom: Adaptor.AxiomAdaptor,
     otlp: Adaptor.OtlpAdaptor,
     last9: Adaptor.Last9Adaptor,
-    syslog: Adaptor.SyslogAdaptor
+    syslog: Adaptor.SyslogAdaptor,
+    dynatrace: Adaptor.DynatraceAdaptor
   }
 
   typed_schema "backends" do

--- a/lib/logflare_web/live/backends/backends_live.ex
+++ b/lib/logflare_web/live/backends/backends_live.ex
@@ -381,7 +381,8 @@ defmodule LogflareWeb.BackendsLive do
       {"Axiom", :axiom},
       {"OTLP", :otlp},
       {"Last9", :last9},
-      {"Syslog", :syslog}
+      {"Syslog", :syslog},
+      {"Dynatrace", :dynatrace}
     ])
   end
 

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -469,6 +469,21 @@
               Optional client key for mutual TLS authentication. Must be in PEM format.
             </small>
           </div>
+        <% "dynatrace" -> %>
+          <div class="form-group">
+            {label(f_config, :url, "Environment URL")}
+            {text_input(f_config, :url, class: "form-control")}
+            <small class="form-text text-muted">
+              Your Dynatrace environment URL, e.g. <code>https://&lt;env-id&gt;.live.dynatrace.com</code> for SaaS or <code>https://&lt;server&gt;/e/&lt;env-id&gt;</code> for Managed/ActiveGate. The <code>/api/v2/logs/ingest</code> path is appended automatically.
+            </small>
+          </div>
+          <div class="form-group">
+            {label(f_config, :api_token, "API Token")}
+            {text_input(f_config, :api_token, class: "form-control", type: "password")}
+            <small class="form-text text-muted">
+              An access token with the <code>logs.ingest</code> (<em>Ingest logs v2</em>) scope.
+            </small>
+          </div>
         <% _ -> %>
           <div>Select a Backend Type</div>
       <% end %>

--- a/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
@@ -1,0 +1,239 @@
+defmodule Logflare.Backends.Adaptor.DynatraceAdaptorTest do
+  use Logflare.DataCase, async: false
+
+  alias Logflare.Backends
+  alias Logflare.Backends.Adaptor
+  alias Logflare.Backends.Adaptor.DynatraceAdaptor
+  alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.SystemMetrics.AllLogsLogged
+
+  @subject DynatraceAdaptor
+  @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
+
+  doctest @subject
+
+  setup do
+    start_supervised!(AllLogsLogged)
+    insert(:plan)
+    :ok
+  end
+
+  describe "cast and validate" do
+    test "url and api_token are required and url must be http(s)" do
+      refute Adaptor.cast_and_validate_config(@subject, %{}).valid?
+
+      refute Adaptor.cast_and_validate_config(@subject, %{
+               "api_token" => "dt0c01.abc"
+             }).valid?
+
+      refute Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "https://abc.live.dynatrace.com"
+             }).valid?
+
+      refute Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "abc.live.dynatrace.com",
+               "api_token" => "dt0c01.abc"
+             }).valid?
+
+      assert Adaptor.cast_and_validate_config(@subject, %{
+               "url" => "https://abc.live.dynatrace.com",
+               "api_token" => "dt0c01.abc"
+             }).valid?
+    end
+  end
+
+  describe "redact_config/1" do
+    test "redacts api_token field" do
+      config = %{url: "https://abc.live.dynatrace.com", api_token: "dt0c01.secret"}
+      assert %{api_token: "REDACTED"} = @subject.redact_config(config)
+    end
+  end
+
+  describe "test_connection/1" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :dynatrace,
+          sources: [source],
+          config: %{
+            url: "https://abc.live.dynatrace.com",
+            api_token: "dt0c01.token"
+          }
+        )
+
+      [backend: backend]
+    end
+
+    test "POSTs an empty array to the env logs ingest path", %{backend: backend} do
+      @client
+      |> expect(:send, fn req ->
+        assert req[:url] == "https://abc.live.dynatrace.com/api/v2/logs/ingest"
+        assert req[:body] == []
+        assert req[:headers]["Authorization"] == "Api-Token dt0c01.token"
+        {:ok, %Tesla.Env{status: 204, body: ""}}
+      end)
+
+      assert :ok = @subject.test_connection(backend)
+    end
+
+    test "trailing slashes in url are normalized" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :dynatrace,
+          sources: [source],
+          config: %{
+            url: "https://abc.live.dynatrace.com/",
+            api_token: "dt0c01.token"
+          }
+        )
+
+      @client
+      |> expect(:send, fn req ->
+        assert req[:url] == "https://abc.live.dynatrace.com/api/v2/logs/ingest"
+        {:ok, %Tesla.Env{status: 204, body: ""}}
+      end)
+
+      assert :ok = @subject.test_connection(backend)
+    end
+
+    test "returns error on non-2xx response", %{backend: backend} do
+      @client
+      |> expect(:send, fn _req ->
+        {:ok, %Tesla.Env{status: 401, body: %{"error" => %{"message" => "Unauthorized"}}}}
+      end)
+
+      assert {:error, reason} = @subject.test_connection(backend)
+      assert reason =~ "401"
+    end
+
+    test "returns error on transport failure", %{backend: backend} do
+      @client
+      |> expect(:send, fn _req -> {:error, :nxdomain} end)
+
+      assert {:error, reason} = @subject.test_connection(backend)
+      assert reason =~ "nxdomain"
+    end
+  end
+
+  describe "logs ingestion" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      source_with_service_name = insert(:source, user: user, service_name: "checkout-api")
+
+      backend =
+        insert(:backend,
+          type: :dynatrace,
+          sources: [source, source_with_service_name],
+          config: %{
+            url: "https://abc.live.dynatrace.com",
+            api_token: "dt0c01.token"
+          }
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}}, id: :source1)
+      start_supervised!({AdaptorSupervisor, {source_with_service_name, backend}}, id: :source2)
+      :timer.sleep(500)
+
+      [
+        backend: backend,
+        source: source,
+        source_with_service_name: source_with_service_name,
+        user: user
+      ]
+    end
+
+    test "sent logs are delivered", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn _req ->
+        send(this, ref)
+        %Tesla.Env{status: 204, body: ""}
+      end)
+
+      le = build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive ^ref, 2000
+    end
+
+    test "nil event_message is handled correctly", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 204, body: ""}
+      end)
+
+      le = build(:log_event, source: source, message: nil, event_message: nil)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, [entry]}, 2000
+      assert entry["content"] == ""
+    end
+
+    test "service field is set to source.service_name", %{source_with_service_name: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 204, body: ""}
+      end)
+
+      le = build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, [entry]}, 2000
+      assert entry["service"] == source.service_name
+    end
+
+    test "service field falls back to source name", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 204, body: ""}
+      end)
+
+      le = build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, [entry]}, 2000
+      assert entry["service"] == source.name
+    end
+
+    test "timestamp is ISO 8601 and content is the event message", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body]})
+        %Tesla.Env{status: 204, body: ""}
+      end)
+
+      le = build(:log_event, source: source, event_message: "hello world")
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, [entry]}, 2000
+      assert entry["content"] == "hello world"
+      assert {:ok, _, _} = DateTime.from_iso8601(entry["timestamp"])
+      assert entry["log.source"] == "logflare"
+      assert entry["data"] == le.body
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
@@ -51,6 +51,17 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptorTest do
       refute changeset.valid?
       assert {"must use HTTPS to protect API credentials", _} = changeset.errors[:url]
     end
+
+    test "rejects http:// urls that embed https:// later in the string" do
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "url" => "http://attacker.example.com/?x=https://abc.live.dynatrace.com",
+          "api_token" => "dt0c01.abc"
+        })
+
+      refute changeset.valid?
+      assert {"must use HTTPS to protect API credentials", _} = changeset.errors[:url]
+    end
   end
 
   describe "redact_config/1" do

--- a/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/dynatrace_adaptor_test.exs
@@ -40,6 +40,17 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptorTest do
                "api_token" => "dt0c01.abc"
              }).valid?
     end
+
+    test "rejects http:// urls to prevent cleartext credential transmission" do
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          "url" => "http://abc.live.dynatrace.com",
+          "api_token" => "dt0c01.abc"
+        })
+
+      refute changeset.valid?
+      assert {"must use HTTPS to protect API credentials", _} = changeset.errors[:url]
+    end
   end
 
   describe "redact_config/1" do
@@ -89,6 +100,29 @@ defmodule Logflare.Backends.Adaptor.DynatraceAdaptorTest do
           sources: [source],
           config: %{
             url: "https://abc.live.dynatrace.com/",
+            api_token: "dt0c01.token"
+          }
+        )
+
+      @client
+      |> expect(:send, fn req ->
+        assert req[:url] == "https://abc.live.dynatrace.com/api/v2/logs/ingest"
+        {:ok, %Tesla.Env{status: 204, body: ""}}
+      end)
+
+      assert :ok = @subject.test_connection(backend)
+    end
+
+    test "url already ending in /api/v2/logs/ingest is not double-suffixed" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :dynatrace,
+          sources: [source],
+          config: %{
+            url: "https://abc.live.dynatrace.com/api/v2/logs/ingest",
             api_token: "dt0c01.token"
           }
         )


### PR DESCRIPTION
## Summary

- Adds `Logflare.Backends.Adaptor.DynatraceAdaptor`, an ingest-only backend that wraps `WebhookAdaptor` to POST log events to a Dynatrace environment's [Generic Log Ingest v2 endpoint](https://docs.dynatrace.com/docs/shortlink/lma-generic-log-ingest-api) (`{env_url}/api/v2/logs/ingest`, header `Authorization: Api-Token <token>`, scope `logs.ingest`).
- Config takes a base **environment URL** (so SaaS, Managed, and ActiveGate deployments all work — the path is appended automatically) and an `api_token`. Each event is translated into Dynatrace's expected shape (`timestamp` ISO 8601 / `content` / `service` / `log.source` / `data`) before being sent. `redact_config` masks the token; `test_connection` POSTs an empty `[]` array.
- Registers `:dynatrace` in `Backend.adaptor_mapping`, the backend-types dropdown in `backends_live.ex`, and adds form fields in `backend_form.heex`. Tests mirror the `DatadogAdaptor` pattern: cast/validate, redaction, `test_connection` (success / 401 / nxdomain / trailing-slash url) and ingestion-path assertions on payload shape and service-name fallback.

## Test plan

- [ ] `mix format --check-formatted` — passes locally
- [ ] `mix compile` — passes locally on Elixir 1.19.5 / OTP 28 with no warnings touching the new files
- [ ] `mix test test/logflare/backends/adaptor/dynatrace_adaptor_test.exs` — **not run locally** (no Postgres on the dev machine used to author this); needs to be run in a setup with the test DB
- [ ] Manual smoke: create a Dynatrace backend in the UI, attach to a source, ingest a few events, confirm they land in Dynatrace's log viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)