### PR TITLE
perf(cleaner): flatten metadata without per-level intermediate lists

### DIFF
--- a/lib/logflare/logs/cleaner.ex
+++ b/lib/logflare/logs/cleaner.ex
@@ -4,6 +4,8 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   Also provides flattening of nested maps into dot-delimited key paths.
   """
 
+  import Logflare.Utils.Guards, only: [is_non_empty_map: 1]
+
   @type flat_key :: String.t()
   @typep pair_acc :: [{flat_key(), term()}]
 
@@ -65,7 +67,7 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   end
 
   @spec do_flatten_pairs([{term(), term()}], [String.t()], pair_acc()) :: pair_acc()
-  defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_map(v) and v != %{} do
+  defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_non_empty_map(v) do
     acc = do_flatten_map(v, [k | prefix], acc)
     do_flatten_pairs(rest, prefix, acc)
   end
@@ -82,7 +84,7 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   defp do_flatten_pairs([], _prefix, acc), do: acc
 
   @spec do_flatten_list(list(), non_neg_integer(), [String.t()], pair_acc()) :: pair_acc()
-  defp do_flatten_list([v | rest], idx, prefix, acc) when is_map(v) and v != %{} do
+  defp do_flatten_list([v | rest], idx, prefix, acc) when is_non_empty_map(v) do
     acc = do_flatten_map(v, [Integer.to_string(idx) | prefix], acc)
     do_flatten_list(rest, idx + 1, prefix, acc)
   end

--- a/lib/logflare/logs/cleaner.ex
+++ b/lib/logflare/logs/cleaner.ex
@@ -49,43 +49,62 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   """
   @spec flatten(map()) :: %{flat_key() => term()}
   def flatten(map) when is_map(map) do
-    Map.new(do_flatten_map(map, []))
+    map
+    |> do_flatten_map([], [])
+    |> :lists.reverse()
+    |> :maps.from_list()
   end
 
   def nil_or_empty?(x) when nil_or_empty(x), do: true
   def nil_or_empty?(_), do: false
 
-  @spec do_flatten_map(map(), [String.t()]) :: [{flat_key(), term()}]
-  defp do_flatten_map(map, prefix) do
-    Enum.flat_map(map, fn
-      {k, v} when is_map(v) and v != %{} ->
-        do_flatten_map(v, [k | prefix])
-
-      {k, v} when is_list(v) and v != [] ->
-        do_flatten_list(v, [k | prefix])
-
-      {k, v} ->
-        [{build_key([k | prefix]), v}]
-    end)
+  @spec do_flatten_map(map(), [String.t()], [{flat_key(), term()}]) :: [{flat_key(), term()}]
+  defp do_flatten_map(map, prefix, acc) do
+    do_flatten_pairs(:maps.to_list(map), prefix, acc)
   end
 
-  @spec do_flatten_list(list(), [String.t()]) :: [{flat_key(), term()}]
-  defp do_flatten_list(list, prefix) do
-    list
-    |> Enum.with_index()
-    |> Enum.flat_map(fn
-      {v, idx} when is_map(v) and v != %{} ->
-        do_flatten_map(v, [Integer.to_string(idx) | prefix])
-
-      {v, idx} when is_list(v) and v != [] ->
-        do_flatten_list(v, [Integer.to_string(idx) | prefix])
-
-      {v, idx} ->
-        [{build_key([Integer.to_string(idx) | prefix]), v}]
-    end)
+  @spec do_flatten_pairs([{term(), term()}], [String.t()], [{flat_key(), term()}]) ::
+          [{flat_key(), term()}]
+  defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_map(v) and v != %{} do
+    acc = do_flatten_map(v, [k | prefix], acc)
+    do_flatten_pairs(rest, prefix, acc)
   end
 
