### PR TITLE
chore: update to clickhouse query templates to reflect latest index changes

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_templates.ex
@@ -159,7 +159,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates do
         `ingested_at` Nullable(DateTime64(6)) CODEC(Delta(8), ZSTD(1)),
         `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
         `timestamp_time` DateTime DEFAULT toDateTime(timestamp),
-        INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1
+        INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
+        INDEX idx_source_name source_name TYPE bloom_filter(0.01) GRANULARITY 1
       )
       ENGINE = #{engine}
       PARTITION BY toDate(timestamp)
@@ -229,7 +230,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates do
         `exemplars.trace_id` Array(String) CODEC(ZSTD(1)),
         `mapping_config_id` UUID,
         `ingested_at` Nullable(DateTime64(6)) CODEC(Delta(8), ZSTD(1)),
-        `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1))
+        `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+        INDEX idx_source_name source_name TYPE bloom_filter(0.01) GRANULARITY 1
       )
       ENGINE = #{engine}
       PARTITION BY toDate(timestamp)
@@ -288,7 +290,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates do
         `ingested_at` Nullable(DateTime64(6)) CODEC(Delta(8), ZSTD(1)),
         `timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
         INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
-        INDEX idx_duration duration TYPE minmax GRANULARITY 1
+        INDEX idx_duration duration TYPE minmax GRANULARITY 1,
+        INDEX idx_source_name source_name TYPE bloom_filter(0.01) GRANULARITY 1
       )
       ENGINE = #{engine}
       PARTITION BY toDate(timestamp)


### PR DESCRIPTION
Updates to the DDL template to align with new `source_name` bloom filter index on all three ingestion tables.