### PR TITLE
feat: render unix timestamps in human readable format

### DIFF
--- a/assets/js/live_modal.js
+++ b/assets/js/live_modal.js
@@ -1,7 +1,11 @@
 import $ from "jquery"
+import { activateDelegatedTooltips } from "./utils"
+
 export default {
   LiveModal: {
-    updated() {},
+    updated() {
+      activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
+    },
     mounted() {
       const $modal = $(this.el)
 
@@ -9,8 +13,11 @@ export default {
         // click outside modal so phx-click-away is triggered
         $("main").trigger("click");
       });
+
+      activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
     },
     destroyed() {
+      $(this.el).tooltip("dispose")
       $("body").removeClass("modal-open").removeAttr("style")
       $(".modal-backdrop").remove()
     },

--- a/assets/js/source_lv_hooks.js
+++ b/assets/js/source_lv_hooks.js
@@ -1,5 +1,6 @@
 import {
-  activateClipboardForSelector
+  activateClipboardForSelector,
+  activateDelegatedTooltips
 } from "./utils"
 import $ from "jquery"
 import _ from "lodash"
@@ -23,6 +24,7 @@ hooks.SourceSchemaModalTable = {
 hooks.SourceLogsSearchList = {
   updated() {
     const hook = this
+    activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
 
     window.scrollTo(0, document.body.scrollHeight)
 
@@ -44,9 +46,14 @@ hooks.SourceLogsSearchList = {
     observer.observe(target)
   },
   mounted() {
+    activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
+
     $("html, body").animate({
       scrollTop: document.body.scrollHeight
     })
+  },
+  destroyed() {
+    $(this.el).tooltip("dispose")
   },
 }
 
@@ -302,10 +309,7 @@ hooks.DocumentVisibility = {
 
 hooks.LiveTooltips = {
   mounted() {
-    $(this.el).tooltip({
-      selector: ".logflare-tooltip",
-      delay: { show: 100, hide: 200 },
-    });
+    activateDelegatedTooltips(this.el, ".logflare-tooltip")
   },
   destroyed() {
     $(this.el).tooltip("dispose");

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,4 +1,12 @@
 import ClipboardJS from "clipboard"
+import $ from "jquery"
+
+export function activateDelegatedTooltips(el, selector) {
+  $(el).tooltip({
+    selector,
+    delay: { show: 100, hide: 200 },
+  })
+}
 
 export function activateClipboardForSelector(selector, options) {
   const clipboard = new ClipboardJS(selector, options)

--- a/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
+++ b/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
@@ -214,4 +214,36 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
   defp flatten_node(%{t: type}, key, acc) do
     Map.put(acc, key, type)
   end
+
+  @spec get_type_for_path([term()], map()) :: atom() | nil
+  def get_type_for_path(path, flat_schema_map) when is_list(path) and is_map(flat_schema_map) do
+    path
+    |> schema_keys_for_path()
+    |> Enum.find_value(fn key -> Map.get(flat_schema_map, key) end)
+  end
+
+  def get_type_for_path(_path, _flat_schema_map), do: nil
+
+  defp schema_keys_for_path(path) do
+    direct_key = path |> Enum.map(&to_string/1) |> Enum.join(".")
+
+    without_array_indexes =
+      path
+      |> Enum.reject(&array_index?/1)
+      |> Enum.map(&to_string/1)
+      |> Enum.join(".")
+
+    [direct_key, without_array_indexes]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp array_index?(segment) when is_integer(segment), do: true
+
+  defp array_index?(segment) do
+    case Integer.parse(to_string(segment)) do
+      {_index, ""} -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/logflare_web/components/formatted_timestamp_component.ex
+++ b/lib/logflare_web/components/formatted_timestamp_component.ex
@@ -1,0 +1,46 @@
+defmodule LogflareWeb.FormattedTimestampComponent do
+  @moduledoc """
+  Renders a formatted timestamp hint for log event field values.
+  """
+
+  use Phoenix.Component
+
+  alias LogflareWeb.Helpers.BqSchema
+
+  @display_format "%Y-%m-%d %H:%M:%S"
+  @title_format "%Y-%m-%dT%H:%M:%SZ"
+
+  attr :value, :integer, required: true
+  attr :timezone, :string, default: nil
+
+  def formatted_timestamp(%{value: value, timezone: timezone} = assigns) do
+    formatted = formatted(value, timezone)
+
+    assigns =
+      assigns
+      |> assign(:formatted, formatted)
+      |> assign(:title, title(value, formatted))
+
+    ~H"""
+    <span :if={@formatted} class="tw-ml-2 tw-text-neutral-400" title={@title} data-toggle="tooltip" data-placement="top">
+      {@formatted}
+    </span>
+    """
+  end
+
+  defp formatted(timestamp, timezone) when is_integer(timestamp) do
+    formatted = BqSchema.format_timestamp(timestamp, timezone, format: @display_format)
+
+    if active_timezone?(timezone), do: formatted, else: formatted <> " UTC"
+  end
+
+  defp formatted(_timestamp, _timezone), do: nil
+
+  defp title(timestamp, formatted) when is_integer(timestamp) and is_binary(formatted) do
+    BqSchema.format_timestamp(timestamp, "UTC", format: @title_format)
+  end
+
+  defp title(_timestamp, _formatted), do: nil
+
+  defp active_timezone?(timezone), do: match?(%Timex.TimezoneInfo{}, Timex.Timezone.get(timezone))
+end

--- a/lib/logflare_web/live/log_event_live/search_log_event_viewer_component.ex
+++ b/lib/logflare_web/live/log_event_live/search_log_event_viewer_component.ex
@@ -120,6 +120,7 @@ defmodule LogflareWeb.Search.LogEventViewerComponent do
       lql_schema: get_lql_schema(source),
       timestamp: timestamp,
       local_timezone: tz,
+      search_timezone: assigns.search_params["tz"] || tz,
       local_timestamp: local_timestamp
     )
   end

--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -135,10 +135,21 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
       |> Enum.join("\n")
 
     """
-    #{formatted_timestamp(log, search_op.search_timezone)}    #{log.body["event_message"]}
+    #{format_timestamp_for_clipboard(log.body["timestamp"], search_op.search_timezone)}    #{log.body["event_message"]}
 
     #{select_fields}
     """
+  end
+
+  defp format_timestamp_for_clipboard(timestamp, timezone) do
+    format_timestamp(timestamp, timezone) <> timezone_offset(timezone)
+  end
+
+  defp timezone_offset(timezone) when is_binary(timezone) do
+    case Timex.Timezone.get(timezone) do
+      {:error, _} -> DateTimeUtils.humanize_timezone_offset(0)
+      timezone_info -> DateTimeUtils.humanize_timezone_offset(timezone_info.offset_utc)
+    end
   end
 
   attr :log_event, Logflare.LogEvent, required: true
@@ -192,16 +203,6 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
     </mark>
     <mark :if={@log_level} class={"log-level-#{@log_level}"}>{@log_level}</mark>
     """
-  end
-
-  def formatted_timestamp(log_event, timezone) do
-    tz_part =
-      case Timex.Timezone.get(timezone) do
-        {:error, _} -> DateTimeUtils.humanize_timezone_offset(0)
-        tz_info -> DateTimeUtils.humanize_timezone_offset(tz_info.offset_utc)
-      end
-
-    format_timestamp(log_event.body["timestamp"], timezone) <> tz_part
   end
 
   attr :log_event, Logflare.LogEvent, required: true

--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -8,10 +8,13 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   import LogflareWeb.ModalLiveHelpers
 
   alias Logflare.DateTimeUtils
+  alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.Lql
   alias Logflare.Lql.Rules
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Sources.Source
+  alias LogflareWeb.FormattedTimestampComponent
+  alias LogflareWeb.Search.LogEventViewerComponent
   alias Phoenix.LiveView.JS
 
   @log_levels ~W(debug info warning error alert critical notice emergency)
@@ -24,6 +27,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   attr :tailing?, :boolean, required: true
   attr :querystring, :string, required: true
   attr :empty_event_message_placeholder, :string, default: @default_empty_event_message
+  attr :source_schema_flat_map, :map, default: %{}
   attr :search_op, Logflare.Logs.SearchOperation
 
   def results_list(assigns) do
@@ -32,12 +36,12 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
     ~H"""
     <div :if={@search_op_log_events} id="source-logs-search-list" data-last-query-completed-at={@last_query_completed_at} phx-hook="SourceLogsSearchList" class="mt-4">
       <ul id="logs-list" class={["list-unstyled console-text-list", if(@loading, do: "blurred", else: nil)]}>
-        <.log_event :for={log <- @search_op_log_events.rows} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)}>
+        <.log_event :for={log <- @search_op_log_events.rows} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)} source_schema_flat_map={@source_schema_flat_map}>
           {log.body["event_message"]}
           <:actions phx-no-format>
           <div class={if(Enum.any?(@select_fields), do: "tw-ml-[13rem] tw-pb-1.5", else: "tw-inline")}>
           <.modal_link
-                   component={LogflareWeb.Search.LogEventViewerComponent}
+                   component={LogEventViewerComponent}
                    class="tw-text-[0.65rem]"
                    modal_id={:log_event_viewer}
                    title="Log Event"
@@ -157,6 +161,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   attr :timezone, :string, required: true
   attr :empty_event_message_placeholder, :string, default: @default_empty_event_message
   attr :select_fields, :list, default: []
+  attr :source_schema_flat_map, :map, default: %{}
   attr :rest, :global, default: %{class: "tw-group"}
   slot :inner_block
   slot :actions
@@ -183,7 +188,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
       </.metadata>
       <%= if @message do %>
         {render_slot(@inner_block) || @message}
-        <.selected_fields :if={@select_fields != []} log_event={@log_event} select_fields={@select_fields} />
+        <.selected_fields :if={@select_fields != []} log_event={@log_event} select_fields={@select_fields} source_schema_flat_map={@source_schema_flat_map} timezone={@timezone} />
       <% else %>
         <span class="tw-italic tw-text-gray-500">{@empty_event_message_placeholder}</span>
       <% end %>
@@ -207,6 +212,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
   attr :log_event, Logflare.LogEvent, required: true
   attr :select_fields, :list, required: true
+  attr :source_schema_flat_map, :map, default: %{}
+  attr :timezone, :string, default: nil
 
   def selected_fields(assigns) do
     ~H"""
@@ -216,7 +223,10 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
           <div class="tw-w-[13rem] tw-text-right ">
             <span class="tw-whitespace-nowrap tw-w-fit tw-px-1 tw-py-0.5 tw-bg-neutral-600 tw-text-white tw-mr-2">{truncate_display(field.display)}</span>
           </div>
-          <span class="tw-text-white">{get_field_value(@log_event.body, field.key)}</span>
+          <span class="tw-text-white">
+            {get_field_value(@log_event.body, field.key)}
+            <FormattedTimestampComponent.formatted_timestamp :if={datetime_field?(field.path, @source_schema_flat_map)} value={Map.get(@log_event.body, field.key)} timezone={@timezone} />
+          </span>
         </div>
       <% end %>
     </div>
@@ -243,10 +253,10 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
       %{path: path, alias: nil} ->
         key = String.replace(path, ".", "_")
         display = path |> String.split(".") |> List.last()
-        %{display: display, key: key}
+        %{display: display, key: key, path: path}
 
-      %{path: _path, alias: alias} ->
-        %{display: alias, key: alias}
+      %{path: path, alias: alias} ->
+        %{display: alias, key: alias, path: path}
     end)
     |> Enum.reject(fn field -> is_nil(field.display) end)
   end
@@ -320,6 +330,21 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
     ~p"/sources/#{search_op.source}/search?#{[querystring: query, tailing?: false]}"
   end
+
+  @spec datetime_field?(String.t() | [term()], map() | nil) :: boolean()
+  def datetime_field?(path, source_schema_flat_map)
+      when is_binary(path) and is_map(source_schema_flat_map) do
+    path
+    |> String.split(".")
+    |> datetime_field?(source_schema_flat_map)
+  end
+
+  def datetime_field?(path, source_schema_flat_map)
+      when is_list(path) and is_map(source_schema_flat_map) do
+    SchemaUtils.get_type_for_path(path, source_schema_flat_map) == :datetime
+  end
+
+  def datetime_field?(_path, _source_schema_flat_map), do: false
 
   defp first_date_with_results(%{rows: rows}) when is_list(rows) do
     Enum.find(

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -256,7 +256,16 @@ defmodule LogflareWeb.Source.SearchLV do
     <div class="container source-logs-search-container console-text">
       <div id="logs-list-container">
         <LogEventComponents.empty_result_list :if={not @loading} search_op_log_events={@search_op_log_events} search_op_log_aggregates={@search_op_log_aggregates} />
-        <LogEventComponents.results_list search_op={@search_op} search_op_log_events={@search_op_log_events} last_query_completed_at={@last_query_completed_at} search_timezone={@search_timezone} loading={@loading} tailing?={@tailing?} querystring={@querystring} />
+        <LogEventComponents.results_list
+          search_op={@search_op}
+          search_op_log_events={@search_op_log_events}
+          last_query_completed_at={@last_query_completed_at}
+          search_timezone={@search_timezone}
+          loading={@loading}
+          tailing?={@tailing?}
+          querystring={@querystring}
+          source_schema_flat_map={@source_schema_flat_map}
+        />
       </div>
       <div>
         {live_react_component(

--- a/lib/logflare_web/templates/log/log_event_body.html.heex
+++ b/lib/logflare_web/templates/log/log_event_body.html.heex
@@ -76,6 +76,7 @@
           <div class="tab-pane active" id="metadata-viewer" role="tabpanel" style="font-size: 14px;">
             <JSONViewerComponent.json_viewer data={@fmt_body |> JSON.decode!()} id={"log-event-tree-#{@id}"}>
               <:action :let={node}>
+                <.formatted_timestamp :if={datetime_field?(node.path, @source_schema_flat_map)} value={node.value} timezone={@local_timezone} />
                 <.quick_filter lql={@lql || ""} node={node} source={@source} source_schema_flat_map={@source_schema_flat_map} lql_schema={@lql_schema} search_params={@search_params} team={@team} />
               </:action>
             </JSONViewerComponent.json_viewer>

--- a/lib/logflare_web/views/helpers/bq_schema_helpers.ex
+++ b/lib/logflare_web/views/helpers/bq_schema_helpers.ex
@@ -4,8 +4,10 @@ defmodule LogflareWeb.Helpers.BqSchema do
   alias Logflare.BigQuery.SchemaTypes
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.JSON
+  alias Logflare.Utils
 
   @type field_and_type :: {String.t(), String.t()}
+  @type timestamp_format_opts :: [format: String.t()]
 
   def format_bq_schema(nil), do: ""
 
@@ -30,21 +32,29 @@ defmodule LogflareWeb.Helpers.BqSchema do
     |> Enum.sort_by(fn {k, _v} -> k end)
   end
 
-  @fmt_string "%a %b %d %Y %H:%M:%S"
-  def format_timestamp(timestamp) do
+  @timestamp_format "%a %b %d %Y %H:%M:%S"
+
+  @spec format_timestamp(integer(), String.t() | nil, timestamp_format_opts()) :: String.t()
+  def format_timestamp(timestamp, search_timezone \\ nil, opts \\ [])
+      when is_integer(timestamp) do
+    format = Keyword.get(opts, :format, @timestamp_format)
+
     timestamp
-    |> Timex.from_unix(:microsecond)
-    |> Timex.format!(@fmt_string, :strftime)
+    |> Utils.to_microseconds()
+    |> DateTime.from_unix!(:microsecond)
+    |> convert_timezone(search_timezone)
+    |> Timex.format!(format, :strftime)
   end
 
-  def format_timestamp(timestamp, search_timezone) do
-    dt = Timex.from_unix(timestamp, :microsecond)
-
-    case Timex.Timezone.convert(dt, search_timezone) do
-      {:error, _} -> Timex.format!(dt, @fmt_string, :strftime)
-      converted -> Timex.format!(converted, @fmt_string, :strftime)
+  defp convert_timezone(%DateTime{} = datetime, timezone) when is_binary(timezone) do
+    with %DateTime{} = converted <- Timex.Timezone.convert(datetime, timezone) do
+      converted
+    else
+      _ -> datetime
     end
   end
+
+  defp convert_timezone(%DateTime{} = datetime, _timezone), do: datetime
 
   def encode_metadata(metadata) do
     metadata

--- a/lib/logflare_web/views/log_view.ex
+++ b/lib/logflare_web/views/log_view.ex
@@ -2,6 +2,8 @@ defmodule LogflareWeb.LogView do
   use LogflareWeb, :view
 
   import LogflareWeb.CoreComponents, only: [log_event_permalink: 1]
+  import LogflareWeb.FormattedTimestampComponent, only: [formatted_timestamp: 1]
+  import LogflareWeb.SearchLive.LogEventComponents, only: [datetime_field?: 2]
   import LogflareWeb.QueryComponents, only: [quick_filter: 1]
 
   alias LogflareWeb.JSONViewerComponent

--- a/test/logflare/google/bigquery/schema_utils_test.exs
+++ b/test/logflare/google/bigquery/schema_utils_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Google.BigQuery.SchemaUtilsTest do
   use ExUnitProperties
 
   alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.TestUtils
 
   describe "flatten_typemap/1" do
     test "nil and empty map both return empty map" do
@@ -157,5 +158,42 @@ defmodule Logflare.Google.BigQuery.SchemaUtilsTest do
           Map.put(acc, flat_key, type)
       end
     end)
+  end
+
+  describe "get_type_for_path/2" do
+    setup do
+      flat_schema =
+        %{
+          "metadata" => %{
+            "timestamp" => 1_777_263_766_765_189,
+            "count" => 1,
+            "items" => [%{"name" => "item"}]
+          }
+        }
+        |> TestUtils.build_bq_schema()
+        |> SchemaUtils.bq_schema_to_flat_typemap()
+
+      %{flat_schema: flat_schema}
+    end
+
+    test "returns the correct type for paths", %{flat_schema: flat_schema} do
+      assert SchemaUtils.get_type_for_path(["metadata", "timestamp"], flat_schema) == :integer
+      assert SchemaUtils.get_type_for_path(["metadata", "count"], flat_schema) == :integer
+      assert SchemaUtils.get_type_for_path(["metadata", "items", "name"], flat_schema) == :string
+    end
+
+    test "handles array indices correctly", %{flat_schema: flat_schema} do
+      assert SchemaUtils.get_type_for_path(["metadata", "items", 0, "name"], flat_schema) ==
+               :string
+
+      assert SchemaUtils.get_type_for_path(["metadata", "items", "1", "name"], flat_schema) ==
+               :string
+    end
+
+    test "returns nil for unknown paths or invalid inputs", %{flat_schema: flat_schema} do
+      assert SchemaUtils.get_type_for_path(["metadata", "unknown"], flat_schema) == nil
+      assert SchemaUtils.get_type_for_path(nil, flat_schema) == nil
+      assert SchemaUtils.get_type_for_path(["metadata", "timestamp"], nil) == nil
+    end
   end
 end

--- a/test/logflare_web/components/formatted_timestamp_component_test.exs
+++ b/test/logflare_web/components/formatted_timestamp_component_test.exs
@@ -1,0 +1,56 @@
+defmodule LogflareWeb.FormattedTimestampComponentTest do
+  use LogflareWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import LogflareWeb.FormattedTimestampComponent
+
+  describe "formatted_timestamp/1" do
+    test "renders formatted timestamp with ISO8601 tooltip" do
+      timestamp = 1_777_263_766_765_189
+
+      html =
+        render_component(&formatted_timestamp/1,
+          value: timestamp,
+          timezone: "Etc/UTC"
+        )
+
+      assert html =~ "2026-04-27 04:22:46"
+      assert html =~ ~s(title="2026-04-27T04:22:46Z")
+    end
+
+    test "renders search timezone adjusted timestamp without timezone suffix" do
+      timestamp = 1_777_263_766_765_189
+
+      html =
+        render_component(&formatted_timestamp/1,
+          value: timestamp,
+          timezone: "Australia/Brisbane"
+        )
+
+      assert html |> Floki.parse_document!() |> Floki.text() |> String.trim() ==
+               "2026-04-27 14:22:46"
+
+      assert html =~ ~s(title="2026-04-27T04:22:46Z")
+    end
+
+    test "renders explicit UTC suffix when no timezone is active" do
+      timestamp = 1_777_263_766_765_189
+
+      html =
+        render_component(&formatted_timestamp/1,
+          value: timestamp
+        )
+
+      assert html =~ "2026-04-27 04:22:46 UTC"
+      assert html =~ ~s(title="2026-04-27T04:22:46Z")
+    end
+
+    test "does not render when the value is not parseable as a timestamp" do
+      ["not-a-timestamp", nil]
+      |> Enum.each(fn bad_value ->
+        html = render_component(&formatted_timestamp/1, value: bad_value)
+        assert html == ""
+      end)
+    end
+  end
+end

--- a/test/logflare_web/live/search_live/log_event_components_test.exs
+++ b/test/logflare_web/live/search_live/log_event_components_test.exs
@@ -197,23 +197,36 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         build(:log_event,
           metadata_user_id: "user_123",
           metadata_store_city: "San Francisco",
-          food: "Pizza"
+          food: "Pizza",
+          deployment_time: 1_777_263_766_765_189
         )
 
       select_fields = [
-        %{display: "metadata.user_id", key: "metadata_user_id"},
-        %{display: "metadata.store.city", key: "metadata_store_city"},
-        %{display: "food", key: "food"}
+        %{display: "metadata.user_id", key: "metadata_user_id", path: "metadata.user_id"},
+        %{
+          display: "metadata.store.city",
+          key: "metadata_store_city",
+          path: "metadata.store.city"
+        },
+        %{display: "food", key: "food", path: "food"},
+        %{display: "deployment_time", key: "deployment_time", path: "deployment_time"}
       ]
 
       assigns = %{
         log_event: log_event,
-        select_fields: select_fields
+        select_fields: select_fields,
+        source_schema_flat_map: %{"deployment_time" => :datetime},
+        timezone: "Australia/Brisbane"
       }
 
       html =
         rendered_to_string(~H"""
-        <LogEventComponents.selected_fields log_event={@log_event} select_fields={@select_fields} />
+        <LogEventComponents.selected_fields
+          log_event={@log_event}
+          select_fields={@select_fields}
+          source_schema_flat_map={@source_schema_flat_map}
+          timezone={@timezone}
+        />
         """)
 
       assert html =~ "user_id"
@@ -222,13 +235,27 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
       assert html =~ "San Francisco"
       assert html =~ "food"
       assert html =~ "Pizza"
+
+      {:ok, document} = Floki.parse_document(html)
+
+      deployment_field =
+        document
+        |> Floki.find("div.tw-flex")
+        |> Enum.find(&(Floki.text(&1) =~ "deployment_time"))
+
+      assert Floki.text(deployment_field) =~ "1777263766765189"
+      assert Floki.text(deployment_field) =~ "2026-04-27 14:22:46"
+
+      assert Floki.attribute(deployment_field, "span[title]", "title") == [
+               "2026-04-27T04:22:46Z"
+             ]
     end
 
     test "handles null values" do
       log_event = build(:log_event, metadata_user_id: nil)
 
       select_fields = [
-        %{display: "metadata.user_id", key: "metadata_user_id"}
+        %{display: "metadata.user_id", key: "metadata_user_id", path: "metadata.user_id"}
       ]
 
       assigns = %{

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -5,10 +5,13 @@ defmodule LogflareWeb.Source.SearchLVTest do
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL
+  alias GoogleApi.BigQuery.V2.Model.TableSchema, as: TS
+  alias GoogleApi.BigQuery.V2.Model.TableFieldSchema, as: TFS
   alias Logflare.Backends
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.SingleTenant
   alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Sources.Source.BigQuery.SchemaBuilder
   alias Logflare.Utils.Tasks
   alias LogflareWeb.Source.SearchLV
 
@@ -380,7 +383,8 @@ defmodule LogflareWeb.Source.SearchLVTest do
       source = insert(:source, source_attrs)
       plan = insert(:plan)
 
-      bq_schema = TestUtils.build_bq_schema(%{"user_id" => "some_value"})
+      bq_schema =
+        Map.get(context, :source_schema, TestUtils.build_bq_schema(%{"user_id" => "some_value"}))
 
       insert(:source_schema,
         source: source,
@@ -1047,15 +1051,41 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert link =~ ~r/phx-value-lql="\w+/
     end
 
+    @tag source_schema:
+           %TS{
+             fields: [
+               %TFS{
+                 name: "metadata",
+                 type: "RECORD",
+                 mode: "REPEATED",
+                 fields: [
+                   %TFS{name: "deployment_time", type: "TIMESTAMP", mode: "NULLABLE"},
+                   %TFS{name: "release_time", type: "TIMESTAMP", mode: "NULLABLE"}
+                 ]
+               }
+             ]
+           }
+           |> then(&SchemaBuilder.build_table_schema(%{"user_id" => "string"}, &1))
     test "log event selected fields", %{conn: conn, source: source} do
+      response_schema =
+        TestUtils.build_bq_schema(%{
+          "event_message" => "string",
+          "testing" => "string",
+          "user_id" => "string",
+          "id" => "string"
+        })
+
       stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, _opts ->
         {:ok,
-         TestUtils.gen_bq_response(%{
-           "event_message" => "some event message",
-           "testing" => "modal123",
-           "user_id" => "user-abc-123",
-           "id" => "some-uuid"
-         })}
+         TestUtils.gen_bq_response(
+           %{
+             "event_message" => "some event message",
+             "testing" => "modal123",
+             "user_id" => "user-abc-123",
+             "id" => "some-uuid"
+           },
+           response_schema
+         )}
       end)
 
       {:ok, view, _html} =
@@ -1079,23 +1109,56 @@ defmodule LogflareWeb.Source.SearchLVTest do
     end
 
     test "log event modal", %{conn: conn, user: user} do
-      schema = TestUtils.build_bq_schema(%{"testing" => "string"})
+      schema =
+        %TS{
+          fields: [
+            %TFS{name: "deployment_time", type: "TIMESTAMP", mode: "NULLABLE"}
+          ]
+        }
+        |> then(&SchemaBuilder.build_table_schema(%{"testing" => "string"}, &1))
+
+      response_schema =
+        %TS{
+          fields: [
+            %TFS{name: "deployment_time", type: "TIMESTAMP"}
+          ]
+        }
+        |> then(&SchemaBuilder.build_table_schema(%{"testing" => "string"}, &1))
+
+      deployment_time = TestUtils.gen_bq_timestamp(~U[2026-04-27 04:22:46.765189Z])
+
+      {:ok, _user} =
+        Logflare.Users.update_user_with_preferences(user, %{
+          preferences: %{timezone: "Australia/Brisbane"}
+        })
+
       source = insert(:source, user: user)
-      insert(:source_schema, source: source, bigquery_schema: schema)
+
+      insert(:source_schema,
+        source: source,
+        bigquery_schema: schema
+      )
+
+      Cachex.clear(Logflare.SourceSchemas.Cache)
+
       # TODO: use expect, remove UDFs creation query
       stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, _opts ->
         {:ok,
-         TestUtils.gen_bq_response(%{
-           "event_message" => "some modal message",
-           "testing" => "modal123",
-           "id" => "some-uuid"
-         })}
+         TestUtils.gen_bq_response(
+           %{
+             "event_message" => "some modal message",
+             "testing" => "modal123",
+             "deployment_time" => deployment_time,
+             "id" => "some-uuid"
+           },
+           response_schema
+         )}
       end)
 
       {:ok, view, _html} =
         live_with_redirect(
           conn,
-          ~p"/sources/#{source.id}/search?#{%{querystring: "testing:modal123"}}"
+          ~p"/sources/#{source.id}/search?#{%{querystring: "testing:modal123", tz: "Australia/Brisbane"}}"
         )
 
       %{executor_pid: search_executor_pid} = get_view_assigns(view)
@@ -1105,9 +1168,6 @@ defmodule LogflareWeb.Source.SearchLVTest do
       view
       |> TestUtils.wait_for_render("li:first-of-type a[phx-value-log-event-id='some-uuid']")
 
-      schema = TestUtils.build_bq_schema(%{"testing" => "string"})
-      source = insert(:source, user: user)
-      insert(:source_schema, source: source, bigquery_schema: schema)
       pid = self()
 
       expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, opts ->
@@ -1115,11 +1175,15 @@ defmodule LogflareWeb.Source.SearchLVTest do
         send(pid, {:query, query})
 
         {:ok,
-         TestUtils.gen_bq_response(%{
-           "event_message" => "some modal message",
-           "testing" => "modal123",
-           "id" => "some-uuid"
-         })}
+         TestUtils.gen_bq_response(
+           %{
+             "event_message" => "some modal message",
+             "testing" => "modal123",
+             "deployment_time" => deployment_time,
+             "id" => "some-uuid"
+           },
+           response_schema
+         )}
       end)
 
       TestUtils.retry_assert(fn ->
@@ -1134,6 +1198,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
         assert html =~ "Raw JSON"
         assert html =~ "modal123"
         assert html =~ "some modal message"
+        assert html =~ "deployment_time"
+        assert html =~ "1777263766765189"
+        assert html =~ "2026-04-27 14:22:46"
+        assert html =~ ~s(title="2026-04-27T04:22:46Z")
       end)
 
       assert_receive {:query, query}

--- a/test/logflare_web/views/helpers/bq_schema_helpers_test.exs
+++ b/test/logflare_web/views/helpers/bq_schema_helpers_test.exs
@@ -1,0 +1,36 @@
+defmodule LogflareWeb.Helpers.BqSchemaTest do
+  use LogflareWeb.ConnCase, async: true
+
+  alias LogflareWeb.Helpers.BqSchema
+
+  describe "format_timestamp/3" do
+    test "formats timestamps with the default log timestamp format" do
+      timestamp = 1_234_567_890_000_000
+
+      assert BqSchema.format_timestamp(timestamp, "America/Los_Angeles") ==
+               "Fri Feb 13 2009 15:31:30"
+    end
+
+    test "formats timestamps with a custom Timex format" do
+      timestamp = 1_777_263_766_765_189
+
+      assert BqSchema.format_timestamp(timestamp, "Australia/Brisbane",
+               format: "%Y-%m-%d %H:%M:%S"
+             ) == "2026-04-27 14:22:46"
+    end
+
+    test "falls back to UTC when timezone conversion fails" do
+      timestamp = 1_777_263_766_765_189
+
+      assert BqSchema.format_timestamp(timestamp, "Not/A_Zone") ==
+               "Mon Apr 27 2026 04:22:46"
+    end
+
+    test "falls back to UTC when timezone is missing" do
+      timestamp = 1_777_263_766_765_189
+
+      assert BqSchema.format_timestamp(timestamp, nil) ==
+               "Mon Apr 27 2026 04:22:46"
+    end
+  end
+end


### PR DESCRIPTION
Renders timestamp field values in a human readable format.

* Add `FormattedTimestampComponent.formatted_timestamp/1` for rendering formatted timestamps
* `datetime` fields are rendered in the user's timezone, otherwise UTC.
* Tooltip shows timestamp is UTC format for reference 


Follows #3499 

Closes O11Y-1594

<img width="2114" height="1278" alt="CleanShot 2026-05-20 at 10 12 25@2x" src="https://github.com/user-attachments/assets/851582be-c912-446e-b819-516436b60dcd" />

<img width="1430" height="962" alt="CleanShot 2026-05-20 at 10 14 09@2x" src="https://github.com/user-attachments/assets/566de513-6bea-4b29-b465-243d1a496762" />


### Limitations

* Only fields identified as `datetime` in the source schema are formatted, such as the event timestamp.
* Search event modal currently only shows the search timezone if a user has saved it to their settings:

https://github.com/Logflare/logflare/blob/b8d6cbab1a53c3d8f99f9baef68d7d8ab2a6530f/lib/logflare_web/live/log_event_live/search_log_event_viewer_component.ex#L96-L100 



## Demo

https://github.com/user-attachments/assets/aaa52e61-4956-42a8-9edd-819965423d79


