### PR TITLE
Exploring `Schema` optimizations

### DIFF
--- a/bench/process_info_message_queue_len_bench.exs
+++ b/bench/process_info_message_queue_len_bench.exs
@@ -5,8 +5,9 @@
 #   ITERATIONS=1000000
 #   SENDERS=1
 #
-# Measures the cost of repeatedly calling:
+# Measures the cost of repeatedly checking queue pressure with either:
 #   Process.info(pid, :message_queue_len)
+#   :atomics.add_get(ref, 1, 1)
 
 iterations = String.to_integer(System.get_env("ITERATIONS") || "1000000")
 senders = String.to_integer(System.get_env("SENDERS") || "1")
@@ -34,6 +35,22 @@ defmodule ProcessInfoMessageQueueLenBench do
 
   def stop(pid) when is_pid(pid) do
     send(pid, :stop)
+  end
+
+  def atomic_counter do
+    :atomics.new(1, signed: false)
+  end
+
+  def atomic_checkout(counter, limit) do
+    queued = :atomics.add_get(counter, 1, 1)
+
+    if queued <= limit do
+      :atomics.sub(counter, 1, 1)
+      1
+    else
+      :atomics.sub(counter, 1, 1)
+      0
+    end
   end
 
   def bench(iterations, fun) do
@@ -103,3 +120,16 @@ Bench.stop(draining_pid)
 
 IO.puts("\ndraining process, concurrent sender pressure")
 IO.inspect(draining_result)
+
+accepted_counter = Bench.atomic_counter()
+accepted_result = Bench.bench(iterations, fn -> Bench.atomic_checkout(accepted_counter, 10) end)
+
+IO.puts("\natomics checkout, accepted and decremented")
+IO.inspect(accepted_result)
+
+rejected_counter = Bench.atomic_counter()
+:atomics.put(rejected_counter, 1, 10)
+rejected_result = Bench.bench(iterations, fn -> Bench.atomic_checkout(rejected_counter, 10) end)
+
+IO.puts("\natomics checkout, rejected and rolled back")
+IO.inspect(rejected_result)

--- a/bench/process_info_message_queue_len_bench.exs
+++ b/bench/process_info_message_queue_len_bench.exs
@@ -1,0 +1,105 @@
+# Usage:
+#   mix run bench/process_info_message_queue_len_bench.exs
+#
+# Env:
+#   ITERATIONS=1000000
+#   SENDERS=1
+#
+# Measures the cost of repeatedly calling:
+#   Process.info(pid, :message_queue_len)
+
+iterations = String.to_integer(System.get_env("ITERATIONS") || "1000000")
+senders = String.to_integer(System.get_env("SENDERS") || "1")
+
+defmodule ProcessInfoMessageQueueLenBench do
+  @moduledoc false
+
+  def sleeping_process do
+    spawn_link(fn ->
+      receive do
+        :stop -> :ok
+      after
+        :infinity -> :ok
+      end
+    end)
+  end
+
+  def draining_process do
+    spawn_link(fn -> drain_loop() end)
+  end
+
+  def send_forever(pid) do
+    spawn(fn -> send_loop(pid) end)
+  end
+
+  def stop(pid) when is_pid(pid) do
+    send(pid, :stop)
+  end
+
+  def bench(iterations, fun) do
+    {us, result} = :timer.tc(fn -> repeat(iterations, fun, 0) end)
+
+    %{
+      total_us: us,
+      ns_per_call: us * 1_000 / iterations,
+      result: result
+    }
+  end
+
+  defp repeat(0, _fun, acc), do: acc
+
+  defp repeat(n, fun, acc) do
+    repeat(n - 1, fun, acc + fun.())
+  end
+
+  defp drain_loop do
+    receive do
+      :stop -> :ok
+      _ -> drain_loop()
+    end
+  end
+
+  defp send_loop(pid) do
+    send(pid, :msg)
+    send_loop(pid)
+  end
+end
+
+alias ProcessInfoMessageQueueLenBench, as: Bench
+
+read_len = fn pid ->
+  case Process.info(pid, :message_queue_len) do
+    {:message_queue_len, len} -> len
+    nil -> 0
+  end
+end
+
+IO.puts("iterations=#{iterations}")
+IO.puts("senders=#{senders}")
+
+sleeping_pid = Bench.sleeping_process()
+sleeping_result = Bench.bench(iterations, fn -> read_len.(sleeping_pid) end)
+Bench.stop(sleeping_pid)
+
+IO.puts("\nsleeping process, empty mailbox")
+IO.inspect(sleeping_result)
+
+backlogged_pid = Bench.sleeping_process()
+for _ <- 1..100_000, do: send(backlogged_pid, :msg)
+backlogged_result = Bench.bench(iterations, fn -> read_len.(backlogged_pid) end)
+Bench.stop(backlogged_pid)
+
+IO.puts("\nsleeping process, 100k queued messages")
+IO.inspect(backlogged_result)
+
+draining_pid = Bench.draining_process()
+sender_pids = for _ <- 1..senders, do: Bench.send_forever(draining_pid)
+
+Process.sleep(100)
+draining_result = Bench.bench(iterations, fn -> read_len.(draining_pid) end)
+
+Enum.each(sender_pids, &Process.exit(&1, :kill))
+Bench.stop(draining_pid)
+
+IO.puts("\ndraining process, concurrent sender pressure")
+IO.inspect(draining_result)

--- a/bench/schema_helpers_bench.exs
+++ b/bench/schema_helpers_bench.exs
@@ -1,0 +1,20 @@
+# Benchmark the Schema helper hot paths without involving the GenServer.
+#
+# Run with:
+#   mix run bench/schema_helpers_bench.exs
+#
+# Optional env vars:
+#   SCHEMA_BENCH_SUITE=all|payload_helpers|builder|schema_helpers
+#   BENCH_TIME=5
+#   BENCH_WARMUP=2
+#   BENCH_MEMORY_TIME=3
+#   BENCH_REDUCTION_TIME=3
+#
+# Public helper functions are exposed via `Logflare.Profiling.SchemaHelpersBench`
+# so they can be targeted directly with `:eprof` after this.
+
+Code.require_file("support/schema_helpers_bench.ex", __DIR__)
+
+alias Logflare.Profiling.SchemaHelpersBench
+
+SchemaHelpersBench.run()

