### PR TITLE
test: fix flake in shorthand timestamp search test

### DIFF
--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1620,9 +1620,13 @@ defmodule LogflareWeb.Source.SearchLVTest do
           allow_sandbox(search_executor_pid)
 
           TestUtils.retry_assert(fn ->
+            prev_completed_at = get_view_assigns(view)[:last_query_completed_at]
+
             render_change(view, :start_search, %{
               "querystring" => "#{querystring} c:count(*) c:group_by(t::#{chart_period})"
             })
+
+            wait_for_search_completed(prev_completed_at)
 
             html = view |> element("#logs-list-container") |> render()
 
@@ -2118,6 +2122,19 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       assert html =~ source.name
       assert view |> has_element?(~s|a[href="/sources/#{source.id}?t=#{team_user.team_id}"]|)
+    end
+  end
+
+  defp wait_for_search_completed(prev_completed_at, timeout \\ 2_000) do
+    receive do
+      {:wait_for_render, %{last_query_completed_at: completed_at}}
+      when completed_at != prev_completed_at and not is_nil(completed_at) ->
+        :ok
+
+      {:wait_for_render, _assigns} ->
+        wait_for_search_completed(prev_completed_at, timeout)
+    after
+      timeout -> :timeout
     end
   end
 


### PR DESCRIPTION
## Summary

The `shorthand timestamp filters are not shifted by search timezone` test in `logs_search_lv_test.exs` failed once on `main` on the latest commit (PR #3449), with the rendered HTML stuck on a previous iteration's events. After digging in, this turns out to be a pre-existing race in the test's retry loop, not anything PR #3449 changed — and it can recur, this just happened to be the first roll that lost.

## What was wrong

The test was structured as:

```elixir
TestUtils.retry_assert(fn ->                       # retries every 50 ms for 5 s
  render_change(view, :start_search, %{"querystring" => ...})
  html = view |> element("#logs-list-container") |> render()
  assert html =~ matching_message
  ...
end)
```

Every `start_search` event handler in `LogsSearchLV` calls `SearchQueryExecutor.cancel_query/1`, which does `Task.shutdown(ref, :brutal_kill)` on the in-flight search task before starting a new one. So when `retry_assert` re-sends `start_search` every 50 ms, each retry brutal-kills the previous retry's task before it can deliver `:search_result` to the LiveView.

If the search task ever takes longer than ~50 ms to run (plausible under CI load — especially on first invocations with cold connection pools) it never completes. The LV's `search_op_log_events` assigns stay frozen on whatever the mount-time initial search returned. In the failing CI run, the mount-time search ran before iteration 2's events had flushed through Broadway's 1 s `batch_timeout` to postgres, so it returned only iteration 1's events — and every subsequent retry killed its own task before it could replace them.

The failure HTML even shows the smoking gun: `data-last-query-completed-at` was set ~2 s before the retry window even started, meaning no search completed inside `retry_assert` at all.

## The fix

Capture `last_query_completed_at` before dispatching `start_search`, then wait for it to advance — using the `:wait_for_render` telemetry hook that's already attached via `setup {TestUtils, :attach_wait_for_render}` and fires on every LV render. The only place `last_query_completed_at` gets bumped is the LV's `handle_info({:search_result, %{events: …}})` clause, so observing it advance is a precise signal that an event search has actually completed.

Each retry now runs one full search-to-assertion cycle: dispatch → wait for completion → render → assert. No more rapid-fire cancellation, no hardcoded sleeps.

Race safety: search tasks deliver their result to `SearchQueryExecutor` via `Tasks.async`'s `{ref, value}` return path, and `Task.shutdown` itself consumes any pending `{ref, …}` message for a killed task — so a brutal-killed task can't sneak a stale `:search_result` through to the LV and falsely advance the timestamp.

## Test plan

- [x] `mix test test/logflare_web/live/search_live/logs_search_lv_test.exs:1580` × 10 with random seeds — all pass (~6.5 s each)
- [x] `mix lint.diff` — no new issues
- [ ] CI green