### PR TITLE
test: stabilize syslog truncation properties and scheduler metrics

### DIFF
--- a/lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex
@@ -34,6 +34,13 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Syslog do
   @tag_bytes 16
   @aes_overhead @iv_bytes + @tag_bytes
 
+  @doc """
+  Formats a log event as an RFC5424 syslog frame with octet-counting framing.
+
+  When `max_message_bytes` is smaller than the headers length, the frame falls
+  back to headers-only and will exceed `max_message_bytes` — RFC5424 headers
+  are never truncated.
+  """
   def format(log_event, config) do
     cipher_key = config[:cipher_key]
     structured_data = config[:structured_data]

--- a/test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs
@@ -43,13 +43,18 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SyslogTest do
     property "plaintext truncation respects max_message_bytes" do
       check all max_bytes <- integer(1..100_000),
                 body_text <- string(:utf8, min_length: 1, max_length: 100_000) do
+        log_event = build(:log_event, message: body_text)
+        headers_floor = byte_size(headers_only(log_event))
+
         [length_str, syslog_msg] =
-          build(:log_event, message: body_text)
+          log_event
           |> format_to_binary(%{max_message_bytes: max_bytes})
           |> unframe()
 
         assert String.to_integer(length_str) == byte_size(syslog_msg)
-        assert byte_size(syslog_msg) <= max_bytes
+        # Headers are always emitted in full, so the frame can exceed
+        # max_bytes when it falls below the headers floor.
+        assert byte_size(syslog_msg) <= max(max_bytes, headers_floor)
       end
     end
 
@@ -58,40 +63,46 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SyslogTest do
 
       check all max_bytes <- integer(1..100_000),
                 body_text <- string(:utf8, min_length: 1, max_length: 100_000) do
+        log_event = build(:log_event, message: body_text)
+        headers_only = headers_only(log_event)
+        headers_floor = byte_size(headers_only)
+
         [length_str, syslog_msg] =
-          build(:log_event, message: body_text)
+          log_event
           |> format_to_binary(%{max_message_bytes: max_bytes, cipher_key: cipher_key})
           |> unframe()
 
         assert String.to_integer(length_str) == byte_size(syslog_msg)
-        assert byte_size(syslog_msg) <= max_bytes
+        assert byte_size(syslog_msg) <= max(max_bytes, headers_floor)
 
-        # and now we ensure we can decrypt
+        # When max_bytes leaves no room for a non-empty encrypted payload,
+        # the frame is just headers and there is nothing to decrypt.
+        if syslog_msg != headers_only do
+          assert [
+                   _pri_version,
+                   _timestamp,
+                   _hostname,
+                   _app_name,
+                   _procid,
+                   _msgid,
+                   _structured_data,
+                   encrypted_message
+                 ] = String.split(syslog_msg, " ")
 
-        assert [
-                 _pri_version,
-                 _timestamp,
-                 _hostname,
-                 _app_name,
-                 _procid,
-                 _msgid,
-                 _structured_data,
-                 encrypted_message
-               ] = String.split(syslog_msg, " ")
+          assert <<iv::12-bytes, tag::16-bytes, ciphertext::bytes>> =
+                   Base.decode64!(encrypted_message)
 
-        assert <<iv::12-bytes, tag::16-bytes, ciphertext::bytes>> =
-                 Base.decode64!(encrypted_message)
-
-        assert <<_::bytes>> =
-                 :crypto.crypto_one_time_aead(
-                   :aes_256_gcm,
-                   cipher_key,
-                   iv,
-                   ciphertext,
-                   "syslog",
-                   tag,
-                   false
-                 )
+          assert <<_::bytes>> =
+                   :crypto.crypto_one_time_aead(
+                     :aes_256_gcm,
+                     cipher_key,
+                     iv,
+                     ciphertext,
+                     "syslog",
+                     tag,
+                     false
+                   )
+        end
       end
     end
   end
@@ -105,5 +116,15 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SyslogTest do
   # splits octet-counting prefix (MSG-LEN and the space) from the actual message
   defp unframe(payload) do
     String.split(payload, " ", parts: 2)
+  end
+
+  # formats with max_message_bytes: 0 to capture the headers-only frame
+  defp headers_only(log_event) do
+    [_length_str, headers] =
+      log_event
+      |> format_to_binary(%{max_message_bytes: 0})
+      |> unframe()
+
+    headers
   end
 end

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -132,7 +132,7 @@ defmodule Logflare.TelemetryTest do
     on_exit(fn -> :telemetry.detach(ref) end)
 
     sample_duration = to_timeout(millisecond: 10)
-    Schedulers.async_dispatch_stats(sample_duration)
+    Schedulers.collect_dispatch_stats(sample_duration)
 
     assert_receive {^event, ^ref, %{utilization: _}, %{name: "total", type: "total"}}
     assert_receive {^event, ^ref, %{utilization: _}, %{name: "weighted", type: "weighted"}}


### PR DESCRIPTION
## Summary

Fixes two intermittent CI failures observed on `main`.

### 1. Syslog truncation property tests

The two property tests in `test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs` (added in #3379) asserted `byte_size(syslog_msg) <= max_bytes` for all `max_bytes` in `1..100_000`, but `SyslogAdaptor.Syslog.format/2` always emits the full RFC5424 headers — when `max_message_bytes` falls below the headers length (~74 bytes for a factory log event), the frame is `headers + empty body` and exceeds `max_bytes`. This is intentional in `lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex` (`allowed_length/3` floors to 0), and is also encoded by the existing non-property test "drops encrypted message when encryption overhead would exceed max_message_bytes".

The properties intermittently failed on `main` when StreamData picked a small `max_bytes` — the failure on main used seed 769458 → `max_bytes=6`.

**Fix:** measure the headers length per log event (via a new `headers_only/1` helper that calls `format` with `max_message_bytes: 0`) and assert `byte_size(syslog_msg) <= max(max_bytes, headers_floor)` in both properties. For the ciphertext property, skip the decryption assertions when the frame is headers-only.

Also added a `@doc` to `Syslog.format/2` so the headers-floor contract is visible to callers without reading the implementation.

### 2. Scheduler metrics test

`test/logflare/telemetry_test.exs:129 "scheduler metrics"` called `Schedulers.async_dispatch_stats/1` (which spawns a supervised task) and then `assert_receive` with the default 100ms timeout. Spawn + 10ms sample + dispatch can exceed 100ms under CI load, producing `Assertion failed, no matching message after 100ms`.

**Fix:** switch to the synchronous `Schedulers.collect_dispatch_stats/1` — same emission logic, no race. Matches the synchronous-call pattern other tests in the same file already use (`Telemetry.process_memory_metrics()`, etc.).

## Test plan

- [x] `mix test test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs` passes with default seed and with the originally failing seed `769458`.
- [x] `mix test test/logflare/telemetry_test.exs` passes.
- [x] `mix lint.diff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)