--- a/bench/schema_update_bench.exs
+++ b/bench/schema_update_bench.exs
@@ -1,0 +1,151 @@
+# Benchmark the local Schema update work without starting the application or
+# touching BigQuery/Postgres. This approximates the work inside the Schema
+# GenServer before a remote patch would be attempted.
+#
+# Run with:
+#   mix run --no-start bench/schema_update_bench.exs
+#
+# Optional env vars:
+#   SCHEMA_UPDATE_BENCH_SCENARIO=all|wide_top_level|cloudflare_nested|otel_trace
+#   BENCH_TIME=5
+#   BENCH_WARMUP=2
+#   BENCH_MEMORY_TIME=0
+#   BENCH_REDUCTION_TIME=0
+#   PROFILE_AFTER=false|eprof|tprof|cprof|fprof
+
+Code.require_file("support/schema_helpers_bench.ex", __DIR__)
+
+defmodule Logflare.Profiling.SchemaUpdateBench do
+  @moduledoc false
+
+  alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Profiling.SchemaHelpersBench
+  alias Logflare.Sources.Source.BigQuery.SchemaBuilder
+
+  @type scenario :: SchemaHelpersBench.scenario()
+  @type update_result :: :same | {:changed, map(), non_neg_integer()}
+
+  @spec run() :: :ok
+  def run do
+    scenarios = selected_scenarios()
+
+    Benchee.run(
+      %{
+        "existing payload: build + diff" => fn scenario ->
+          existing_payload_update(scenario)
+        end,
+        "one new field: build + diff" => fn scenario ->
+          new_field_update(scenario)
+        end,
+        "one new field: build + diff + flatmap" => fn scenario ->
+          new_field_update_with_flatmap(scenario)
+        end
+      },
+      benchmark_opts(inputs: benchee_inputs(scenarios))
+    )
+
+    :ok
+  end
+
+  @spec existing_payload_update(scenario()) :: update_result()
+  def existing_payload_update(scenario) do
+    scenario
+    |> SchemaHelpersBench.payload_for()
+    |> local_update(SchemaHelpersBench.schema_for(scenario), false)
+  end
+
+  @spec new_field_update(scenario()) :: update_result()
+  def new_field_update(scenario) do
+    scenario
+    |> SchemaHelpersBench.extended_payload_for()
+    |> local_update(SchemaHelpersBench.schema_for(scenario), false)
+  end
+
+  @spec new_field_update_with_flatmap(scenario()) :: update_result()
+  def new_field_update_with_flatmap(scenario) do
+    scenario
+    |> SchemaHelpersBench.extended_payload_for()
+    |> local_update(SchemaHelpersBench.schema_for(scenario), true)
+  end
+
+  defp local_update(payload, old_schema, build_flatmap?) do
+    new_schema = SchemaBuilder.build_table_schema(payload, old_schema)
+
+    if same_schemas?(old_schema, new_schema) do
+      :same
+    else
+      flatmap =
+        if build_flatmap? do
+          SchemaUtils.bq_schema_to_flat_typemap(new_schema)
+        else
+          %{}
+        end
+
+      {:changed, new_schema, map_size(flatmap)}
+    end
+  end
+
+  defp same_schemas?(old_schema, new_schema) do
+    old_schema == new_schema
+  end
+
+  defp benchmark_opts(overrides) do
+    [
+      time: benchmark_seconds("BENCH_TIME", 5.0),
+      warmup: benchmark_seconds("BENCH_WARMUP", 2.0),
+      memory_time: benchmark_seconds("BENCH_MEMORY_TIME", 0.0),
+      reduction_time: benchmark_seconds("BENCH_REDUCTION_TIME", 0.0),
+      profile_after: profile_after(),
+      print: [configuration: false],
+      formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
+    ]
+    |> Keyword.merge(overrides)
+  end
+
+  defp profile_after do
+    case System.get_env("PROFILE_AFTER", "false") do
+      value when value in ["", "false", "0"] -> false
+      value when value in ["true", "1"] -> true
+      "eprof" -> :eprof
+      "tprof" -> :tprof
+      "cprof" -> :cprof
+      "fprof" -> :fprof
+      other -> raise ArgumentError, "Unknown PROFILE_AFTER=#{inspect(other)}"
+    end
+  end
+
+  defp benchmark_seconds(env_var, default) do
+    case System.get_env(env_var) do
+      nil ->
+        default
+
+      value ->
+        case Float.parse(value) do
+          {seconds, ""} when seconds >= 0 -> seconds
+          _ -> raise ArgumentError, "Expected #{env_var} to be a non-negative number"
+        end
+    end
+  end
+
+  defp selected_scenarios do
+    case System.get_env("SCHEMA_UPDATE_BENCH_SCENARIO", "all") do
+      "all" -> SchemaHelpersBench.scenario_names()
+      "wide_top_level" -> [:wide_top_level]
+      "cloudflare_nested" -> [:cloudflare_nested]
+      "otel_trace" -> [:otel_trace]
+      other -> raise ArgumentError, "Unknown SCHEMA_UPDATE_BENCH_SCENARIO=#{inspect(other)}"
+    end
+  end
+
+  defp benchee_inputs(scenarios) do
+    for scenario <- scenarios, into: %{} do
+      {scenario_label(scenario), scenario}
+    end
+  end
+
+  defp scenario_label(:wide_top_level), do: "wide top-level log"
+  defp scenario_label(:cloudflare_nested), do: "cloudflare nested log"
+  defp scenario_label(:otel_trace), do: "otel trace"
+end
+
+Logflare.Profiling.SchemaUpdateBench.run()

--- a/bench/schema_update_bench.exs
+++ b/bench/schema_update_bench.exs
@@ -69,9 +69,10 @@ defmodule Logflare.Profiling.SchemaUpdateBench do
   end
 
   defp local_update(payload, old_schema, build_flatmap?) do
-    new_schema = SchemaBuilder.build_table_schema(payload, old_schema)
+    {new_schema, schema_changed?} =
+      SchemaBuilder.build_table_schema_with_change(payload, old_schema)
 
-    if same_schemas?(old_schema, new_schema) do
+    if not schema_changed? do
       :same
     else
       flatmap =
@@ -83,10 +84,6 @@ defmodule Logflare.Profiling.SchemaUpdateBench do
 
       {:changed, new_schema, map_size(flatmap)}
     end
-  end
-
-  defp same_schemas?(old_schema, new_schema) do
-    old_schema == new_schema
   end
 
   defp benchmark_opts(overrides) do

--- a/bench/support/schema_helpers_bench.ex
+++ b/bench/support/schema_helpers_bench.ex
@@ -142,7 +142,7 @@ defmodule Logflare.Profiling.SchemaHelpersBench do
     |> SchemaUtils.bq_schema_to_flat_typemap()
   end
 
-  @spec repeat(pos_integer(), (() -> term())) :: :ok
+  @spec repeat(pos_integer(), (-> term())) :: :ok
   def repeat(count, fun) when is_integer(count) and count > 0 and is_function(fun, 0) do
     do_repeat(count, fun)
   end
@@ -199,16 +199,29 @@ defmodule Logflare.Profiling.SchemaHelpersBench do
     end
   end
 
-  defp benchmark_opts(overrides \\ []) do
+  defp benchmark_opts(overrides) do
     [
       time: benchmark_seconds("BENCH_TIME", 5.0),
       warmup: benchmark_seconds("BENCH_WARMUP", 2.0),
       memory_time: benchmark_seconds("BENCH_MEMORY_TIME", 3.0),
       reduction_time: benchmark_seconds("BENCH_REDUCTION_TIME", 3.0),
+      profile_after: profile_after(),
       print: [configuration: false],
       formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
     ]
     |> Keyword.merge(overrides)
+  end
+
+  defp profile_after do
+    case System.get_env("PROFILE_AFTER", "false") do
+      value when value in ["", "false", "0"] -> false
+      value when value in ["true", "1"] -> true
+      "eprof" -> :eprof
+      "tprof" -> :tprof
+      "cprof" -> :cprof
+      "fprof" -> :fprof
+      other -> raise ArgumentError, "Unknown PROFILE_AFTER=#{inspect(other)}"
+    end
   end
 
   defp benchmark_seconds(env_var, default) do

