### PR TITLE
chore: bump memory for instances

### DIFF
--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -9,7 +9,7 @@ steps:
       - $_TEMPLATE_NAME
       - --boot-disk-size=10GB
       - --boot-disk-type=pd-balanced
-      - --machine-type=c2d-highcpu-32
+      - --machine-type=c2d-standard-32
       - --project=logflare-232118
       - --network-interface=network=global,network-tier=PREMIUM,no-address
       - --maintenance-policy=TERMINATE


### PR DESCRIPTION
doubles prod memory from 64 to 128GB for an additional running cost of around ~250USD/mo additional per instance.