### PR TITLE
fix(self-hosted): improve support for bigquery backend

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -23,7 +23,8 @@ config :logflare, Logflare.Repo,
 config :logger, :default_handler,
   config: %{
     sync_mode_qlen: 10_000,
-    drop_mode_qlen: 10_000
+    drop_mode_qlen: 10_000,
+    flush_qlen: 20_000
   }
 
 config :logger,

--- a/lib/logflare/google/bigquery/bigquery.ex
+++ b/lib/logflare/google/bigquery/bigquery.ex
@@ -27,11 +27,13 @@ defmodule Logflare.Google.BigQuery do
   def init_table!(user_id, source, project_id, ttl, dataset_location, dataset_id)
       when is_integer(user_id) and is_atom(source) and is_binary(project_id) and is_integer(ttl) and
              is_binary(dataset_location) and is_binary(dataset_id) do
-    case create_dataset(user_id, dataset_id, dataset_location, project_id) do
+    case with_rate_limit_retry(fn ->
+           create_dataset(user_id, dataset_id, dataset_location, project_id)
+         end) do
       {:ok, _} ->
         Logger.info("BigQuery dataset created: #{dataset_id}")
 
-        case create_table(source, dataset_id, project_id, ttl) do
+        case with_rate_limit_retry(fn -> create_table(source, dataset_id, project_id, ttl) end) do
           {:ok, table} ->
             Logger.info("BigQuery table created: #{source}")
             {:ok, table}
@@ -43,7 +45,7 @@ defmodule Logflare.Google.BigQuery do
       {:error, %Tesla.Env{status: 409}} ->
         Logger.info("BigQuery dataset found: #{dataset_id}")
 
-        case create_table(source, dataset_id, project_id, ttl) do
+        case with_rate_limit_retry(fn -> create_table(source, dataset_id, project_id, ttl) end) do
           {:ok, table} ->
             Logger.info("BigQuery table created: #{source}")
             {:ok, table}
@@ -61,6 +63,37 @@ defmodule Logflare.Google.BigQuery do
         )
     end
   end
+
+  @retry_max_attempts 5
+  @retry_base_ms 1_000
+
+  defp with_rate_limit_retry(fun, attempt \\ 1) do
+    result = fun.()
+
+    if attempt < @retry_max_attempts and rate_limit_error?(result) do
+      base = trunc(:math.pow(2, attempt - 1) * @retry_base_ms)
+      sleep_ms = base + :rand.uniform(div(base, 2) + 1)
+
+      Logger.warning(
+        "BigQuery rate-limited, retrying in #{sleep_ms}ms (attempt #{attempt}/#{@retry_max_attempts - 1})"
+      )
+
+      Process.sleep(sleep_ms)
+      with_rate_limit_retry(fun, attempt + 1)
+    else
+      result
+    end
+  end
+
+  defp rate_limit_error?({:error, %Tesla.Env{} = env}) do
+    message = GenUtils.get_tesla_error_message(env) || ""
+
+    String.contains?(message, "rate limit") or
+      String.contains?(message, "rateLimitExceeded") or
+      String.contains?(message, "quota")
+  end
+
+  defp rate_limit_error?(_), do: false
 
   @spec delete_table(atom) :: {:error, Tesla.Env.t()} | {:ok, term}
   def delete_table(source_id) do

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -312,6 +312,7 @@ defmodule Logflare.SingleTenant do
   def update_supabase_source_schemas do
     if supabase_mode?() do
       user = get_default_user()
+      backend = get_default_backend()
 
       sources =
         user
@@ -326,12 +327,24 @@ defmodule Logflare.SingleTenant do
             event = read_ingest_sample_json(source.name)
             log_event = LogEvent.make(event, %{source: source})
 
-            Backends.via_source(source, Schema)
-            |> Schema.update(log_event, source)
+            try do
+              Backends.via_source(source, Schema, backend.id)
+              |> Schema.update_sync(log_event, source)
+
+              Cachex.del(
+                SourceSchemas.Cache,
+                {:get_source_schema_by, [[source_id: source.id]]}
+              )
+            catch
+              :exit, reason ->
+                Logger.warning(
+                  "Schema seed failed for #{source.name}: #{inspect(reason)}"
+                )
+            end
           end)
         end
 
