### PR TITLE
perf: cache Playwright browser binaries in Supabase integration workflow

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -92,8 +92,19 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Install Playwright ${{ matrix.browsers.name }} Browser
-      run: npx playwright install ${{ matrix.browsers.project }} --with-deps
+    - name: Cache Playwright ${{ matrix.browsers.name }} browser
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ matrix.browsers.project }}-${{ hashFiles('test/e2e/supabase/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-${{ matrix.browsers.project }}-
+
+    - name: Install Playwright ${{ matrix.browsers.name }} browser
+      run: npx playwright install ${{ matrix.browsers.project }}
+
+    - name: Install Playwright ${{ matrix.browsers.name }} system deps
+      run: npx playwright install-deps ${{ matrix.browsers.project }}
 
     - name: Run Playwright tests (only ${{ matrix.browsers.name }})
       run: npx playwright test --project ${{ matrix.browsers.project }}


### PR DESCRIPTION
Split `playwright install --with-deps` into separate browser and system-dep steps, and cache `~/.cache/ms-playwright`. The cache is per-browser (chromium/firefox/webkit) since each matrix job only installs one.

## Results

### Before

| |
|-|
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/e6424d49-3162-4e1e-9aba-2fa4d4b3c9e6" /> | 
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/844c2e82-5fee-45f3-a51f-616cafcb1d0d" /> 
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/00aec5e2-ca70-481e-8dbe-f7b03d57d0d4" /> |

### After

| |
|-|
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/9e66a364-9d20-4276-89dd-57a2444d0581" /> |
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/847a9db8-44bc-4d81-a285-ddf5b7339228" /> |
| <img width="1873" height="1027" alt="image" src="https://github.com/user-attachments/assets/32a6ae36-9c38-4507-b49d-e9f2b9fa4b44" /> |