### PR TITLE
Add syslog adaptor benchmarks

### DIFF
--- a/lib/logflare/backends/adaptor/syslog_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/pipeline.ex
@@ -6,32 +6,41 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Pipeline do
 
   alias Broadway.Message
   alias Logflare.Backends
-  alias Logflare.Backends.Adaptor.SyslogAdaptor.{Pool, Syslog}
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Pool
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
 
-  def start_link(opts) do
-    backend = Keyword.fetch!(opts, :backend)
-    source = Keyword.fetch!(opts, :source)
-    pool = Keyword.fetch!(opts, :pool)
-    name = Keyword.fetch!(opts, :name)
+  @spec start_link(keyword(), keyword()) :: GenServer.on_start()
+  def start_link(args, broadway_opts \\ []) do
+    backend = Keyword.fetch!(args, :backend)
+    source = Keyword.fetch!(args, :source)
+    pool = Keyword.fetch!(args, :pool)
+    name = Keyword.fetch!(args, :name)
+    {pipeline_module, broadway_opts} = Keyword.pop(broadway_opts, :pipeline_module, __MODULE__)
 
-    Broadway.start_link(__MODULE__,
-      name: name,
-      producer: [
-        module: {Backends.BufferProducer, backend_id: backend.id, source_id: source.id},
-        transformer: {__MODULE__, :transform, []}
-      ],
-      processors: [
-        default: [min_demand: 1]
-      ],
-      batchers: [
-        syslog: [concurrency: 5, batch_size: 50]
-      ],
-      context: %{
-        source_id: source.id,
-        backend_id: backend.id,
-        pool: pool
-      }
-    )
+    opts =
+      Keyword.merge(
+        [
+          name: name,
+          producer: [
+            module: {Backends.BufferProducer, backend_id: backend.id, source_id: source.id},
+            transformer: {__MODULE__, :transform, []}
+          ],
+          processors: [
+            default: [min_demand: 1]
+          ],
+          batchers: [
+            syslog: [concurrency: 5, batch_size: 50]
+          ],
+          context: %{
+            source_id: source.id,
+            backend_id: backend.id,
+            pool: pool
+          }
+        ],
+        broadway_opts
+      )
+
+    Broadway.start_link(pipeline_module, opts)
   end
 
   @impl Broadway

--- a/test/logflare/backends/adaptor/syslog_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/pipeline_test.exs
@@ -1,0 +1,26 @@
+defmodule Logflare.Backends.Adaptor.SyslogAdaptor.PipelineTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Pipeline
+  alias Logflare.Backends.Backend
+  alias Logflare.Sources.Source
+
+  test "accepts Broadway topology overrides" do
+    source = %Source{id: System.unique_integer([:positive])}
+    backend = %Backend{id: System.unique_integer([:positive])}
+    name = Backends.via_source(source, Pipeline, backend)
+
+    assert {:ok, pipeline} =
+             Pipeline.start_link(
+               [source: source, backend: backend, pool: self(), name: name],
+               producer: [module: {Broadway.DummyProducer, []}],
+               processors: [default: [concurrency: 1]],
+               batchers: [],
+               context: %{}
+             )
+
+    assert Process.alive?(pipeline)
+    assert :ok = Broadway.stop(pipeline)
+  end
+end

