### PR TITLE
feat: multi-source ingestion

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
+++ b/docs/docs.logflare.com/docs/concepts/ingestion/index.mdx
@@ -95,6 +95,35 @@ To ingest by batch, send your request with the following JSON body:
 
 Note that if you have multiple sources with the same name, it will result in an error on ingestion and the log event will be discarded.
 
+### Multi-source batching (`__LF_SOURCE`)
+
+A single ingestion request can write different events from the same payload into **different sources** by setting the reserved field `__LF_SOURCE` on each event you want to route explicitly.
+
+- **Value**: The **source UUID** (the same identifier you use for the `source` query parameter or in the dashboard). It must be a valid UUID string.
+
+Example — two sources in one `batch`:
+
+```json
+{
+  "batch": [
+    {
+      "__LF_SOURCE": "9dd9a6f6-8e9b-4fa4-b682-4f2f5cd99da3",
+      "message": "to source A",
+    },
+    {
+      "__LF_SOURCE": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "message": "to source B",
+    }
+  ]
+}
+```
+
+The same routing applies when POSTing a **bare JSON array** (array root with `application/json`), which maps to `_json`-style ingestion.
+
+:::note
+In multi-source batches, events that omit `__LF_SOURCE` fall back to the source from the **`source`** or **`source_name`** query string. Omitting both per-event routing and a query-parameter default returns **406** with ingestion errors.
+:::
+
 ## Pipeline Transformations
 
 At ingestion, the pipeline will perform the following in sequence:

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -68,25 +68,87 @@ defmodule LogflareWeb.LogController do
     }
   )
 
-  def create(%{assigns: %{source: source}} = conn, %{"batch" => batch}) when is_list(batch) do
-    batch
-    |> Processor.ingest(Logs.Raw, source)
-    |> handle(conn)
+  def create(conn, %{"batch" => batch}) when is_list(batch) do
+    create_dispatch(conn, batch)
   end
 
-  def create(%{assigns: %{source: source}} = conn, %{"_json" => batch})
-      when is_list(batch) do
-    batch
-    |> Processor.ingest(Logs.Raw, source)
-    |> handle(conn)
+  def create(conn, %{"_json" => batch}) when is_list(batch) do
+    create_dispatch(conn, batch)
   end
 
-  def create(%{assigns: %{source: source}} = conn, _slog_params) do
-    conn.body_params
-    |> Map.drop(~w[timestamp id])
-    |> List.wrap()
-    |> Processor.ingest(Logs.Raw, source)
-    |> handle(conn)
+  def create(conn, _slog_params) do
+    event = Map.drop(conn.body_params, ~w[timestamp id])
+    create_dispatch(conn, [event])
+  end
+
+  @lf_source_key "__LF_SOURCE"
+
+  defp create_dispatch(conn, events) when is_list(events) do
+    default_source = Map.get(conn.assigns, :source)
+    multi_source? = Map.has_key?(conn.assigns, :declared_sources)
+
+    if not multi_source? and default_source != nil do
+      events
+      |> Processor.ingest(Logs.Raw, default_source)
+      |> handle(conn)
+    else
+      declared = Map.get(conn.assigns, :declared_sources, %{})
+      {grouped, errors} = group_events_by_source(events, declared, default_source)
+
+      results =
+        for {source, batch} <- grouped do
+          Processor.ingest(batch, Logs.Raw, source)
+        end
+
+      results
+      |> aggregate_results(errors)
+      |> handle(conn)
+    end
+  end
+
+  defp group_events_by_source(events, declared, default_source) do
+    {groups, errors} =
+      Enum.reduce(events, {%{}, []}, fn event, {groups, errors} ->
+        token = event_source_token(event)
+        stripped = Map.drop(event, [@lf_source_key, :"#{@lf_source_key}"])
+
+        cond do
+          is_binary(token) and is_map_key(declared, token) ->
+            source = Map.fetch!(declared, token)
+            {Map.update(groups, source, [stripped], &[stripped | &1]), errors}
+
+          is_binary(token) ->
+            {groups, ["event references unknown or unauthorized source #{token}" | errors]}
+
+          token != nil ->
+            {groups, ["invalid __LF_SOURCE value" | errors]}
+
+          default_source != nil ->
+            {Map.update(groups, default_source, [stripped], &[stripped | &1]), errors}
+
+          true ->
+            {groups, ["event missing __LF_SOURCE and no source query param" | errors]}
+        end
+      end)
+
+    grouped = for {source, batch} <- groups, do: {source, Enum.reverse(batch)}
+    {grouped, Enum.reverse(errors)}
+  end
+
+  defp event_source_token(event) when is_map(event) do
+    Map.get(event, @lf_source_key) || Map.get(event, :"#{@lf_source_key}")
+  end
+
+  defp aggregate_results(results, errors) do
+    {count, all_errors} =
+      Enum.reduce(results, {0, errors}, fn
+        {:ok, n}, {acc, errs} -> {acc + n, errs}
+        :ok, {acc, errs} -> {acc, errs}
+        {:error, more}, {acc, errs} when is_list(more) -> {acc, errs ++ more}
+        {:error, err}, {acc, errs} -> {acc, errs ++ [err]}
+      end)
+
+    if all_errors == [], do: {:ok, count}, else: {:error, all_errors}
   end
 
   operation :cloudflare, false

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -137,7 +137,7 @@ defmodule LogflareWeb.LogController do
   end
 
   defp event_source_token(%{@lf_source_key => token}), do: token
-  defp event_source_token(%{:"__LF_SOURCE" => token}), do: token
+  defp event_source_token(%{:__LF_SOURCE => token}), do: token
   defp event_source_token(_), do: nil
 
   defp aggregate_results(results, errors) do

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -108,45 +108,49 @@ defmodule LogflareWeb.LogController do
 
   defp group_events_by_source(events, declared, default_source) do
     {groups, errors} =
-      Enum.reduce(events, {%{}, []}, fn event, {groups, errors} ->
-        token = event_source_token(event)
-        stripped = Map.drop(event, [@lf_source_key, :"#{@lf_source_key}"])
+      for event <- events, reduce: {%{}, []} do
+        {groups, errors} ->
+          token = event_source_token(event)
+          stripped = Map.drop(event, [@lf_source_key, :"#{@lf_source_key}"])
 
-        cond do
-          is_binary(token) and is_map_key(declared, token) ->
-            source = Map.fetch!(declared, token)
-            {Map.update(groups, source, [stripped], &[stripped | &1]), errors}
+          cond do
+            is_binary(token) and is_map_key(declared, token) ->
+              source = Map.fetch!(declared, token)
+              {Map.update(groups, source, [stripped], &[stripped | &1]), errors}
 
-          is_binary(token) ->
-            {groups, ["event references unknown or unauthorized source #{token}" | errors]}
+            is_binary(token) ->
+              {groups, ["event references unknown or unauthorized source #{token}" | errors]}
 
-          token != nil ->
-            {groups, ["invalid __LF_SOURCE value" | errors]}
+            token != nil ->
+              {groups, ["invalid __LF_SOURCE value" | errors]}
 
-          default_source != nil ->
-            {Map.update(groups, default_source, [stripped], &[stripped | &1]), errors}
+            default_source != nil ->
+              {Map.update(groups, default_source, [stripped], &[stripped | &1]), errors}
 
-          true ->
-            {groups, ["event missing __LF_SOURCE and no source query param" | errors]}
-        end
-      end)
+            true ->
+              {groups, ["event missing __LF_SOURCE and no source query param" | errors]}
+          end
+      end
 
     grouped = for {source, batch} <- groups, do: {source, Enum.reverse(batch)}
     {grouped, Enum.reverse(errors)}
   end
 
-  defp event_source_token(event) when is_map(event) do
-    Map.get(event, @lf_source_key) || Map.get(event, :"#{@lf_source_key}")
-  end
+  defp event_source_token(%{@lf_source_key => token}), do: token
+  defp event_source_token(%{:"__LF_SOURCE" => token}), do: token
+  defp event_source_token(_), do: nil
 
   defp aggregate_results(results, errors) do
     {count, all_errors} =
-      Enum.reduce(results, {0, errors}, fn
-        {:ok, n}, {acc, errs} -> {acc + n, errs}
-        :ok, {acc, errs} -> {acc, errs}
-        {:error, more}, {acc, errs} when is_list(more) -> {acc, errs ++ more}
-        {:error, err}, {acc, errs} -> {acc, errs ++ [err]}
-      end)
+      for result <- results, reduce: {0, errors} do
+        {acc, errs} ->
+          case result do
+            {:ok, n} -> {acc + n, errs}
+            :ok -> {acc, errs}
+            {:error, more} when is_list(more) -> {acc, errs ++ more}
+            {:error, err} -> {acc, errs ++ [err]}
+          end
+      end
 
     if all_errors == [], do: {:ok, count}, else: {:error, all_errors}
   end

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -147,8 +147,8 @@ defmodule LogflareWeb.LogController do
           case result do
             {:ok, n} -> {acc + n, errs}
             :ok -> {acc, errs}