--- a/bench/support/schema_helpers_bench.ex
+++ b/bench/support/schema_helpers_bench.ex
@@ -1,0 +1,399 @@
+defmodule Logflare.Profiling.SchemaHelpersBench do
+  @moduledoc false
+
+  alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Sources.Source.BigQuery.SchemaBuilder
+  alias LogflareWeb.Logs.PayloadTestUtils
+
+  @data_key {__MODULE__, :data}
+
+  @type suite :: :all | :builder | :payload_helpers | :schema_helpers
+  @type scenario :: :cloudflare_nested | :otel_trace | :wide_top_level
+
+  @spec run() :: :ok
+  def run do
+    run(selected_suite())
+  end
+
+  @spec run(suite()) :: :ok
+  def run(:all) do
+    Enum.each([:payload_helpers, :builder, :schema_helpers], &run/1)
+    :ok
+  end
+
+  def run(:payload_helpers) do
+    IO.puts("\n== Schema payload helpers ==")
+
+    Benchee.run(
+      %{
+        "to_typemap/1" => fn scenario ->
+          payload_to_typemap(scenario)
+        end,
+        "flatten_typemap/1 (precomputed payload typemap)" => fn scenario ->
+          payload_flatten_typemap(scenario)
+        end,
+        "to_typemap |> flatten_typemap" => fn scenario ->
+          payload_to_flat_typemap(scenario)
+        end
+      },
+      benchmark_opts(inputs: benchee_inputs())
+    )
+
+    :ok
+  end
+
+  def run(:builder) do
+    IO.puts("\n== Schema builder helpers ==")
+
+    Benchee.run(
+      %{
+        "build_table_schema/2 from initial schema" => fn scenario ->
+          builder_from_initial(scenario)
+        end,
+        "build_table_schema/2 against existing schema" => fn scenario ->
+          builder_against_existing(scenario)
+        end,
+        "build_table_schema/2 with 1 new field" => fn scenario ->
+          builder_with_new_field(scenario)
+        end
+      },
+      benchmark_opts(inputs: benchee_inputs())
+    )
+
+    :ok
+  end
+
+  def run(:schema_helpers) do
+    IO.puts("\n== BigQuery schema helpers ==")
+
+    Benchee.run(
+      %{
+        "to_typemap/1 on TableSchema" => fn scenario ->
+          schema_to_typemap(scenario)
+        end,
+        "flatten_typemap/1 (precomputed schema typemap)" => fn scenario ->
+          schema_flatten_typemap(scenario)
+        end,
+        "bq_schema_to_flat_typemap/1" => fn scenario ->
+          schema_to_flat_typemap(scenario)
+        end
+      },
+      benchmark_opts(inputs: benchee_inputs())
+    )
+
+    :ok
+  end
+
+  @spec payload_to_typemap(scenario()) :: map()
+  def payload_to_typemap(scenario) do
+    scenario
+    |> payload_for()
+    |> SchemaUtils.to_typemap()
+  end
+
+  @spec payload_flatten_typemap(scenario()) :: map()
+  def payload_flatten_typemap(scenario) do
+    scenario
+    |> payload_typemap_for()
+    |> SchemaUtils.flatten_typemap()
+  end
+
+  @spec payload_to_flat_typemap(scenario()) :: map()
+  def payload_to_flat_typemap(scenario) do
+    scenario
+    |> payload_for()
+    |> SchemaUtils.to_typemap()
+    |> SchemaUtils.flatten_typemap()
+  end
+
+  @spec builder_from_initial(scenario()) :: GoogleApi.BigQuery.V2.Model.TableSchema.t()
+  def builder_from_initial(scenario) do
+    SchemaBuilder.build_table_schema(payload_for(scenario), initial_schema())
+  end
+
+  @spec builder_against_existing(scenario()) :: GoogleApi.BigQuery.V2.Model.TableSchema.t()
+  def builder_against_existing(scenario) do
+    SchemaBuilder.build_table_schema(payload_for(scenario), schema_for(scenario))
+  end
+
+  @spec builder_with_new_field(scenario()) :: GoogleApi.BigQuery.V2.Model.TableSchema.t()
+  def builder_with_new_field(scenario) do
+    SchemaBuilder.build_table_schema(extended_payload_for(scenario), schema_for(scenario))
+  end
+
+  @spec schema_to_typemap(scenario()) :: map()
+  def schema_to_typemap(scenario) do
+    scenario
+    |> schema_for()
+    |> SchemaUtils.to_typemap()
+  end
+
+  @spec schema_flatten_typemap(scenario()) :: map()
+  def schema_flatten_typemap(scenario) do
+    scenario
+    |> schema_typemap_for()
+    |> SchemaUtils.flatten_typemap()
+  end
+
+  @spec schema_to_flat_typemap(scenario()) :: map()
+  def schema_to_flat_typemap(scenario) do
+    scenario
+    |> schema_for()
+    |> SchemaUtils.bq_schema_to_flat_typemap()
+  end
+
+  @spec repeat(pos_integer(), (() -> term())) :: :ok
+  def repeat(count, fun) when is_integer(count) and count > 0 and is_function(fun, 0) do
+    do_repeat(count, fun)
+  end
+
+  @spec initial_schema() :: GoogleApi.BigQuery.V2.Model.TableSchema.t()
+  def initial_schema do
+    data().initial_schema
+  end
+
+  @spec scenario_names() :: [scenario()]
+  def scenario_names do
+    data().scenario_names
+  end
+
+  @spec payload_for(scenario()) :: map()
+  def payload_for(scenario) do
+    Map.fetch!(data().payloads, scenario)
+  end
+
+  @spec extended_payload_for(scenario()) :: map()
+  def extended_payload_for(scenario) do
+    Map.fetch!(data().extended_payloads, scenario)
+  end
+
+  @spec schema_for(scenario()) :: GoogleApi.BigQuery.V2.Model.TableSchema.t()
+  def schema_for(scenario) do
+    Map.fetch!(data().schemas, scenario)
+  end
+
+  defp do_repeat(0, _fun), do: :ok
+
+  defp do_repeat(count, fun) do
+    fun.()
+    do_repeat(count - 1, fun)
+  end
+
+  defp payload_typemap_for(scenario) do
+    Map.fetch!(data().payload_typemaps, scenario)
+  end
+
+  defp schema_typemap_for(scenario) do
+    Map.fetch!(data().schema_typemaps, scenario)
+  end
+
+  defp selected_suite do
+    case System.get_env("SCHEMA_BENCH_SUITE", "all") do
+      "all" -> :all
+      "payload" -> :payload_helpers
+      "payload_helpers" -> :payload_helpers
+      "builder" -> :builder
+      "schema" -> :schema_helpers
+      "schema_helpers" -> :schema_helpers
+      other -> raise ArgumentError, "Unknown SCHEMA_BENCH_SUITE=#{inspect(other)}"
+    end
+  end
+
+  defp benchmark_opts(overrides \\ []) do
+    [
+      time: benchmark_seconds("BENCH_TIME", 5.0),
+      warmup: benchmark_seconds("BENCH_WARMUP", 2.0),
+      memory_time: benchmark_seconds("BENCH_MEMORY_TIME", 3.0),
+      reduction_time: benchmark_seconds("BENCH_REDUCTION_TIME", 3.0),
+      print: [configuration: false],
+      formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
+    ]
+    |> Keyword.merge(overrides)
+  end
+
+  defp benchmark_seconds(env_var, default) do
+    case System.get_env(env_var) do
+      nil ->
+        default
+
+      value ->
+        case Float.parse(value) do
+          {seconds, ""} when seconds >= 0 -> seconds
+          _ -> raise ArgumentError, "Expected #{env_var} to be a non-negative number"
+        end
+    end
+  end
+
+  defp benchee_inputs do
+    for scenario <- scenario_names(), into: %{} do
+      {scenario_label(scenario), scenario}
+    end
+  end
+
+  defp scenario_label(:wide_top_level), do: "wide top-level log"
+  defp scenario_label(:cloudflare_nested), do: "cloudflare nested log"
+  defp scenario_label(:otel_trace), do: "otel trace"
+
+  defp data do
+    case :persistent_term.get(@data_key, nil) do
+      nil ->
+        data = build_data()
+        :persistent_term.put(@data_key, data)
+        data
+
+      data ->
+        data
+    end
+  end
+
+  defp build_data do
+    initial_schema = SchemaBuilder.initial_table_schema()
+
+    payloads = %{
+      wide_top_level: wide_top_level_payload(),
+      cloudflare_nested: cloudflare_nested_payload(),
+      otel_trace: otel_trace_payload()
+    }
+
+    schemas =
+      for {scenario, payload} <- payloads, into: %{} do
+        {scenario, SchemaBuilder.build_table_schema(payload, initial_schema)}
+      end
+
+    payload_typemaps =
+      for {scenario, payload} <- payloads, into: %{} do
+        {scenario, SchemaUtils.to_typemap(payload)}
+      end
+
+    schema_typemaps =
+      for {scenario, schema} <- schemas, into: %{} do
+        {scenario, SchemaUtils.to_typemap(schema)}
+      end
+
+    %{
+      scenario_names: [:wide_top_level, :cloudflare_nested, :otel_trace],
+      initial_schema: initial_schema,
+      payloads: payloads,
+      extended_payloads: extended_payloads(payloads),
+      payload_typemaps: payload_typemaps,
+      schemas: schemas,
+      schema_typemaps: schema_typemaps
+    }
+  end
+
+  defp extended_payloads(payloads) do
+    %{
+      wide_top_level:
+        put_nested(
+          Map.fetch!(payloads, :wide_top_level),
+          ["nested_metrics", "queue", "lag_ms"],
+          33
+        ),
+      cloudflare_nested:
+        put_nested(
+          Map.fetch!(payloads, :cloudflare_nested),
+          ["metadata", "response", "headers", "server_timing"],
+          "edge;dur=12"
+        ),
+      otel_trace:
+        put_nested(
+          Map.fetch!(payloads, :otel_trace),
+          ["resource", "telemetry", "sdk", "version"],
+          "1.26.0"
+        )
+    }
+  end
+
+  defp wide_top_level_payload do
+    integers =
+      for idx <- 1..25, into: %{} do
+        {"int_field_#{idx}", idx}
+      end
+
+    strings =
+      for idx <- 1..25, into: %{} do
+        {"string_field_#{idx}", "value_#{idx}"}
+      end
+
+    booleans =
+      for idx <- 1..10, into: %{} do
+        {"flag_field_#{idx}", rem(idx, 2) == 0}
+      end
+
+    %{
+      "timestamp" => "2026-01-21T17:54:48.144506Z",
+      "id" => "evt-wide-001",
+      "event_message" => "wide top-level payload",
+      "project" => "wide-top-level-project",
+      "request_id" => "req-wide-001",
+      "duration_ms" => 18.4,
+      "tags" => Enum.map(1..8, &"tag_#{&1}"),
+      "counts" => Enum.to_list(1..8),
+      "items" => [
+        %{"id" => 1, "status" => "ok", "duration_ms" => 12.5},
+        %{"id" => 2, "status" => "warn", "error" => %{"code" => 500, "retryable" => false}}
+      ],
+      "nested_metrics" => %{
+        "http" => %{"status_code" => 200, "method" => "POST", "retryable" => false},
+        "queue" => %{"depth" => 12, "name" => "ingest", "sampled" => true}
+      },
+      "metadata" => %{
+        "environment" => "staging",
+        "service" => %{"name" => "api", "version" => "1.2.3"},
+        "region" => "eu-west-1"
+      }
+    }
+    |> Map.merge(integers)
+    |> Map.merge(strings)
+    |> Map.merge(booleans)
+  end
+
+  defp cloudflare_nested_payload do
+    %{
+      "timestamp" => "2026-01-21T17:54:48.144506Z",
+      "id" => "evt-cf-001",
+      "event_message" => "GET | 200 | cloudflare nested log",
+      "project" => "cloudflare-project",
+      "request_id" => "req-cf-001",
+      "metadata" => PayloadTestUtils.standard_metadata(:cloudflare)
+    }
+  end
+
+  defp otel_trace_payload do
+    %{
+      "timestamp" => "2026-01-21T17:54:48.144506Z",
+      "id" => "evt-otel-001",
+      "event_message" => "POST /functions/v1/stripe-worker",
+      "project" => "otel-project",
+      "metadata" => %{"type" => "span"},
+      "resource" => %{
+        "cloud" => %{"provider" => "aws", "region" => "us-east-1"},
+        "deployment" => %{"environment" => "staging"},
+        "service" => %{"name" => "supabase-api-gateway", "version" => "1.0.0"}
+      },
+      "scope" => %{
+        "name" => "go.opentelemetry.io/contrib/instrumentation/gin",
+        "version" => "0.61.0"
+      },
+      "attributes" => %{
+        "_http_request_method" => "POST",
+        "_http_route" => "/functions/v1/*path",
+        "_http_status_code" => 404,
+        "_network_peer_address" => "99.88.160.11",
+        "_network_peer_port" => 57_785,
+        "_url_path" => "/functions/v1/stripe-worker",
+        "_url_scheme" => "https"
+      },
+      "start_time" => 1_737_482_088_144_506_000,
+      "end_time" => 1_737_482_088_444_334_000,
+      "severity_number" => 9,
+      "retry_count" => 3,
+      "span_id" => "c99f33f1bfa4fb8f",
+      "trace_id" => "f9918d38f5d1cb74ec5656b9a315e5f6"
+    }
+  end
+
+  defp put_nested(map, path, value) do
+    put_in(map, Enum.map(path, &Access.key(&1, %{})), value)
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,9 @@ config :logflare, :clickhouse_backend_adaptor,
   pool_size: 3,
   native_pool_size: 10
 