--- a/test/profiling/syslog_bench_support.exs
+++ b/test/profiling/syslog_bench_support.exs
@@ -1,0 +1,327 @@
+defmodule SyslogBenchSupport do
+  @moduledoc false
+
+  alias Logflare.Backends.Backend
+  alias Logflare.LogEvent
+  alias Logflare.Sources.Source
+
+  @default_events 5_000
+  @default_batch_size 50
+  @default_concurrency 5
+  @default_push_chunk 1_000
+  @default_message_bytes [200, 2_000, 50_000]
+  @default_time 5
+  @default_warmup 2
+
+  def events, do: env_int("SYSLOG_BENCH_EVENTS", @default_events)
+  def batch_size, do: env_int("SYSLOG_BENCH_BATCH_SIZE", @default_batch_size)
+  def concurrency, do: env_int("SYSLOG_BENCH_CONCURRENCY", @default_concurrency)
+  def push_chunk, do: env_int("SYSLOG_BENCH_PUSH_CHUNK", @default_push_chunk)
+  def message_bytes, do: env_int_list("SYSLOG_BENCH_MESSAGE_BYTES", @default_message_bytes)
+  def time, do: env_number("SYSLOG_BENCH_TIME", @default_time)
+  def warmup, do: env_number("SYSLOG_BENCH_WARMUP", @default_warmup)
+
+  def print_config(extra \\ []) do
+    config =
+      [
+        events: events(),
+        batch_size: batch_size(),
+        concurrency: concurrency(),
+        push_chunk: push_chunk(),
+        message_bytes: Enum.join(message_bytes(), ","),
+        time: time(),
+        warmup: warmup()
+      ] ++ extra
+
+    IO.puts("Syslog benchmark config: #{inspect(config)}")
+  end
+
+  def ensure_apps_started do
+    for app <- [:logger, :crypto, :ssl, :telemetry, :cachex, :nimble_pool, :gen_stage, :broadway] do
+      case Application.ensure_all_started(app) do
+        {:ok, _apps} -> :ok
+        {:error, _reason} -> :ok
+      end
+    end
+  end
+
+  def ensure_cache(name) do
+    case Process.whereis(name) do
+      nil -> Cachex.start_link(name, [])
+      _pid -> {:ok, name}
+    end
+  end
+
+  def ensure_ingest_queue_started do
+    case Process.whereis(Logflare.Backends.IngestEventQueue) do
+      nil -> Logflare.Backends.IngestEventQueue.start_link([])
+      pid -> {:ok, pid}
+    end
+  end
+
+  def cache_bench_source_and_backend(source, backend) do
+    Cachex.put(Logflare.Sources.Cache, {:get_by, [[id: source.id]]}, {:cached, source})
+    Cachex.put(Logflare.Sources.Cache, {:get_by, [[token: source.token]]}, {:cached, source})
+    Cachex.put(Logflare.Backends.Cache, {:get_backend, [backend.id]}, {:cached, backend})
+  end
+
+  def source do
+    %Source{
+      id: System.unique_integer([:positive]),
+      name: "syslog-bench",
+      token: :"syslog-bench-#{System.unique_integer([:positive])}",
+      metrics: %{avg: 0},
+      rules: []
+    }
+  end
+
+  def backend(port) do
+    %Backend{
+      id: System.unique_integer([:positive]),
+      name: "syslog-bench",
+      type: :syslog,
+      config: %{
+        host: "127.0.0.1",
+        port: port
+      }
+    }
+  end
+
+  def config(port) do
+    %{
+      host: "127.0.0.1",
+      port: port
+    }
+  end
+
+  def build_events(count, message_bytes) do
+    message = String.duplicate("x", message_bytes)
+    now = System.system_time(:microsecond)
+
+    for i <- 1..count do
+      %LogEvent{
+        id: Ecto.UUID.generate(),
+        body: %{
+          "timestamp" => now + i,
+          "event_message" => message,
+          "metadata" => %{
+            "level" => "info",
+            "app_name" => "syslog-bench",
+            "procid" => "bench"
+          }
+        },
+        event_type: :log,
+        valid: true
+      }
+    end
+  end
+
+  defp env_int(name, default) do
+    case System.get_env(name) do
+      nil -> default
+      value -> String.to_integer(value)
+    end
+  end
+
+  defp env_int_list(name, default) do
+    case System.get_env(name) do
+      nil ->
+        default
+
+      value ->
+        value
+        |> String.split(",", trim: true)
+        |> Enum.map(&String.to_integer/1)
+    end
+  end
+
+  defp env_number(name, default) do
+    case System.get_env(name) do
+      nil ->
+        default
+
+      value ->
+        {number, ""} = Float.parse(value)
+        number
+    end
+  end
+end
+
+defmodule SyslogBenchSupport.TcpSink do
+  @moduledoc false
+
+  def start_link(expected_frames) do
+    parent = self()
+    ref = make_ref()
+
+    pid =
+      spawn_link(fn ->
+        {:ok, listen_socket} =
+          :gen_tcp.listen(0, [
+            :binary,
+            packet: :raw,
+            active: false,
+            reuseaddr: true,
+            ip: {127, 0, 0, 1}
+          ])
+
+        {:ok, {_ip, port}} = :inet.sockname(listen_socket)
+        send(parent, {:syslog_sink_ready, ref, self(), port})
+        accept_loop(listen_socket, parent, ref)
+      end)
+
+    receive do
+      {:syslog_sink_ready, ^ref, ^pid, port} ->
+        state = %{pid: pid, ref: ref, port: port, expected_frames: expected_frames}
+        {:ok, state}
+    after
+      5_000 -> raise "timed out starting syslog sink"
+    end
+  end
+
+  def port(%{port: port}), do: port
+  def ref(%{ref: ref}), do: ref
+
+  def stop(%{pid: pid}) do
+    Process.exit(pid, :normal)
+    :ok
+  end
+
+  defp accept_loop(listen_socket, parent, ref) do
+    case :gen_tcp.accept(listen_socket, 250) do
+      {:ok, socket} ->
+        spawn_link(fn -> recv_loop(socket, parent, ref, <<>>, 0, 0) end)
+        accept_loop(listen_socket, parent, ref)
+
+      {:error, :timeout} ->
+        accept_loop(listen_socket, parent, ref)
+
+      {:error, reason} ->
+        send(parent, {:syslog_sink_error, ref, reason})
+    end
+  end
+
+  defp recv_loop(socket, parent, ref, buffer, frames, bytes) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, data} ->
+        {buffer, new_frames, new_bytes} = parse_frames(buffer <> data, frames, bytes)
+        send(parent, {:syslog_sink_frames, ref, new_frames - frames, new_bytes - bytes})
+        recv_loop(socket, parent, ref, buffer, new_frames, new_bytes)
+
+      {:error, :closed} ->
+        :ok
+
+      {:error, reason} ->
+        send(parent, {:syslog_sink_error, ref, reason})
+    end
+  end
+
+  defp parse_frames(buffer, frames, bytes) do
+    case parse_frame(buffer) do
+      {:ok, rest, frame_bytes} ->
+        parse_frames(rest, frames + 1, bytes + frame_bytes)
+
+      :more ->
+        {buffer, frames, bytes}
+    end
+  end
+
+  defp parse_frame(buffer) do
+    case :binary.match(buffer, " ") do
+      {idx, 1} ->
+        <<len_bin::binary-size(idx), " ", rest::binary>> = buffer
+        len = String.to_integer(len_bin)
+
+        if byte_size(rest) >= len do
+          <<_frame::binary-size(len), tail::binary>> = rest
+          {:ok, tail, idx + 1 + len}
+        else
+          :more
+        end
+
+      :nomatch ->
+        :more
+    end
+  end
+end
+
+defmodule SyslogBenchSupport.SinkCollector do
+  @moduledoc false
+
+  def collect(%{ref: ref, expected_frames: expected_frames}) do
+    collect(ref, expected_frames, 0, 0)
+  end
+
+  defp collect(_ref, expected_frames, frames, bytes) when frames >= expected_frames do
+    %{frames: frames, bytes: bytes}
+  end
+
+  defp collect(ref, expected_frames, frames, bytes) do
+    receive do
+      {:syslog_sink_frames, ^ref, frame_count, byte_count} ->
+        collect(ref, expected_frames, frames + frame_count, bytes + byte_count)
+
+      {:syslog_sink_error, ^ref, reason} ->
+        raise "syslog sink failed: #{inspect(reason)}"
+    after
+      30_000 -> raise "timed out after receiving #{frames}/#{expected_frames} syslog frames"
+    end
+  end
+end
+
+defmodule SyslogBenchSupport.NimbleTcpPool do
+  @moduledoc false
+
+  @behaviour NimblePool
+
+  def start_link(opts) do
+    config = Keyword.fetch!(opts, :config)
+
+    NimblePool.start_link(
+      worker: {__MODULE__, config},
+      lazy: true,
+      name: Keyword.get(opts, :name)
+    )
+  end
+
+  def send(pool, iodata) do
+    NimblePool.checkout!(pool, :checkout, fn _from, socket ->
+      case :gen_tcp.send(socket, iodata) do
+        :ok -> {:ok, socket}
+        {:error, reason} = error -> {error, {:remove, reason}}
+      end
+    end)
+  end
+
+  @impl NimblePool
+  def init_pool(config), do: {:ok, config}
+
+  @impl NimblePool
+  def init_worker(config) do
+    host = config |> Map.fetch!(:host) |> String.to_charlist()
+    port = Map.fetch!(config, :port)
+
+    opts = [:binary, packet: :raw, active: false, nodelay: true]
+    {:ok, socket} = :gen_tcp.connect(host, port, opts, 5_000)
+    {:ok, socket, config}
+  end
+
+  @impl NimblePool
+  def handle_checkout(:checkout, _from, socket, config) do
+    {:ok, socket, socket, config}
+  end
+
+  @impl NimblePool
+  def handle_checkin(socket, _from, _old_socket, config) do
+    {:ok, socket, config}
+  end
+
+  @impl NimblePool
+  def handle_info(_message, socket), do: {:ok, socket}
+
+  @impl NimblePool
+  def terminate_worker(_reason, socket, config) do
+    :gen_tcp.close(socket)
+    {:ok, config}
+  end
+end

--- a/test/profiling/syslog_bench_support.exs
+++ b/test/profiling/syslog_bench_support.exs
@@ -1,99 +1,118 @@
 defmodule SyslogBenchSupport do
-  @moduledoc false
-
   alias Logflare.Backends.Backend
   alias Logflare.LogEvent
   alias Logflare.Sources.Source
 
-  @default_events 5_000
   @default_batch_size 50
-  @default_concurrency 5
-  @default_push_chunk 1_000
+  @default_batcher_concurrency 5
+  @default_processor_concurrency [1, 5]
+  @default_events 5_000
   @default_message_bytes [200, 2_000, 50_000]
   @default_time 5
   @default_warmup 2
 
-  def events, do: env_int("SYSLOG_BENCH_EVENTS", @default_events)
+  @spec batch_size() :: pos_integer()
   def batch_size, do: env_int("SYSLOG_BENCH_BATCH_SIZE", @default_batch_size)
-  def concurrency, do: env_int("SYSLOG_BENCH_CONCURRENCY", @default_concurrency)
-  def push_chunk, do: env_int("SYSLOG_BENCH_PUSH_CHUNK", @default_push_chunk)
+
+  @spec batcher_concurrency() :: pos_integer()
+  def batcher_concurrency do
+    env_int("SYSLOG_BENCH_BATCHER_CONCURRENCY", @default_batcher_concurrency)
+  end
+
+  @spec processor_concurrency() :: [pos_integer()]
+  def processor_concurrency do
+    env_int_list("SYSLOG_BENCH_CONCURRENCY", @default_processor_concurrency)
+  end
+
+  @spec events() :: pos_integer()
+  def events, do: env_int("SYSLOG_BENCH_EVENTS", @default_events)
+
+  @spec message_bytes() :: [pos_integer()]
   def message_bytes, do: env_int_list("SYSLOG_BENCH_MESSAGE_BYTES", @default_message_bytes)
+
+  @spec time() :: number()
   def time, do: env_number("SYSLOG_BENCH_TIME", @default_time)
+
+  @spec warmup() :: number()
   def warmup, do: env_number("SYSLOG_BENCH_WARMUP", @default_warmup)
 
