### PR TITLE
chore: minor adjustments to `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Use the `LogflareWeb` macro system for controllers, views, and LiveViews:
 ```elixir
 use LogflareWeb, :controller
 use LogflareWeb, :live_view
-use LogflareWeb, :component
+use LogflareWeb, :live_component
 ```
 These bundle standard imports, aliases, and helpers - don't manually import Phoenix modules.
 
@@ -158,6 +158,6 @@ end
 
 **Single-tenant mode**: Check `Logflare.SingleTenant.single_tenant?()` - behavior differs between multi-tenant (SaaS) and single-tenant deployments.
 
-**Log processing**: Broadway pipelines handle log ingestion. `Logflare.Backends.DynamicPipeline` scales pipelines dynamically based on load. Incoming events are classified as `:log`, `:metric`, or `:trace` by `Logflare.Logs.LogEvent.TypeDetection`, which determines routing and table selection in backend adaptors. OpenTelemetry protobuf payloads are converted into `LogEvent` structs via modules in `lib/logflare/logs/`.
+**Log processing**: Broadway pipelines handle log ingestion. `Logflare.Backends.DynamicPipeline` scales pipelines dynamically based on load. Incoming events are classified as `:log`, `:metric`, or `:trace` by `Logflare.LogEvent.TypeDetection`, which determines routing and table selection in backend adaptors. OpenTelemetry protobuf payloads are converted into `LogEvent` structs via modules in `lib/logflare/logs/`.
 
 **ClickHouse consolidated pipeline**: The ClickHouse adaptor uses a single Broadway pipeline per backend. Messages are partitioned by `event_type` via `put_batch_key`, routing to type-specific OTEL tables (`otel_logs_*`, `otel_metrics_*`, `otel_traces_*`). See `lib/logflare/backends/adaptor/clickhouse_adaptor/` for internals.


### PR DESCRIPTION
I try to revisit AGENTS.md (_which is referenced by CLAUDE.md_) every few weeks to confirm accuracy of what is stated in that file.

Today I noticed the namespace was not accurate for `Logflare.LogEvent.TypeDetection` and also noticed the macro example was showing `use LogflareWeb, :component` rather than `:live_component`.