-config :logflare, Logflare.Sources.Source.BigQuery.Schema, updates_per_minute: 6
+config :logflare, Logflare.Sources.Source.BigQuery.Schema,
+  updates_per_minute: 6,
+  max_message_queue_len: 10
 
 # Configures the endpoint
 config :logflare, LogflareWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,9 @@ config :logflare, LogflareWeb.Endpoint,
 
 config :logflare, Logflare.Cluster.Utils, min_cluster_size: 1
 
-config :logflare, Logflare.Sources.Source.BigQuery.Schema, updates_per_minute: 900_000
+config :logflare, Logflare.Sources.Source.BigQuery.Schema,
+  updates_per_minute: 900_000,
+  max_message_queue_len: 10
 
 config :logflare, Logflare.Google,
   dataset_id_append: "_test",

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -791,6 +791,15 @@ defmodule Logflare.Backends do
     {:via, Registry, {SourceRegistry, {id, process_id}}}
   end
 
+  @spec via_source_with_value(Source.t() | non_neg_integer(), term(), term()) ::
+          {:via, module(), term()}
+  def via_source_with_value(%Source{id: id}, process_id, value),
+    do: via_source_with_value(id, process_id, value)
+
+  def via_source_with_value(id, process_id, value) when is_number(id) do
+    {:via, Registry, {SourceRegistry, {id, process_id}, value}}
+  end
+
   @doc """
   Registers a unique backend-related process on the backend registry.
   """

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -96,7 +96,12 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
          source: source,
          bigquery_project_id: project_id,
          bigquery_dataset_id: dataset_id,
-         name: Backends.via_source(source, Schema, backend.id)
+         name:
+           Backends.via_source_with_value(
+             source,
+             {Schema, backend.id},
+             Schema.update_counter()
+           )
        ]}
     ]
 

--- a/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
+++ b/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
@@ -107,16 +107,16 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
     end
   end
 
+  # Reached recursively from the list-of-maps branch above when an element
+  # isn't a map (e.g. [%{...}, "x"]). Returning %{} keeps the surrounding
+  # Map.merge a no-op without crashing the walk.
+  def to_typemap(_), do: %{}
+
   defp normalize_typemap_key(k) when is_atom(k), do: k
 
   defp normalize_typemap_key(k) when is_binary(k) do
     if String.valid?(k), do: k, else: decode_until_valid!(k)
   end
-
-  # Reached recursively from the list-of-maps branch above when an element
-  # isn't a map (e.g. [%{...}, "x"]). Returning %{} keeps the surrounding
-  # Map.merge a no-op without crashing the walk.
-  def to_typemap(_), do: %{}
 
   defp decode_until_valid!(k, encodings \\ [:utf8, :unicode, :latin1])
 

--- a/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
+++ b/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
@@ -72,6 +72,8 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
 
   def struct_to_map(struct), do: struct |> Poison.encode!() |> Poison.decode!()
 
+  @type typemap_key :: atom() | String.t()
+
   @spec to_typemap(term()) :: map() | nil
   def to_typemap(nil), do: nil
 
@@ -101,15 +103,14 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
             %{t: type_of(v)}
         end
 
-      k =
-        cond do
-          is_atom(k) -> k
-          String.valid?(k) -> String.to_atom(k)
-          true -> decode_until_valid!(k)
-        end
-
-      {k, v}
+      {normalize_typemap_key(k), v}
     end