-  def print_config(extra \\ []) do
-    config =
-      [
-        events: events(),
-        batch_size: batch_size(),
-        concurrency: concurrency(),
-        push_chunk: push_chunk(),
-        message_bytes: Enum.join(message_bytes(), ","),
-        time: time(),
-        warmup: warmup()
-      ] ++ extra
-
-    IO.puts("Syslog benchmark config: #{inspect(config)}")
+  @spec print_config() :: :ok
+  def print_config do
+    # credo:disable-for-next-line Credo.Check.Refactor.IoPuts
+    IO.puts(
+      "Syslog benchmark config: " <>
+        inspect(
+          events: events(),
+          batch_size: batch_size(),
+          batcher_concurrency: batcher_concurrency(),
+          processor_concurrency: Enum.join(processor_concurrency(), ","),
+          message_bytes: Enum.join(message_bytes(), ","),
+          time: time(),
+          warmup: warmup()
+        )
+    )
   end
 
+  @spec ensure_apps_started() :: :ok
   def ensure_apps_started do
     for app <- [:logger, :crypto, :ssl, :telemetry, :cachex, :nimble_pool, :gen_stage, :broadway] do
-      case Application.ensure_all_started(app) do
-        {:ok, _apps} -> :ok
-        {:error, _reason} -> :ok
-      end
+      {:ok, _apps} = Application.ensure_all_started(app)
     end
+
+    :ok
   end
 
+  @spec ensure_cache(atom()) :: :ok
   def ensure_cache(name) do
     case Process.whereis(name) do
-      nil -> Cachex.start_link(name, [])
-      _pid -> {:ok, name}
+      nil ->
+        {:ok, _pid} = Cachex.start_link(name, [])
+        :ok
+
+      _pid ->
+        :ok
     end
   end
 
-  def ensure_ingest_queue_started do
-    case Process.whereis(Logflare.Backends.IngestEventQueue) do
-      nil -> Logflare.Backends.IngestEventQueue.start_link([])
-      pid -> {:ok, pid}
-    end
+  @spec cache_backend(Backend.t()) :: :ok
+  def cache_backend(backend) do
+    {:ok, true} =
+      Cachex.put(Logflare.Backends.Cache, {:get_backend, [backend.id]}, {:cached, backend})
+
+    :ok
   end
 
-  def cache_bench_source_and_backend(source, backend) do
-    Cachex.put(Logflare.Sources.Cache, {:get_by, [[id: source.id]]}, {:cached, source})
-    Cachex.put(Logflare.Sources.Cache, {:get_by, [[token: source.token]]}, {:cached, source})
-    Cachex.put(Logflare.Backends.Cache, {:get_backend, [backend.id]}, {:cached, backend})
-  end
-
+  @spec source() :: Source.t()
   def source do
     %Source{
       id: System.unique_integer([:positive]),
       name: "syslog-bench",
-      token: :"syslog-bench-#{System.unique_integer([:positive])}",
+      token: :"syslog-bench",
       metrics: %{avg: 0},
       rules: []
     }
   end
 
+  @spec backend(:inet.port_number()) :: Backend.t()
   def backend(port) do
     %Backend{
       id: System.unique_integer([:positive]),
       name: "syslog-bench",
       type: :syslog,
-      config: %{
-        host: "127.0.0.1",
-        port: port
-      }
+      config: config(port)
     }
   end
 
+  @spec config(:inet.port_number()) :: map()
   def config(port) do
     %{
       host: "127.0.0.1",
+      max_message_bytes: 50_000,
       port: port
     }
   end
 
+  @spec build_events(pos_integer(), pos_integer()) :: [LogEvent.t()]
   def build_events(count, message_bytes) do
     message = String.duplicate("x", message_bytes)
     now = System.system_time(:microsecond)
@@ -113,6 +132,53 @@ defmodule SyslogBenchSupport do
         event_type: :log,
         valid: true
       }
+    end
+  end
+
+  @spec start_sink() :: %{pid: pid(), port: :inet.port_number()}
+  def start_sink do
+    parent = self()
+    pid = spawn(fn -> init_sink(parent) end)
+
+    receive do
+      {:syslog_sink_ready, ^pid, port} -> %{pid: pid, port: port}
+    after
+      5_000 -> raise "timed out starting syslog sink"
+    end
+  end
+
+  @spec expect_frames(map(), pos_integer()) :: reference()
+  def expect_frames(%{pid: pid}, expected_frames) do
+    ref = make_ref()
+    send(pid, {:expect_frames, self(), ref, expected_frames})
+
+    receive do
+      {:syslog_sink_armed, ^ref} -> ref
+      {:syslog_sink_busy, ^ref} -> raise "syslog sink already has an active expectation"
+    after
+      5_000 -> raise "timed out arming syslog sink"
+    end
+  end
+
+  @spec await_frames(reference(), timeout()) :: %{bytes: non_neg_integer(), frames: pos_integer()}
+  def await_frames(ref, timeout \\ 30_000) do
+    receive do
+      {:syslog_sink_done, ^ref, stats} -> stats
+      {:syslog_sink_error, reason} -> raise "syslog sink failed: #{inspect(reason)}"
+    after
+      timeout -> raise "timed out waiting for syslog frames"
+    end
+  end
+
+  @spec stop_sink(map()) :: :ok
+  def stop_sink(%{pid: pid}) do
+    monitor = Process.monitor(pid)
+    send(pid, :stop)
+
+    receive do
+      {:DOWN, ^monitor, :process, ^pid, _reason} -> :ok
+    after
+      5_000 -> raise "timed out stopping syslog sink"
     end
   end
 
@@ -145,84 +211,134 @@ defmodule SyslogBenchSupport do
         number
     end
   end
-end
 
-defmodule SyslogBenchSupport.TcpSink do
-  @moduledoc false
-
-  def start_link(expected_frames) do
-    parent = self()
-    ref = make_ref()
-
-    pid =
-      spawn_link(fn ->
-        {:ok, listen_socket} =
-          :gen_tcp.listen(0, [
-            :binary,
-            packet: :raw,
-            active: false,
-            reuseaddr: true,
-            ip: {127, 0, 0, 1}
-          ])
-
-        {:ok, {_ip, port}} = :inet.sockname(listen_socket)
-        send(parent, {:syslog_sink_ready, ref, self(), port})
-        accept_loop(listen_socket, parent, ref)
-      end)
+  defp init_sink(parent) do
+    sink = self()
+    acceptor = spawn(fn -> accept_connections(sink) end)
 
     receive do
-      {:syslog_sink_ready, ^ref, ^pid, port} ->
-        state = %{pid: pid, ref: ref, port: port, expected_frames: expected_frames}
-        {:ok, state}
+      {:syslog_sink_listening, ^acceptor, port} ->
+        send(parent, {:syslog_sink_ready, sink, port})
+
+        sink_loop(%{
+          acceptor: acceptor,
+          bytes: 0,
+          frames: 0,
+          expectation: nil
+        })
     after
-      5_000 -> raise "timed out starting syslog sink"
+      5_000 -> raise "timed out opening syslog listen socket"
     end
   end
 
-  def port(%{port: port}), do: port
-  def ref(%{ref: ref}), do: ref
+  defp sink_loop(state) do
+    receive do
+      {:expect_frames, caller, ref, expected_frames} when state.expectation == nil ->
+        send(caller, {:syslog_sink_armed, ref})
 
-  def stop(%{pid: pid}) do
-    Process.exit(pid, :normal)
-    :ok
-  end
+        sink_loop(%{
+          state
+          | expectation: %{
+              caller: caller,
+              ref: ref,
+              start_bytes: state.bytes,
+              start_frames: state.frames,
+              target: state.frames + expected_frames
+            }
+        })
 