-  @spec build_key([String.t()]) :: flat_key()
+  defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_list(v) and v != [] do
+    acc = do_flatten_list(v, 0, [k | prefix], acc)
+    do_flatten_pairs(rest, prefix, acc)
+  end
+
+  defp do_flatten_pairs([{k, v} | rest], prefix, acc) do
+    do_flatten_pairs(rest, prefix, [{build_key([k | prefix]), v} | acc])
+  end
+
+  defp do_flatten_pairs([], _prefix, acc), do: acc
+
+  @spec do_flatten_list(list(), non_neg_integer(), [String.t()], [{flat_key(), term()}]) ::
+          [{flat_key(), term()}]
+  defp do_flatten_list([v | rest], idx, prefix, acc) when is_map(v) and v != %{} do
+    acc = do_flatten_map(v, [Integer.to_string(idx) | prefix], acc)
+    do_flatten_list(rest, idx + 1, prefix, acc)
+  end
+
+  defp do_flatten_list([v | rest], idx, prefix, acc) when is_list(v) and v != [] do
+    acc = do_flatten_list(v, 0, [Integer.to_string(idx) | prefix], acc)
+    do_flatten_list(rest, idx + 1, prefix, acc)
+  end
+
+  defp do_flatten_list([v | rest], idx, prefix, acc) do
+    do_flatten_list(rest, idx + 1, prefix, [
+      {build_key([Integer.to_string(idx) | prefix]), v} | acc
+    ])
+  end
+
+  defp do_flatten_list([], _idx, _prefix, acc), do: acc
+
+  @spec build_key([term()]) :: flat_key()
+  defp build_key([single]) when is_binary(single), do: single
+  defp build_key([single]), do: to_string(single)
+
   defp build_key(reversed_parts) do
     reversed_parts
     |> Enum.reverse()

--- a/lib/logflare/logs/cleaner.ex
+++ b/lib/logflare/logs/cleaner.ex
@@ -5,6 +5,7 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   """
 
   @type flat_key :: String.t()
+  @typep pair_acc :: [{flat_key(), term()}]
 
   defguardp nil_or_empty(x) when x in [%{}, [], "", {}, nil]
 
@@ -50,7 +51,7 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   @spec flatten(map()) :: %{flat_key() => term()}
   def flatten(map) when is_map(map) do
     map
-    |> do_flatten_map([], [])
+    |> do_flatten_map()
     |> :lists.reverse()
     |> :maps.from_list()
   end
@@ -58,19 +59,18 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   def nil_or_empty?(x) when nil_or_empty(x), do: true
   def nil_or_empty?(_), do: false
 
-  @spec do_flatten_map(map(), [String.t()], [{flat_key(), term()}]) :: [{flat_key(), term()}]
-  defp do_flatten_map(map, prefix, acc) do
+  @spec do_flatten_map(map(), [String.t()], pair_acc()) :: pair_acc()
+  defp do_flatten_map(map, prefix \\ [], acc \\ []) do
     do_flatten_pairs(:maps.to_list(map), prefix, acc)
   end
 
-  @spec do_flatten_pairs([{term(), term()}], [String.t()], [{flat_key(), term()}]) ::
-          [{flat_key(), term()}]
+  @spec do_flatten_pairs([{term(), term()}], [String.t()], pair_acc()) :: pair_acc()
   defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_map(v) and v != %{} do
     acc = do_flatten_map(v, [k | prefix], acc)
     do_flatten_pairs(rest, prefix, acc)
   end
 
-  defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_list(v) and v != [] do
+  defp do_flatten_pairs([{k, [_ | _] = v} | rest], prefix, acc) do
     acc = do_flatten_list(v, 0, [k | prefix], acc)
     do_flatten_pairs(rest, prefix, acc)
   end
@@ -81,14 +81,13 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
 
   defp do_flatten_pairs([], _prefix, acc), do: acc
 
-  @spec do_flatten_list(list(), non_neg_integer(), [String.t()], [{flat_key(), term()}]) ::
-          [{flat_key(), term()}]
+  @spec do_flatten_list(list(), non_neg_integer(), [String.t()], pair_acc()) :: pair_acc()
   defp do_flatten_list([v | rest], idx, prefix, acc) when is_map(v) and v != %{} do
     acc = do_flatten_map(v, [Integer.to_string(idx) | prefix], acc)
     do_flatten_list(rest, idx + 1, prefix, acc)
   end
 
-  defp do_flatten_list([v | rest], idx, prefix, acc) when is_list(v) and v != [] do
+  defp do_flatten_list([[_ | _] = v | rest], idx, prefix, acc) do
     acc = do_flatten_list(v, 0, [Integer.to_string(idx) | prefix], acc)
     do_flatten_list(rest, idx + 1, prefix, acc)
   end

--- a/lib/logflare/logs/cleaner.ex
+++ b/lib/logflare/logs/cleaner.ex
@@ -67,6 +67,8 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
   end
 
   @spec do_flatten_pairs([{term(), term()}], [String.t()], pair_acc()) :: pair_acc()
+  defp do_flatten_pairs([], _prefix, acc), do: acc
+
   defp do_flatten_pairs([{k, v} | rest], prefix, acc) when is_non_empty_map(v) do
     acc = do_flatten_map(v, [k | prefix], acc)
     do_flatten_pairs(rest, prefix, acc)
@@ -81,9 +83,9 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
     do_flatten_pairs(rest, prefix, [{build_key([k | prefix]), v} | acc])
   end
 
-  defp do_flatten_pairs([], _prefix, acc), do: acc
-
   @spec do_flatten_list(list(), non_neg_integer(), [String.t()], pair_acc()) :: pair_acc()
+  defp do_flatten_list([], _idx, _prefix, acc), do: acc
+
   defp do_flatten_list([v | rest], idx, prefix, acc) when is_non_empty_map(v) do
     acc = do_flatten_map(v, [Integer.to_string(idx) | prefix], acc)
     do_flatten_list(rest, idx + 1, prefix, acc)
@@ -99,8 +101,6 @@ defmodule Logflare.Logs.Ingest.MetadataCleaner do
       {build_key([Integer.to_string(idx) | prefix]), v} | acc
     ])
   end
-
-  defp do_flatten_list([], _idx, _prefix, acc), do: acc
 
   @spec build_key([term()]) :: flat_key()
   defp build_key([single]) when is_binary(single), do: single

--- a/lib/logflare/utils/guards.ex
+++ b/lib/logflare/utils/guards.ex
@@ -26,6 +26,11 @@ defmodule Logflare.Utils.Guards do
   defguard is_non_empty_binary(value) when is_binary(value) and value != ""
 
   @doc """