+  end
+
+  defp normalize_typemap_key(k) when is_atom(k), do: k
+
+  defp normalize_typemap_key(k) when is_binary(k) do
+    if String.valid?(k), do: k, else: decode_until_valid!(k)
   end
 
   # Reached recursively from the list-of-maps branch above when an element
@@ -131,7 +132,6 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
       k ->
         k
         |> Unicode.unaccent()
-        |> String.to_atom()
     end
   end
 
@@ -147,7 +147,8 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
     true
   end
 
-  @spec to_typemap(TS.t() | list(TS.t()), keyword) :: %{required(atom) => map | atom}
+  @spec to_typemap(TS.t() | list(TS.t()), keyword) ::
+          %{required(typemap_key()) => map | atom}
   def to_typemap(%TS{fields: fields} = schema, from: :bigquery_schema) when is_map(schema) do
     to_typemap(fields, from: :bigquery_schema)
   end
@@ -155,8 +156,6 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
   def to_typemap(fields, from: :bigquery_schema) when is_list(fields) do
     Map.new(fields, fn
       %TFS{fields: fields, name: n, type: t, mode: mode} ->
-        k = String.to_atom(n)
-
         v =
           cond do
             mode == "REPEATED" and t == "RECORD" ->
@@ -183,7 +182,7 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
             v
           end
 
-        {k, v}
+        {n, v}
     end)
   end
 

--- a/lib/logflare/source_schemas.ex
+++ b/lib/logflare/source_schemas.ex
@@ -152,22 +152,22 @@ defmodule Logflare.SourceSchemas do
   end
 
   defp typemap_to_json_schema({key, %{fields: fields, t: :map}}) do
-    {Atom.to_string(key), typemap_to_json_schema(fields)}
+    {to_string(key), typemap_to_json_schema(fields)}
   end
 
   defp typemap_to_json_schema({key, %{t: {:list, type}}}) do
-    {Atom.to_string(key), %{"type" => "array", "items" => %{"type" => Atom.to_string(type)}}}
+    {to_string(key), %{"type" => "array", "items" => %{"type" => Atom.to_string(type)}}}
   end
 
   defp typemap_to_json_schema({key, %{t: :datetime}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: :integer}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: :float}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: type}}),
-    do: {Atom.to_string(key), %{"type" => Atom.to_string(type)}}
+    do: {to_string(key), %{"type" => Atom.to_string(type)}}
 end

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -254,12 +254,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   defp same_schemas?(old_schema, new_schema) do
-    old_flatmap = SchemaUtils.bq_schema_to_flat_typemap(old_schema)
-    new_flatmap = SchemaUtils.bq_schema_to_flat_typemap(new_schema)
-
-    diff_keys = Map.keys(new_flatmap) -- Map.keys(old_flatmap)
-
-    old_schema == new_schema and Enum.empty?(diff_keys)
+    old_schema == new_schema
   end
 
   defp try_schema_update(body, schema) do

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -31,10 +31,14 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     )
   end
 
-  @spec update(atom(), LogEvent.t(), Source.t()) :: :ok
+  @spec update(pid() | tuple(), LogEvent.t(), Source.t()) :: :ok
   def update(pid, %LogEvent{} = log_event, %Source{} = source)
       when is_pid(pid) or is_tuple(pid) do
-    GenServer.cast(pid, {:update, log_event, source})
+    if accept_update?(pid) do
+      GenServer.cast(pid, {:update, log_event, source})
+    else
+      :ok
+    end
   end
 
   # GenServer callbacks
@@ -193,6 +197,30 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   defp next_update do
     updates_per_minute = Application.get_env(:logflare, __MODULE__)[:updates_per_minute]
     next_update_ts(updates_per_minute)
+  end
+
+  defp accept_update?(pid) when is_pid(pid) do
+    mailbox_below_limit?(pid)
+  end
+
+  defp accept_update?(name) do
+    case GenServer.whereis(name) do
+      pid when is_pid(pid) -> mailbox_below_limit?(pid)
+      _ -> true
+    end
+  end
+
+  defp mailbox_below_limit?(pid) do
+    with limit when is_integer(limit) and limit > 0 <- max_message_queue_len(),
+         {:message_queue_len, len} <- Process.info(pid, :message_queue_len) do
+      len < limit
+    else
+      _ -> true
+    end
+  end
+
+  defp max_message_queue_len do
+    Application.get_env(:logflare, __MODULE__)[:max_message_queue_len]
   end
 
   defp same_schemas?(old_schema, new_schema) do

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -109,9 +109,9 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
         do: source_schema.bigquery_schema,
         else: SchemaBuilder.initial_table_schema()
 
-    schema = try_schema_update(body, db_schema)
+    {schema, schema_changed?} = try_schema_update(body, db_schema)
 
-    if schema_needs_update?(db_schema, schema, state) do
+    if schema_needs_update?(schema_changed?, state) do
       case patch_bigquery_table(state, schema) do
         {:ok, _table_info} ->
           handle_successful_patch(state, schema, db_schema)
@@ -124,8 +124,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     end
   end
 
-  defp schema_needs_update?(db_schema, schema, state) do
-    not same_schemas?(db_schema, schema) and
+  defp schema_needs_update?(schema_changed?, state) do
+    schema_changed? and
       state.next_update <= System.system_time(:millisecond) and
       not SingleTenant.postgres_backend?()
   end
@@ -158,7 +158,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
   defp handle_schema_mismatch(body, state) do
     with {:ok, table} <- BigQuery.get_table(state.source_token),
-         schema <- try_schema_update(body, table.schema),
+         {schema, _schema_changed?} <- try_schema_update(body, table.schema),
          {:ok, _table_info} <- patch_bigquery_table(state, schema) do
       field_count = count_fields(schema)
       persist(state.source_id, schema)
@@ -253,17 +253,13 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     Application.get_env(:logflare, __MODULE__)[:max_message_queue_len]
   end
 
-  defp same_schemas?(old_schema, new_schema) do
-    old_schema == new_schema
-  end
-
   defp try_schema_update(body, schema) do
-    SchemaBuilder.build_table_schema(body, schema)
+    SchemaBuilder.build_table_schema_with_change(body, schema)
   rescue
     e ->
       Logger.warning("Field schema type change error!", error_string: inspect(e))
 
-      schema
+      {schema, false}
   end
 
   # public function for testing

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -17,6 +17,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   alias Logflare.Sources.Source
   alias Logflare.LogEvent
   alias Logflare.AccountEmail
+  alias Logflare.Backends
   alias Logflare.Mailer
   alias Logflare.TeamUsers
   alias Logflare.SingleTenant
@@ -31,13 +32,20 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     )
   end
 
+  @spec update_counter() :: :atomics.atomics_ref()
+  def update_counter do
+    :atomics.new(1, signed: false)
+  end
+
   @spec update(pid() | tuple(), LogEvent.t(), Source.t()) :: :ok
   def update(pid, %LogEvent{} = log_event, %Source{} = source)
       when is_pid(pid) or is_tuple(pid) do
-    if accept_update?(pid) do
-      GenServer.cast(pid, {:update, log_event, source})
-    else
-      :ok
+    case checkout_update(pid) do
+      {:ok, counter} ->
+        GenServer.cast(pid, {:update, counter, log_event, source})
+
+      :drop ->
+        :ok
     end
   end
 
@@ -77,20 +85,21 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     {:noreply, %{state | field_count: count_fields(schema)}}
   end
 
-  def handle_cast(
-        {:update, %LogEvent{}, %Source{lock_schema: true}},
-        state
-      ),
-      do: {:noreply, state}
+  def handle_cast({:update, counter, log_event, source}, state) do
+    try do
+      handle_update(log_event, source, state)
+    after
+      checkin_update(counter)
+    end
+  end
 
-  def handle_cast(
-        {:update, %LogEvent{}, _source},
-        %{field_count: fc, field_count_limit: limit} = state
-      )
-      when fc > limit,
-      do: {:noreply, state}
+  defp handle_update(%LogEvent{}, %Source{lock_schema: true}, state), do: {:noreply, state}
 
