### PR TITLE
perf: relax the max memory health check

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -38,7 +38,7 @@ logflare_metadata =
 logflare_health =
   [
     memory_utilization:
-      System.get_env("LOGFLARE_HEALTH_MAX_MEMORY_UTILIZATION", "0.80") |> String.to_float()
+      System.get_env("LOGFLARE_HEALTH_MAX_MEMORY_UTILIZATION", "0.95") |> String.to_float()
   ]
   |> filter_nil_kv_pairs.()
 


### PR DESCRIPTION
This PR relaxes the max memory threshold the load balancer will pull off the instance due to failing health checks. this helps to accomomdate memory spikes.
And if memory does not recover, then instance group will repair the instance.