### PR TITLE
feat: team switcher redirects to resource index

### DIFF
--- a/lib/logflare_web/controllers/team_controller.ex
+++ b/lib/logflare_web/controllers/team_controller.ex
@@ -1,6 +1,7 @@
 defmodule LogflareWeb.TeamController do
   use LogflareWeb, :controller
 
+  alias Logflare.Teams.Team
   alias Logflare.Teams.TeamContext
 
   def switch(conn, %{"team_id" => team_id, "redirect_to" => redirect_to}) do
@@ -10,7 +11,7 @@ defmodule LogflareWeb.TeamController do
       {:ok, %{team: team}} ->
         conn
         |> put_session(:last_switched_team_id, team.id)
-        |> redirect(to: LogflareWeb.Utils.with_team_param(redirect_to, team))
+        |> redirect(to: index_path(redirect_to, team))
 
       {:error, _reason} ->
         conn
@@ -18,4 +19,19 @@ defmodule LogflareWeb.TeamController do
         |> redirect(to: redirect_to)
     end
   end
+
+  @spec index_path(String.t(), Team.t()) :: String.t()
+  defp index_path(redirect_to, team) do
+    redirect_to
+    |> URI.parse()
+    |> Map.get(:path)
+    |> resource_index_path()
+    |> LogflareWeb.Utils.with_team_param(team)
+  end
+
+  @spec resource_index_path(String.t() | nil) :: String.t()
+  defp resource_index_path("/sources" <> _), do: ~p"/dashboard"
+  defp resource_index_path("/endpoints" <> _), do: ~p"/endpoints"
+  defp resource_index_path("/alerts" <> _), do: ~p"/alerts"
+  defp resource_index_path(_), do: ~p"/dashboard"
 end

--- a/test/logflare_web/controllers/team_controller_test.exs
+++ b/test/logflare_web/controllers/team_controller_test.exs
@@ -14,16 +14,36 @@ defmodule LogflareWeb.TeamControllerTest do
   end
 
   describe "GET /teams/switch" do
-    test "stores last_switched_team_id in session and redirects with team param",
+    test "stores last_switched_team_id in session and redirects to selected team dashboard",
          %{conn: conn, user: user, other_team: other_team} do
       conn =
         conn
         |> login_user(user)
         |> get(~p"/teams/switch?#{[team_id: other_team.id, redirect_to: "/dashboard"]}")
 
-      assert redirected_to(conn) =~ "/dashboard"
-      assert redirected_to(conn) =~ "t=#{other_team.id}"
+      assert redirected_to(conn) == ~p"/dashboard?t=#{other_team.id}"
       assert get_session(conn, :last_switched_team_id) == other_team.id
+    end
+
+    test "redirects successful switch from resource page to index page",
+         %{conn: conn, user: user, other_team: other_team} do
+      [
+        {"/sources/123?t=999", ~p"/dashboard?t=#{other_team.id}"},
+        {"/endpoints?t=999", ~p"/endpoints?t=#{other_team.id}"},
+        {"/endpoints/123?t=999", ~p"/endpoints?t=#{other_team.id}"},
+        {"/alerts?t=999", ~p"/alerts?t=#{other_team.id}"},
+        {"/alerts/123?t=999", ~p"/alerts?t=#{other_team.id}"},
+        {"/anything_else?t=999", ~p"/dashboard?t=#{other_team.id}"}
+      ]
+      |> Enum.each(fn {origin, destination} ->
+        conn =
+          conn
+          |> login_user(user)
+          |> get(~p"/teams/switch?#{[team_id: other_team.id, redirect_to: origin]}")
+
+        assert redirected_to(conn) == destination
+        assert get_session(conn, :last_switched_team_id) == other_team.id
+      end)
     end
 
     test "redirects to home team without error",


### PR DESCRIPTION
* Switching teams redirects the user to the relevant index page:
  * sources &rarr; /dashboard
  * endpoints &rarr; /endpoints
  * alerts &rarr; /alerts
  * otherwise /dashboard

## Demo

Demonstrates switching teams while viewing an endpoint. The browser is redirected to `/endpoints` with the selected team id.

https://github.com/user-attachments/assets/b81422f2-5269-4bab-8469-a84161c9c6dc





Part of O11Y-1754