-  def handle_cast({:update, %LogEvent{body: body, id: event_id}, _source}, state) do
+  defp handle_update(%LogEvent{}, _source, %{field_count: fc, field_count_limit: limit} = state)
+       when fc > limit,
+       do: {:noreply, state}
+
+  defp handle_update(%LogEvent{body: body, id: event_id}, _source, state) do
     LogflareLogger.context(source_id: state.source_token, log_event_id: event_id)
 
     source_schema = SourceSchemas.Cache.get_source_schema_by(source_id: state.source_id)
@@ -199,25 +208,46 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     next_update_ts(updates_per_minute)
   end
 
-  defp accept_update?(pid) when is_pid(pid) do
-    mailbox_below_limit?(pid)
+  defp checkout_update(pid) when is_pid(pid) do
+    {:ok, nil}
   end
 
-  defp accept_update?(name) do
+  defp checkout_update({:via, Registry, {Backends.SourceRegistry, key}}) do
+    checkout_registry_update(key)
+  end
+
+  defp checkout_update({:via, Registry, {Backends.SourceRegistry, key, _value}}) do
+    checkout_registry_update(key)
+  end
+
+  defp checkout_update(name) do
     case GenServer.whereis(name) do
-      pid when is_pid(pid) -> mailbox_below_limit?(pid)
-      _ -> true
+      pid when is_pid(pid) -> {:ok, nil}
+      _ -> :drop
     end
   end
 
-  defp mailbox_below_limit?(pid) do
-    with limit when is_integer(limit) and limit > 0 <- max_message_queue_len(),
-         {:message_queue_len, len} <- Process.info(pid, :message_queue_len) do
-      len < limit
-    else
-      _ -> true
+  defp checkout_registry_update(key) do
+    case Registry.lookup(Backends.SourceRegistry, key) do
+      [{_pid, counter}] -> checkout_counter(counter)
+      _ -> :drop
     end
   end
+
+  defp checkout_counter(counter) do
+    queued = :atomics.add_get(counter, 1, 1)
+    limit = max_message_queue_len()
+
+    if not is_integer(limit) or limit <= 0 or queued <= limit do
+      {:ok, counter}
+    else
+      checkin_update(counter)
+      :drop
+    end
+  end
+
+  defp checkin_update(nil), do: :ok
+  defp checkin_update(counter), do: :atomics.sub(counter, 1, 1)
 
   defp max_message_queue_len do
     Application.get_env(:logflare, __MODULE__)[:max_message_queue_len]

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -126,28 +126,34 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
   @spec build_table_schema([map()] | map(), TFS.t()) :: TFS.t()
 
   def build_table_schema(params, %{fields: old_fields}) do
-    protected_keys = Enum.map(initial_table_schema().fields, & &1.name)
+    initial_schema = initial_table_schema()
+    protected_keys = MapSet.new(initial_schema.fields, & &1.name)
+    param_keys = Map.keys(params)
+    param_key_set = MapSet.new(param_keys)
+    old_fields_by_name = Map.new(old_fields, &{&1.name, &1})
     is_otel = otel_data?(params)
 
     new_fields =
-      for param_key <- Map.keys(params),
-          param_key not in protected_keys do
-        prev_field_schema = Enum.find(old_fields, &(&1.name == param_key)) || %{}
-        param_value = Map.get(params, param_key)
-        new_field_schema = build_fields_schemas({param_key, param_value}, is_otel)
+      Enum.reduce(params, [], fn {param_key, param_value}, acc ->
+        if MapSet.member?(protected_keys, param_key) do
+          acc
+        else
+          prev_field_schema = Map.get(old_fields_by_name, param_key)
+          new_field_schema = build_fields_schemas({param_key, param_value}, is_otel)
 
-        prev_field_schema
-        |> DeepMerge.deep_merge(new_field_schema)
-      end
+          [merge_field_schema(prev_field_schema, new_field_schema) | acc]
+        end
+      end)
+      |> Enum.reverse()
 
     # reject old fields that are now included in the params
-    unrejected_fields = old_fields |> Enum.reject(&(&1.name in Map.keys(params)))
+    unrejected_fields = Enum.reject(old_fields, &MapSet.member?(param_key_set, &1.name))
 
     updated_fields =
-      (unrejected_fields ++ new_fields ++ initial_table_schema().fields)
+      (unrejected_fields ++ new_fields ++ initial_schema.fields)
       |> Enum.uniq_by(fn f -> f.name end)
 
-    initial_table_schema()
+    initial_schema
     |> Map.put(:fields, updated_fields)
     |> deep_sort_by_fields_name()
   end
@@ -192,7 +198,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
 
   defp build_fields_schemas(maps, _is_otel) when is_list(maps) do
     maps