-  defp accept_loop(listen_socket, parent, ref) do
-    case :gen_tcp.accept(listen_socket, 250) do
-      {:ok, socket} ->
-        spawn_link(fn -> recv_loop(socket, parent, ref, <<>>, 0, 0) end)
-        accept_loop(listen_socket, parent, ref)
+      {:expect_frames, caller, ref, _expected_frames} ->
+        send(caller, {:syslog_sink_busy, ref})
+        sink_loop(state)
 
-      {:error, :timeout} ->
-        accept_loop(listen_socket, parent, ref)
+      {:syslog_frames, frame_count, byte_count} ->
+        state
+        |> Map.update!(:frames, &(&1 + frame_count))
+        |> Map.update!(:bytes, &(&1 + byte_count))
+        |> maybe_complete_expectation()
+        |> sink_loop()
 
-      {:error, reason} ->
-        send(parent, {:syslog_sink_error, ref, reason})
+      {:syslog_sink_error, reason} ->
+        if state.expectation do
+          send(state.expectation.caller, {:syslog_sink_error, reason})
+        end
+
+        sink_loop(state)
+
+      :stop ->
+        Process.exit(state.acceptor, :shutdown)
+        :ok
     end
   end
 
-  defp recv_loop(socket, parent, ref, buffer, frames, bytes) do
-    case :gen_tcp.recv(socket, 0, 5_000) do
+  defp maybe_complete_expectation(%{expectation: nil} = state), do: state
+
+  defp maybe_complete_expectation(%{frames: frames, expectation: %{target: target}} = state)
+       when frames >= target do
+    expectation = state.expectation
+
+    send(
+      expectation.caller,
+      {:syslog_sink_done, expectation.ref,
+       %{
+         bytes: state.bytes - expectation.start_bytes,
+         frames: state.frames - expectation.start_frames
+       }}
+    )
+
+    %{state | expectation: nil}
+  end
+
+  defp maybe_complete_expectation(state), do: state
+
+  defp accept_connections(sink) do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, {_ip, port}} = :inet.sockname(listen_socket)
+    send(sink, {:syslog_sink_listening, self(), port})
+    accept_connection(listen_socket, sink)
+  end
+
+  defp accept_connection(listen_socket, sink) do
+    {:ok, socket} = :gen_tcp.accept(listen_socket)
+    receiver = spawn(fn -> receive_frames(sink) end)
+    :ok = :gen_tcp.controlling_process(socket, receiver)
+    send(receiver, {:socket, socket})
+    accept_connection(listen_socket, sink)
+  end
+
+  defp receive_frames(sink) do
+    receive do
+      {:socket, socket} -> receive_frames(socket, sink, <<>>)
+    end
+  end
+
+  defp receive_frames(socket, sink, buffer) do
+    case :gen_tcp.recv(socket, 0, :infinity) do
       {:ok, data} ->
-        {buffer, new_frames, new_bytes} = parse_frames(buffer <> data, frames, bytes)
-        send(parent, {:syslog_sink_frames, ref, new_frames - frames, new_bytes - bytes})
-        recv_loop(socket, parent, ref, buffer, new_frames, new_bytes)
+        {buffer, frames, bytes} = parse_frames(buffer <> data, 0, 0)
+        send(sink, {:syslog_frames, frames, bytes})
+        receive_frames(socket, sink, buffer)
 
       {:error, :closed} ->
         :ok
 
       {:error, reason} ->
-        send(parent, {:syslog_sink_error, ref, reason})
+        send(sink, {:syslog_sink_error, reason})
     end
   end
 
   defp parse_frames(buffer, frames, bytes) do
     case parse_frame(buffer) do
-      {:ok, rest, frame_bytes} ->
-        parse_frames(rest, frames + 1, bytes + frame_bytes)
-
-      :more ->
-        {buffer, frames, bytes}
+      {:ok, rest, frame_bytes} -> parse_frames(rest, frames + 1, bytes + frame_bytes)
+      :more -> {buffer, frames, bytes}
     end
   end
 
@@ -242,86 +358,5 @@ defmodule SyslogBenchSupport.TcpSink do
       :nomatch ->
         :more
     end
-  end
-end
-
-defmodule SyslogBenchSupport.SinkCollector do
-  @moduledoc false
-
-  def collect(%{ref: ref, expected_frames: expected_frames}) do
-    collect(ref, expected_frames, 0, 0)
-  end
-
-  defp collect(_ref, expected_frames, frames, bytes) when frames >= expected_frames do
-    %{frames: frames, bytes: bytes}
-  end
-
-  defp collect(ref, expected_frames, frames, bytes) do
-    receive do
-      {:syslog_sink_frames, ^ref, frame_count, byte_count} ->
-        collect(ref, expected_frames, frames + frame_count, bytes + byte_count)
-
-      {:syslog_sink_error, ^ref, reason} ->
-        raise "syslog sink failed: #{inspect(reason)}"
-    after
-      30_000 -> raise "timed out after receiving #{frames}/#{expected_frames} syslog frames"
-    end
-  end
-end
-
-defmodule SyslogBenchSupport.NimbleTcpPool do
-  @moduledoc false
-
-  @behaviour NimblePool
-
-  def start_link(opts) do
-    config = Keyword.fetch!(opts, :config)
-
-    NimblePool.start_link(
-      worker: {__MODULE__, config},
-      lazy: true,
-      name: Keyword.get(opts, :name)
-    )
-  end
-
-  def send(pool, iodata) do
-    NimblePool.checkout!(pool, :checkout, fn _from, socket ->
-      case :gen_tcp.send(socket, iodata) do
-        :ok -> {:ok, socket}
-        {:error, reason} = error -> {error, {:remove, reason}}
-      end
-    end)
-  end
-
-  @impl NimblePool
-  def init_pool(config), do: {:ok, config}
-
-  @impl NimblePool
-  def init_worker(config) do
-    host = config |> Map.fetch!(:host) |> String.to_charlist()
-    port = Map.fetch!(config, :port)
-
-    opts = [:binary, packet: :raw, active: false, nodelay: true]
-    {:ok, socket} = :gen_tcp.connect(host, port, opts, 5_000)
-    {:ok, socket, config}
-  end
-
-  @impl NimblePool
-  def handle_checkout(:checkout, _from, socket, config) do
-    {:ok, socket, socket, config}
-  end
-
-  @impl NimblePool
-  def handle_checkin(socket, _from, _old_socket, config) do
-    {:ok, socket, config}
-  end
-
-  @impl NimblePool
-  def handle_info(_message, socket), do: {:ok, socket}
-
-  @impl NimblePool
-  def terminate_worker(_reason, socket, config) do
-    :gen_tcp.close(socket)
-    {:ok, config}
   end
 end

