### PR TITLE
chore: increase timeout for integration tests

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -44,7 +44,7 @@ jobs:
           - name: Safari
             project: webkit
 
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Sometimes the timeout of 20 minutes is not enough for safari browser (when we don't have a cache hit), e.g., https://github.com/Logflare/logflare/actions/runs/26040994119/job/76552259663.