-    |> Enum.reduce(%{}, &DeepMerge.deep_merge/2)
+    |> Enum.reduce(%{}, &merge_payload_maps/2)
     |> Enum.reject(fn
       {_, v} when v == [] when v == %{} when v == [[]] -> true
       _ -> false
@@ -242,51 +248,41 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
     Map.has_key?(params, "resource") and Map.has_key?(params, "scope")
   end
 
-  defimpl DeepMerge.Resolver, for: Model.TableFieldSchema do
-    @doc """
-    Implements merge for schema key conflicts.
-    Overwrites fields schemas that are present BOTH in old and new TFS structs and keeps fields schemas present ONLY in old.
-    """
-
-    @spec resolve(TFS.t(), TFS.t(), fun) :: TFS.t()
-    def resolve(old, new, _standard_resolver) do
-      resolve(old, new)
-    end
-
-    @spec resolve(TFS.t(), TFS.t()) :: TFS.t()
-    def resolve(
-          %TFS{fields: old_fields},
-          %TFS{fields: new_fields} = new_tfs
-        )
-        when is_list(old_fields)
-        when is_list(new_fields) do
-      # collect all names for new fields schemas
-      new_fields_names = Enum.map(new_fields || [], & &1.name)
-
-      # filter field schemas that are present only in old table field schema
-      uniq_old_fs = for fs <- old_fields, fs.name not in new_fields_names, do: fs
-
-      %{new_tfs | fields: resolve_list(old_fields, new_fields) ++ uniq_old_fs}
-    end
-
-    def resolve(_old, %TFS{} = new) do
-      new
-    end
-
-    @spec resolve_list(list(TFS.t()), list(TFS.t())) :: list(TFS.t())
-    def resolve_list(old_fields, new_fields)
-        when is_list(old_fields)
-        when is_list(new_fields) do
-      for %TFS{} = new_field <- new_fields do
-        old_fields
-        |> maybe_find_with_name(new_field)
-        |> resolve(new_field)
+  defp merge_payload_maps(map, acc) when is_map(map) do
+    Map.merge(acc, map, fn _key, left, right ->
+      if is_map(left) and is_map(right) do
+        merge_payload_maps(right, left)
+      else
+        right
       end
-    end
-
-    @spec maybe_find_with_name(list(TFS.t()), TFS.t()) :: TFS.t() | nil
-    def maybe_find_with_name(enumerable, %TFS{name: name}) do
-      Enum.find(enumerable, &(&1.name === name))
-    end
+    end)
   end
+
+  defp merge_payload_maps(_value, acc), do: acc
+
+  defp merge_field_schema(nil, %TFS{} = new), do: new
+
+  defp merge_field_schema(%TFS{fields: old_fields}, %TFS{fields: new_fields} = new)
+       when is_list(old_fields) and is_list(new_fields) do
+    old_fields_by_name = Map.new(old_fields, &{&1.name, &1})
+    new_field_names = MapSet.new(new_fields, & &1.name)
+
+    merged_new_fields =
+      Enum.map(new_fields, fn %TFS{} = new_field ->
+        old_fields_by_name
+        |> Map.get(new_field.name)
+        |> merge_field_schema(new_field)
+      end)
+
+    old_only_fields = Enum.reject(old_fields, &MapSet.member?(new_field_names, &1.name))
+
+    %{new | fields: merged_new_fields ++ old_only_fields}
+  end
+
+  defp merge_field_schema(%TFS{fields: old_fields} = old, %TFS{fields: new_fields})
+       when is_list(old_fields) or is_list(new_fields) do
+    raise Protocol.UndefinedError, protocol: DeepMerge.Resolver, value: old
+  end
+
+  defp merge_field_schema(_old, %TFS{} = new), do: new
 end

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -150,35 +150,57 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
 
   """
   @spec build_table_schema([map()] | map(), TFS.t()) :: TFS.t()
+  def build_table_schema(params, old_schema) do
+    params
+    |> build_table_schema_with_change(old_schema)
+    |> elem(0)
+  end
 
-  def build_table_schema(params, %{fields: old_fields}) do
+  @spec build_table_schema_with_change([map()] | map(), TFS.t()) :: {TFS.t(), boolean()}
+  def build_table_schema_with_change(params, %{fields: old_fields} = old_schema) do
     initial_schema = initial_table_schema()
     old_fields_by_name = Map.new(old_fields, &{&1.name, &1})
     is_otel = otel_data?(params)
 
-    new_fields =
-      Enum.reduce(params, [], fn {param_key, param_value}, acc ->
+    {new_fields, changed?} =
+      Enum.reduce(params, {[], false}, fn {param_key, param_value}, {new_fields, changed?} ->
         if protected_key?(param_key) do
-          acc
+          {new_fields, changed?}
         else
           prev_field_schema = Map.get(old_fields_by_name, param_key)
           new_field_schema = build_fields_schemas({param_key, param_value}, is_otel)
 
-          [merge_field_schema(prev_field_schema, new_field_schema) | acc]
+          {merged_field_schema, field_changed?} =
+            merge_field_schema(prev_field_schema, new_field_schema)
+
+          {[merged_field_schema | new_fields], changed? or field_changed?}
         end
       end)
-      |> Enum.reverse()
 
+    if changed? do
+      schema =
+        initial_schema
+        |> Map.put(
+          :fields,
+          updated_fields(old_fields, params, Enum.reverse(new_fields), initial_schema)
+        )
+        |> deep_sort_by_fields_name()
+
+      {schema, true}
+    else
+      {old_schema, false}
+    end
+  end
+
+  defp updated_fields(old_fields, params, new_fields, initial_schema) do
     # reject old fields that are now included in the params
     unrejected_fields = Enum.reject(old_fields, &Map.has_key?(params, &1.name))
+    field_names = MapSet.new(unrejected_fields ++ new_fields, & &1.name)
 
-    updated_fields =
-      (unrejected_fields ++ new_fields ++ initial_schema.fields)
-      |> Enum.uniq_by(fn f -> f.name end)
+    missing_initial_fields =
+      Enum.reject(initial_schema.fields, &MapSet.member?(field_names, &1.name))
 
-    initial_schema
-    |> Map.put(:fields, updated_fields)
-    |> deep_sort_by_fields_name()
+    unrejected_fields ++ new_fields ++ missing_initial_fields
   end
 
   def initial_table_schema do
@@ -264,23 +286,27 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
 
   defp merge_payload_maps(_value, acc), do: acc
 
-  defp merge_field_schema(nil, %TFS{} = new), do: new
+  defp merge_field_schema(nil, %TFS{} = new), do: {new, true}
 
-  defp merge_field_schema(%TFS{fields: old_fields}, %TFS{fields: new_fields} = new)
+  defp merge_field_schema(%TFS{fields: old_fields} = old, %TFS{fields: new_fields} = new)
        when is_list(old_fields) and is_list(new_fields) do
     old_fields_by_name = Map.new(old_fields, &{&1.name, &1})
     new_field_names = MapSet.new(new_fields, & &1.name)
 
-    merged_new_fields =
-      Enum.map(new_fields, fn %TFS{} = new_field ->
-        old_fields_by_name
-        |> Map.get(new_field.name)
-        |> merge_field_schema(new_field)
+    {merged_new_fields, children_changed?} =
+      Enum.map_reduce(new_fields, false, fn %TFS{} = new_field, changed? ->
+        {merged_field_schema, field_changed?} =
+          old_fields_by_name
+          |> Map.get(new_field.name)
+          |> merge_field_schema(new_field)
+
+        {merged_field_schema, changed? or field_changed?}
       end)
 
     old_only_fields = Enum.reject(old_fields, &MapSet.member?(new_field_names, &1.name))
+    merged = %{new | fields: merged_new_fields ++ old_only_fields}
 
-    %{new | fields: merged_new_fields ++ old_only_fields}
+    {merged, children_changed? or merged != old}
   end
 
   defp merge_field_schema(%TFS{fields: old_fields} = old, %TFS{fields: new_fields})
@@ -288,5 +314,5 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
     raise Protocol.UndefinedError, protocol: DeepMerge.Resolver, value: old
   end
 
-  defp merge_field_schema(_old, %TFS{} = new), do: new
+  defp merge_field_schema(old, %TFS{} = new), do: {new, old != new}
 end

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -7,6 +7,32 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
   alias Logflare.BigQuery.SchemaTypes
   alias Model.TableFieldSchema, as: TFS
 
+  @initial_table_schema %Model.TableSchema{
+    fields: [
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "REQUIRED",
+        name: "timestamp",
+        type: "TIMESTAMP"
+      },
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "NULLABLE",
+        name: "id",
+        type: "STRING"
+      },
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "NULLABLE",
+        name: "event_message",
+        type: "STRING"
+      }
+    ]
+  }
+
   @doc """
   Builds table schema from event metadata and prev schema.
 
@@ -127,15 +153,12 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
 
   def build_table_schema(params, %{fields: old_fields}) do
     initial_schema = initial_table_schema()
-    protected_keys = MapSet.new(initial_schema.fields, & &1.name)
-    param_keys = Map.keys(params)
-    param_key_set = MapSet.new(param_keys)
     old_fields_by_name = Map.new(old_fields, &{&1.name, &1})
     is_otel = otel_data?(params)
 
     new_fields =
       Enum.reduce(params, [], fn {param_key, param_value}, acc ->
-        if MapSet.member?(protected_keys, param_key) do
+        if protected_key?(param_key) do
           acc
         else
           prev_field_schema = Map.get(old_fields_by_name, param_key)
@@ -147,7 +170,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
       |> Enum.reverse()
 
     # reject old fields that are now included in the params
-    unrejected_fields = Enum.reject(old_fields, &MapSet.member?(param_key_set, &1.name))
+    unrejected_fields = Enum.reject(old_fields, &Map.has_key?(params, &1.name))
 
     updated_fields =
       (unrejected_fields ++ new_fields ++ initial_schema.fields)
@@ -159,32 +182,13 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
   end
 
   def initial_table_schema do
-    %Model.TableSchema{
-      fields: [
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "REQUIRED",
-          name: "timestamp",
-          type: "TIMESTAMP"
-        },
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "NULLABLE",
-          name: "id",
-          type: "STRING"
-        },
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "NULLABLE",
-          name: "event_message",
-          type: "STRING"
-        }
-      ]
-    }
+    @initial_table_schema
   end
