### PR TITLE
test: stop bigquery_adaptor_test flaking on cross-test mock leaks

### DIFF
--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -48,10 +48,13 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       pid = self()
 
       Logflare.Google.BigQuery
-      |> expect(:stream_batch!, fn arg, _ ->
-        assert arg.bigquery_project_id == "some-project"
-        assert arg.bigquery_dataset_id == "some-id"
-        send(pid, :ok)
+      |> stub(:stream_batch!, fn arg, _ ->
+        if arg.source_id == source.id do
+          assert arg.bigquery_project_id == "some-project"
+          assert arg.bigquery_dataset_id == "some-id"
+          send(pid, :ok)
+        end
+
         {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
       end)
 
@@ -311,10 +314,13 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       pid = self()
 
       Logflare.Google.BigQuery
-      |> expect(:stream_batch!, fn arg, _ ->
-        assert arg.bigquery_project_id == "some-project"
-        assert arg.bigquery_dataset_id == "some-id"
-        send(pid, :ok)
+      |> stub(:stream_batch!, fn arg, _ ->
+        if arg.source_id == source.id do
+          assert arg.bigquery_project_id == "some-project"
+          assert arg.bigquery_dataset_id == "some-id"
+          send(pid, :ok)
+        end
+
         {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
       end)
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure of `test default bigquery backend - storage write api does not use LF managed BQ if legacy user BQ config is set` in `test/logflare/backends/bigquery_adaptor_test.exs`. The identical sibling test at line 42 had the same flake shape and is patched the same way.

## What was happening

`data_case.ex` calls `Mimic.set_mimic_global` for every non-async test, so any process on the BEAM can satisfy the current test's expectations. The failing test set a single-shot `expect(:stream_batch!, fn arg, _ -> assert arg.bigquery_project_id == "some-project" ... end)`. When a Broadway batch processor from an earlier test (whose user had no `bigquery_project_id`) survived its owning `start_supervised!` teardown and called `stream_batch!` inside our expectation window, that leftover call consumed the expectation with `arg.bigquery_project_id == "logflare-dev-238720"`. The in-mock assertion blew up, `send(pid, :ok)` never ran, and the test timed out at 60s waiting on `assert_receive :ok`.

The failed run (Elixir CI, commit `8e03624a4`) showed the leak in the log: minutes of `Mimic.UnexpectedCallError`s and stale Tesla calls from Schema GenServers belonging to long-dead tests, all firing into the next test's globally-scoped Mimic state.

## The fix

Swap `expect` for `stub` and gate the assertion on `arg.source_id == source.id`. Two effects:

- `stub` is multi-shot, so a leftover call no longer consumes the test's one-shot allowance.
- The `if` filter makes the assertions and the `send(pid, :ok)` fire only for this test's own pipeline. Leftover calls return the canned `{:ok, ...}` response and are otherwise ignored.

The test still proves what it intends — the user's legacy `bigquery_project_id`/`dataset_id` flow into the streaming-insert context — because `retry_assert(:ok)` still waits specifically for our pipeline's call.

## Out of scope (follow-up worth doing)

The real root cause is that Broadway batch processors are surviving `start_supervised!({SourceSup, source})` teardown long enough to make rogue calls during subsequent tests. A proper fix would either tighten the supervision-tree shutdown (audit `shutdown:` keys across `SourceSup` → `AdaptorSupervisor` → `BigQueryAdaptor` → `DynamicPipeline` → Broadway, since none of the inner specs set one explicitly) or move `data_case.ex` off `set_mimic_global` to `set_mimic_private` + `Mimic.allow/3`. Both touch a lot more surface area than this flake warrants.

## Test plan

- [x] `mix test test/logflare/backends/bigquery_adaptor_test.exs` — 26 tests pass locally
- [x] `mix lint.diff` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)