-            {:error, more} when is_list(more) -> {acc, errs ++ more}
-            {:error, err} -> {acc, errs ++ [err]}
+            {:error, more} when is_list(more) -> {acc, Enum.reverse(more) ++ errs}
+            {:error, err} -> {acc, [err | errs]}
           end
       end
 

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -23,6 +23,11 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
   Checks buffer capacity and applies rate limiting based on source configuration.
   """
   @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
+  def call(%{assigns: %{declared_sources: declared}} = conn, _opts)
+      when map_size(declared) > 0 do
+    conn
+  end
+
   def call(%{assigns: %{source: %Source{} = source}} = conn, _opts) do
     if SystemCache.memory_utilization() >= @memory_limit or
          Backends.cached_local_pending_buffer_full?(source) do

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -28,13 +28,15 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
     if SystemCache.memory_utilization() >= @memory_limit do
       handle_buffer_full(conn, nil)
     else
-      Enum.reduce_while(declared, conn, fn {_token, source}, acc ->
-        if Backends.cached_local_pending_buffer_full?(source) do
-          {:halt, handle_buffer_full(acc, source)}
-        else
-          {:cont, acc}
-        end
-      end)
+      Enum.reduce_while(declared, conn, &reduce_declared_source/2)
+    end
+  end
+
+  defp reduce_declared_source({_token, source}, conn) do
+    if Backends.cached_local_pending_buffer_full?(source) do
+      {:halt, handle_buffer_full(conn, source)}
+    else
+      {:cont, conn}
     end
   end
 

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -25,21 +25,35 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
   @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
   def call(%{assigns: %{declared_sources: declared}} = conn, _opts)
       when map_size(declared) > 0 do
-    conn
+    if SystemCache.memory_utilization() >= @memory_limit do
+      handle_buffer_full(conn, nil)
+    else
+      Enum.reduce_while(declared, conn, fn {_token, source}, acc ->
+        if Backends.cached_local_pending_buffer_full?(source) do
+          {:halt, handle_buffer_full(acc, source)}
+        else
+          {:cont, acc}
+        end
+      end)
+    end
   end
 
   def call(%{assigns: %{source: %Source{} = source}} = conn, _opts) do
     if SystemCache.memory_utilization() >= @memory_limit or
          Backends.cached_local_pending_buffer_full?(source) do
-      :telemetry.execute(
-        [:logflare, :ingest, :requests, :buffer_full],
-        %{count: 1},
-        %{source_id: source.id, source_token: source.token}
-      )
-
-      FallbackController.call(conn, {:error, :buffer_full})
+      handle_buffer_full(conn, source)
     else
       conn
     end
+  end
+
+  defp handle_buffer_full(conn, source) do
+    :telemetry.execute(
+      [:logflare, :ingest, :requests, :buffer_full],
+      %{count: 1},
+      %{source_id: source && source.id, source_token: source && source.token}
+    )
+
+    FallbackController.call(conn, {:error, :buffer_full})
   end
 end

--- a/lib/logflare_web/controllers/plugs/rate_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/rate_limiter.ex
@@ -10,6 +10,36 @@ defmodule LogflareWeb.Plugs.RateLimiter do
 
   def init(_opts), do: nil
 
+  def call(
+        %{assigns: %{user: user, plan: plan, declared_sources: declared}} = conn,
+        _opts
+      )
+      when map_size(declared) > 0 do
+    Enum.reduce_while(declared, conn, fn {_token, source}, acc ->
+      case Users.API.verify_api_rates_quotas(%{
+             user: user,
+             source: source,
+             plan: plan,
+             type: {:api_call, :logs_post}
+           }) do
+        {:ok, _} ->
+          {:cont, acc}
+
+        {:error, %{message: message, metrics: metrics}} ->
+          :telemetry.execute(
+            [:logflare, :rate_limiter],
+            %{rejected: true},
+            %{user_id: user.id, source_id: source.id, source_token: source.token}
+          )
+
+          {:halt,
+           acc
+           |> put_x_rate_limit_headers(metrics)
+           |> FallbackController.call({:error, :too_many_requests, message})}
+      end
+    end)
+  end
+
   def call(%{assigns: %{user: user, source: source, plan: plan}} = conn, _opts \\ []) do
     %{
       user: user,

--- a/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
+++ b/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
@@ -51,14 +51,13 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSources do
     access_token = Map.get(conn.assigns, :access_token)
 
     tokens =
-      events
-      |> Enum.reduce(MapSet.new(), fn event, acc ->
-        case Utils.Map.get(event, :"#{@lf_source_key}") do
-          token when is_binary(token) -> MapSet.put(acc, token)
-          _ -> acc
-        end
-      end)
-      |> Enum.filter(&uuid?/1)
+      for event <- events,
+          token = Utils.Map.get(event, :"#{@lf_source_key}"),
+          is_binary(token),
+          uuid?(token),
+          into: MapSet.new() do
+        token
+      end
 
     case resolve_sources(tokens, user, access_token) do
       {:ok, declared} ->

--- a/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
+++ b/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
@@ -28,12 +28,9 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSources do
 
   def call(%{assigns: %{resource_type: :source, user: %User{} = user}} = conn, _opts) do
     case extract_events(conn.body_params) do
-      [first | _] = events when is_map(first) ->
-        if Utils.Map.get(first, :"#{@lf_source_key}") do
-          resolve_and_verify(conn, events, user)
-        else
-          conn
-        end
+      [first | _] = events
+      when is_map(first) and (is_map_key(first, :__LF_SOURCE) or is_map_key(first, "__LF_SOURCE")) ->
+        resolve_and_verify(conn, events, user)
 
       _ ->
         conn

--- a/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
+++ b/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
@@ -1,0 +1,100 @@
+defmodule LogflareWeb.Plugs.VerifyDeclaredSources do
+  @moduledoc """
+  Resolves and authorizes sources declared per-event via the `__LF_SOURCE`
+  body field for multi-source ingestion.
+
+  Multi-source mode is detected by pattern matching on the first event in the
+  batch: if the first event has `__LF_SOURCE`, every unique UUID across the
+  batch is resolved and ownership/scope is verified for each. The resolved
+  sources are stored in `conn.assigns.declared_sources` as
+  `%{uuid_string => %Source{}}` for the controller to dispatch against.
+
+  If the first event lacks `__LF_SOURCE`, the plug is a no-op and the
+  existing single-source ingest flow handles the request.
+  """
+
+  import Plug.Conn
+
+  alias Logflare.Sources
+  alias Logflare.Sources.Source
+  alias Logflare.User
+  alias Logflare.Utils
+  alias LogflareWeb.Api.FallbackController
+  alias LogflareWeb.Plugs.VerifyResourceAccess
+
+  @lf_source_key "__LF_SOURCE"
+
+  def init(_opts), do: nil
+
+  def call(%{assigns: %{resource_type: :source, user: %User{} = user}} = conn, _opts) do
+    case extract_events(conn.body_params) do
+      [first | _] = events when is_map(first) ->
+        if Utils.Map.get(first, :"#{@lf_source_key}") do
+          resolve_and_verify(conn, events, user)
+        else
+          conn
+        end
+
+      _ ->
+        conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp extract_events(%{"batch" => batch}) when is_list(batch), do: batch
+  defp extract_events(%{"_json" => batch}) when is_list(batch), do: batch
+  defp extract_events(event) when is_map(event), do: [event]
+  defp extract_events(_), do: []
+
+  defp resolve_and_verify(conn, events, user) do
+    access_token = Map.get(conn.assigns, :access_token)
+
+    tokens =
+      events
+      |> Enum.reduce(MapSet.new(), fn event, acc ->
+        case Utils.Map.get(event, :"#{@lf_source_key}") do
+          token when is_binary(token) -> MapSet.put(acc, token)
+          _ -> acc
+        end
+      end)
+      |> Enum.filter(&uuid?/1)
+
+    case resolve_sources(tokens, user, access_token) do
+      {:ok, declared} ->
+        assign(conn, :declared_sources, declared)
+
+      :error ->
+        conn
+        |> FallbackController.call({:error, :unauthorized})
+        |> halt()
+    end
+  end
+
+  defp resolve_sources(tokens, user, access_token) do
+    Enum.reduce_while(tokens, {:ok, %{}}, fn token, {:ok, acc} ->
+      case Sources.Cache.get_by_and_preload_rules(token: token) do
+        %Source{} = source ->
+          source = Sources.refresh_source_metrics_for_ingest(source)
+
+          if VerifyResourceAccess.verify_source_access(source, user, access_token) do
+            {:cont, {:ok, Map.put(acc, token, source)}}
+          else
+            {:halt, :error}
+          end
+
+        _ ->
+          {:halt, :error}
+      end
+    end)
+  end
+
+  defp uuid?(value) when is_binary(value) do
+    case Ecto.UUID.dump(value) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  defp uuid?(_), do: false
+end

--- a/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
+++ b/lib/logflare_web/controllers/plugs/verify_declared_sources.ex
@@ -71,18 +71,21 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSources do
     Enum.reduce_while(tokens, {:ok, %{}}, fn token, {:ok, acc} ->
       case Sources.Cache.get_by_and_preload_rules(token: token) do
         %Source{} = source ->
-          source = Sources.refresh_source_metrics_for_ingest(source)
-
-          if VerifyResourceAccess.verify_source_access(source, user, access_token) do
-            {:cont, {:ok, Map.put(acc, token, source)}}
-          else
-            {:halt, :error}
-          end
+          put_verified_declared(acc, token, source, user, access_token)
 
         _ ->
           {:halt, :error}
       end
     end)
+  end
+
+  defp put_verified_declared(acc, token, source, user, access_token) do
+    source = Sources.refresh_source_metrics_for_ingest(source)
+
+    case VerifyResourceAccess.verify_source_access(source, user, access_token) do
+      true -> {:cont, {:ok, Map.put(acc, token, source)}}
+      false -> {:halt, :error}
+    end
   end
 
   defp uuid?(value) when is_binary(value) do

--- a/lib/logflare_web/controllers/plugs/verify_resource_access.ex
+++ b/lib/logflare_web/controllers/plugs/verify_resource_access.ex
@@ -63,12 +63,35 @@ defmodule LogflareWeb.Plugs.VerifyResourceAccess do
     end
   end
 
+  # Passthrough when no query-param source was resolved but the request
+  # declared sources per-event via __LF_SOURCE; VerifyDeclaredSources already
+  # ran and verified ownership on those.
+  def call(
+        %{assigns: %{resource_type: :source, source: nil, declared_sources: declared}} = conn,
+        _
+      )
+      when map_size(declared) > 0 do
+    conn
+  end
+
   def call(%{assigns: assigns} = conn, _) when is_map_key(assigns, :resource_type) do
     FallbackController.call(conn, {:error, :unauthorized})
   end
 
   # no resource is set, passthrough
   def call(conn, _), do: conn
+
+  @doc """
+  Checks that a user owns a source and (if an access token is present) that
+  the token's scopes cover ingestion for that source.
+  """
+  @spec verify_source_access(Source.t(), User.t(), String.t() | nil) :: boolean()
+  def verify_source_access(%Source{user_id: source_user_id} = source, %User{id: user_id}, token)
+      when source_user_id == user_id do
+    check_resource(source, token)
+  end
+
+  def verify_source_access(%Source{}, %User{}, _token), do: false
 
   def check_resource(%Source{}, nil), do: true
 

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -107,6 +107,7 @@ defmodule LogflareWeb.Router do
     )
 
     plug(LogflareWeb.Plugs.FetchResource)
+    plug(LogflareWeb.Plugs.VerifyDeclaredSources)
     plug(LogflareWeb.Plugs.VerifyResourceAccess)
     plug(:accepts, ["json", "bert"])
     plug(LogflareWeb.Plugs.SetHeaders)

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -654,33 +654,20 @@ defmodule LogflareWeb.LogControllerTest do
   end
 
   describe "create with __LF_SOURCE multi-source ingestion" do
-    setup [:multi_source_setup, :warm_caches, :reject_context_functions]
+    setup [:multi_source_setup, :warm_caches]
 
     setup %{user: user, conn: conn} do
       conn = put_req_header(conn, "x-api-key", user.api_key)
       {:ok, conn: conn}
     end
 
-    test "single event with __LF_SOURCE routes to declared source and strips field",
-         %{conn: conn, source_a: source_a} do
-      {_pid, ref} = expect_webhook_with_body()
-
-      conn =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> post(
-          ~p"/logs",
-          Jason.encode!(%{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "a"})
-        )
-
-      assert_logged_successfully(conn)
-      assert_receive {^ref, [event]}, 3000
-      refute Map.has_key?(event, "__LF_SOURCE")
-      assert event["event_message"] == "a"
-    end
-
     test "batch with __LF_SOURCE per event fans out to multiple sources",
-         %{conn: conn, source_a: source_a, source_b: source_b} do
+         %{conn: conn, source_a: source_a, user: user} do
+      source_b = insert(:source, user: user)
+      insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b"})
+      start_supervised!({SourceSup, source_b})
+      :timer.sleep(200)
+
       this = self()
 
       Logflare.Backends.Adaptor.WebhookAdaptor.Client
@@ -689,18 +676,15 @@ defmodule LogflareWeb.LogControllerTest do
         %Tesla.Env{status: 200, body: ""}
       end)
 
-      token_a = Atom.to_string(source_a.token)
-      token_b = Atom.to_string(source_b.token)
-
       conn =
         conn
         |> post(
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => token_a, "event_message" => "to_a_1"},
-              %{"__LF_SOURCE" => token_b, "event_message" => "to_b"},
-              %{"__LF_SOURCE" => token_a, "event_message" => "to_a_2"}
+              %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a_1"},
+              %{"__LF_SOURCE" => source_b.token, "event_message" => "to_b"},
+              %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a_2"}
             ]
           }
         )
@@ -727,15 +711,50 @@ defmodule LogflareWeb.LogControllerTest do
       end
     end
 
+    test "_json batch with __LF_SOURCE per event fans out to multiple sources",
+         %{conn: conn, source_a: source_a, user: user} do
+      source_b = insert(:source, user: user)
+      insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b2"})
+      start_supervised!({SourceSup, source_b})
+      :timer.sleep(200)
+
+      this = self()
+
+      Logflare.Backends.Adaptor.WebhookAdaptor.Client
+      |> stub(:send, fn req ->
+        send(this, {:webhook, req[:body]})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          Routes.log_path(conn, :create),
+          Jason.encode!([
+            %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a"},
+            %{"__LF_SOURCE" => source_b.token, "event_message" => "to_b"}
+          ])
+        )
+
+      assert_logged_successfully(conn)
+      received = collect_webhook_messages([], 3000)
+      all_events = Enum.flat_map(received, & &1)
+      assert Enum.any?(all_events, &(&1["event_message"] == "to_a"))
+      assert Enum.any?(all_events, &(&1["event_message"] == "to_b"))
+    end
+
     test "batch referencing an unowned source returns 401 from the plug",
-         %{conn: conn, other_source: other_source} do
+         %{conn: conn, user: user} do
+      other_source = insert(:source, user: insert(:user))
+
       conn =
         conn
         |> post(
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => Atom.to_string(other_source.token), "event_message" => "x"}
+              %{"__LF_SOURCE" => other_source.token, "event_message" => "x"}
             ]
           }
         )
@@ -754,17 +773,10 @@ defmodule LogflareWeb.LogControllerTest do
       assert json_response(conn, 401)
     end
 
-    test "batch with __LF_SOURCE on first event but later events lack it",
+    test "batch with __LF_SOURCE on first event but later events lack it returns 406",
          %{conn: conn, source_a: source_a} do
-      this = self()
-
       Logflare.Backends.Adaptor.WebhookAdaptor.Client
-      |> stub(:send, fn req ->
-        send(this, {:webhook, req[:body]})
-        %Tesla.Env{status: 200, body: ""}
-      end)
-
-      token_a = Atom.to_string(source_a.token)
+      |> stub(:send, fn _req -> %Tesla.Env{status: 200, body: ""} end)
 
       conn =
         conn
@@ -772,20 +784,16 @@ defmodule LogflareWeb.LogControllerTest do
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => token_a, "event_message" => "with"},
+              %{"__LF_SOURCE" => source_a.token, "event_message" => "with"},
               %{"event_message" => "without"}
             ]
           }
         )
 
-      # Multi-source mode is active (first event has __LF_SOURCE) but the
-      # second event lacks it and there's no query-param default, so the
-      # ingest returns errors for the orphan event while the valid one is
-      # delivered.
       assert json_response(conn, 406)
     end
 
-    test "first event lacks __LF_SOURCE → falls back to single-source query param flow",
+    test "first event lacks __LF_SOURCE falls back to single-source query param flow",
          %{conn: conn, source_a: source_a} do
       {_pid, ref} = expect_webhook_success()
 
@@ -812,26 +820,12 @@ defmodule LogflareWeb.LogControllerTest do
   defp multi_source_setup(%{conn: conn}) do
     insert(:plan, name: "Free")
     user = insert(:user)
-    other_user = insert(:user)
     source_a = insert(:source, user: user)
-    source_b = insert(:source, user: user)
-    other_source = insert(:source, user: other_user)
-
     insert(:backend, sources: [source_a], type: :webhook, config: %{url: "some-a"})
-    insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b"})
-
     start_supervised!({SourceSup, source_a})
-    start_supervised!({SourceSup, source_b})
     :timer.sleep(500)
 
-    {:ok,
-     user: user,
-     source: source_a,
-     source_a: source_a,
-     source_b: source_b,
-     other_user: other_user,
-     other_source: other_source,
-     conn: conn}
+    {:ok, user: user, source: source_a, source_a: source_a, conn: conn}
   end
 
   defp pipeline_setup(%{conn: conn}) do

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -682,9 +682,9 @@ defmodule LogflareWeb.LogControllerTest do
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a_1"},
-              %{"__LF_SOURCE" => source_b.token, "event_message" => "to_b"},
-              %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a_2"}
+              %{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "to_a_1"},
+              %{"__LF_SOURCE" => Atom.to_string(source_b.token), "event_message" => "to_b"},
+              %{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "to_a_2"}
             ]
           }
         )
@@ -732,8 +732,8 @@ defmodule LogflareWeb.LogControllerTest do
         |> post(
           Routes.log_path(conn, :create),
           Jason.encode!([
-            %{"__LF_SOURCE" => source_a.token, "event_message" => "to_a"},
-            %{"__LF_SOURCE" => source_b.token, "event_message" => "to_b"}
+            %{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "to_a"},
+            %{"__LF_SOURCE" => Atom.to_string(source_b.token), "event_message" => "to_b"}
           ])
         )
 
@@ -745,7 +745,7 @@ defmodule LogflareWeb.LogControllerTest do
     end
 
     test "batch referencing an unowned source returns 401 from the plug",
-         %{conn: conn, user: user} do
+         %{conn: conn} do
       other_source = insert(:source, user: insert(:user))
 
       conn =
@@ -754,7 +754,7 @@ defmodule LogflareWeb.LogControllerTest do
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => other_source.token, "event_message" => "x"}
+              %{"__LF_SOURCE" => Atom.to_string(other_source.token), "event_message" => "x"}
             ]
           }
         )
@@ -784,7 +784,7 @@ defmodule LogflareWeb.LogControllerTest do
           Routes.log_path(conn, :create),
           %{
             "batch" => [
-              %{"__LF_SOURCE" => source_a.token, "event_message" => "with"},
+              %{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "with"},
               %{"event_message" => "without"}
             ]
           }

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -653,6 +653,187 @@ defmodule LogflareWeb.LogControllerTest do
     end
   end
 
+  describe "create with __LF_SOURCE multi-source ingestion" do
+    setup [:multi_source_setup, :warm_caches, :reject_context_functions]
+
+    setup %{user: user, conn: conn} do
+      conn = put_req_header(conn, "x-api-key", user.api_key)
+      {:ok, conn: conn}
+    end
+
+    test "single event with __LF_SOURCE routes to declared source and strips field",
+         %{conn: conn, source_a: source_a} do
+      {_pid, ref} = expect_webhook_with_body()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/logs",
+          Jason.encode!(%{"__LF_SOURCE" => Atom.to_string(source_a.token), "event_message" => "a"})
+        )
+
+      assert_logged_successfully(conn)
+      assert_receive {^ref, [event]}, 3000
+      refute Map.has_key?(event, "__LF_SOURCE")
+      assert event["event_message"] == "a"
+    end
+
+    test "batch with __LF_SOURCE per event fans out to multiple sources",
+         %{conn: conn, source_a: source_a, source_b: source_b} do
+      this = self()
+
+      Logflare.Backends.Adaptor.WebhookAdaptor.Client
+      |> stub(:send, fn req ->
+        send(this, {:webhook, req[:body]})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      token_a = Atom.to_string(source_a.token)
+      token_b = Atom.to_string(source_b.token)
+
+      conn =
+        conn
+        |> post(
+          Routes.log_path(conn, :create),
+          %{
+            "batch" => [
+              %{"__LF_SOURCE" => token_a, "event_message" => "to_a_1"},
+              %{"__LF_SOURCE" => token_b, "event_message" => "to_b"},
+              %{"__LF_SOURCE" => token_a, "event_message" => "to_a_2"}
+            ]
+          }
+        )
+
+      assert_logged_successfully(conn)
+
+      received = collect_webhook_messages([], 3000)
+
+      a_events =
+        received
+        |> Enum.flat_map(& &1)
+        |> Enum.filter(&String.starts_with?(&1["event_message"], "to_a"))
+
+      b_events =
+        received
+        |> Enum.flat_map(& &1)
+        |> Enum.filter(&(&1["event_message"] == "to_b"))
+
+      assert length(a_events) == 2
+      assert length(b_events) == 1
+
+      for event <- a_events ++ b_events do
+        refute Map.has_key?(event, "__LF_SOURCE")
+      end
+    end
+
+    test "batch referencing an unowned source returns 401 from the plug",
+         %{conn: conn, other_source: other_source} do
+      conn =
+        conn
+        |> post(
+          Routes.log_path(conn, :create),
+          %{
+            "batch" => [
+              %{"__LF_SOURCE" => Atom.to_string(other_source.token), "event_message" => "x"}
+            ]
+          }
+        )
+
+      assert json_response(conn, 401)
+    end
+
+    test "batch with no __LF_SOURCE and no query-param source returns 401",
+         %{conn: conn} do
+      conn =
+        conn
+        |> post(Routes.log_path(conn, :create), %{
+          "batch" => [%{"event_message" => "no source"}]
+        })
+
+      assert json_response(conn, 401)
+    end
+
+    test "batch with __LF_SOURCE on first event but later events lack it",
+         %{conn: conn, source_a: source_a} do
+      this = self()
+
+      Logflare.Backends.Adaptor.WebhookAdaptor.Client
+      |> stub(:send, fn req ->
+        send(this, {:webhook, req[:body]})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      token_a = Atom.to_string(source_a.token)
+
+      conn =
+        conn
+        |> post(
+          Routes.log_path(conn, :create),
+          %{
+            "batch" => [
+              %{"__LF_SOURCE" => token_a, "event_message" => "with"},
+              %{"event_message" => "without"}
+            ]
+          }
+        )
+
+      # Multi-source mode is active (first event has __LF_SOURCE) but the
+      # second event lacks it and there's no query-param default, so the
+      # ingest returns errors for the orphan event while the valid one is
+      # delivered.
+      assert json_response(conn, 406)
+    end
+
+    test "first event lacks __LF_SOURCE → falls back to single-source query param flow",
+         %{conn: conn, source_a: source_a} do
+      {_pid, ref} = expect_webhook_success()
+
+      conn =
+        conn
+        |> post(
+          Routes.log_path(conn, :create, source: source_a.token),
+          %{"batch" => [%{"event_message" => "a"}, %{"event_message" => "b"}]}
+        )
+
+      assert_logged_successfully(conn)
+      assert_eventually_received(ref)
+    end
+
+    defp collect_webhook_messages(acc, timeout) do
+      receive do
+        {:webhook, body} -> collect_webhook_messages([body | acc], timeout)
+      after
+        timeout -> acc
+      end
+    end
+  end
+
+  defp multi_source_setup(%{conn: conn}) do
+    insert(:plan, name: "Free")
+    user = insert(:user)
+    other_user = insert(:user)
+    source_a = insert(:source, user: user)
+    source_b = insert(:source, user: user)
+    other_source = insert(:source, user: other_user)
+
+    insert(:backend, sources: [source_a], type: :webhook, config: %{url: "some-a"})
+    insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b"})
+
+    start_supervised!({SourceSup, source_a})
+    start_supervised!({SourceSup, source_b})
+    :timer.sleep(500)
+
+    {:ok,
+     user: user,
+     source: source_a,
+     source_a: source_a,
+     source_b: source_b,
+     other_user: other_user,
+     other_source: other_source,
+     conn: conn}
+  end
+
   defp pipeline_setup(%{conn: conn}) do
     insert(:plan, name: "Free")
     user = insert(:user)

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -714,9 +714,12 @@ defmodule LogflareWeb.LogControllerTest do
     test "_json batch with __LF_SOURCE per event fans out to multiple sources",
          %{conn: conn, source_a: source_a, user: user} do
       source_b = insert(:source, user: user)
-      insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b2"})
+      backend_b = insert(:backend, sources: [source_b], type: :webhook, config: %{url: "some-b2"})
       start_supervised!({SourceSup, source_b})
-      :timer.sleep(200)
+
+      TestUtils.retry_assert(fn ->
+        assert Logflare.Backends.backend_child_started?(backend_b.id, source_b.id)
+      end)
 
       this = self()
 
@@ -823,7 +826,6 @@ defmodule LogflareWeb.LogControllerTest do
     source_a = insert(:source, user: user)
     insert(:backend, sources: [source_a], type: :webhook, config: %{url: "some-a"})
     start_supervised!({SourceSup, source_a})
-    :timer.sleep(500)
 
     {:ok, user: user, source: source_a, source_a: source_a, conn: conn}
   end

--- a/test/logflare_web/controllers/plugs/rate_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/rate_limiter_test.exs
@@ -42,6 +42,7 @@ defmodule LogflareWeb.Plugs.RateLimiterTest do
         |> RateLimiter.call()
 
       assert conn.halted
+
       assert json_response(conn, 429) == %{
                "error" =>
                  "Source rate is over the API quota. Email support@logflare.app to increase your rate limit."

--- a/test/logflare_web/controllers/plugs/rate_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/rate_limiter_test.exs
@@ -3,6 +3,52 @@ defmodule LogflareWeb.Plugs.RateLimiterTest do
   use LogflareWeb.ConnCase
   alias LogflareWeb.Plugs.RateLimiter
 
+  describe "multi-source mode" do
+    test "passes when all declared sources are within rate limits" do
+      plan = insert(:plan, limit_rate_limit: 5)
+      user = insert(:user)
+      source_a = insert(:source, user_id: user.id)
+      source_b = insert(:source, user_id: user.id)
+
+      conn =
+        build_conn(:post, "/logs")
+        |> assign(:user, user)
+        |> assign(:source, nil)
+        |> assign(:plan, plan)
+        |> assign(:declared_sources, %{
+          Atom.to_string(source_a.token) => source_a,
+          Atom.to_string(source_b.token) => source_b
+        })
+        |> RateLimiter.call()
+
+      refute conn.halted
+    end
+
+    test "halts with 429 when any declared source exceeds its rate limit" do
+      plan = insert(:plan, limit_source_rate_limit: 0)
+      user = insert(:user)
+      source_a = insert(:source, user_id: user.id)
+      source_b = insert(:source, user_id: user.id)
+
+      conn =
+        build_conn(:post, "/logs")
+        |> assign(:user, user)
+        |> assign(:source, nil)
+        |> assign(:plan, plan)
+        |> assign(:declared_sources, %{
+          Atom.to_string(source_a.token) => source_a,
+          Atom.to_string(source_b.token) => source_b
+        })
+        |> RateLimiter.call()
+
+      assert conn.halted
+      assert json_response(conn, 429) == %{
+               "error" =>
+                 "Source rate is over the API quota. Email support@logflare.app to increase your rate limit."
+             }
+    end
+  end
+
   describe "rate limiter plug works correctly" do
     test "doesn't halt when POST logs action is allowed" do
       plan = insert(:plan, limit_rate_limit: 5)

--- a/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
@@ -101,15 +101,16 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
   describe "authorization failures" do
     test "halts with 401 for unauthorized sources", %{user: user} do
       source_a = insert(:source, user: user)
+      source_b = insert(:source, user: user)
       other_source = insert(:source, user: insert(:user))
+
       {:ok, scoped_token} =
         Logflare.Auth.create_access_token(user, %{scopes: "ingest:source:#{source_a.id}"})
 
       for {label, body, extra_assigns} <- [
             {"source owned by another user",
              %{"batch" => [%{"__LF_SOURCE" => Atom.to_string(other_source.token)}]}, []},
-            {"non-existent UUID",
-             %{"batch" => [%{"__LF_SOURCE" => Ecto.UUID.generate()}]}, []},
+            {"non-existent UUID", %{"batch" => [%{"__LF_SOURCE" => Ecto.UUID.generate()}]}, []},
             {"one of many sources unauthorized",
              %{
                "batch" => [
@@ -118,7 +119,7 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
                ]
              }, []},
             {"scope does not cover declared source",
-             %{"batch" => [%{"__LF_SOURCE" => Atom.to_string(source_a.token)}]},
+             %{"batch" => [%{"__LF_SOURCE" => Atom.to_string(source_b.token)}]},
              [access_token: scoped_token]}
           ] do
         conn =

--- a/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
@@ -7,17 +7,7 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
   setup do
     insert(:plan)
     user = insert(:user)
-    source_a = insert(:source, user: user)
-    source_b = insert(:source, user: user)
-    other_user = insert(:user)
-    other_source = insert(:source, user: other_user)
-
-    {:ok,
-     user: user,
-     source_a: source_a,
-     source_b: source_b,
-     other_user: other_user,
-     other_source: other_source}
+    {:ok, user: user}
   end
 
   defp build_ingest_conn(body, user) do
@@ -27,31 +17,19 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
   end
 
   describe "passthrough" do
-    test "no __LF_SOURCE on first event - single event map", %{user: user} do
-      conn =
-        build_ingest_conn(%{"message" => "hi"}, user)
-        |> VerifyDeclaredSources.call(%{})
+    test "no __LF_SOURCE on first event is a no-op for all body shapes", %{user: user} do
+      for body <- [
+            %{"message" => "hi"},
+            %{"batch" => [%{"message" => "a"}, %{"message" => "b"}]},
+            %{"_json" => [%{"message" => "a"}]}
+          ] do
+        conn =
+          build_ingest_conn(body, user)
+          |> VerifyDeclaredSources.call(%{})
 
-      refute conn.halted
-      refute Map.get(conn.assigns, :declared_sources)
-    end
-
-    test "no __LF_SOURCE on first event - batch", %{user: user} do
-      conn =
-        build_ingest_conn(%{"batch" => [%{"message" => "a"}, %{"message" => "b"}]}, user)
-        |> VerifyDeclaredSources.call(%{})
-
-      refute conn.halted
-      refute Map.get(conn.assigns, :declared_sources)
-    end
-
-    test "no __LF_SOURCE on first event - _json batch", %{user: user} do
-      conn =
-        build_ingest_conn(%{"_json" => [%{"message" => "a"}]}, user)
-        |> VerifyDeclaredSources.call(%{})
-
-      refute conn.halted
-      refute Map.get(conn.assigns, :declared_sources)
+        refute conn.halted
+        refute Map.get(conn.assigns, :declared_sources)
+      end
     end
 
     test "missing resource_type", %{user: user} do
@@ -64,7 +42,7 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
       refute Map.get(conn.assigns, :declared_sources)
     end
 
-    test "missing user", %{} do
+    test "missing user" do
       conn =
         build_conn(:post, "/logs", %{"batch" => [%{"__LF_SOURCE" => "x"}]})
         |> assign(:resource_type, :source)
@@ -76,27 +54,27 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
   end
 
   describe "multi-source mode" do
-    test "resolves single declared source in batch", %{user: user, source_a: source_a} do
-      token = Atom.to_string(source_a.token)
+    test "resolves single declared source across all body shapes", %{user: user} do
+      source = insert(:source, user: user)
+      token = Atom.to_string(source.token)
 
-      conn =
-        build_ingest_conn(
-          %{"batch" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
-          user
-        )
-        |> VerifyDeclaredSources.call(%{})
+      for body <- [
+            %{"batch" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
+            %{"_json" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
+            %{"__LF_SOURCE" => token, "message" => "a"}
+          ] do
+        conn =
+          build_ingest_conn(body, user)
+          |> VerifyDeclaredSources.call(%{})
 
-      refute conn.halted
-      declared = conn.assigns.declared_sources
-      assert Map.has_key?(declared, token)
-      assert declared[token].id == source_a.id
+        refute conn.halted
+        assert conn.assigns.declared_sources[token].id == source.id
+      end
     end
 
-    test "resolves multiple distinct declared sources", %{
-      user: user,
-      source_a: source_a,
-      source_b: source_b
-    } do
+    test "resolves multiple distinct declared sources", %{user: user} do
+      source_a = insert(:source, user: user)
+      source_b = insert(:source, user: user)
       token_a = Atom.to_string(source_a.token)
       token_b = Atom.to_string(source_b.token)
 
@@ -118,136 +96,63 @@ defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
       assert conn.assigns.declared_sources[token_a].id == source_a.id
       assert conn.assigns.declared_sources[token_b].id == source_b.id
     end
-
-    test "single event map with __LF_SOURCE", %{user: user, source_a: source_a} do
-      token = Atom.to_string(source_a.token)
-
-      conn =
-        build_ingest_conn(%{"__LF_SOURCE" => token, "message" => "a"}, user)
-        |> VerifyDeclaredSources.call(%{})
-
-      refute conn.halted
-      assert conn.assigns.declared_sources[token].id == source_a.id
-    end
-
-    test "_json batch shape with __LF_SOURCE", %{user: user, source_a: source_a} do
-      token = Atom.to_string(source_a.token)
-
-      conn =
-        build_ingest_conn(
-          %{"_json" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
-          user
-        )
-        |> VerifyDeclaredSources.call(%{})
-
-      refute conn.halted
-      assert conn.assigns.declared_sources[token].id == source_a.id
-    end
   end
 
   describe "authorization failures" do
-    test "halts when declared source is owned by a different user", %{
-      user: user,
-      other_source: other_source
-    } do
-      token = Atom.to_string(other_source.token)
+    test "halts with 401 for unauthorized sources", %{user: user} do
+      source_a = insert(:source, user: user)
+      other_source = insert(:source, user: insert(:user))
+      {:ok, scoped_token} =
+        Logflare.Auth.create_access_token(user, %{scopes: "ingest:source:#{source_a.id}"})
+
+      for {label, body, extra_assigns} <- [
+            {"source owned by another user",
+             %{"batch" => [%{"__LF_SOURCE" => Atom.to_string(other_source.token)}]}, []},
+            {"non-existent UUID",
+             %{"batch" => [%{"__LF_SOURCE" => Ecto.UUID.generate()}]}, []},
+            {"one of many sources unauthorized",
+             %{
+               "batch" => [
+                 %{"__LF_SOURCE" => Atom.to_string(source_a.token)},
+                 %{"__LF_SOURCE" => Atom.to_string(other_source.token)}
+               ]
+             }, []},
+            {"scope does not cover declared source",
+             %{"batch" => [%{"__LF_SOURCE" => Atom.to_string(source_a.token)}]},
+             [access_token: scoped_token]}
+          ] do
+        conn =
+          build_ingest_conn(body, user)
+          |> then(fn c ->
+            Enum.reduce(extra_assigns, c, fn {k, v}, c -> assign(c, k, v) end)
+          end)
+          |> VerifyDeclaredSources.call(%{})
+
+        assert conn.halted, "expected halt for: #{label}"
+        assert conn.status == 401, "expected 401 for: #{label}"
+      end
+    end
+
+    test "allows when access token scope covers all declared sources", %{user: user} do
+      source = insert(:source, user: user)
+      {:ok, access_token} = Logflare.Auth.create_access_token(user, %{scopes: "ingest"})
+      token = Atom.to_string(source.token)
 
       conn =
         build_ingest_conn(
           %{"batch" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
           user
         )
-        |> VerifyDeclaredSources.call(%{})
-
-      assert conn.halted
-      assert conn.status == 401
-    end
-
-    test "halts when declared source UUID does not exist", %{user: user} do
-      unknown_uuid = Ecto.UUID.generate()
-
-      conn =
-        build_ingest_conn(
-          %{"batch" => [%{"__LF_SOURCE" => unknown_uuid, "message" => "a"}]},
-          user
-        )
-        |> VerifyDeclaredSources.call(%{})
-
-      assert conn.halted
-      assert conn.status == 401
-    end
-
-    test "halts when one of many sources is unauthorized", %{
-      user: user,
-      source_a: source_a,
-      other_source: other_source
-    } do
-      token_a = Atom.to_string(source_a.token)
-      token_other = Atom.to_string(other_source.token)
-
-      conn =
-        build_ingest_conn(
-          %{
-            "batch" => [
-              %{"__LF_SOURCE" => token_a, "message" => "a"},
-              %{"__LF_SOURCE" => token_other, "message" => "b"}
-            ]
-          },
-          user
-        )
-        |> VerifyDeclaredSources.call(%{})
-
-      assert conn.halted
-      assert conn.status == 401
-    end
-
-    test "halts when access token scope does not cover declared source", %{
-      user: user,
-      source_a: source_a,
-      source_b: source_b
-    } do
-      {:ok, access_token} =
-        Logflare.Auth.create_access_token(user, %{scopes: "ingest:source:#{source_a.id}"})
-
-      token_b = Atom.to_string(source_b.token)
-
-      conn =
-        build_ingest_conn(
-          %{"batch" => [%{"__LF_SOURCE" => token_b, "message" => "b"}]},
-          user
-        )
-        |> assign(:access_token, access_token)
-        |> VerifyDeclaredSources.call(%{})
-
-      assert conn.halted
-      assert conn.status == 401
-    end
-
-    test "allows when access token scope covers all declared sources", %{
-      user: user,
-      source_a: source_a
-    } do
-      {:ok, access_token} =
-        Logflare.Auth.create_access_token(user, %{scopes: "ingest"})
-
-      token_a = Atom.to_string(source_a.token)
-
-      conn =
-        build_ingest_conn(
-          %{"batch" => [%{"__LF_SOURCE" => token_a, "message" => "a"}]},
-          user
-        )
         |> assign(:access_token, access_token)
         |> VerifyDeclaredSources.call(%{})
 
       refute conn.halted
-      assert conn.assigns.declared_sources[token_a].id == source_a.id
+      assert conn.assigns.declared_sources[token].id == source.id
     end
   end
 
   describe "invalid __LF_SOURCE values" do
-    test "non-UUID value on first event still triggers multi-source mode but no declared sources resolved",
-         %{user: user} do
+    test "non-UUID value triggers multi-source mode but resolves no sources", %{user: user} do
       conn =
         build_ingest_conn(
           %{"batch" => [%{"__LF_SOURCE" => "not-a-uuid", "message" => "a"}]},

--- a/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_declared_sources_test.exs
@@ -1,0 +1,262 @@
+defmodule LogflareWeb.Plugs.VerifyDeclaredSourcesTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  alias LogflareWeb.Plugs.VerifyDeclaredSources
+
+  setup do
+    insert(:plan)
+    user = insert(:user)
+    source_a = insert(:source, user: user)
+    source_b = insert(:source, user: user)
+    other_user = insert(:user)
+    other_source = insert(:source, user: other_user)
+
+    {:ok,
+     user: user,
+     source_a: source_a,
+     source_b: source_b,
+     other_user: other_user,
+     other_source: other_source}
+  end
+
+  defp build_ingest_conn(body, user) do
+    build_conn(:post, "/logs", body)
+    |> assign(:user, user)
+    |> assign(:resource_type, :source)
+  end
+
+  describe "passthrough" do
+    test "no __LF_SOURCE on first event - single event map", %{user: user} do
+      conn =
+        build_ingest_conn(%{"message" => "hi"}, user)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      refute Map.get(conn.assigns, :declared_sources)
+    end
+
+    test "no __LF_SOURCE on first event - batch", %{user: user} do
+      conn =
+        build_ingest_conn(%{"batch" => [%{"message" => "a"}, %{"message" => "b"}]}, user)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      refute Map.get(conn.assigns, :declared_sources)
+    end
+
+    test "no __LF_SOURCE on first event - _json batch", %{user: user} do
+      conn =
+        build_ingest_conn(%{"_json" => [%{"message" => "a"}]}, user)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      refute Map.get(conn.assigns, :declared_sources)
+    end
+
+    test "missing resource_type", %{user: user} do
+      conn =
+        build_conn(:post, "/logs", %{"batch" => [%{"__LF_SOURCE" => "x"}]})
+        |> assign(:user, user)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      refute Map.get(conn.assigns, :declared_sources)
+    end
+
+    test "missing user", %{} do
+      conn =
+        build_conn(:post, "/logs", %{"batch" => [%{"__LF_SOURCE" => "x"}]})
+        |> assign(:resource_type, :source)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      refute Map.get(conn.assigns, :declared_sources)
+    end
+  end
+
+  describe "multi-source mode" do
+    test "resolves single declared source in batch", %{user: user, source_a: source_a} do
+      token = Atom.to_string(source_a.token)
+
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      declared = conn.assigns.declared_sources
+      assert Map.has_key?(declared, token)
+      assert declared[token].id == source_a.id
+    end
+
+    test "resolves multiple distinct declared sources", %{
+      user: user,
+      source_a: source_a,
+      source_b: source_b
+    } do
+      token_a = Atom.to_string(source_a.token)
+      token_b = Atom.to_string(source_b.token)
+
+      conn =
+        build_ingest_conn(
+          %{
+            "batch" => [
+              %{"__LF_SOURCE" => token_a, "message" => "a"},
+              %{"__LF_SOURCE" => token_b, "message" => "b"},
+              %{"__LF_SOURCE" => token_a, "message" => "a2"}
+            ]
+          },
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      assert map_size(conn.assigns.declared_sources) == 2
+      assert conn.assigns.declared_sources[token_a].id == source_a.id
+      assert conn.assigns.declared_sources[token_b].id == source_b.id
+    end
+
+    test "single event map with __LF_SOURCE", %{user: user, source_a: source_a} do
+      token = Atom.to_string(source_a.token)
+
+      conn =
+        build_ingest_conn(%{"__LF_SOURCE" => token, "message" => "a"}, user)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      assert conn.assigns.declared_sources[token].id == source_a.id
+    end
+
+    test "_json batch shape with __LF_SOURCE", %{user: user, source_a: source_a} do
+      token = Atom.to_string(source_a.token)
+
+      conn =
+        build_ingest_conn(
+          %{"_json" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      assert conn.assigns.declared_sources[token].id == source_a.id
+    end
+  end
+
+  describe "authorization failures" do
+    test "halts when declared source is owned by a different user", %{
+      user: user,
+      other_source: other_source
+    } do
+      token = Atom.to_string(other_source.token)
+
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => token, "message" => "a"}]},
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+
+    test "halts when declared source UUID does not exist", %{user: user} do
+      unknown_uuid = Ecto.UUID.generate()
+
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => unknown_uuid, "message" => "a"}]},
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+
+    test "halts when one of many sources is unauthorized", %{
+      user: user,
+      source_a: source_a,
+      other_source: other_source
+    } do
+      token_a = Atom.to_string(source_a.token)
+      token_other = Atom.to_string(other_source.token)
+
+      conn =
+        build_ingest_conn(
+          %{
+            "batch" => [
+              %{"__LF_SOURCE" => token_a, "message" => "a"},
+              %{"__LF_SOURCE" => token_other, "message" => "b"}
+            ]
+          },
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+
+    test "halts when access token scope does not cover declared source", %{
+      user: user,
+      source_a: source_a,
+      source_b: source_b
+    } do
+      {:ok, access_token} =
+        Logflare.Auth.create_access_token(user, %{scopes: "ingest:source:#{source_a.id}"})
+
+      token_b = Atom.to_string(source_b.token)
+
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => token_b, "message" => "b"}]},
+          user
+        )
+        |> assign(:access_token, access_token)
+        |> VerifyDeclaredSources.call(%{})
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+
+    test "allows when access token scope covers all declared sources", %{
+      user: user,
+      source_a: source_a
+    } do
+      {:ok, access_token} =
+        Logflare.Auth.create_access_token(user, %{scopes: "ingest"})
+
+      token_a = Atom.to_string(source_a.token)
+
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => token_a, "message" => "a"}]},
+          user
+        )
+        |> assign(:access_token, access_token)
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      assert conn.assigns.declared_sources[token_a].id == source_a.id
+    end
+  end
+
+  describe "invalid __LF_SOURCE values" do
+    test "non-UUID value on first event still triggers multi-source mode but no declared sources resolved",
+         %{user: user} do
+      conn =
+        build_ingest_conn(
+          %{"batch" => [%{"__LF_SOURCE" => "not-a-uuid", "message" => "a"}]},
+          user
+        )
+        |> VerifyDeclaredSources.call(%{})
+
+      refute conn.halted
+      assert conn.assigns.declared_sources == %{}
+    end
+  end
+end

--- a/test/logflare_web/controllers/plugs/verify_resource_access_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_resource_access_test.exs
@@ -176,42 +176,29 @@ defmodule LogflareWeb.Plugs.VerifyResourceAccessTest do
     refute conn.halted
   end
 
-  test "source resource_type with nil source and no declared_sources still 401s",
-       %{user: user} do
-    conn =
-      build_conn(:post, "/logs", %{})
-      |> assign(:user, user)
-      |> assign(:resource_type, :source)
-      |> assign(:source, nil)
-      |> VerifyResourceAccess.call(%{})
+  test "halts with 401 when resource_type is set but no resource resolves", %{user: user} do
+    for {label, conn} <- [
+          {"source resource_type with nil source and no declared_sources",
+           build_conn(:post, "/logs", %{})
+           |> assign(:user, user)
+           |> assign(:resource_type, :source)
+           |> assign(:source, nil)},
+          {"source resource_type with nil source and empty declared_sources",
+           build_conn(:post, "/logs", %{})
+           |> assign(:user, user)
+           |> assign(:resource_type, :source)
+           |> assign(:source, nil)
+           |> assign(:declared_sources, %{})},
+          {"non-source resource_type with no resource",
+           build_conn(:get, "/endpoints/x", %{})
+           |> assign(:user, user)
+           |> assign(:resource_type, :endpoint)}
+        ] do
+      conn = VerifyResourceAccess.call(conn, %{})
 
-    assert conn.halted
-    assert conn.status == 401
-  end
-
-  test "source resource_type with nil source and empty declared_sources still 401s",
-       %{user: user} do
-    conn =
-      build_conn(:post, "/logs", %{})
-      |> assign(:user, user)
-      |> assign(:resource_type, :source)
-      |> assign(:source, nil)
-      |> assign(:declared_sources, %{})
-      |> VerifyResourceAccess.call(%{})
-
-    assert conn.halted
-    assert conn.status == 401
-  end
-
-  test "non-source resource_type with no resource still 401s", %{user: user} do
-    conn =
-      build_conn(:get, "/endpoints/x", %{})
-      |> assign(:user, user)
-      |> assign(:resource_type, :endpoint)
-      |> VerifyResourceAccess.call(%{})
-
-    assert conn.halted
-    assert conn.status == 401
+      assert conn.halted, "expected halt for: #{label}"
+      assert conn.status == 401, "expected 401 for: #{label}"
+    end
   end
 
   test "no user/resource provided" do

--- a/test/logflare_web/controllers/plugs/verify_resource_access_test.exs
+++ b/test/logflare_web/controllers/plugs/verify_resource_access_test.exs
@@ -163,6 +163,57 @@ defmodule LogflareWeb.Plugs.VerifyResourceAccessTest do
     refute conn.halted
   end
 
+  test "source resource_type with nil source and declared_sources passes through",
+       %{user: user, source: source} do
+    conn =
+      build_conn(:post, "/logs", %{})
+      |> assign(:user, user)
+      |> assign(:resource_type, :source)
+      |> assign(:source, nil)
+      |> assign(:declared_sources, %{Atom.to_string(source.token) => source})
+      |> VerifyResourceAccess.call(%{})
+
+    refute conn.halted
+  end
+
+  test "source resource_type with nil source and no declared_sources still 401s",
+       %{user: user} do
+    conn =
+      build_conn(:post, "/logs", %{})
+      |> assign(:user, user)
+      |> assign(:resource_type, :source)
+      |> assign(:source, nil)
+      |> VerifyResourceAccess.call(%{})
+
+    assert conn.halted
+    assert conn.status == 401
+  end
+
+  test "source resource_type with nil source and empty declared_sources still 401s",
+       %{user: user} do
+    conn =
+      build_conn(:post, "/logs", %{})
+      |> assign(:user, user)
+      |> assign(:resource_type, :source)
+      |> assign(:source, nil)
+      |> assign(:declared_sources, %{})
+      |> VerifyResourceAccess.call(%{})
+
+    assert conn.halted
+    assert conn.status == 401
+  end
+
+  test "non-source resource_type with no resource still 401s", %{user: user} do
+    conn =
+      build_conn(:get, "/endpoints/x", %{})
+      |> assign(:user, user)
+      |> assign(:resource_type, :endpoint)
+      |> VerifyResourceAccess.call(%{})
+
+    assert conn.halted
+    assert conn.status == 401
+  end
+
   test "no user/resource provided" do
     conn = build_conn(:get, "/any", %{})
     refute conn.halted

--- a/test/profiling/multi_source_ingest_bench.exs
+++ b/test/profiling/multi_source_ingest_bench.exs
@@ -1,18 +1,42 @@
-alias Logflare.Sources
-alias Logflare.Users
+# Usage: MIX_ENV=test mix run test/profiling/multi_source_ingest_bench.exs
+
+import Logflare.Factory
+
 require Phoenix.ConnTest
+
+{:ok, _} = Application.ensure_all_started(:mimic)
+
 Mimic.copy(Broadway)
 Mimic.copy(Logflare.Backends)
-Mimic.copy(Logflare.Logs)
+Mimic.copy(Goth)
 Mimic.copy(Logflare.Partners)
+Mimic.copy(Logflare.Sources.Source.Data)
 
-Mimic.stub(Logflare.Backends, :ingest_logs, fn _, _ -> :ok end)
-Mimic.stub(Logflare.Logs, :ingest_logs, fn _, _ -> :ok end)
+# RateCounterServer boots in SourceSup and calls Goth / Data.get_log_count; private-mode
+# Mimic stubs would not apply. Global mode mirrors ExUnit setups that stub GenServers.
+Mimic.set_mimic_global()
 
-v1_source = Sources.get(:"9f37d86e-e4fa-4ef2-a47e-e8d4ac1fceba")
-v2_source = Sources.get(:"94d07aab-30f5-460e-8871-eb85f4674e35")
+Mimic.stub(Goth)
 
-user = Users.get(v1_source.user_id)
+Mimic.stub(Logflare.Sources.Source.Data, :get_log_count, fn _, _ ->
+  0
+end)
+
+Mimic.stub(Logflare.Backends, :ingest_logs, fn events, _ ->
+  {:ok, length(events)}
+end)
+
+pid =
+  Ecto.Adapters.SQL.Sandbox.start_owner!(Logflare.Repo,
+    shared: true,
+    ownership_timeout: 1_200_000
+  )
+
+insert(:plan)
+
+user = insert(:user)
+v1_source = insert(:source, user: user)
+v2_source = insert(:source, user: user)
 
 token_a = Atom.to_string(v1_source.token)
 token_b = Atom.to_string(v2_source.token)
@@ -50,13 +74,11 @@ Benchee.run(
     "VerifyDeclaredSources - passthrough (no __LF_SOURCE)" =>
       {fn conn ->
          LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
-       end,
-       before_each: fn _ -> build_single_source_conn.() end},
+       end, before_each: fn _ -> build_single_source_conn.() end},
     "VerifyDeclaredSources - multi-source (2 sources, 10 events)" =>
       {fn conn ->
          LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
-       end,
-       before_each: fn _ -> build_multi_source_conn.() end},
+       end, before_each: fn _ -> build_multi_source_conn.() end},
     "Full ingest pipeline - single source (baseline)" =>
       {fn _ ->
          Phoenix.ConnTest.build_conn()

--- a/test/profiling/multi_source_ingest_bench.exs
+++ b/test/profiling/multi_source_ingest_bench.exs
@@ -1,0 +1,90 @@
+alias Logflare.Sources
+alias Logflare.Users
+require Phoenix.ConnTest
+Mimic.copy(Broadway)
+Mimic.copy(Logflare.Backends)
+Mimic.copy(Logflare.Logs)
+Mimic.copy(Logflare.Partners)
+
+Mimic.stub(Logflare.Backends, :ingest_logs, fn _, _ -> :ok end)
+Mimic.stub(Logflare.Logs, :ingest_logs, fn _, _ -> :ok end)
+
+v1_source = Sources.get(:"9f37d86e-e4fa-4ef2-a47e-e8d4ac1fceba")
+v2_source = Sources.get(:"94d07aab-30f5-460e-8871-eb85f4674e35")
+
+user = Users.get(v1_source.user_id)
+
+token_a = Atom.to_string(v1_source.token)
+token_b = Atom.to_string(v2_source.token)
+
+build_single_source_conn = fn ->
+  Phoenix.ConnTest.build_conn(
+    :post,
+    "/api/logs?source=#{token_a}&api_key=#{user.api_key}",
+    %{"batch" => for(_ <- 1..10, do: %{message: "some msg", field: "1234"})}
+  )
+  |> Plug.Conn.assign(:resource_type, :source)
+  |> Plug.Conn.assign(:user, user)
+  |> Plug.Conn.assign(:source, v1_source)
+end
+
+build_multi_source_conn = fn ->
+  events =
+    for i <- 1..10 do
+      token = if rem(i, 2) == 0, do: token_a, else: token_b
+      %{"__LF_SOURCE" => token, "message" => "some msg #{i}"}
+    end
+
+  Phoenix.ConnTest.build_conn(
+    :post,
+    "/api/logs?api_key=#{user.api_key}",
+    %{"batch" => events}
+  )
+  |> Plug.Conn.assign(:resource_type, :source)
+  |> Plug.Conn.assign(:user, user)
+  |> Plug.Conn.assign(:source, nil)
+end
+
+Benchee.run(
+  %{
+    "VerifyDeclaredSources - passthrough (no __LF_SOURCE)" =>
+      {fn conn ->
+         LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
+       end,
+       before_each: fn _ -> build_single_source_conn.() end},
+    "VerifyDeclaredSources - multi-source (2 sources, 10 events)" =>
+      {fn conn ->
+         LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
+       end,
+       before_each: fn _ -> build_multi_source_conn.() end},
+    "Full ingest pipeline - single source (baseline)" =>
+      {fn _ ->
+         Phoenix.ConnTest.build_conn()
+         |> Phoenix.ConnTest.dispatch(
+           LogflareWeb.Endpoint,
+           :post,
+           "/api/logs?source=#{token_a}&api_key=#{user.api_key}",
+           %{"batch" => for(_ <- 1..10, do: %{message: "some msg"})}
+         )
+       end, before_each: fn _ -> nil end},
+    "Full ingest pipeline - multi source (2 declared sources)" =>
+      {fn _ ->
+         events =
+           for i <- 1..10 do
+             token = if rem(i, 2) == 0, do: token_a, else: token_b
+             %{"__LF_SOURCE" => token, "message" => "some msg #{i}"}
+           end
+
+         Phoenix.ConnTest.build_conn()
+         |> Phoenix.ConnTest.dispatch(
+           LogflareWeb.Endpoint,
+           :post,
+           "/api/logs?api_key=#{user.api_key}",
+           %{"batch" => events}
+         )
+       end, before_each: fn _ -> nil end}
+  },
+  inputs: %{"default" => nil},
+  time: 4,
+  memory_time: 0
+)

--- a/test/profiling/multi_source_ingest_bench.exs
+++ b/test/profiling/multi_source_ingest_bench.exs
@@ -1,3 +1,4 @@
+# VerifyDeclaredSources plug, then full HTTP→ingest (two Benchee runs, sequential).
 # Usage: MIX_ENV=test mix run test/profiling/multi_source_ingest_bench.exs
 
 import Logflare.Factory
@@ -26,7 +27,7 @@ Mimic.stub(Logflare.Backends, :ingest_logs, fn events, _ ->
   {:ok, length(events)}
 end)
 
-pid =
+_pid =
   Ecto.Adapters.SQL.Sandbox.start_owner!(Logflare.Repo,
     shared: true,
     ownership_timeout: 1_200_000
@@ -36,27 +37,27 @@ insert(:plan)
 
 user = insert(:user)
 v1_source = insert(:source, user: user)
-v2_source = insert(:source, user: user)
 
 token_a = Atom.to_string(v1_source.token)
-token_b = Atom.to_string(v2_source.token)
+batch_size = 500
 
 build_single_source_conn = fn ->
   Phoenix.ConnTest.build_conn(
     :post,
     "/api/logs?source=#{token_a}&api_key=#{user.api_key}",
-    %{"batch" => for(_ <- 1..10, do: %{message: "some msg", field: "1234"})}
+    %{"batch" => for(_ <- 1..batch_size, do: %{message: "some msg", field: "1234"})}
   )
   |> Plug.Conn.assign(:resource_type, :source)
   |> Plug.Conn.assign(:user, user)
   |> Plug.Conn.assign(:source, v1_source)
 end
 
+# One unique __LF_SOURCE per batch so VerifyDeclaredSources calls
+# VerifyResourceAccess.verify_source_access/3 once (not once per distinct token).
 build_multi_source_conn = fn ->
   events =
-    for i <- 1..10 do
-      token = if rem(i, 2) == 0, do: token_a, else: token_b
-      %{"__LF_SOURCE" => token, "message" => "some msg #{i}"}
+    for i <- 1..batch_size do
+      %{"__LF_SOURCE" => token_a, "message" => "some msg #{i}"}
     end
 
   Phoenix.ConnTest.build_conn(
@@ -69,16 +70,24 @@ build_multi_source_conn = fn ->
   |> Plug.Conn.assign(:source, nil)
 end
 
+bench_opts = [inputs: %{"default" => nil}, time: 6, reduction_time: 4, memory_time: 0]
+
 Benchee.run(
   %{
     "VerifyDeclaredSources - passthrough (no __LF_SOURCE)" =>
       {fn conn ->
          LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
        end, before_each: fn _ -> build_single_source_conn.() end},
-    "VerifyDeclaredSources - multi-source (2 sources, 10 events)" =>
+    "VerifyDeclaredSources - multi-source (1 source, 500 events)" =>
       {fn conn ->
          LogflareWeb.Plugs.VerifyDeclaredSources.call(conn, [])
-       end, before_each: fn _ -> build_multi_source_conn.() end},
+       end, before_each: fn _ -> build_multi_source_conn.() end}
+  },
+  bench_opts
+)
+
+Benchee.run(
+  %{
     "Full ingest pipeline - single source (baseline)" =>
       {fn _ ->
          Phoenix.ConnTest.build_conn()
@@ -86,15 +95,14 @@ Benchee.run(
            LogflareWeb.Endpoint,
            :post,
            "/api/logs?source=#{token_a}&api_key=#{user.api_key}",
-           %{"batch" => for(_ <- 1..10, do: %{message: "some msg"})}
+           %{"batch" => for(_ <- 1..batch_size, do: %{message: "some msg"})}
          )
        end, before_each: fn _ -> nil end},
-    "Full ingest pipeline - multi source (2 declared sources)" =>
+    "Full ingest pipeline - multi source (1 declared source)" =>
       {fn _ ->
          events =
-           for i <- 1..10 do
-             token = if rem(i, 2) == 0, do: token_a, else: token_b
-             %{"__LF_SOURCE" => token, "message" => "some msg #{i}"}
+           for i <- 1..batch_size do
+             %{"__LF_SOURCE" => token_a, "message" => "some msg #{i}"}
            end
 
          Phoenix.ConnTest.build_conn()
@@ -106,7 +114,5 @@ Benchee.run(
          )
        end, before_each: fn _ -> nil end}
   },
-  inputs: %{"default" => nil},
-  time: 4,
-  memory_time: 0
+  bench_opts
 )


### PR DESCRIPTION
This allows source routing at the payload level, with `__LF_SOURCE` being provided as a special routing key.<br>This allows separate HTTP pipelines to be merged together into a multi-source request, while maintaining backwards compatability with query parameter source routing.

internally, at LogEvent.make/2 nothing changes. All changes are done at the controller level.

Pre-merge todos:

- [X] test locally
- [X] verify performance
- [X] docs update

Closes [O11Y-1838](https://linear.app/supabase/issue/O11Y-1838/support-multi-source-requests-in-ingest-controller)

here i am sending a multi-source payload to all sources named loadfest.

for benchmark of 500 events:

```
##### With input default #####
Name                                                                  ips        average  deviation         median         99th %
VerifyDeclaredSources - multi-source (1 source, 500 events)       16.80 K       59.51 μs    ±99.27%       53.04 μs      121.76 μs
VerifyDeclaredSources - passthrough (no __LF_SOURCE)              12.80 K       78.14 μs    ±34.03%       78.37 μs      122.00 μs

Comparison: 
VerifyDeclaredSources - multi-source (1 source, 500 events)       16.80 K
VerifyDeclaredSources - passthrough (no __LF_SOURCE)              12.80 K - 1.31x slower +18.63 μs

Reduction count statistics:

Name                                                        Reduction count
VerifyDeclaredSources - multi-source (1 source, 500 events)          9.63 K
VerifyDeclaredSources - passthrough (no __LF_SOURCE)              0.00400 K - 0.00x reduction count -9.62100 K

##### With input default #####
Name                                                              ips        average  deviation         median         99th %
Full ingest pipeline - single source (baseline)                1.67 K      598.03 μs  ±3055.95%      244.88 μs     3814.65 μs
Full ingest pipeline - multi source (1 declared source)        1.64 K      610.24 μs   ±621.85%      315.63 μs     2450.91 μs

Comparison: 
Full ingest pipeline - single source (baseline)                1.67 K
Full ingest pipeline - multi source (1 declared source)        1.64 K - 1.02x slower +12.21 μs

Name                                                            average  deviation         median         99th %
Full ingest pipeline - single source (baseline)                 28.36 K     ±0.00%        28.36 K        28.36 K
Full ingest pipeline - multi source (1 declared source)         51.70 K     ±0.00%        51.70 K        51.70 K

Comparison: 
Full ingest pipeline - single source (baseline)                 28.36 K
Full ingest pipeline - multi source (1 declared source)         51.70 K - 1.82x reduction count +23.35 K
```

there is very marginal performance impact, in the grand scheme of things it would speed things up as less http requests are made overall.

https://github.com/user-attachments/assets/90bf5082-f10c-4710-ba12-965a7b2bfe49