-      Task.await_many(tasks)
+      Task.await_many(tasks, 60_000)
     end
   end
 
@@ -410,7 +423,7 @@ defmodule Logflare.SingleTenant do
           length(source_schema.bigquery_schema.fields) > 3
         end
 
-      !!Enum.empty?(checks) and !!Enum.empty?(sources) and Enum.all?(checks)
+      not Enum.empty?(sources) and Enum.any?(checks)
     else
       false
     end

--- a/lib/logflare/single_tenant.ex
+++ b/lib/logflare/single_tenant.ex
@@ -423,7 +423,7 @@ defmodule Logflare.SingleTenant do
           length(source_schema.bigquery_schema.fields) > 3
         end
 
-      not Enum.empty?(sources) and Enum.any?(checks)
+      not Enum.empty?(sources) and not Enum.empty?(checks) and Enum.all?(checks)
     else
       false
     end

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -37,6 +37,12 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     GenServer.cast(pid, {:update, log_event, source})
   end
 
+  @spec update_sync(atom() | tuple(), LogEvent.t(), Source.t()) :: :ok
+  def update_sync(pid, %LogEvent{} = log_event, %Source{} = source)
+      when is_pid(pid) or is_tuple(pid) do
+    GenServer.call(pid, {:update, log_event, source}, 30_000)
+  end
+
   # GenServer callbacks
 
   def init(args) do
@@ -109,6 +115,11 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     else
       {:noreply, state}
     end
+  end
+
+  def handle_call({:update, _log_event, _source} = msg, _from, state) do
+    {:noreply, new_state} = handle_cast(msg, state)
+    {:reply, :ok, new_state}
   end
 
   defp schema_needs_update?(db_schema, schema, state) do

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -118,7 +118,11 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   def handle_call({:update, _log_event, _source} = msg, _from, state) do
-    {:noreply, new_state} = handle_cast(msg, state)
+    # Force the schema update through regardless of the rate-limit throttle.
+    # `update_sync` is the seed/authoritative path; a prior error from a racing
+    # log event (e.g. Vector posting before init_table! finished) must not
+    # poison the source by pushing next_update into the future.
+    {:noreply, new_state} = handle_cast(msg, %{state | next_update: 0})
     {:reply, :ok, new_state}
   end
 

--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -496,6 +496,39 @@ defmodule Logflare.Sql.DialectTranslation do
     {k, %{v | "expr" => processed_expr}}
   end
 
+  # handle LIKE/ILIKE expressions - cast LHS to text since LIKE doesn't work on jsonb.
+  # CTE fields are JSONB in the postgres backend; without this, `event_message LIKE 'x'`
+  # produces `operator does not exist: jsonb ~~ unknown` at runtime.
+  defp pg_traverse_final_pass({k, %{"expr" => expr} = v})
+       when k in ["Like", "ILike"] do
+    processed_expr =
+      cond do
+        identifier?(expr) ->
+          %{
+            "Cast" => %{
+              "data_type" => %{"Text" => nil},
+              "expr" => expr,
+              "format" => nil,
+              "kind" => "DoubleColon"
+            }
+          }
+
+        json_access?(expr) ->
+          case expr do
+            %{"Nested" => %{"BinaryOp" => %{"op" => "Arrow"} = bin_op}} ->
+              %{"Nested" => %{"BinaryOp" => %{bin_op | "op" => "LongArrow"}}}
+
+            other ->
+              pg_traverse_final_pass(other)
+          end
+
+        true ->
+          pg_traverse_final_pass(expr)
+      end
+
+    {k, %{v | "expr" => processed_expr} |> pg_traverse_final_pass()}
+  end
+
   # convert backticks to double quotes
   defp pg_traverse_final_pass({"quote_style" = k, "`"}), do: {k, "\""}
 