+
+  defp protected_key?("event_message"), do: true
+  defp protected_key?("id"), do: true
+  defp protected_key?("timestamp"), do: true
+  defp protected_key?(_key), do: false
 
   defp build_fields_schemas({params_key, params_val}, _is_otel) when is_map(params_val) do
     %TFS{

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -19,6 +19,22 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
       assert prev_schema == curr_schema
     end
 
+    test "reports whether schema changed" do
+      {prev_schema, true} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"b" => 1.0}}, @default_schema)
+
+      {same_schema, false} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"b" => 1.0}}, prev_schema)
+
+      {changed_schema, true} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"c" => 1.0}}, same_schema)
+
+      assert same_schema == prev_schema
+
+      assert %TFS{name: "c", type: "FLOAT", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(changed_schema, "a.c")
+    end
+
     test "adding new field schemas" do
       prev_schema = SchemaBuilder.build_table_schema(%{"a" => %{"b" => 1.0}}, @default_schema)
       curr_schema = SchemaBuilder.build_table_schema(%{"a" => [%{"c" => 1.0}]}, prev_schema)

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -18,6 +18,29 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     assert seconds > 9
   end
 
+  test "update/3 skips casts when schema process mailbox is full" do
+    put_schema_config(max_message_queue_len: 1)
+
+    pid = start_mailbox_holder!()
+    send(pid, :queued)
+
+    assert :ok = Schema.update(pid, %Logflare.LogEvent{id: "id", body: %{}}, build(:source))
+    assert {:message_queue_len, 1} = Process.info(pid, :message_queue_len)
+
+    send(pid, :stop)
+  end
+
+  test "update/3 casts when schema process mailbox is below limit" do
+    put_schema_config(max_message_queue_len: 2)
+
+    pid = start_mailbox_holder!()
+
+    assert :ok = Schema.update(pid, %Logflare.LogEvent{id: "id", body: %{}}, build(:source))
+    assert {:message_queue_len, 1} = Process.info(pid, :message_queue_len)
+
+    send(pid, :stop)
+  end
+
   test "updates correctly" do
     user = insert(:user)
     source = insert(:source, user: user)
@@ -112,5 +135,34 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     old_schema = TestUtils.default_bq_schema()
     new_schema = TestUtils.build_bq_schema(%{"test" => "value"})
     Schema.notify_maybe(source.token, new_schema, old_schema)
+  end
+
+  defp start_mailbox_holder! do
+    test_pid = self()
+
+    pid =
+      spawn_link(fn ->
+        send(test_pid, {:ready, self()})
+
+        receive do
+          :stop -> :ok
+        after
+          5_000 -> :ok
+        end
+      end)
+
+    assert_receive {:ready, ^pid}
+
+    pid
+  end
+
+  defp put_schema_config(config) do
+    old_config = Application.get_env(:logflare, Schema)
+
+    on_exit(fn ->
+      Application.put_env(:logflare, Schema, old_config)
+    end)
+
+    Application.put_env(:logflare, Schema, Keyword.merge(old_config, config))
   end
 end

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -2,8 +2,9 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
   @moduledoc false
   use Logflare.DataCase
 
-  alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Backends
   alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Sources.Source.BigQuery.Schema
 
   setup do
     insert(:plan)
@@ -18,30 +19,49 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     assert seconds > 9
   end
 
-  test "update/3 skips casts when schema process mailbox is full" do
+  test "update/3 skips casts when outstanding schema updates hit the limit" do
     put_schema_config(max_message_queue_len: 1)
 
-    pid = start_mailbox_holder!()
-    send(pid, :queued)
+    user = insert(:user)
+    source = insert(:source, user: user)
+    backend_id = 123
+    counter = Schema.update_counter()
+    pid = start_schema_update_holder!(source, backend_id, counter)
+    name = Backends.via_source(source, Schema, backend_id)
+    log_event = build(:log_event, source: source, metadata: %{})
 
-    assert :ok = Schema.update(pid, %Logflare.LogEvent{id: "id", body: %{}}, build(:source))
-    assert {:message_queue_len, 1} = Process.info(pid, :message_queue_len)
+    assert :ok = Schema.update(name, log_event, source)
+    assert_receive {:schema_cast, {:update, ^counter, ^log_event, ^source}}
+    assert :atomics.get(counter, 1) == 1
+
+    assert :ok = Schema.update(name, log_event, source)
+    refute_receive {:schema_cast, _}, 50
+    assert :atomics.get(counter, 1) == 1
 
     send(pid, :stop)
   end
 
-  test "update/3 casts when schema process mailbox is below limit" do
+  test "update/3 casts while outstanding schema updates are below the limit" do
     put_schema_config(max_message_queue_len: 2)
 
-    pid = start_mailbox_holder!()
+    user = insert(:user)
+    source = insert(:source, user: user)
+    backend_id = 123
+    counter = Schema.update_counter()
+    pid = start_schema_update_holder!(source, backend_id, counter)
+    name = Backends.via_source(source, Schema, backend_id)
+    log_event = build(:log_event, source: source, metadata: %{})
 
-    assert :ok = Schema.update(pid, %Logflare.LogEvent{id: "id", body: %{}}, build(:source))
-    assert {:message_queue_len, 1} = Process.info(pid, :message_queue_len)
+    assert :ok = Schema.update(name, log_event, source)
+    assert_receive {:schema_cast, {:update, ^counter, ^log_event, ^source}}
+    assert :atomics.get(counter, 1) == 1
 
     send(pid, :stop)
   end
 
   test "updates correctly" do
+    put_schema_config(updates_per_minute: 6)
+
     user = insert(:user)
     source = insert(:source, user: user)
     schema = TestUtils.default_bq_schema()
@@ -137,23 +157,35 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     Schema.notify_maybe(source.token, new_schema, old_schema)
   end
 
-  defp start_mailbox_holder! do
+  defp start_schema_update_holder!(source, backend_id, counter) do
     test_pid = self()
 
     pid =
       spawn_link(fn ->
-        send(test_pid, {:ready, self()})
+        {:ok, _} =
+          Registry.register(Backends.SourceRegistry, {source.id, {Schema, backend_id}}, counter)
 
-        receive do
-          :stop -> :ok
-        after
-          5_000 -> :ok
-        end
+        send(test_pid, {:ready, self()})
+        schema_update_holder_loop(test_pid)
       end)
 
     assert_receive {:ready, ^pid}
 
     pid
+  end
+
+  defp schema_update_holder_loop(test_pid) do
+    receive do
+      {:"$gen_cast", message} ->
+        send(test_pid, {:schema_cast, message})
+        schema_update_holder_loop(test_pid)
+
+      :stop ->
+        :ok
+    after
+      5_000 ->
+        :ok
+    end
   end
 
   defp put_schema_config(config) do

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -58,6 +58,12 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
       assert validate(le, source) === :ok
     end
 
+    test "correctly builds a typemap from metadata" do
+      assert :metadata
+             |> SchemaFactory.build(variant: :third)
+             |> SchemaUtils.to_typemap() == typemap_for_third()["metadata"].fields
+    end
+
     test "returns {:error, _} when a leaf type conflicts with the cached schema" do
       user = Factory.insert(:user)
       source = Factory.insert(:source, user_id: user.id) |> then(&Sources.get_by(id: &1.id))
@@ -338,5 +344,38 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
       })
 
     source
+  end
+
+  defp typemap_for_third do
+    %{
+      "timestamp" => %{t: :datetime},
+      "event_message" => %{t: :string},
+      "metadata" => %{
+        t: :map,
+        fields: %{
+          "datacenter" => %{t: :string},
+          "ip_address" => %{t: :string},
+          "request_method" => %{t: :string},
+          "user" => %{
+            t: :map,
+            fields: %{
+              "browser" => %{t: :string},
+              "id" => %{t: :integer},
+              "vip" => %{t: :boolean},
+              "company" => %{t: :string},
+              "login_count" => %{t: :integer},
+              "address" => %{
+                t: :map,
+                fields: %{
+                  "street" => %{t: :string},
+                  "city" => %{t: :string},
+                  "st" => %{t: :string}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   end
 end


### PR DESCRIPTION
Please ignore this PR for now :)

---

Adds a Benchee harness for BigQuery schema helper hot paths under `bench/`.

Adds a pre-cast mailbox guard to `Logflare.Sources.Source.BigQuery.Schema.update/3` so sampled schema updates are dropped when the Schema process already has a backlog.

This targets observed queue spikes where in-process schema rate limiting still allowed ingest pipelines to keep filling the Schema inbox.

Validation: syntax-parsed changed files with `elixir`; `mix test test/logflare/source/bigquery/schema_test.exs` and `mix format` are blocked in this workspace by dependency lock mismatches that require `mix deps.get`.