+  Guard that indicates if the value provided is a map with at least one key.
+  """
+  defguard is_non_empty_map(value) when is_map(value) and map_size(value) > 0
+
+  @doc """
   Checks to see if the value is an `atom`, but _not_ a boolean or nil value.
   """
   defguard is_atom_value(value)

--- a/test/logflare/logs/ingest/metadata_cleaner_test.exs
+++ b/test/logflare/logs/ingest/metadata_cleaner_test.exs
@@ -152,5 +152,10 @@ defmodule Logflare.Logs.Ingest.MetadataCleanerTest do
       assert Cleaner.flatten(%{"xs" => [1, %{"k" => "v"}, [2, 3]]}) ==
                %{"xs.0" => 1, "xs.1.k" => "v", "xs.2.0" => 2, "xs.2.1" => 3}
     end
+
+    test "literal dot-keys take precedence over nested-derived paths on collision" do
+      assert Cleaner.flatten(%{"a.b" => :explicit, "a" => %{"b" => :nested}}) ==
+               %{"a.b" => :explicit}
+    end
   end
 end

--- a/test/logflare/logs/ingest/metadata_cleaner_test.exs
+++ b/test/logflare/logs/ingest/metadata_cleaner_test.exs
@@ -134,5 +134,23 @@ defmodule Logflare.Logs.Ingest.MetadataCleanerTest do
                "metadata.context.request_id" => "abc"
              }
     end
+
+    test "empty containers at leaves pass through as values" do
+      assert Cleaner.flatten(%{"empty_map" => %{}, "empty_list" => []}) ==
+               %{"empty_map" => %{}, "empty_list" => []}
+
+      assert Cleaner.flatten(%{"a" => %{"b" => %{}, "c" => []}}) ==
+               %{"a.b" => %{}, "a.c" => []}
+    end
+
+    test "nested lists use compound integer index paths" do
+      assert Cleaner.flatten(%{"a" => [[1, 2], [3, 4]]}) ==
+               %{"a.0.0" => 1, "a.0.1" => 2, "a.1.0" => 3, "a.1.1" => 4}
+    end
+
+    test "lists with mixed element types" do
+      assert Cleaner.flatten(%{"xs" => [1, %{"k" => "v"}, [2, 3]]}) ==
+               %{"xs.0" => 1, "xs.1.k" => "v", "xs.2.0" => 2, "xs.2.1" => 3}
+    end
   end
 end

--- a/test/logflare/logs/ingest/metadata_cleaner_test.exs
+++ b/test/logflare/logs/ingest/metadata_cleaner_test.exs
@@ -1,6 +1,8 @@
 defmodule Logflare.Logs.Ingest.MetadataCleanerTest do
   @moduledoc false
   use ExUnit.Case
+  use ExUnitProperties
+
   alias LogflareWeb.Logs.PayloadTestUtils
   alias Logflare.Logs.Ingest.MetadataCleaner, as: Cleaner
 
@@ -157,5 +159,102 @@ defmodule Logflare.Logs.Ingest.MetadataCleanerTest do
       assert Cleaner.flatten(%{"a.b" => :explicit, "a" => %{"b" => :nested}}) ==
                %{"a.b" => :explicit}
     end
+
+    property "no output value is a non-empty map or non-empty list" do
+      check all input <- nested_map_generator() do
+        for {_k, v} <- Cleaner.flatten(input) do
+          refute is_map(v) and not is_struct(v) and map_size(v) > 0
+          refute match?([_ | _], v)
+        end
+      end
+    end
+
+    property "leaf count is preserved when no key collisions are possible" do
+      check all input <- nested_map_generator(no_dot_keys: true) do
+        assert map_size(Cleaner.flatten(input)) == count_leaves(input)
+      end
+    end
+
+    property "every output key reconstructs to its value via the input path" do
+      check all input <- nested_map_generator(no_dot_keys: true) do
+        for {key, value} <- Cleaner.flatten(input) do
+          assert reconstruct_path(input, String.split(key, ".")) == value
+        end
+      end
+    end
+
+    property "already-flat string-keyed maps pass through unchanged" do
+      check all input <- flat_string_keyed_map_generator() do
+        assert Cleaner.flatten(input) == input
+      end
+    end
   end
+
+  defp scalar_value do
+    one_of([
+      integer(),
+      string(:alphanumeric),
+      boolean(),
+      constant(nil),
+      constant(%{}),
+      constant([])
+    ])
+  end
+
+  defp key_string(opts) do
+    if Keyword.get(opts, :no_dot_keys, false) do
+      string([?a..?z, ?0..?9, ?_], min_length: 1, max_length: 8)
+    else
+      string(:alphanumeric, min_length: 1, max_length: 8)
+    end
+  end
+
+  defp nested_value_generator(opts) do
+    tree(scalar_value(), fn child ->
+      one_of([
+        map_of(key_string(opts), child, max_length: 3),
+        list_of(child, max_length: 3)
+      ])
+    end)
+  end
+
+  defp nested_map_generator(opts \\ []) do
+    map_of(key_string(opts), nested_value_generator(opts),
+      min_length: 1,
+      max_length: 4
+    )
+  end
+
+  defp flat_string_keyed_map_generator do
+    map_of(string(:alphanumeric, min_length: 1, max_length: 8), scalar_value(), max_length: 6)
+  end
+
+  defp count_leaves(map) when is_map(map) and map_size(map) > 0 do
+    Enum.reduce(map, 0, fn {_k, v}, acc -> acc + count_leaves(v) end)
+  end
+
+  defp count_leaves([_ | _] = list) do
+    Enum.reduce(list, 0, fn v, acc -> acc + count_leaves(v) end)
+  end
+
+  defp count_leaves(_), do: 1
+
+  defp reconstruct_path(value, []), do: value
+
+  defp reconstruct_path(map, [segment | rest]) when is_map(map) do
+    if Map.has_key?(map, segment) do
+      reconstruct_path(Map.get(map, segment), rest)
+    else
+      :__not_found__
+    end
+  end
+
+  defp reconstruct_path(list, [segment | rest]) when is_list(list) do
+    case Integer.parse(segment) do
+      {idx, ""} -> reconstruct_path(Enum.at(list, idx), rest)
+      _ -> :__not_found__
+    end
+  end
+
+  defp reconstruct_path(_, _), do: :__not_found__
 end

--- a/test/logflare/utils/guards_test.exs
+++ b/test/logflare/utils/guards_test.exs
@@ -103,6 +103,28 @@ defmodule Logflare.Utils.GuardsTest do
     end
   end
 
+  describe "is_non_empty_map/1" do
+    test "passes for maps with at least one key" do
+      assert match?(x when is_non_empty_map(x), %{a: 1})
+      assert match?(x when is_non_empty_map(x), %{"k" => "v"})
+      assert match?(x when is_non_empty_map(x), %{a: 1, b: 2})
+    end
+
+    test "passes for non-empty structs (which are maps with __struct__)" do
+      assert match?(x when is_non_empty_map(x), ~D[2026-04-29])
+    end
+
+    test "fails for the empty map" do
+      refute match?(x when is_non_empty_map(x), %{})
+    end
+
+    test "fails for non-maps" do
+      for value <- [[], [a: 1], "map", :map, 1, nil] do
+        refute match?(x when is_non_empty_map(x), value)
+      end
+    end
+  end
+
   describe "is_atom_value/1" do
     test "passes for regular atoms" do
       assert match?(x when is_atom_value(x), :foo)

--- a/test/profiling/metadata_cleaner_flatten_bench.exs
+++ b/test/profiling/metadata_cleaner_flatten_bench.exs
@@ -1,0 +1,154 @@
+alias Logflare.Logs.Ingest.MetadataCleaner
+
+# OTEL trace shape (shallow, ~15 leaves, depth 2-3)
+otel_trace = %{
+  "attributes" => %{
+    "_client_address" => "2600:1fc4:22a5:ae73:2887:684b:66c0:1f85",
+    "_http_request_method" => "POST",
+    "_http_route" => "/functions/v1/*path",
+    "_http_status_code" => 404,
+    "_network_peer_address" => "99.88.160.11",
+    "_network_peer_port" => 57_785,
+    "_network_protocol_version" => "1.1",
+    "_server_address" => "supabase-api-gateway",
+    "_url_path" => "/functions/v1/stripe-worker",
+    "_url_scheme" => "https",
+    "_user_agent_original" => "pg_net/0.19.5"
+  },
+  "end_time" => "2026-01-21T17:54:48.444334Z",
+  "event_message" => "POST /functions/v1/*path",
+  "metadata" => %{"type" => "span"},
+  "project" => "supabase-api-gateway",
+  "resource" => %{
+    "cloud" => %{"region" => "us-east-1"},
+    "deployment" => %{"environment" => "staging"},
+    "service" => %{"name" => "supabase-api-gateway", "version" => "1.0.0"}
+  },
+  "scope" => %{
+    "name" => "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin",
+    "version" => "0.61.0"
+  },
+  "span_id" => "c99f33f1bfa4fb8f",
+  "start_time" => "2026-01-21T17:54:48.144506Z",
+  "timestamp" => "2026-01-21T17:54:48.144506Z",
+  "trace_id" => "f9918d38f5d1cb74ec5656b9a315e5f6"
+}
+
+# Edge log shape (~80 leaves, depth 4-5)
+edge_log = %{
+  "event_message" =>
+    "POST | 200 | 3.254.227.51 | 9ca90d4f3f7cc99e | https://example.supabase.co/rest/v1/calls",
+  "id" => "3701391c-dead-405d-9943-61cc7576da87",
+  "identifier" => "example_project",
+  "metadata" => %{
+    "logflare_worker" => %{"worker_id" => "ZZ79SS"},
+    "request" => %{
+      "cf" => %{
+        "asOrganization" => "Amazon Data Services Ireland Limited",
+        "asn" => 16_509,
+        "botManagement" => %{
+          "corporateProxy" => false,
+          "ja3Hash" => "a1465cad7ff59adb0e36ccd6339ba5db",
+          "ja4" => "t23e1011h2_61a7dd8aa9b6_3fcd1a44f3e3",
+          "ja4Signals" => %{
+            "browser_ratio_1h" => 0.0026,
+            "cache_ratio_1h" => 0.0389,
+            "h2h3_ratio_1h" => 0.9899,
+            "heuristic_ratio_1h" => 0.2229,
+            "ips_quantile_1h" => 0.9997,
+            "ips_rank_1h" => 218,
+            "paths_rank_1h" => 16,
+            "reqs_quantile_1h" => 0.9999,
+            "reqs_rank_1h" => 36,
+            "uas_rank_1h" => 294
+          },
+          "jsDetection" => %{"passed" => false},
+          "score" => 46,
+          "staticResource" => false,
+          "verifiedBot" => false
+        },
+        "city" => "Dublin",
+        "clientAcceptEncoding" => "gzip, br",
+        "clientTcpRtt" => 4,
+        "clientTrustScore" => 46,
+        "colo" => "DUB",
+        "continent" => "EU",
+        "country" => "IE",
+        "edgeRequestKeepAliveStatus" => 1,
+        "httpProtocol" => "HTTP/2",
+        "latitude" => "53.33326",
+        "longitude" => "-6.24789",
+        "postalCode" => "D02",
+        "region" => "Leinster",
+        "regionCode" => "L",
+        "requestPriority" => "weight=16;exclusive=0",
+        "timezone" => "Europe/Dublin",
+        "tlsCipher" => "AEAD-AES256-GCM-SHA384",
+        "tlsClientAuth" => %{
+          "certPresented" => "0",
+          "certRevoked" => "0",
+          "certVerified" => "NONE"
+        },
+        "tlsVersion" => "TLSv1.3"
+      },
+      "headers" => %{
+        "accept" => "*/*",
+        "cf_connecting_ip" => "3.254.227.51",
+        "cf_ipcountry" => "IE",
+        "cf_ray" => "9ca90d4f3f7cc99e",
+        "content_length" => "18466",
+        "content_type" => "application/json",
+        "host" => "example.supabase.co",
+        "user_agent" => "Deno/2.1.4"
+      },
+      "host" => "example.supabase.co",
+      "method" => "POST",
+      "path" => "/rest/v1/calls",
+      "protocol" => "https:",
+      "search" => "?on_conflict=call_id",
+      "url" => "https://example.supabase.co/rest/v1/calls?on_conflict=call_id"
+    },
+    "response" => %{
+      "headers" => %{
+        "cf_cache_status" => "DYNAMIC",
+        "cf_ray" => "ba903a6f47bfc12f-DUB",
+        "content_length" => "0",
+        "date" => "Tue, 16 Dec 2025 18:26:18 GMT",
+        "sb_gateway_version" => "1"
+      },
+      "origin_time" => 12,
+      "status_code" => 200
+    }
+  },
+  "project" => "example_project",
+  "request_id" => "a99b2a69-dead-752e-78bb-14ca90530fe1",
+  "timestamp" => "2026-01-21T17:54:48.144506Z"
+}
+
+# List-heavy payload (stacktrace-like; exercises do_flatten_list / index keys)
+list_heavy = %{
+  "stacktrace" =>
+    for i <- 0..49 do
+      %{
+        "file" => "lib/some/module#{i}.ex",
+        "function" => "do_thing/#{rem(i, 5)}",
+        "line" => i * 7,
+        "module" => "Some.Module#{i}",
+        "arity_or_args" => [i, "arg", %{"k" => i}]
+      }
+    end,
+  "tags" => for(i <- 0..19, do: "tag-#{i}"),
+  "event_message" => "exception"
+}
+
+Benchee.run(
+  %{
+    "otel trace" => fn -> MetadataCleaner.flatten(otel_trace) end,
+    "edge log" => fn -> MetadataCleaner.flatten(edge_log) end,
+    "list heavy" => fn -> MetadataCleaner.flatten(list_heavy) end
+  },
+  time: 5,
+  warmup: 2,
+  memory_time: 3,
+  reduction_time: 3
+)


### PR DESCRIPTION
## Summary
- Refactor `MetadataCleaner.flatten/1` to accumulate flattened `{key, value}` pairs in a single list (prepend + `:lists.reverse` + `:maps.from_list`) instead of building and concatenating a fresh list at every recursion level via `Enum.flat_map`.
- Replace `Enum.with_index` on list elements with an inline index counter threaded through the recursion.
- Add a single-element fast path to `build_key/1` so root-level keys skip the `Enum.reverse |> Enum.join(".")` round-trip.
- Add tests covering empty-container-at-leaf passthrough, nested integer-index list paths, mixed-type list elements, and literal-dot-key vs nested-derived-key collision resolution.
- Add a Benchee profiling script (`test/profiling/metadata_cleaner_flatten_bench.exs`) with realistic OTEL trace, edge log, and list-heavy payload shapes.

## Behavior
Equivalent to the previous implementation across all observable cases (DFS source order preserved; duplicate-key resolution still "last wins"; empty containers at leaves still pass through as values; list indices still 0-based stringified).

## Benchmarks
All runs on Apple M5, Elixir 1.19.5 / Erlang 27.3.4.6. Lower is better in every column.

### `flatten/1` in isolation (`test/profiling/metadata_cleaner_flatten_bench.exs`)

| Payload      | Metric     | main      | this branch | Δ       |
| ------------ | ---------- | --------- | ----------- | ------- |
| otel trace   | time       | 1.39 μs   | 1.11 μs     | −20.1%  |
| otel trace   | memory     | 8.77 KB   | 6.86 KB     | −21.8%  |
| otel trace   | reductions | 800       | 440         | −45.0%  |
| edge log     | time       | 8.24 μs   | 7.33 μs     | −11.0%  |
| edge log     | memory     | 38.41 KB  | 31.32 KB    | −18.5%  |
| edge log     | reductions | 2,390     | 1,570       | −34.3%  |
| list heavy   | time       | 50.05 μs  | 44.56 μs    | −11.0%  |
| list heavy   | memory     | 202.59 KB | 156.49 KB   | −22.8%  |
| list heavy   | reductions | 13,930    | 9,430       | −32.3%  |

### End-to-end `LogEvent.make/2` (`test/profiling/log_event_make_bench.exs`)

Shows how the `flatten/1` win translates through the full event-construction path (parse, classify, clean, flatten, build struct). `flatten/1` is a small slice of this work, so the deltas are correspondingly smaller — but they are still in the right direction across all three metrics.

| Payload      | Metric     | main       | this branch | Δ      |
| ------------ | ---------- | ---------- | ----------- | ------ |
| otel trace   | time       | 85.05 μs   | 81.61 μs    | −4.0%  |
| otel trace   | memory     | 0.29 MB    | 0.29 MB     | ~flat  |
| otel trace   | reductions | 31,250     | 30,910      | −1.1%  |
| edge log     | time       | 318.01 μs  | 312.73 μs   | −1.7%  |
| edge log     | memory     | 1.29 MB    | 1.28 MB     | −0.8%  |
| edge log     | reductions | 137,660    | 136,600     | −0.8%  |

## Test plan
- [x] `mix test test/logflare/logs/ingest/metadata_cleaner_test.exs` — 13 tests, 0 failures
- [x] `mix run test/profiling/metadata_cleaner_flatten_bench.exs` against `main` and this branch
- [x] `mix run test/profiling/log_event_make_bench.exs` against `main` and this branch
