### PR TITLE
feat: team param for key value LiveView

### DIFF
--- a/lib/logflare_web/live/key_values_live.ex
+++ b/lib/logflare_web/live/key_values_live.ex
@@ -6,6 +6,7 @@ defmodule LogflareWeb.KeyValuesLive do
   alias Logflare.KeyValues
   alias Logflare.KeyValues.Cache
   alias Logflare.Repo
+  alias LogflareWeb.Utils
 
   @page_size 500
 
@@ -49,7 +50,8 @@ defmodule LogflareWeb.KeyValuesLive do
     key = params["key"]
 
     if non_blank?(key) do
-      {:noreply, push_patch(socket, to: ~p"/key-values?#{%{"key" => key}}")}
+      path = Utils.with_team_param(~p"/key-values?#{%{"key" => key}}", socket.assigns[:team])
+      {:noreply, push_patch(socket, to: path)}
     else
       {:noreply, put_flash(socket, :error, "Key filter is required")}
     end
@@ -97,7 +99,8 @@ defmodule LogflareWeb.KeyValuesLive do
   end
 
   def handle_event("clear-search", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/key-values")}
+    path = Utils.with_team_param(~p"/key-values", socket.assigns[:team])
+    {:noreply, push_patch(socket, to: path)}
   end
 
   defp create_key_value(socket, key, value) do

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -240,6 +240,7 @@ defmodule LogflareWeb.Router do
       live("/backends/new", BackendsLive, :new)
       live("/backends/:id", BackendsLive, :show)
       live("/backends/:id/edit", BackendsLive, :edit)
+      live("/key-values", KeyValuesLive, :index)
 
       scope "/alerts" do
         live "/", AlertsLive, :index
@@ -259,7 +260,6 @@ defmodule LogflareWeb.Router do
     live_session :without_team_param, on_mount: @common_on_mount_hooks ++ @auth_live_hooks do
       live("/access-tokens", AccessTokensLive, :index)
       live("/query", QueryLive, :index)
-      live("/key-values", KeyValuesLive, :index)
 
       scope "/integrations" do
         live("/vercel/edit", VercelLogDrainsLive, :edit)

--- a/test/logflare_web/live/key_values_live_test.exs
+++ b/test/logflare_web/live/key_values_live_test.exs
@@ -25,7 +25,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
     test "renders initial page with count and search prompt", %{conn: conn, user: user} do
       insert(:key_value, user: user, key: "k1", value: %{"org" => "abc"})
 
-      {:ok, _view, html} = live(conn, ~p"/key-values")
+      {:ok, _view, html} = live_with_redirect(conn, ~p"/key-values")
 
       assert html =~ "key values"
       assert html =~ "Total: 1"
@@ -33,7 +33,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
     end
 
     test "search requires key filter", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/key-values")
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/key-values")
 
       html =
         view
@@ -47,7 +47,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
       insert(:key_value, user: user, key: "target", value: %{"v" => "1"})
       insert(:key_value, user: user, key: "other", value: %{"v" => "2"})
 
-      {:ok, view, _html} = live(conn, ~p"/key-values")
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/key-values")
 
       view
       |> form("#search-form", %{"key" => "target"})
@@ -59,7 +59,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
     end
 
     test "can create a key-value pair with JSON value", %{conn: conn} do
-      {:ok, view, html} = live(conn, ~p"/key-values")
+      {:ok, view, html} = live_with_redirect(conn, ~p"/key-values")
       assert html =~ "Total: 0"
 
       view |> element("button", "Create key-value pair") |> render_click()
@@ -76,7 +76,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
     test "create shows error on duplicate key", %{conn: conn, user: user} do
       insert(:key_value, user: user, key: "dup_key", value: %{"v" => "1"})
 
-      {:ok, view, _html} = live(conn, ~p"/key-values")
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/key-values")
 
       view |> element("button", "Create key-value pair") |> render_click()
 
@@ -94,7 +94,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
       Plan.changeset(plan, %{limit_key_values: 0})
       |> Repo.update!()
 
-      {:ok, view, _html} = live(conn, ~p"/key-values")
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/key-values")
 
       view |> element("button", "Create key-value pair") |> render_click()
 
@@ -110,7 +110,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
       insert(:key_value, user: user, key: "del_key", value: %{"v" => "1"})
       insert(:key_value, user: user, key: "keep_key", value: %{"v" => "2"})
 
-      {:ok, view, html} = live(conn, ~p"/key-values")
+      {:ok, view, html} = live_with_redirect(conn, ~p"/key-values")
       assert html =~ "Total: 2"
 
       # Search by key to see del_key
@@ -135,7 +135,7 @@ defmodule LogflareWeb.KeyValuesLiveTest do
     test "clear search resets to initial state", %{conn: conn, user: user} do
       insert(:key_value, user: user, key: "k1", value: %{"v" => "1"})
 
-      {:ok, view, _html} = live(conn, ~p"/key-values")
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/key-values")
 
       view
       |> form("#search-form", %{"key" => "k1"})


### PR DESCRIPTION
Ensures current team `t=` param is set in request URI.

Follows #3454