### PR TITLE
fix: avoid stale timestamp in BERT ingestion test

### DIFF
--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -482,7 +482,8 @@ defmodule LogflareWeb.LogControllerTest do
               "level" => "info",
               "message" => "bert body source_name test",
               "metadata" => %{},
-              "timestamp" => "2026-05-14T17:00:00Z"
+              "timestamp" =>
+                DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
             }
           ]
         })


### PR DESCRIPTION
Test failed once the timestamp was more than 72 hours old.