--- a/test/profiling/syslog_broadway_bench.exs
+++ b/test/profiling/syslog_broadway_bench.exs
@@ -1,0 +1,268 @@
+# Benchmark syslog adaptor pipeline shapes end-to-end through Broadway.
+#
+# Run with:
+#   mix run --no-start test/profiling/syslog_broadway_bench.exs
+#
+# Useful env:
+#   SYSLOG_BENCH_MESSAGE_BYTES=200,2000,50000
+#   SYSLOG_BENCH_CONCURRENCY=1,5
+#   SYSLOG_BENCH_BATCH_SIZE=50
+#   SYSLOG_BENCH_EVENTS=5000
+#   SYSLOG_BENCH_PUSH_CHUNK=1000
+#   SYSLOG_BENCH_TIME=5
+#   SYSLOG_BENCH_WARMUP=2
+
+Code.require_file("syslog_bench_support.exs", __DIR__)
+
+defmodule SyslogBroadwayBench.Pipeline do
+  @moduledoc false
+
+  alias Broadway.Message
+  alias Logflare.Backends
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
+  alias SyslogBenchSupport.NimbleTcpPool
+
+  def producer(source, backend) do
+    [
+      module:
+        {Backends.BufferProducer,
+         backend_id: backend.id,
+         source_id: source.id,
+         interval: 10,
+         buffer_size: SyslogBenchSupport.events() * 2},
+      transformer: {__MODULE__, :transform, []}
+    ]
+  end
+
+  def processor_opts(concurrency) do
+    [default: [concurrency: concurrency, min_demand: 1]]
+  end
+
+  def batcher_opts(concurrency, batch_size) do
+    [syslog: [concurrency: concurrency, batch_size: batch_size]]
+  end
+
+  def context(pool, backend) do
+    %{pool: pool, backend_id: backend.id}
+  end
+
+  def send_batch(pool, content, messages) do
+    case NimbleTcpPool.send(pool, content) do
+      :ok -> messages
+      {:error, reason} -> fail_batch(messages, reason)
+    end
+  end
+
+  def lookup_backend_config(backend_id) do
+    %{config: config} =
+      Backends.Cache.get_backend(backend_id) || raise "missing backend #{backend_id}"
+
+    config
+  end
+
+  def transform(event, _opts) do
+    %Message{data: event, acknowledger: {__MODULE__, _ref = nil, _meta = []}}
+  end
+
+  def ack(_ack_ref, _successful, _failed), do: :ok
+
+  defp fail_batch(messages, reason) do
+    Enum.map(messages, fn message ->
+      Broadway.Message.failed(message, reason)
+    end)
+  end
+end
+
+defmodule SyslogBroadwayBench.BatchedPipeline do
+  @moduledoc false
+
+  use Broadway
+
+  alias Broadway.Message
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
+  alias SyslogBroadwayBench.Pipeline
+
+  @behaviour Broadway.Acknowledger
+
+  def start_link(opts) do
+    Broadway.start_link(__MODULE__,
+      name: Keyword.fetch!(opts, :name),
+      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
+      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
+      batchers:
+        Pipeline.batcher_opts(
+          Keyword.fetch!(opts, :batcher_concurrency),
+          Keyword.fetch!(opts, :batch_size)
+        ),
+      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
+    )
+  end
+
+  @impl Broadway
+  def handle_message(_processor_name, message, _context) do
+    Message.put_batcher(message, :syslog)
+  end
+
+  @impl Broadway
+  def handle_batch(:syslog, messages, _batch_info, context) do
+    config = Pipeline.lookup_backend_config(context.backend_id)
+    content = for %Message{data: event} <- messages, do: Syslog.format(event, config)
+    Pipeline.send_batch(context.pool, content, messages)
+  end
+
+  @impl Broadway.Acknowledger
+  defdelegate ack(ack_ref, successful, failed), to: Pipeline
+end
+
+defmodule SyslogBroadwayBench.NoBatcherPipeline do
+  @moduledoc false
+
+  use Broadway
+
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
+  alias SyslogBenchSupport.NimbleTcpPool
+  alias SyslogBroadwayBench.Pipeline
+
+  @behaviour Broadway.Acknowledger
+
+  def start_link(opts) do
+    Broadway.start_link(__MODULE__,
+      name: Keyword.fetch!(opts, :name),
+      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
+      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
+      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
+    )
+  end
+
+  @impl Broadway
+  def handle_message(_processor_name, message, context) do
+    config = Pipeline.lookup_backend_config(context.backend_id)
+
+    case NimbleTcpPool.send(context.pool, Syslog.format(message.data, config)) do
+      :ok -> message
+      {:error, reason} -> Broadway.Message.failed(message, reason)
+    end
+  end
+
+  @impl Broadway.Acknowledger
+  defdelegate ack(ack_ref, successful, failed), to: Pipeline
+end
+
+defmodule SyslogBroadwayBench.PreformattedPipeline do
+  @moduledoc false
+
+  use Broadway
+
+  alias Broadway.Message
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
+  alias SyslogBroadwayBench.Pipeline
+
+  @behaviour Broadway.Acknowledger
+
+  def start_link(opts) do
+    Broadway.start_link(__MODULE__,
+      name: Keyword.fetch!(opts, :name),
+      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
+      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
+      batchers:
+        Pipeline.batcher_opts(
+          Keyword.fetch!(opts, :batcher_concurrency),
+          Keyword.fetch!(opts, :batch_size)
+        ),
+      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
+    )
+  end
+
+  @impl Broadway
+  def handle_message(_processor_name, message, context) do
+    config = Pipeline.lookup_backend_config(context.backend_id)
+
+    message
+    |> Message.update_data(fn event -> Syslog.format(event, config) end)
+    |> Message.put_batcher(:syslog)
+  end
+
+  @impl Broadway
+  def handle_batch(:syslog, messages, _batch_info, context) do
+    content = for %Message{data: frame} <- messages, do: frame
+    Pipeline.send_batch(context.pool, content, messages)
+  end
+
+  @impl Broadway.Acknowledger
+  defdelegate ack(ack_ref, successful, failed), to: Pipeline
+end
+
+alias Logflare.Backends.IngestEventQueue
+alias SyslogBenchSupport.NimbleTcpPool
+alias SyslogBenchSupport.SinkCollector
+alias SyslogBenchSupport.TcpSink
+
+SyslogBenchSupport.ensure_apps_started()
+SyslogBenchSupport.ensure_cache(Logflare.Sources.Cache)
+SyslogBenchSupport.ensure_cache(Logflare.Backends.Cache)
+SyslogBenchSupport.ensure_cache(Logflare.PubSubRates.Cache)
+SyslogBenchSupport.ensure_ingest_queue_started()
+SyslogBenchSupport.print_config()
+
+event_count = SyslogBenchSupport.events()
+batch_size = SyslogBenchSupport.batch_size()
+concurrency = SyslogBenchSupport.concurrency()
+push_chunk = SyslogBenchSupport.push_chunk()
+
+inputs =
+  Map.new(SyslogBenchSupport.message_bytes(), fn bytes ->
+    {"#{bytes} byte message", SyslogBenchSupport.build_events(event_count, bytes)}
+  end)
+
+run_pipeline = fn pipeline_module ->
+  fn events ->
+    {:ok, sink} = TcpSink.start_link(length(events))
+
+    source = SyslogBenchSupport.source()
+    backend = sink |> TcpSink.port() |> SyslogBenchSupport.backend()
+    SyslogBenchSupport.cache_bench_source_and_backend(source, backend)
+
+    {:ok, pool} = NimbleTcpPool.start_link(config: SyslogBenchSupport.config(TcpSink.port(sink)))
+
+    {:ok, pipeline} =
+      pipeline_module.start_link(
+        name: :"#{inspect(pipeline_module)}-#{System.unique_integer([:positive])}",
+        source: source,
+        backend: backend,
+        pool: pool,
+        processor_concurrency: concurrency,
+        batcher_concurrency: concurrency,
+        batch_size: batch_size
+      )
+
+    events
+    |> Enum.chunk_every(push_chunk)
+    |> Enum.each(fn events ->
+      :ok = IngestEventQueue.add_to_table({source.id, backend.id}, events, chunk_size: push_chunk)
+    end)
+
+    stats = SinkCollector.collect(sink)
+
+    Broadway.stop(pipeline)
+    GenServer.stop(pool)
+    TcpSink.stop(sink)
+
+    stats
+  end
+end
+
+Benchee.run(
+  %{
+    "broadway: handle_message routes, handle_batch formats+sends batch" =>
+      run_pipeline.(SyslogBroadwayBench.BatchedPipeline),
+    "broadway: no batcher, handle_message formats+sends each message" =>
+      run_pipeline.(SyslogBroadwayBench.NoBatcherPipeline),
+    "broadway: handle_message preformats, handle_batch sends preformatted frames" =>
+      run_pipeline.(SyslogBroadwayBench.PreformattedPipeline)
+  },
+  inputs: inputs,
+  time: SyslogBenchSupport.time(),
+  warmup: SyslogBenchSupport.warmup(),
+  memory_time: 1,
+  reduction_time: 1
+)