--- a/priv/supabase/ingest_samples/postgres.logs.json
+++ b/priv/supabase/ingest_samples/postgres.logs.json
@@ -3,14 +3,18 @@
   "metadata": {
     "host": "db-default",
     "parsed": {
+      "application_name": "pgbouncer",
       "backend_type": "client backend",
       "command_tag": "SELECT",
       "connection_from": "127.0.0.1:53482",
       "context": "PL/pgSQL function pgbouncer.get_auth(text) line 3 at RAISE",
       "database_name": "postgres",
+      "detail": "Authentication request received",
       "error_severity": "WARNING",
+      "hint": "Verify pgbouncer auth configuration",
       "leader_pid": 0,
       "process_id": 19302,
+      "query": "select pgbouncer.get_auth($1)",
       "query_id": 0,
       "session_id": "641c59c7.4b66",
       "session_line_num": 5215,

--- a/test/logflare/single_tenant_test.exs
+++ b/test/logflare/single_tenant_test.exs
@@ -178,6 +178,18 @@ defmodule Logflare.SingleTenantTest do
                source_schemas_updated: nil
              } = SingleTenant.supabase_mode_status()
     end
+
+    test "supabase_mode_status/0 reports :ok once source schemas have been enriched" do
+      {:ok, sources} = SingleTenant.create_supabase_sources()
+      enriched = TestUtils.build_bq_schema(%{"my_field" => "value"})
+
+      for source <- sources do
+        insert(:source_schema, source: source, bigquery_schema: enriched)
+      end
+
+      assert SingleTenant.supabase_mode_source_schemas_updated?()
+      assert %{source_schemas_updated: :ok} = SingleTenant.supabase_mode_status()
+    end
   end
 
   describe "single tenant mode using Postgres" do

--- a/test/logflare/sql/dialect_translation_test.exs
+++ b/test/logflare/sql/dialect_translation_test.exs
@@ -331,6 +331,31 @@ defmodule Logflare.Sql.DialectTranslationTest do
     assert String.contains?(pg_query, "~")
   end
 
+  test "casts CTE identifiers to text when used with LIKE" do
+    # Mirrors the regex test above: a CTE field (which is JSONB in the postgres
+    # backend) used with LIKE produces "operator does not exist: jsonb ~~ unknown"
+    # at runtime. This is the path the Studio cron-logs chart query takes.
+    bq_query = """
+    WITH postgres_logs AS (
+      SELECT t.timestamp, t.event_message
+      FROM `table` AS t
+      WHERE t.project = 'test'
+    )
+    SELECT event_message
+    FROM postgres_logs
+    WHERE event_message LIKE '%cron job%'
+    """
+
+    assert {:ok, pg_query} = DialectTranslation.translate_bq_to_pg(bq_query)
+    assert is_binary(pg_query)
+
+    # event_message must be coerced to text before LIKE: either ::text cast or ->> extraction
+    assert String.contains?(pg_query, "::text") or String.contains?(pg_query, "::TEXT") or
+             String.contains?(pg_query, "->>")
+
+    assert String.contains?(pg_query, "LIKE")
+  end
+
   test "handles CAST to numeric types on CTE fields by adding ::TEXT first" do
     # This tests the fix for "cannot cast type jsonb to bigint" errors
     # when CTE fields (which are JSONB) are cast to numeric types


### PR DESCRIPTION
## Summary

For additional context, see [supabase/supabase#44104](https://github.com/supabase/supabase/issues/44104).

## Fixed

### 1. `supabase_mode_source_schemas_updated?` always returns `false` when sources exist

Regression introduced via PR #2001 ("feat: BigQuery V1-V2 pipeline compat adjustments", commit `6cd81cebf`). Pre-regression line was `Enum.all?(checks) and not Enum.empty?(sources)`.

The fix is slightly stricter than the pre-regression code, which passed when no schemas had been cached yet. The new `not Enum.empty?(checks)` guard catches that case explicitly. Made safe by the seed-task throttle fix.

### 2. `update_supabase_source_schemas/0` casts to a non-existent process name

`lib/logflare/single_tenant.ex:330-331`:

```elixir
Backends.via_source(source, Schema)
|> Schema.update(log_event, source)
```

Observable symptom: BQ tables seeded at boot stay at the 3 default columns (`timestamp | id | event_message`) instead of being enriched from `priv/supabase/ingest_samples/<source>.json`.

**Fix:** use the 3-arity name + a synchronous variant so the seed task actually waits for the BQ patch and the PG `source_schemas` insert to complete. Adds `Schema.update_sync/3` with a matching `handle_call`, an explicit `Cachex.del` on `SourceSchemas.Cache` for each seeded source (in case the WAL → CacheBuster path isn't connected in self-hosted), a `try/catch :exit` so one missing supervisor doesn't fail the whole batch, and a 60s `Task.await_many` timeout to accommodate BQ latency under retry backoff.

### 3. Logger config violates OTP's `:logger_olp` invariant

`config/prod.exs` after #3455 (commit `c93825683`, 2026-05-14):

```elixir
config :logger, :default_handler,
  config: %{
    sync_mode_qlen: 10_000,
    drop_mode_qlen: 10_000
  }
```

Visible signature:

```
Could not attach default Logger handler: {:handler_not_added, {:invalid_olp_levels, %{drop_mode_qlen: 10000, flush_qlen: 1000, sync_mode_qlen: 10000}}}
```

**Fix:** add `flush_qlen: 20_000` so the invariant holds while preserving the high-throughput intent of the original tuning.

### 4. Rate-limit cascade orphans BQ tables on cold boot

`create_supabase_sources/0` creates 9 source rows in a tight loop; each auto-starts a source supervisor that fires `init_table!` in a `Tasks.start_child`. The 9 concurrent `create_dataset` + `create_table` calls breach BigQuery's "5 dataset metadata-update operations per dataset per 10 seconds" quota; 4 typically fail with `rateLimitExceeded`. `init_table!` logs the error and exits without retry, leaving 4 sources without BQ tables. Studio's `logs.all` CTE then can't validate.

Existing workaround is to restart the analytics container - the dataset already exists, so the second boot's `create_table` calls don't hit the metadata-update quota path. RedChops's supabase/supabase#44104 thread describes this state.

**Fix:** wrap `create_dataset` and `create_table` inside `init_table!/6` with exponential backoff + jitter, up to 5 attempts. Detects rate-limit specifically via the Tesla error body (`rate limit` / `rateLimitExceeded` / `quota`); non-rate-limit errors propagate unchanged. Backoff schedule: ~1s, 2s, 4s, 8s base with up to +50% jitter; total sleep time ranges from ~15s to ~22s - comfortably outlasts BQ's 10s quota window.

### 5. Sync seed task is silenced when racing log traffic poisons the throttle timer

`Schema.handle_cast/2` gates schema updates on `schema_needs_update?/3`, which respects a per-source `next_update` timer that gets pushed forward in `log_error_and_update_state/3` after a failed `patch_table` call. When Vector (or any client) posts a log event to the freshly-open Bandit port before `init_table!` has finished creating the source's BQ table, the resulting 404 from `patch_table` pushes `next_update` several seconds into the future. The subsequent `update_supabase_source_schemas/0` seed call then enters `handle_cast` (via the new `handle_call` wrapper) but is short-circuited by the stale timer - the seed returns `:ok` but the schema is never enriched. That source stays at 3 fields, the `Enum.all?` health predicate fails forever.

Observable signature: a `[warning] Source schema update error!` log line during startup, followed by one source stuck at `length(bigquery_schema.fields) == 3` even after seeding "completes." `/health` returns 503 indefinitely.

**Fix:** force `next_update: 0` in the `handle_call` wrapper so the sync seed path always reaches `patch_bigquery_table`, regardless of prior throttle state. The existing `handle_cast` path used by real log ingestion is unchanged and still honours the throttle.

### 6. `postgres.logs` seed missing fields

Studio's PG-logs queries reference `parsed.{application_name,detail,hint,query}`, but the seed sample omits them - so the self-hosted BQ schema never grew those columns and Studio's Postgres/Cron tabs returned 400 at query-parse time. Added the missing fields to `priv/supabase/ingest_samples/postgres.logs.json`.

### 7. `BQ → PG` translator chokes on `LIKE` against JSONB columns

Studio's pg_cron logs chart query 500s on self-hosted with the Postgres analytics backend because `event_message LIKE '%cron job%'` references the CTE-projected JSONB column, and PostgreSQL has no `jsonb ~~ text` operator.

The dialect translator already handles this for `REGEXP_CONTAINS` (cast LHS to text). Apply the same treatment to `Like` / `ILike` AST nodes.

Verified by translating the actual failing Studio query:
- before: `WHERE event_message LIKE '%cron job%'`  → jsonb ~~ unknown
- after:  `WHERE event_message::TEXT LIKE '%cron job%'` → valid PG

Includes a regression test mirroring `casts CTE identifiers to text when used with regex operators`.

### Related work in supabase/supabase

- Vector should have `depends_on` for `analytics`.
- Extend Vector configuration.