--- a/test/profiling/syslog_broadway_bench.exs
+++ b/test/profiling/syslog_broadway_bench.exs
@@ -5,264 +5,190 @@
 #
 # Useful env:
 #   SYSLOG_BENCH_MESSAGE_BYTES=200,2000,50000
-#   SYSLOG_BENCH_CONCURRENCY=1,5
+#   SYSLOG_BENCH_CONCURRENCY=1,5  # processor concurrency
+#   SYSLOG_BENCH_BATCHER_CONCURRENCY=5
 #   SYSLOG_BENCH_BATCH_SIZE=50
 #   SYSLOG_BENCH_EVENTS=5000
-#   SYSLOG_BENCH_PUSH_CHUNK=1000
 #   SYSLOG_BENCH_TIME=5
 #   SYSLOG_BENCH_WARMUP=2
 
 Code.require_file("syslog_bench_support.exs", __DIR__)
 
-defmodule SyslogBroadwayBench.Pipeline do
-  @moduledoc false
+defmodule SyslogBroadwayBench do
+  use Broadway
 
   alias Broadway.Message
   alias Logflare.Backends
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Pipeline
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Pool
   alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
-  alias SyslogBenchSupport.NimbleTcpPool
+  alias SyslogBenchSupport, as: Support
 
-  def producer(source, backend) do
-    [
-      module:
-        {Backends.BufferProducer,
-         backend_id: backend.id,
-         source_id: source.id,
-         interval: 10,
-         buffer_size: SyslogBenchSupport.events() * 2},
-      transformer: {__MODULE__, :transform, []}
+  @spec setup(map(), :batched | :unbatched | :preformatted) :: map()
+  def setup(input, mode) do
+    sink = Support.start_sink()
+    source = Support.source()
+    backend = Support.backend(sink.port)
+    :ok = Support.cache_backend(backend)
+
+    pool_name = __MODULE__.Pool
+    pipeline_name = __MODULE__.Pipeline
+
+    {:ok, pool} =
+      Pool.start_link(
+        backend_id: backend.id,
+        name: pool_name,
+        worker_idle_timeout: 60_000
+      )
+
+    context = %{
+      backend_id: backend.id,
+      mode: mode,
+      pool: pool,
+      source_id: source.id
+    }
+
+    broadway_opts = [
+      pipeline_module: __MODULE__,
+      producer: [module: {Broadway.DummyProducer, []}],
+      processors: [default: [concurrency: input.concurrency, min_demand: 1]],
+      batchers: batchers(mode),
+      context: context
     ]
+
+    {:ok, pipeline} =
+      Pipeline.start_link(
+        [source: source, backend: backend, pool: pool, name: pipeline_name],
+        broadway_opts
+      )
+
+    state = %{
+      events: Enum.map(input.events, &Pipeline.transform(&1, [])),
+      pipeline: pipeline,
+      pipeline_name: pipeline_name,
+      pool: pool,
+      sink: sink
+    }
+
+    run(state)
+    state
   end
 
-  def processor_opts(concurrency) do
-    [default: [concurrency: concurrency, min_demand: 1]]
+  @spec run(map()) :: map()
+  def run(state) do
+    ref = Support.expect_frames(state.sink, length(state.events))
+    :ok = Broadway.push_messages(state.pipeline_name, state.events)
+    Support.await_frames(ref)
   end
 
-  def batcher_opts(concurrency, batch_size) do
-    [syslog: [concurrency: concurrency, batch_size: batch_size]]
-  end
-
-  def context(pool, backend) do
-    %{pool: pool, backend_id: backend.id}
-  end
-
-  def send_batch(pool, content, messages) do
-    case NimbleTcpPool.send(pool, content) do
-      :ok -> messages
-      {:error, reason} -> fail_batch(messages, reason)
-    end
-  end
-
-  def lookup_backend_config(backend_id) do
-    %{config: config} =
-      Backends.Cache.get_backend(backend_id) || raise "missing backend #{backend_id}"
-
-    config
-  end
-
-  def transform(event, _opts) do
-    %Message{data: event, acknowledger: {__MODULE__, _ref = nil, _meta = []}}
-  end
-
-  def ack(_ack_ref, _successful, _failed), do: :ok
-
-  defp fail_batch(messages, reason) do
-    Enum.map(messages, fn message ->
-      Broadway.Message.failed(message, reason)
-    end)
-  end
-end
-
-defmodule SyslogBroadwayBench.BatchedPipeline do
-  @moduledoc false
-
-  use Broadway
-
-  alias Broadway.Message
-  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
-  alias SyslogBroadwayBench.Pipeline
-
-  @behaviour Broadway.Acknowledger
-
-  def start_link(opts) do
-    Broadway.start_link(__MODULE__,
-      name: Keyword.fetch!(opts, :name),
-      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
-      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
-      batchers:
-        Pipeline.batcher_opts(
-          Keyword.fetch!(opts, :batcher_concurrency),
-          Keyword.fetch!(opts, :batch_size)
-        ),
-      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
-    )
+  @spec teardown(map()) :: map()
+  def teardown(state) do
+    :ok = Broadway.stop(state.pipeline)
+    :ok = GenServer.stop(state.pool)
+    :ok = Support.stop_sink(state.sink)
+    state
   end
 
   @impl Broadway
-  def handle_message(_processor_name, message, _context) do
+  def handle_message(_processor_name, message, %{mode: :batched}) do
     Message.put_batcher(message, :syslog)
   end
 
-  @impl Broadway
-  def handle_batch(:syslog, messages, _batch_info, context) do
-    config = Pipeline.lookup_backend_config(context.backend_id)
-    content = for %Message{data: event} <- messages, do: Syslog.format(event, config)
-    Pipeline.send_batch(context.pool, content, messages)
+  def handle_message(_processor_name, message, %{mode: :unbatched} = context) do
+    config = lookup_backend_config(context.backend_id)
+    send_one(message, Syslog.format(message.data, config), context.pool)
   end
 
-  @impl Broadway.Acknowledger
-  defdelegate ack(ack_ref, successful, failed), to: Pipeline
-end
-
-defmodule SyslogBroadwayBench.NoBatcherPipeline do
-  @moduledoc false
-
-  use Broadway
-
-  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
-  alias SyslogBenchSupport.NimbleTcpPool
-  alias SyslogBroadwayBench.Pipeline
-
-  @behaviour Broadway.Acknowledger
-
-  def start_link(opts) do
-    Broadway.start_link(__MODULE__,
-      name: Keyword.fetch!(opts, :name),
-      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
-      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
-      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
-    )
-  end
-
-  @impl Broadway
-  def handle_message(_processor_name, message, context) do
-    config = Pipeline.lookup_backend_config(context.backend_id)
-
-    case NimbleTcpPool.send(context.pool, Syslog.format(message.data, config)) do
-      :ok -> message
-      {:error, reason} -> Broadway.Message.failed(message, reason)
-    end
-  end
-
-  @impl Broadway.Acknowledger
-  defdelegate ack(ack_ref, successful, failed), to: Pipeline
-end
-
-defmodule SyslogBroadwayBench.PreformattedPipeline do
-  @moduledoc false
-
-  use Broadway
-
-  alias Broadway.Message
-  alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
-  alias SyslogBroadwayBench.Pipeline
-
-  @behaviour Broadway.Acknowledger
-
-  def start_link(opts) do
-    Broadway.start_link(__MODULE__,
-      name: Keyword.fetch!(opts, :name),
-      producer: Pipeline.producer(Keyword.fetch!(opts, :source), Keyword.fetch!(opts, :backend)),
-      processors: Pipeline.processor_opts(Keyword.fetch!(opts, :processor_concurrency)),
-      batchers:
-        Pipeline.batcher_opts(
-          Keyword.fetch!(opts, :batcher_concurrency),
-          Keyword.fetch!(opts, :batch_size)
-        ),
-      context: Pipeline.context(Keyword.fetch!(opts, :pool), Keyword.fetch!(opts, :backend))
-    )
-  end
-
-  @impl Broadway
-  def handle_message(_processor_name, message, context) do
-    config = Pipeline.lookup_backend_config(context.backend_id)
+  def handle_message(_processor_name, message, %{mode: :preformatted} = context) do
+    config = lookup_backend_config(context.backend_id)
 
     message
-    |> Message.update_data(fn event -> Syslog.format(event, config) end)
+    |> Message.update_data(&Syslog.format(&1, config))
     |> Message.put_batcher(:syslog)
   end
 
   @impl Broadway
-  def handle_batch(:syslog, messages, _batch_info, context) do
-    content = for %Message{data: frame} <- messages, do: frame
-    Pipeline.send_batch(context.pool, content, messages)
+  def handle_batch(:syslog, messages, _batch_info, %{mode: :batched} = context) do
+    config = lookup_backend_config(context.backend_id)
+    content = for %Message{data: event} <- messages, do: Syslog.format(event, config)
+    send_batch(messages, content, context.pool)
   end
 
-  @impl Broadway.Acknowledger
-  defdelegate ack(ack_ref, successful, failed), to: Pipeline
+  def handle_batch(:syslog, messages, _batch_info, %{mode: :preformatted} = context) do
+    content = for %Message{data: frame} <- messages, do: frame
+    send_batch(messages, content, context.pool)
+  end
+
+  defp batchers(:unbatched), do: []
+
+  defp batchers(_mode) do
+    [
+      syslog: [
+        concurrency: Support.batcher_concurrency(),
+        batch_size: Support.batch_size()
+      ]
+    ]
+  end
+
+  defp lookup_backend_config(backend_id) do
+    %{config: config} =
+      Backends.Cache.get_backend(backend_id) || raise "missing backend #{backend_id}"
+
+    if cipher_key = config[:cipher_key] do
+      Map.put(config, :cipher_key, Base.decode64!(cipher_key))
+    else
+      config
+    end
+  end
+
+  defp send_one(message, content, pool) do
+    case Pool.send(pool, content) do
+      :ok -> message
+      {:error, reason} -> Message.failed(message, reason)
+    end
+  end
+
+  defp send_batch(messages, content, pool) do
+    case Pool.send(pool, content) do
+      :ok -> messages
+      {:error, reason} -> Enum.map(messages, &Message.failed(&1, reason))
+    end
+  end
 end
 
-alias Logflare.Backends.IngestEventQueue
-alias SyslogBenchSupport.NimbleTcpPool
-alias SyslogBenchSupport.SinkCollector
-alias SyslogBenchSupport.TcpSink
+alias SyslogBenchSupport, as: Support
 
-SyslogBenchSupport.ensure_apps_started()
-SyslogBenchSupport.ensure_cache(Logflare.Sources.Cache)
-SyslogBenchSupport.ensure_cache(Logflare.Backends.Cache)
-SyslogBenchSupport.ensure_cache(Logflare.PubSubRates.Cache)
-SyslogBenchSupport.ensure_ingest_queue_started()
-SyslogBenchSupport.print_config()
+Support.ensure_apps_started()
+Support.ensure_cache(Logflare.Backends.Cache)
+Support.print_config()
 
-event_count = SyslogBenchSupport.events()
-batch_size = SyslogBenchSupport.batch_size()
-concurrency = SyslogBenchSupport.concurrency()
-push_chunk = SyslogBenchSupport.push_chunk()
+event_count = Support.events()
 
 inputs =
-  Map.new(SyslogBenchSupport.message_bytes(), fn bytes ->
-    {"#{bytes} byte message", SyslogBenchSupport.build_events(event_count, bytes)}
-  end)
+  Map.new(
+    for bytes <- Support.message_bytes(), concurrency <- Support.processor_concurrency() do
+      label = "#{bytes} byte message, processor concurrency #{concurrency}"
+      {label, %{concurrency: concurrency, events: Support.build_events(event_count, bytes)}}
+    end
+  )
 
-run_pipeline = fn pipeline_module ->
-  fn events ->
-    {:ok, sink} = TcpSink.start_link(length(events))
-
-    source = SyslogBenchSupport.source()
-    backend = sink |> TcpSink.port() |> SyslogBenchSupport.backend()
-    SyslogBenchSupport.cache_bench_source_and_backend(source, backend)
-
-    {:ok, pool} = NimbleTcpPool.start_link(config: SyslogBenchSupport.config(TcpSink.port(sink)))
-
-    {:ok, pipeline} =
-      pipeline_module.start_link(
-        name: :"#{inspect(pipeline_module)}-#{System.unique_integer([:positive])}",
-        source: source,
-        backend: backend,
-        pool: pool,
-        processor_concurrency: concurrency,
-        batcher_concurrency: concurrency,
-        batch_size: batch_size
-      )
-
-    events
-    |> Enum.chunk_every(push_chunk)
-    |> Enum.each(fn events ->
-      :ok = IngestEventQueue.add_to_table({source.id, backend.id}, events, chunk_size: push_chunk)
-    end)
-
-    stats = SinkCollector.collect(sink)
-
-    Broadway.stop(pipeline)
-    GenServer.stop(pool)
-    TcpSink.stop(sink)
-
-    stats
-  end
+job = fn mode ->
+  {&SyslogBroadwayBench.run/1,
+   before_scenario: &SyslogBroadwayBench.setup(&1, mode),
+   after_scenario: &SyslogBroadwayBench.teardown/1}
 end
+
+# credo:disable-for-next-line Credo.Check.Refactor.IoPuts
+IO.puts("Each iteration sends #{event_count} events; multiply iterations/second by that count.")
 
 Benchee.run(
   %{
-    "broadway: handle_message routes, handle_batch formats+sends batch" =>
-      run_pipeline.(SyslogBroadwayBench.BatchedPipeline),
-    "broadway: no batcher, handle_message formats+sends each message" =>
-      run_pipeline.(SyslogBroadwayBench.NoBatcherPipeline),
+    "broadway: handle_message routes, handle_batch formats+sends batch" => job.(:batched),
+    "broadway: no batcher, handle_message formats+sends each message" => job.(:unbatched),
     "broadway: handle_message preformats, handle_batch sends preformatted frames" =>
-      run_pipeline.(SyslogBroadwayBench.PreformattedPipeline)
+      job.(:preformatted)
   },
   inputs: inputs,
-  time: SyslogBenchSupport.time(),
-  warmup: SyslogBenchSupport.warmup(),
-  memory_time: 1,
-  reduction_time: 1
+  time: Support.time(),
+  warmup: Support.warmup()
 )

--- a/test/profiling/syslog_send_bench.exs
+++ b/test/profiling/syslog_send_bench.exs
@@ -1,0 +1,102 @@
+# Benchmark syslog formatter + TCP send shapes against a local RFC6587 sink.
+#
+# Run with:
+#   mix run --no-start test/profiling/syslog_send_bench.exs
+#
+# Useful env:
+#   SYSLOG_BENCH_MESSAGE_BYTES=200,2000,50000
+#   SYSLOG_BENCH_BATCH_SIZE=50
+#   SYSLOG_BENCH_EVENTS=5000
+#   SYSLOG_BENCH_TIME=5
+#   SYSLOG_BENCH_WARMUP=2
+
+Code.require_file("syslog_bench_support.exs", __DIR__)
+
+alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
+alias SyslogBenchSupport.SinkCollector
+alias SyslogBenchSupport.TcpSink
+
+SyslogBenchSupport.ensure_apps_started()
+SyslogBenchSupport.print_config()
+
+batch_size = SyslogBenchSupport.batch_size()
+event_count = SyslogBenchSupport.events()
+message_bytes = SyslogBenchSupport.message_bytes()
+
+inputs =
+  Map.new(message_bytes, fn bytes ->
+    {"#{bytes} byte message", SyslogBenchSupport.build_events(event_count, bytes)}
+  end)
+
+connect = fn port ->
+  opts = [
+    :binary,
+    packet: :raw,
+    active: false,
+    nodelay: true
+  ]
+
+  Enum.reduce_while(1..20, nil, fn _, _ ->
+    case :gen_tcp.connect(~c"127.0.0.1", port, opts, 1_000) do
+      {:ok, socket} ->
+        {:halt, socket}
+
+      {:error, reason} when reason in [:econnrefused, :etimedout] ->
+        Process.sleep(10)
+        {:cont, nil}
+
+      {:error, reason} ->
+        raise "failed to connect to syslog sink: #{inspect(reason)}"
+    end
+  end) || raise "timed out connecting to syslog sink"
+end
+
+send_and_wait = fn send_fun ->
+  fn events ->
+    {:ok, sink} = TcpSink.start_link(length(events))
+    socket = connect.(TcpSink.port(sink))
+
+    send_fun.(events, socket)
+
+    :gen_tcp.close(socket)
+    stats = SinkCollector.collect(sink)
+    TcpSink.stop(sink)
+    stats
+  end
+end
+
+config = %{}
+
+Benchee.run(
+  %{
+    "handle_message routes, handle_batch formats+sends batch" =>
+      send_and_wait.(fn events, socket ->
+        events
+        |> Enum.chunk_every(batch_size)
+        |> Enum.each(fn events ->
+          content = for event <- events, do: Syslog.format(event, config)
+          :ok = :gen_tcp.send(socket, content)
+        end)
+      end),
+    "no batcher: handle_message formats+sends each message" =>
+      send_and_wait.(fn events, socket ->
+        Enum.each(events, fn event ->
+          :ok = :gen_tcp.send(socket, Syslog.format(event, config))
+        end)
+      end),
+    "preformat in handle_message, handle_batch sends preformatted frames" =>
+      send_and_wait.(fn events, socket ->
+        events
+        |> Enum.map(&Syslog.format(&1, config))
+        |> Enum.chunk_every(batch_size)
+        |> Enum.each(fn frames ->
+          :ok = :gen_tcp.send(socket, frames)
+        end)
+      end)
+  },
+  inputs: inputs,
+  time: SyslogBenchSupport.time(),
+  warmup: SyslogBenchSupport.warmup(),
+  memory_time: 1,
+  reduction_time: 1
+)

--- a/test/profiling/syslog_send_bench.exs
+++ b/test/profiling/syslog_send_bench.exs
@@ -12,77 +12,65 @@
 
 Code.require_file("syslog_bench_support.exs", __DIR__)
 
+alias Logflare.Backends.Adaptor.SyslogAdaptor.Socket
 alias Logflare.Backends.Adaptor.SyslogAdaptor.Syslog
-alias SyslogBenchSupport.SinkCollector
-alias SyslogBenchSupport.TcpSink
+alias SyslogBenchSupport, as: Support
 
-SyslogBenchSupport.ensure_apps_started()
-SyslogBenchSupport.print_config()
+Support.ensure_apps_started()
+Support.print_config()
 
-batch_size = SyslogBenchSupport.batch_size()
-event_count = SyslogBenchSupport.events()
-message_bytes = SyslogBenchSupport.message_bytes()
+batch_size = Support.batch_size()
+event_count = Support.events()
 
 inputs =
-  Map.new(message_bytes, fn bytes ->
-    {"#{bytes} byte message", SyslogBenchSupport.build_events(event_count, bytes)}
+  Map.new(Support.message_bytes(), fn bytes ->
+    {"#{bytes} byte message", Support.build_events(event_count, bytes)}
   end)
 
-connect = fn port ->
-  opts = [
-    :binary,
-    packet: :raw,
-    active: false,
-    nodelay: true
-  ]
+setup = fn events ->
+  sink = Support.start_sink()
+  {:ok, socket} = Socket.connect(Support.config(sink.port), 5_000)
 
-  Enum.reduce_while(1..20, nil, fn _, _ ->
-    case :gen_tcp.connect(~c"127.0.0.1", port, opts, 1_000) do
-      {:ok, socket} ->
-        {:halt, socket}
+  %{events: events, sink: sink, socket: socket}
+end
 
-      {:error, reason} when reason in [:econnrefused, :etimedout] ->
-        Process.sleep(10)
-        {:cont, nil}
-
-      {:error, reason} ->
-        raise "failed to connect to syslog sink: #{inspect(reason)}"
-    end
-  end) || raise "timed out connecting to syslog sink"
+teardown = fn state ->
+  :ok = Socket.close(state.socket)
+  :ok = Support.stop_sink(state.sink)
+  state
 end
 
 send_and_wait = fn send_fun ->
-  fn events ->
-    {:ok, sink} = TcpSink.start_link(length(events))
-    socket = connect.(TcpSink.port(sink))
-
-    send_fun.(events, socket)
-
-    :gen_tcp.close(socket)
-    stats = SinkCollector.collect(sink)
-    TcpSink.stop(sink)
-    stats
+  fn state ->
+    ref = Support.expect_frames(state.sink, length(state.events))
+    :ok = send_fun.(state.events, state.socket)
+    Support.await_frames(ref)
   end
 end
 
-config = %{}
+config = %{max_message_bytes: 50_000}
+
+# credo:disable-for-next-line Credo.Check.Refactor.IoPuts
+IO.puts("Each iteration sends #{event_count} events; multiply iterations/second by that count.")
 
 Benchee.run(
   %{
     "handle_message routes, handle_batch formats+sends batch" =>
       send_and_wait.(fn events, socket ->
-        events
-        |> Enum.chunk_every(batch_size)
-        |> Enum.each(fn events ->
+        Enum.each(Enum.chunk_every(events, batch_size), fn events ->
           content = for event <- events, do: Syslog.format(event, config)
-          :ok = :gen_tcp.send(socket, content)
+          :ok = Socket.send(socket, content)
         end)
+
+        :ok
       end),
     "no batcher: handle_message formats+sends each message" =>
       send_and_wait.(fn events, socket ->
         Enum.each(events, fn event ->
-          :ok = :gen_tcp.send(socket, Syslog.format(event, config))
+          :ok = Socket.send(socket, Syslog.format(event, config))
         end)
+
+        :ok
       end),
     "preformat in handle_message, handle_batch sends preformatted frames" =>
       send_and_wait.(fn events, socket ->
@@ -90,13 +78,15 @@ Benchee.run(
         |> Enum.map(&Syslog.format(&1, config))
         |> Enum.chunk_every(batch_size)
         |> Enum.each(fn frames ->
-          :ok = :gen_tcp.send(socket, frames)
+          :ok = Socket.send(socket, frames)
         end)
+
+        :ok
       end)
   },
   inputs: inputs,
-  time: SyslogBenchSupport.time(),
-  warmup: SyslogBenchSupport.warmup(),
-  memory_time: 1,
-  reduction_time: 1
+  before_scenario: setup,
+  after_scenario: teardown,
+  time: Support.time(),
+  warmup: Support.warmup()
 )


### PR DESCRIPTION
Please ignore this PR for now :)

---

Adds benchmark-only syslog profiling scripts under test/profiling.

The benchmarks compare current batcher routing, no-batcher per-message sends, and preformatted batch sends using a local RFC6587 octet-counting TCP sink.

The Broadway benchmark runs through real Broadway processors/batchers, BufferProducer, a local NimblePool TCP sender, and fake cache entries so it can run with mix run --no-start.

Validated with mix format and small smoke runs for both benchmark scripts.