### PR TITLE
feat: use new code editor component in QueryLive

### DIFF
--- a/assets/build.mjs
+++ b/assets/build.mjs
@@ -57,11 +57,11 @@ let sassPostcssPlugin = sassPlugin({
 
 const options = {
   logLevel: "info",
-  entryPoints: ["js/app.js", "js/source.js"],
+  entryPoints: ["js/app.js", "js/source.js", "js/monaco_editor_worker.js"],
   bundle: true,
   minify: watch ? false : true,
   sourcemap: true,
-  loader: { ".svg": "file", ".png": "file" },
+  loader: { ".svg": "file", ".png": "file", ".ttf": "file" },
   outdir: "../priv/static/js",
   plugins: [sassPostcssPlugin, externalizeCssImages, copyStatic],
   jsx: "automatic",

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,7 +23,7 @@ import $ from "jquery";
 import moment from "moment";
 import { CodeEditorHook } from "../../deps/live_monaco_editor/priv/static/live_monaco_editor.esm"
 import LqlEditorWrapper from "./lql_editor_wrapper_hook"
-
+import MonacoHook from "./monaco_hook";
 
 // set moment globally before daterangepicker
 window.moment = moment;
@@ -51,6 +51,7 @@ const hooks = {
   ...BillingHooks,
   CodeEditorHook,
   LqlEditorWrapper,
+  MonacoHook,
 };
 
 let liveSocket = new LiveSocket("/live", Socket, {

--- a/assets/js/monaco_editor_theme.js
+++ b/assets/js/monaco_editor_theme.js
@@ -1,0 +1,88 @@
+// Copied from live_monaco_editor's bundled theme:
+// https://github.com/BeaconCMS/live_monaco_editor/blob/c5c11d9f3632ea110f86e7eb0b68e4f48dc2a14e/assets/js/live_monaco_editor/editor/themes.js
+// Copyright (c) 2023 DockYard, Inc
+// Licensed under MIT license
+// live_monaco_editor copied and modified the original work from:
+// https://github.com/livebook-dev/livebook/blob/23e58ac604de92ce54472f36fe3e28dc27576d6c/assets/js/hooks/cell_editor/live_editor/theme.js
+// Copyright (C) 2021 Dashbit
+// Licensed under Apache 2.0 available at https://www.apache.org/licenses/LICENSE-2.0
+
+// This is a port of the One Dark theme to the Monaco editor.
+// We color graded the comment so it has AA accessibility and
+// then similarly scaled the default font.
+const colors = {
+  background: "#282c34",
+  default: "#c4cad6",
+  lightRed: "#e06c75",
+  blue: "#61afef",
+  gray: "#8c92a3",
+  green: "#98c379",
+  purple: "#c678dd",
+  red: "#be5046",
+  teal: "#56b6c2",
+  peach: "#d19a66",
+};
+
+const rules = (colors) => [
+  { token: "", foreground: colors.default },
+  { token: "variable", foreground: colors.lightRed },
+  { token: "constant", foreground: colors.blue },
+  { token: "constant.character.escape", foreground: colors.blue },
+  { token: "comment", foreground: colors.gray },
+  { token: "number", foreground: colors.blue },
+  { token: "regexp", foreground: colors.lightRed },
+  { token: "type", foreground: colors.lightRed },
+  { token: "string", foreground: colors.green },
+  { token: "keyword", foreground: colors.purple },
+  { token: "operator", foreground: colors.peach },
+  { token: "delimiter.bracket.embed", foreground: colors.red },
+  { token: "sigil", foreground: colors.teal },
+  { token: "function", foreground: colors.blue },
+  { token: "function.call", foreground: colors.default },
+
+  // Markdown specific
+  { token: "emphasis", fontStyle: "italic" },
+  { token: "strong", fontStyle: "bold" },
+  { token: "keyword.md", foreground: colors.lightRed },
+  { token: "keyword.table", foreground: colors.lightRed },
+  { token: "string.link.md", foreground: colors.blue },
+  { token: "variable.md", foreground: colors.teal },
+  { token: "string.md", foreground: colors.default },
+  { token: "variable.source.md", foreground: colors.default },
+
+  // XML specific
+  { token: "tag", foreground: colors.lightRed },
+  { token: "metatag", foreground: colors.lightRed },
+  { token: "attribute.name", foreground: colors.peach },
+  { token: "attribute.value", foreground: colors.green },
+
+  // JSON specific
+  { token: "string.key", foreground: colors.lightRed },
+  { token: "keyword.json", foreground: colors.blue },
+
+  // SQL specific
+  { token: "operator.sql", foreground: colors.purple },
+];
+
+const theme = {
+  base: "vs-dark",
+  inherit: false,
+  rules: rules(colors),
+  colors: {
+    "editor.background": colors.background,
+    "editor.foreground": colors.default,
+    "editorLineNumber.foreground": "#636d83",
+    "editorCursor.foreground": "#636d83",
+    "editor.selectionBackground": "#3e4451",
+    "editor.findMatchHighlightBackground": "#528bff3d",
+    "editorSuggestWidget.background": "#21252b",
+    "editorSuggestWidget.border": "#181a1f",
+    "editorSuggestWidget.selectedBackground": "#2c313a",
+    "input.background": "#1b1d23",
+    "input.border": "#181a1f",
+    "editorBracketMatch.border": "#282c34",
+    "editorBracketMatch.background": "#3e4451",
+  },
+};
+
+export { theme };

--- a/assets/js/monaco_editor_worker.js
+++ b/assets/js/monaco_editor_worker.js
@@ -1,0 +1,1 @@
+import "monaco-editor/esm/vs/editor/editor.worker.js";

--- a/assets/js/monaco_hook.js
+++ b/assets/js/monaco_hook.js
@@ -1,0 +1,212 @@
+import * as monaco from "monaco-editor/esm/vs/editor/edcore.main.js";
+import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js";
+import {
+  registerLqlLanguage,
+  registerLqlCompletionProvider,
+} from "./lql_language";
+
+import { theme } from "./monaco_editor_theme";
+
+const minEditorHeight = 100;
+
+const MonacoHook = {
+  mounted() {
+    window.MonacoEnvironment = {
+      getWorkerUrl() {
+        return "/js/monaco_editor_worker.js";
+      },
+    };
+    window.monaco = monaco;
+
+    this.editorContainer = this.el.querySelector("[data-editor-container]");
+    this.formField = this.el.querySelector("[data-editor-input]");
+    this.loadDataset();
+    this.ignoreEditorChange = false;
+    this.disposables = [];
+
+    monaco.editor.defineTheme("default", theme);
+
+    const { minHeight: _minHeight, ...configuredOptions } = this.options;
+
+    this.editor = monaco.editor.create(this.editorContainer, {
+      ...configuredOptions,
+      language: this.language,
+      value: this.formField.value,
+    });
+
+    this.editorContainer.style.minHeight = `${this.minEditorHeight}px`;
+    this.resizeToContent();
+
+    if (this.language === "lql") {
+      this.registerLqlLanguage();
+      this.registerLqlCompletions();
+      this.registerLqlSubmitCommand();
+    } else {
+      this.registerConfiguredCompletions();
+    }
+
+    this.disposables.push(
+      this.editor.onDidChangeModelContent(() => {
+        if (this.ignoreEditorChange) return;
+
+        this.syncFormField(this.editor.getValue());
+      }),
+    );
+
+    this.disposables.push(
+      this.editor.onDidContentSizeChange(() => {
+        this.resizeToContent();
+      }),
+    );
+  },
+
+  updated() {
+    if (!this.editor || !this.formField) return;
+
+    const serverValue = this.formField.value;
+    const editorValue = this.editor.getValue();
+
+    if (serverValue === editorValue) {
+      return;
+    }
+
+    if (this.editor.hasTextFocus()) {
+      this.formField.value = editorValue;
+      return;
+    }
+
+    this.setValue(serverValue);
+  },
+
+  destroyed() {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+
+    if (this.editor) {
+      this.editor.dispose();
+    }
+  },
+
+  loadDataset() {
+    this.language = this.el.dataset.language || "sql";
+    this.options = this.loadJsonDataset("options", {});
+    this.completions = this.loadJsonDataset("completions", []);
+    this.schemaFields = this.loadJsonDataset("schemaFieldsJson", {});
+    this.suggestedSearches = this.loadJsonDataset("suggestedSearchesJson", []);
+    this.minEditorHeight = this.options.minHeight || minEditorHeight;
+  },
+
+  setValue(value) {
+    const model = this.editor.getModel();
+
+    if (!model || model.getValue() === value) return;
+
+    this.ignoreEditorChange = true;
+    this.formField.value = value;
+    this.editor.executeEdits("server_update", [
+      {
+        range: model.getFullModelRange(),
+        text: value,
+      },
+    ]);
+    this.ignoreEditorChange = false;
+  },
+
+  resizeToContent() {
+    const height = Math.max(
+      this.editor.getContentHeight(),
+      this.minEditorHeight,
+    );
+    this.editorContainer.style.height = `${height}px`;
+    this.editor.layout();
+  },
+
+  registerLqlLanguage() {
+    registerLqlLanguage(monaco);
+    monaco.editor.setModelLanguage(this.editor.getModel(), "lql");
+  },
+
+  registerLqlCompletions() {
+    this.disposables.push(
+      registerLqlCompletionProvider(
+        monaco,
+        () => this.schemaFields,
+        () => this.suggestedSearches,
+      ),
+    );
+  },
+
+  registerConfiguredCompletions() {
+    const editor = this.editor;
+
+    if (this.completions.length === 0) return;
+
+    const suggestions = this.completions;
+
+    this.disposables.push(
+      monaco.languages.registerCompletionItemProvider(this.language, {
+        provideCompletionItems(model, position) {
+          if (model !== editor.getModel()) {
+            return { suggestions: [] };
+          }
+
+          const word = model.getWordUntilPosition(position);
+          const range = {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endColumn: word.endColumn,
+          };
+
+          return {
+            suggestions: suggestions.map((name) => ({
+              label: name,
+              kind: monaco.languages.CompletionItemKind.Module,
+              insertText: name,
+              range,
+            })),
+          };
+        },
+      }),
+    );
+  },
+
+  registerLqlSubmitCommand() {
+    this.editor.addCommand(
+      monaco.KeyCode.Enter,
+      () => {
+        this.syncFormField(this.editor.getValue());
+        this.submitClosestForm();
+      },
+      "!suggestWidgetVisible",
+    );
+  },
+
+  syncFormField(value) {
+    this.formField.value = value;
+    this.formField.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+
+  submitClosestForm() {
+    const form = this.el.closest("form");
+
+    if (form) {
+      form.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    }
+  },
+
+  loadJsonDataset(key, fallback) {
+    const value = this.el.dataset[key];
+
+    try {
+      return JSON.parse(value) || fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  },
+};
+
+export default MonacoHook;

--- a/assets/js/test/monaco_hook.test.js
+++ b/assets/js/test/monaco_hook.test.js
@@ -1,0 +1,473 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const defineTheme = vi.fn();
+const create = vi.fn();
+const setModelLanguage = vi.fn();
+const registerCompletionItemProvider = vi.fn();
+const register = vi.fn();
+const setMonarchTokensProvider = vi.fn();
+const setLanguageConfiguration = vi.fn();
+let editor;
+let model;
+
+vi.stubGlobal("window", {});
+
+vi.mock("monaco-editor/esm/vs/editor/edcore.main.js", () => ({
+  editor: {
+    create,
+    defineTheme,
+    setModelLanguage,
+  },
+  languages: {
+    CompletionItemKind: {
+      Field: "field",
+      Keyword: "keyword",
+      Module: "module",
+      Operator: "operator",
+      Snippet: "snippet",
+    },
+    CompletionItemInsertTextRule: {
+      InsertAsSnippet: "insert-as-snippet",
+    },
+    getLanguages: () => [],
+    register,
+    registerCompletionItemProvider,
+    setLanguageConfiguration,
+    setMonarchTokensProvider,
+  },
+  KeyCode: {
+    Enter: "Enter",
+  },
+}));
+
+vi.mock(
+  "monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js",
+  () => ({}),
+);
+vi.mock("../monaco_editor_theme", () => ({ theme: {} }));
+
+const monacoHookModule = await import("../monaco_hook.js");
+const { default: MonacoHook } = monacoHookModule;
+
+function buildHook({ language = "lql", form, dataset = {} } = {}) {
+  const editorContainer = { style: {} };
+  const input = {
+    dispatchEvent: vi.fn(),
+    value: "m.level:error",
+  };
+  const root = {
+    dataset: {
+      language,
+      options: "{}",
+      completions: "[]",
+      schemaFieldsJson: "{}",
+      suggestedSearchesJson: "[]",
+      ...dataset,
+    },
+    isConnected: true,
+    closest: vi.fn(() => form),
+    querySelector: vi.fn((selector) => {
+      if (selector === "[data-editor-container]") return editorContainer;
+      if (selector === "[data-editor-input]") return input;
+      return null;
+    }),
+  };
+  const hook = { ...MonacoHook, el: root };
+
+  return { editorContainer, hook, input, root };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete window.MonacoEnvironment;
+
+  model = {
+    getFullModelRange: vi.fn(() => "full-range"),
+    getValue: vi.fn(() => "m.level:error"),
+  };
+
+  editor = {
+    addCommand: vi.fn(),
+    dispose: vi.fn(),
+    executeEdits: vi.fn(),
+    getContentHeight: vi.fn(() => 32),
+    getModel: vi.fn(() => model),
+    getValue: vi.fn(() => "m.level:error"),
+    hasTextFocus: vi.fn(() => false),
+    layout: vi.fn(),
+    onDidChangeModelContent: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidContentSizeChange: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+
+  create.mockReturnValue(editor);
+  registerCompletionItemProvider.mockReturnValue({ dispose: vi.fn() });
+});
+
+describe("MonacoHook", () => {
+  describe("MonacoEnvironment management", () => {
+    it("creates MonacoEnvironment during mount", () => {
+      expect(window.MonacoEnvironment).toBeUndefined();
+
+      const { hook } = buildHook({ language: "sql" });
+      hook.mounted();
+      expect(window.MonacoEnvironment.getWorkerUrl()).toBe(
+        "/js/monaco_editor_worker.js",
+      );
+    });
+  });
+
+  describe("mounting and basic events", () => {
+    it("creates the editor with merged options and keeps minHeight off Monaco options", () => {
+      const { editorContainer, hook, input } = buildHook({
+        language: "sql",
+        dataset: {
+          options: JSON.stringify({
+            fontSize: 16,
+            minHeight: 240,
+            scrollbar: { horizontal: "auto" },
+          }),
+        },
+      });
+
+      hook.mounted();
+
+      expect(defineTheme).toHaveBeenCalledWith("default", {});
+      expect(create).toHaveBeenCalledWith(
+        editorContainer,
+        expect.objectContaining({
+          fontSize: 16,
+          language: "sql",
+          scrollbar: { horizontal: "auto" },
+          value: input.value,
+        }),
+      );
+      expect(create.mock.calls[0][1]).not.toHaveProperty("minHeight");
+      expect(editorContainer.style.minHeight).toBe("240px");
+    });
+
+    it("syncs editor changes into the hidden form field", () => {
+      const { hook, input } = buildHook({ language: "sql" });
+
+      hook.mounted();
+      editor.getValue.mockReturnValue("select * from events");
+
+      const [onChange] = editor.onDidChangeModelContent.mock.calls[0];
+      onChange();
+
+      expect(input.value).toBe("select * from events");
+      expect(input.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ bubbles: true, type: "input" }),
+      );
+    });
+  });
+
+  describe("hook updates", () => {
+    it("ignores update before the editor is mounted", () => {
+      const { hook } = buildHook({ language: "sql" });
+      hook.updated();
+      expect(editor.getValue).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when form field and editor values match", () => {
+      const { hook, input } = buildHook({ language: "sql" });
+      hook.mounted();
+      editor.getValue.mockReturnValue(input.value);
+      hook.updated();
+      expect(editor.executeEdits).not.toHaveBeenCalled();
+    });
+
+    it("keeps focused editor content and updates form field when patch has stale content", () => {
+      const { hook, input } = buildHook({ language: "sql" });
+      hook.mounted();
+      editor.hasTextFocus.mockReturnValue(true);
+      editor.getValue.mockReturnValue("select fresh");
+      input.value = "select stale";
+
+      hook.updated();
+
+      expect(input.value).toBe("select fresh");
+      expect(editor.executeEdits).not.toHaveBeenCalled();
+    });
+
+    it("applies changed form field content when the editor is not focused", () => {
+      const { hook, input } = buildHook({ language: "sql" });
+      hook.mounted();
+      editor.hasTextFocus.mockReturnValue(false);
+      editor.getValue.mockReturnValue("select old");
+      model.getValue.mockReturnValue("select old");
+      input.value = "select new";
+
+      hook.updated();
+
+      expect(editor.executeEdits).toHaveBeenCalledWith("server_update", [
+        { range: "full-range", text: "select new" },
+      ]);
+    });
+  });
+
+  describe("setValue", () => {
+    let hook;
+    let input;
+
+    beforeEach(() => {
+      ({ hook, input } = buildHook({ language: "sql" }));
+      hook.mounted();
+    });
+
+    it("does not edit when there is no model or the model already has the value", () => {
+      editor.getModel.mockReturnValue(null);
+      hook.setValue("select new");
+
+      editor.getModel.mockReturnValue(model);
+      model.getValue.mockReturnValue("select new");
+      hook.setValue("select new");
+
+      expect(editor.executeEdits).not.toHaveBeenCalled();
+    });
+
+    it("ignores editor change events while applying server values", () => {
+      editor.getValue.mockReturnValue("select from callback");
+      model.getValue.mockReturnValue("select old");
+
+      editor.executeEdits.mockImplementation(() => {
+        const [onChange] = editor.onDidChangeModelContent.mock.calls[0];
+        onChange();
+      });
+
+      hook.setValue("select new");
+
+      expect(input.value).toBe("select new");
+      expect(input.dispatchEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "input" }),
+      );
+    });
+  });
+
+  describe("resizeToContent", () => {
+    it("resizes to the larger of content height and min height", () => {
+      const { editorContainer, hook } = buildHook({
+        language: "sql",
+        dataset: { options: JSON.stringify({ minHeight: 120 }) },
+      });
+
+      editor.getContentHeight.mockReturnValue(240);
+      hook.mounted();
+
+      expect(editorContainer.style.height).toBe("240px");
+      expect(editor.layout).toHaveBeenCalled();
+    });
+
+  });
+
+  describe("disposal and destruction", () => {
+    it("disposes registered subscriptions and the editor", () => {
+      const disposables = [
+        { dispose: vi.fn() },
+        { dispose: vi.fn() },
+        { dispose: vi.fn() },
+      ];
+      editor.onDidChangeModelContent.mockReturnValue(disposables[0]);
+      editor.onDidContentSizeChange.mockReturnValue(disposables[1]);
+      registerCompletionItemProvider.mockReturnValue(disposables[2]);
+
+      const { hook } = buildHook();
+      hook.mounted();
+      hook.destroyed();
+
+      disposables.forEach((d) => expect(d.dispose).toHaveBeenCalled());
+      expect(editor.dispose).toHaveBeenCalled();
+    });
+
+    it("does not fail destroying when no editor was created", () => {
+      const { hook } = buildHook();
+      hook.disposables = [{ dispose: vi.fn() }];
+
+      expect(() => hook.destroyed()).not.toThrow();
+      expect(editor.dispose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("LQL language features", () => {
+    it("registers LQL language support", () => {
+      const { hook } = buildHook({ language: "lql" });
+      hook.registerLqlLanguage = vi.fn(hook.registerLqlLanguage);
+
+      hook.mounted();
+
+      expect(hook.registerLqlLanguage).toHaveBeenCalled();
+      expect(register).toHaveBeenCalledWith({ id: "lql" });
+      expect(setMonarchTokensProvider).toHaveBeenCalledWith(
+        "lql",
+        expect.any(Object),
+      );
+      expect(setModelLanguage).toHaveBeenCalledWith(model, "lql");
+    });
+
+    it("dispatches a submit event when the LQL Enter command runs", () => {
+      const form = { dispatchEvent: vi.fn(), requestSubmit: vi.fn() };
+      const { hook } = buildHook({ language: "lql", form });
+
+      hook.mounted();
+
+      const [, submit] = editor.addCommand.mock.calls[0];
+      submit();
+
+      expect(form.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bubbles: true,
+          cancelable: true,
+          type: "submit",
+        }),
+      );
+      expect(form.requestSubmit).not.toHaveBeenCalled();
+    });
+
+    it("uses mounted LQL schema fields in completion providers", () => {
+      const { hook } = buildHook({
+        language: "lql",
+        dataset: {
+          schemaFieldsJson: JSON.stringify({ "metadata.level": "string" }),
+        },
+      });
+      hook.registerLqlCompletions = vi.fn(hook.registerLqlCompletions);
+
+      hook.mounted();
+
+      expect(hook.registerLqlCompletions).toHaveBeenCalled();
+      const provider = registerCompletionItemProvider.mock.calls[0][1];
+
+      const suggestions = provider.provideCompletionItems(
+        {
+          getLineContent: () => "m.",
+          getLineMaxColumn: () => 3,
+          getValueInRange: () => "m.",
+          getWordUntilPosition: () => ({ startColumn: 1, endColumn: 3 }),
+        },
+        { column: 3, lineNumber: 1 },
+      ).suggestions;
+
+      expect(suggestions).toEqual([
+        expect.objectContaining({ detail: "string", label: "level" }),
+      ]);
+    });
+  });
+
+  describe("SQL language features", () => {
+    it("does not register an Enter submit command for SQL editors", () => {
+      const { hook } = buildHook({ language: "sql" });
+      hook.registerLqlLanguage = vi.fn(hook.registerLqlLanguage);
+      hook.registerLqlCompletions = vi.fn(hook.registerLqlCompletions);
+      hook.registerLqlSubmitCommand = vi.fn(hook.registerLqlSubmitCommand);
+
+      hook.mounted();
+
+      expect(hook.registerLqlLanguage).not.toHaveBeenCalled();
+      expect(hook.registerLqlCompletions).not.toHaveBeenCalled();
+      expect(hook.registerLqlSubmitCommand).not.toHaveBeenCalled();
+      expect(editor.addCommand).not.toHaveBeenCalled();
+    });
+
+    it("registers SQL completions for the active editor model only", () => {
+      const { hook } = buildHook({
+        language: "sql",
+        dataset: { completions: JSON.stringify(["events", "sources"]) },
+      });
+      hook.registerConfiguredCompletions = vi.fn(
+        hook.registerConfiguredCompletions,
+      );
+
+      hook.mounted();
+
+      expect(hook.registerConfiguredCompletions).toHaveBeenCalled();
+      const provider = registerCompletionItemProvider.mock.calls[0][1];
+      const position = { column: 3, lineNumber: 1 };
+      model.getWordUntilPosition = vi.fn(() => ({
+        endColumn: 3,
+        startColumn: 1,
+      }));
+
+      expect(provider.provideCompletionItems({}, position)).toEqual({
+        suggestions: [],
+      });
+
+      const completions = provider.provideCompletionItems(model, position);
+      expect(completions.suggestions).toEqual([
+        expect.objectContaining({
+          insertText: "events",
+          kind: "module",
+          label: "events",
+          range: {
+            endColumn: 3,
+            endLineNumber: 1,
+            startColumn: 1,
+            startLineNumber: 1,
+          },
+        }),
+        expect.objectContaining({ label: "sources" }),
+      ]);
+    });
+
+    it("does not register SQL completions when none are configured", () => {
+      const { hook } = buildHook({ language: "sql" });
+      hook.mounted();
+      expect(registerCompletionItemProvider).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("MonacoHook helpers", () => {
+  describe("loadJsonDataset", () => {
+    it("parses dataset JSON", () => {
+      const hook = {
+        ...MonacoHook,
+        el: { dataset: { options: JSON.stringify({ minHeight: 120 }) } },
+      };
+
+      expect(hook.loadJsonDataset("options", {})).toEqual({ minHeight: 120 });
+    });
+
+    it("falls back when dataset JSON is missing or invalid", () => {
+      const hook = { ...MonacoHook, el: { dataset: { options: "{" } } };
+      const fallback = { minHeight: 100 };
+
+      expect(hook.loadJsonDataset("options", fallback)).toBe(fallback);
+
+      hook.el.dataset = {};
+      expect(hook.loadJsonDataset("missing", [])).toEqual([]);
+    });
+  });
+
+  it("syncs a form field value and dispatches input", () => {
+    const hook = {
+      ...MonacoHook,
+      formField: { dispatchEvent: vi.fn(), value: "" },
+    };
+
+    hook.syncFormField("select 1");
+
+    expect(hook.formField.value).toBe("select 1");
+    expect(hook.formField.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ bubbles: true, type: "input" }),
+    );
+  });
+
+  describe("submitClosestForm", () => {
+    it("submits the closest form if one exists, or does nothing if not found", () => {
+      const form = { dispatchEvent: vi.fn() };
+      const hook = { ...MonacoHook, el: { closest: vi.fn(() => form) } };
+
+      hook.submitClosestForm();
+      expect(hook.el.closest).toHaveBeenCalledWith("form");
+      expect(form.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bubbles: true,
+          cancelable: true,
+          type: "submit",
+        }),
+      );
+
+      hook.el.closest.mockReturnValue(null);
+      expect(() => hook.submitClosestForm()).not.toThrow();
+    });
+  });
+});

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "^4.18.1",
         "luxon": "^3.2.1",
         "moment": "^2.29.4",
+        "monaco-editor": "^0.55.1",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
         "phoenix_live_react": "file:../deps/phoenix_live_react",
@@ -98,8 +99,7 @@
     "node_modules/@bufbuild/protobuf": {
       "version": "2.2.3",
       "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -549,28 +549,18 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1437,6 +1427,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
@@ -1667,6 +1664,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -1713,6 +1711,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -1729,8 +1728,7 @@
     "node_modules/buffer-builder": {
       "version": "0.2.0",
       "dev": true,
-      "license": "MIT/X11",
-      "peer": true
+      "license": "MIT/X11"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1866,8 +1864,7 @@
     "node_modules/colorjs.io": {
       "version": "0.5.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2037,6 +2034,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -2070,6 +2076,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2487,7 +2494,8 @@
     },
     "node_modules/jquery": {
       "version": "3.7.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2576,6 +2584,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -2623,6 +2643,16 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -2876,6 +2906,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3032,6 +3063,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3069,6 +3101,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3079,7 +3112,8 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -3106,6 +3140,7 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3195,7 +3230,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3305,7 +3341,6 @@
       "version": "7.8.1",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3391,7 +3426,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3409,7 +3443,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3427,7 +3460,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3445,7 +3477,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3463,7 +3494,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3479,7 +3509,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3497,7 +3526,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3515,7 +3543,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3533,7 +3560,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3551,7 +3577,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3569,7 +3594,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3587,7 +3611,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3605,7 +3628,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3623,7 +3645,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3641,7 +3662,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3659,7 +3679,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3677,7 +3696,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3695,7 +3713,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3713,7 +3730,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3731,7 +3747,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3740,7 +3755,6 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4039,7 +4053,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sync-message-port": "^1.0.0"
       },
@@ -4051,7 +4064,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4175,6 +4187,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4225,8 +4238,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/uncontrollable": {
       "version": "7.2.1",
@@ -4289,8 +4301,7 @@
     "node_modules/varint": {
       "version": "6.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -4377,6 +4388,7 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4499,6 +4511,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,6 +19,7 @@
     "lodash": "^4.18.1",
     "luxon": "^3.2.1",
     "moment": "^2.29.4",
+    "monaco-editor": "^0.55.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_react": "file:../deps/phoenix_live_react",

--- a/lib/logflare_web/components/code_editor_component.ex
+++ b/lib/logflare_web/components/code_editor_component.ex
@@ -1,0 +1,112 @@
+defmodule LogflareWeb.MonacoEditorComponentNew do
+  use Phoenix.Component
+
+  @default_opts %{
+    "automaticLayout" => true,
+    "contextmenu" => false,
+    "editContext" => false,
+    "folding" => false,
+    "fontFamily" => "JetBrains Mono, monospace",
+    "fontSize" => 12,
+    "formatOnPaste" => true,
+    "formatOnType" => true,
+    "glyphMargin" => false,
+    "guides" => %{
+      "indentation" => false
+    },
+    "hideCursorInOverviewRuler" => true,
+    "lineNumbers" => "off",
+    "lineNumbersMinChars" => 0,
+    "minimap" => %{
+      "enabled" => false
+    },
+    "occurrencesHighlight" => false,
+    "padding" => %{
+      "top" => 14,
+      "bottom" => 14
+    },
+    "parameterHints" => true,
+    "renderLineHighlight" => "none",
+    "roundedSelection" => true,
+    "scrollbar" => %{
+      "vertical" => "auto",
+      "horizontal" => "hidden",
+      "verticalScrollbarSize" => 6,
+      "alwaysConsumeMouseWheel" => false
+    },
+    "scrollBeyondLastLine" => false,
+    "smoothScrolling" => true,
+    "stickyScroll" => %{
+      "enabled" => false
+    },
+    "suggestSelection" => "first",
+    "tabCompletion" => "on",
+    "tabIndex" => -1,
+    "tabSize" => 2,
+    "theme" => "default",
+    "wordWrap" => "on"
+  }
+
+  attr :field, Phoenix.HTML.FormField, required: true
+  attr :id, :string, default: "lf-monaco"
+  attr :language, :string, default: "sql"
+  attr :opts, :map, default: %{}
+  attr :completions, :list, default: []
+  attr :schema_fields, :map, default: %{}
+  attr :suggested_searches, :list, default: []
+  attr :class, :string, default: "tw-mb-12"
+  attr :editor_class, :string, default: "tw-w-full"
+
+  def code_editor(assigns) do
+    opts =
+      assigns.opts
+      |> default_opts()
+
+    assigns =
+      assigns
+      |> assign(:completions_json, Jason.encode!(assigns.completions))
+      |> assign(:opts_json, Jason.encode!(opts))
+      |> assign(:schema_fields_json, Jason.encode!(assigns.schema_fields))
+      |> assign(:suggested_searches_json, Jason.encode!(assigns.suggested_searches))
+
+    ~H"""
+    <div class={@class} id={@id} phx-hook="MonacoHook" data-language={@language} data-options={@opts_json} data-completions={@completions_json} data-schema-fields-json={@schema_fields_json} data-suggested-searches-json={@suggested_searches_json}>
+      <input type="hidden" name={@field.name} value={@field.value} phx-debounce="300" data-editor-input />
+      <div id={[@id, "-editor"]} phx-update="ignore" class={@editor_class}>
+        <div data-editor-container></div>
+      </div>
+    </div>
+    """
+  end
+
+  @spec default_opts(map()) :: map()
+  def default_opts(overrides \\ %{}) do
+    DeepMerge.deep_merge(@default_opts, overrides)
+  end
+
+  @spec lql_editor_opts() :: map()
+  def lql_editor_opts do
+    %{
+      "lineDecorationsWidth" => 8,
+      "wordWrap" => "off",
+      "scrollbar" => %{
+        "vertical" => "hidden",
+        "handleMouseWheel" => false
+      },
+      "overviewRulerLanes" => 0,
+      "overviewRulerBorder" => false,
+      "fixedOverflowWidgets" => true,
+      "suggest" => %{"enabled" => true, "showWords" => false},
+      "parameterHints" => %{"enabled" => false},
+      "quickSuggestions" => true,
+      "matchBrackets" => "never",
+      "fontSize" => 14,
+      "tabIndex" => 0,
+      "fontFamily" =>
+        "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "padding" => %{"top" => 5, "bottom" => 5},
+      "minHeight" => 32
+    }
+    |> default_opts()
+  end
+end

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -340,6 +340,10 @@ defmodule LogflareWeb.QueryLive do
     {:noreply, assign_form(socket, params)}
   end
 
+  def handle_event("set_backend", _params, socket) do
+    {:noreply, socket}
+  end
+
   defp run_query(socket, user, query_string) do
     backend = get_selected_backend(socket)
     language = EndpointQuery.map_backend_to_language(backend, false)

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -10,6 +10,7 @@ defmodule LogflareWeb.QueryLive do
   alias Logflare.Endpoints.EndpointQuery
   alias Logflare.Repo
   alias Logflare.Sql
+  alias Logflare.Sources
   alias Logflare.Teams.TeamContext
   alias LogflareWeb.AuthLive
   alias LogflareWeb.QueryComponents
@@ -40,52 +41,18 @@ defmodule LogflareWeb.QueryLive do
       </p>
     </section>
     <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-4">
-      <.form for={@form} id="query-form" phx-submit="run-query" phx-change="set_backend" class="tw-min-h-[80px] tw-flex tw-flex-col tw-gap-4">
+      <.form :let={f} for={query_form(@query_string)} id="query-form" phx-change="parse-query" phx-submit="run-query" class="tw-min-h-[80px] tw-flex tw-flex-col tw-gap-4">
         <QueryComponents.backend_select :if={Enum.any?(@backends)} backends={@backends} form={@form} default_backend={@default_backend}>
           <:help>Choose which backend to execute this query against.</:help>
         </QueryComponents.backend_select>
-        <LiveMonacoEditor.code_editor
-          value={@query_string}
-          change="parse-query"
-          path="query"
-          id="query"
-          opts={
-            Map.merge(
-              LiveMonacoEditor.default_opts(),
-              %{
-                "wordWrap" => "on",
-                "language" => "sql",
-                "fontSize" => 12,
-                "padding" => %{
-                  "top" => 14,
-                  "bottom" => 14
-                },
-                "contextmenu" => false,
-                "hideCursorInOverviewRuler" => true,
-                "smoothScrolling" => true,
-                "scrollbar" => %{
-                  "vertical" => "auto",
-                  "horizontal" => "hidden",
-                  "verticalScrollbarSize" => 6,
-                  "alwaysConsumeMouseWheel" => false
-                },
-                "lineNumbers" => "off",
-                "glyphMargin" => false,
-                "lineNumbersMinChars" => 0,
-                "folding" => false,
-                "roundedSelection" => true,
-                "minimap" => %{
-                  "enabled" => false
-                }
-              }
-            )
-          }
-        />
+        <LogflareWeb.MonacoEditorComponentNew.code_editor id="monaco-hook" field={f[:value]} completions={@completions} />
         <div class="tw-ml-auto">
-          <button type="button" class="btn btn-secondary" phx-click="format-query">
+          <button type="submit" name="action" value="format" class="btn btn-secondary">
             Format
           </button>
-          {submit("Run query", class: "btn btn-secondary")}
+          <button type="submit" name="action" value="run" class="btn btn-secondary">
+            Run query
+          </button>
         </div>
       </.form>
 
@@ -169,9 +136,6 @@ defmodule LogflareWeb.QueryLive do
   def mount(%{}, _session, socket) do
     %{assigns: %{user: user}} = socket
 
-    endpoints = Endpoints.list_endpoints_by(user_id: user.id)
-    alerts = Alerting.list_alert_queries_by_user_id(user.id)
-
     socket =
       socket
       |> assign(:user_id, user.id)
@@ -180,12 +144,16 @@ defmodule LogflareWeb.QueryLive do
       |> assign(:parse_error_message, nil)
       |> assign(:run_error_message, nil)
       |> assign(:query_string, nil)
-      |> assign(:endpoints, endpoints)
-      |> assign(:alerts, alerts)
       |> assign_backends()
       |> assign_form(%{})
+      |> assign_query_resources()
 
     {:ok, socket}
+  end
+
+  defp query_form(query_string) do
+    %{"value" => query_string}
+    |> to_form()
   end
 
   def handle_params(params, _uri, socket) do
@@ -202,21 +170,23 @@ defmodule LogflareWeb.QueryLive do
           formatted
       end
 
-    %{assigns: %{user: user}} = socket
-    endpoints = Endpoints.list_endpoints_by(user_id: user.id)
-    alerts = Alerting.list_alert_queries_by_user_id(user.id)
-
     socket =
       socket
-      |> assign(:user_id, user.id)
-      |> assign(:endpoints, endpoints)
-      |> assign(:alerts, alerts)
+      |> maybe_assign_team_context(params, q)
       |> assign_form(params)
+      |> assign_query_resources()
 
     query_string =
-      q ||
-        socket.assigns.query_string ||
-        "SELECT id, timestamp, metadata, event_message \nFROM YourSource \nWHERE timestamp > '#{DateTime.utc_now() |> DateTime.to_iso8601()}'"
+      cond do
+        q != nil ->
+          q
+
+        socket.assigns.query_string != nil ->
+          socket.assigns.query_string
+
+        true ->
+          "SELECT id, timestamp, metadata, event_message \nFROM YourSource \nWHERE timestamp > '#{DateTime.utc_now() |> DateTime.to_iso8601()}'"
+      end
 
     next_backend_id = backend_id_from_form(socket)
 
@@ -272,9 +242,27 @@ defmodule LogflareWeb.QueryLive do
     end
   end
 
+  defp assign_query_resources(socket) do
+    %{assigns: %{user: user}} = socket
+
+    socket
+    |> assign(:user_id, user.id)
+    |> assign(:endpoints, Endpoints.list_endpoints_by(user_id: user.id))
+    |> assign(:alerts, Alerting.list_alert_queries_by_user_id(user.id))
+    |> assign_completions()
+  end
+
   defp assign_team_context_for_query(socket, nil), do: socket
 
   defp assign_team_context_for_query(socket, query_string) do
+    maybe_assign_team_context(socket, %{}, query_string)
+  end
+
+  defp maybe_assign_team_context(socket, %{"t" => _team_id}, _query), do: socket
+
+  defp maybe_assign_team_context(socket, _params, nil), do: socket
+
+  defp maybe_assign_team_context(socket, _params, query_string) do
     effective_user = socket.assigns[:team_user] || socket.assigns.user
 
     case TeamContext.resource_team_id_query(__MODULE__, %{"q" => query_string}, effective_user) do
@@ -295,9 +283,26 @@ defmodule LogflareWeb.QueryLive do
 
   def handle_event(
         "run-query",
-        params,
-        %{assigns: %{query_string: query_string}} = socket
+        %{"action" => "format", "value" => query_string},
+        socket
       ) do
+    {:ok, formatted} = Sql.format(query_string)
+
+    {:noreply, assign(socket, :query_string, formatted)}
+  end
+
+  def handle_event(
+        "run-query",
+        params,
+        socket
+      ) do
+    query_string =
+      if Map.has_key?(params, "action") do
+        Map.get(params, "value", socket.assigns.query_string)
+      else
+        socket.assigns.query_string
+      end
+
     socket = assign_team_context_for_query(socket, query_string)
     %{assigns: %{user: user}} = socket
 
@@ -316,28 +321,19 @@ defmodule LogflareWeb.QueryLive do
 
   def handle_event(
         "parse-query",
-        %{"value" => query_string},
+        %{"value" => query_string} = params,
         socket
       ) do
     socket =
       socket
+      |> maybe_assign_form(params)
       |> assign(:query_string, query_string)
 
     {:noreply, parse_query(socket)}
   end
 
-  def handle_event("parse-query", %{"_target" => ["live_monaco_editor", _]}, socket) do
-    # ignore change events from the editor field
-    {:noreply, socket}
-  end
-
-  def handle_event("format-query", _params, socket) do
-    {:ok, formatted} = Sql.format(socket.assigns.query_string)
-    {:noreply, LiveMonacoEditor.set_value(socket, formatted, to: "query")}
-  end
-
-  def handle_event("set_backend", %{"backend" => params}, socket) do
-    {:noreply, assign_form(socket, params)}
+  def handle_event("parse-query", %{"backend" => params}, socket) do
+    {:noreply, socket |> assign_form(params) |> parse_query()}
   end
 
   def handle_event("set_backend", _params, socket) do
@@ -375,7 +371,12 @@ defmodule LogflareWeb.QueryLive do
     if is_binary(error), do: error, else: inspect(error)
   end
 
+  defp maybe_assign_form(socket, %{"backend" => params}), do: assign_form(socket, params)
+  defp maybe_assign_form(socket, _params), do: socket
+
   defp build_params(%{assigns: assigns} = _socket, params) do
+    params = params || %{}
+
     %{
       "q" => assigns.query_string,
       "t" => assigns.team.id,
@@ -420,5 +421,17 @@ defmodule LogflareWeb.QueryLive do
         |> assign(:parse_error_message, format_query_error(err))
         |> assign(:run_error_message, nil)
     end
+  end
+
+  defp assign_completions(socket) do
+    %{endpoints: endpoints, alerts: alerts, user_id: user_id} = socket.assigns
+    sources = Sources.list_sources_by_user(user_id)
+
+    completions =
+      [sources, endpoints, alerts]
+      |> List.flatten()
+      |> Enum.map(& &1.name)
+
+    assign(socket, completions: completions)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -72,14 +72,14 @@ defmodule Logflare.Mixfile do
       plt_local_path: "dialyzer",
       plt_core_path: "dialyzer",
       plt_add_deps: :apps_tree,
-      plt_add_apps: [:ex_unit, :mix],
+      plt_add_apps: [:ex_unit, :mix, :phoenix_test, :phoenix_test_playwright, :playwright_ex],
       ignore_warnings: ".dialyzer_ignore.exs"
     ]
   end
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:dev), do: ["lib", "priv/tasks", "test/support"]
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support", "test/e2e"]
   defp elixirc_paths(_), do: ["lib", "priv/tasks"]
 
   defp deps do

--- a/test/e2e/features/alerts_live_test.exs
+++ b/test/e2e/features/alerts_live_test.exs
@@ -1,0 +1,29 @@
+defmodule E2e.Features.AlertsLiveTest do
+  use Logflare.FeatureCase, async: false
+
+  import LogflareWeb.MonacoEditorTestUtils
+
+  describe "alerts page Monaco editor" do
+    TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
+
+    test "creates an alert with the query entered in Monaco", %{conn: conn} do
+      alert_name = "MonacoAlert#{System.unique_integer([:positive])}"
+      alert_query = "select 42 as answer, 'alert monaco e2e result' as label"
+      cron = "*/5 * * * *"
+
+      conn
+      |> visit(~p"/auth/login/single_tenant")
+      |> assert_path(~p"/dashboard")
+      |> visit(~p"/alerts/new")
+      |> wait_for_monaco_editor()
+      |> fill_input("input[name='alert[name]']", alert_name)
+      |> replace_monaco_text(alert_query)
+      |> wait_for_input_value("input[name='alert[query]']", alert_query)
+      |> fill_input("input[name='alert[cron]']", cron)
+      |> click("button", "Save changes")
+      |> assert_has("h2", text: alert_name)
+      |> assert_has("code", text: alert_query)
+      |> assert_has("li", text: cron)
+    end
+  end
+end

--- a/test/e2e/features/endpoints_live_test.exs
+++ b/test/e2e/features/endpoints_live_test.exs
@@ -1,0 +1,26 @@
+defmodule E2e.Features.EndpointsLiveTest do
+  use Logflare.FeatureCase, async: false
+
+  import LogflareWeb.MonacoEditorTestUtils
+
+  describe "endpoints page Monaco editor" do
+    TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
+
+    test "creates an endpoint with the query entered in Monaco", %{conn: conn} do
+      endpoint_name = "MonacoBaseline#{System.unique_integer([:positive])}"
+      endpoint_query = "select 42 as answer, 'endpoint monaco e2e result' as label"
+
+      conn
+      |> visit(~p"/auth/login/single_tenant")
+      |> assert_path(~p"/dashboard")
+      |> visit(~p"/endpoints/new")
+      |> wait_for_monaco_editor()
+      |> fill_input("input[name='endpoint[name]']", endpoint_name)
+      |> replace_monaco_text(endpoint_query)
+      |> wait_for_input_value("input[name='endpoint[query]']", endpoint_query)
+      |> click("button", "Save changes")
+      |> assert_has("h1,h2,h3,h4,h5", text: endpoint_name)
+      |> assert_has("code", text: endpoint_query)
+    end
+  end
+end

--- a/test/e2e/features/query_live_test.exs
+++ b/test/e2e/features/query_live_test.exs
@@ -1,0 +1,27 @@
+defmodule E2e.Features.QueryLiveTest do
+  use Logflare.FeatureCase, async: false
+
+  import LogflareWeb.MonacoEditorTestUtils
+
+  describe "query page Monaco editor" do
+    TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
+
+    test "runs the query entered in Monaco", %{conn: conn} do
+      query = "select 42 as answer, 'monaco e2e result' as label"
+
+      conn =
+        conn
+        |> visit(~p"/auth/login/single_tenant")
+        |> assert_path(~p"/dashboard")
+        |> visit(~p"/query")
+        |> wait_for_monaco_editor()
+        |> replace_monaco_text(query)
+        |> click("button", "Run query")
+
+      conn
+      |> assert_has("table", text: "answer")
+      |> assert_has("table", text: "42")
+      |> assert_has("table", text: "monaco e2e result")
+    end
+  end
+end

--- a/test/e2e/monaco_editor_test_utils.ex
+++ b/test/e2e/monaco_editor_test_utils.ex
@@ -1,6 +1,4 @@
 defmodule LogflareWeb.MonacoEditorTestUtils do
-  @moduledoc false
-
   alias PhoenixTest.Playwright
   alias PlaywrightEx.Frame
 

--- a/test/e2e/monaco_editor_test_utils.ex
+++ b/test/e2e/monaco_editor_test_utils.ex
@@ -1,0 +1,102 @@
+defmodule LogflareWeb.MonacoEditorTestUtils do
+  @moduledoc false
+
+  alias PhoenixTest.Playwright
+  alias PlaywrightEx.Frame
+
+  @editor_input_selector ".monaco-editor textarea.inputarea"
+  @editor_selector ".monaco-editor"
+
+  @spec wait_for_monaco_editor(Playwright.t()) :: Playwright.t()
+  def wait_for_monaco_editor(conn) do
+    conn
+    |> Playwright.unwrap(fn %{frame_id: frame_id} ->
+      {:ok, _} =
+        Frame.wait_for_selector(frame_id,
+          selector: @editor_input_selector,
+          state: "attached",
+          timeout: 40_000
+        )
+    end)
+  end
+
+  @spec replace_monaco_text(Playwright.t(), String.t()) :: Playwright.t()
+  def replace_monaco_text(conn, text) do
+    conn =
+      conn
+      |> Playwright.click(@editor_selector)
+      |> Playwright.unwrap(fn %{frame_id: frame_id} ->
+        {:ok, _} = Frame.focus(frame_id, selector: @editor_input_selector, timeout: 5_000)
+
+        {:ok, _} =
+          Frame.press(frame_id,
+            selector: @editor_input_selector,
+            key: "Control+A",
+            timeout: 5_000
+          )
+
+        {:ok, _} =
+          Frame.type(frame_id, selector: @editor_input_selector, text: text, timeout: 5_000)
+      end)
+
+    wait_for_monaco_text(conn, text)
+  end
+
+  @spec fill_input(Playwright.t(), String.t(), String.t()) :: Playwright.t()
+  def fill_input(conn, selector, value) do
+    conn
+    |> Playwright.unwrap(fn %{frame_id: frame_id} ->
+      {:ok, _} =
+        Frame.fill(frame_id,
+          selector: selector,
+          value: value,
+          timeout: 5_000
+        )
+    end)
+  end
+
+  @spec wait_for_input_value(Playwright.t(), String.t(), String.t(), non_neg_integer()) ::
+          Playwright.t()
+  def wait_for_input_value(conn, selector, expected_value, timeout_ms \\ 10_000) do
+    conn
+    |> Playwright.unwrap(fn %{frame_id: frame_id} ->
+      {:ok, _} =
+        Frame.wait_for_function(frame_id,
+          expression: """
+          ({ selector, expectedValue }) => {
+            return Array.from(document.querySelectorAll(selector))
+              .some((field) => field.value === expectedValue)
+          }
+          """,
+          is_function: true,
+          arg: %{selector: selector, expectedValue: expected_value},
+          timeout: timeout_ms
+        )
+    end)
+  end
+
+  @spec wait_for_monaco_text(Playwright.t(), String.t(), non_neg_integer()) :: Playwright.t()
+  def wait_for_monaco_text(conn, expected_text, timeout_ms \\ 10_000) do
+    conn
+    |> Playwright.unwrap(fn %{frame_id: frame_id} ->
+      {:ok, _} =
+        Frame.wait_for_function(frame_id,
+          expression: """
+          ({ expectedText }) => {
+            const editorText =
+              window.monaco?.editor?.getModels?.()[0]?.getValue?.() ||
+              document.querySelector(".monaco-editor textarea.inputarea")?.value ||
+              Array.from(document.querySelectorAll(".monaco-editor .view-line"))
+                .map((line) => line.textContent)
+                .join("\\n")
+
+            return editorText.includes(expectedText)
+          }
+          """,
+          is_function: true,
+          arg: %{expectedText: expected_text},
+          timeout: timeout_ms
+        )
+    end)
+  end
+end

--- a/test/logflare_web/live_views/query_live_test.exs
+++ b/test/logflare_web/live_views/query_live_test.exs
@@ -38,6 +38,65 @@ defmodule LogflareWeb.QueryLiveTest do
       assert render(view) =~ "some-data"
     end
 
+    test "runs the current form query value", %{conn: conn} do
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
+        assert opts[:body].query =~ "current_timestamp()"
+
+        {:ok, TestUtils.gen_bq_response([%{"ts" => "some-data"}])}
+      end)
+
+      {:ok, view, _html} = live_with_redirect(conn, "/query")
+
+      html =
+        view
+        |> element("form")
+        |> render_submit(%{
+          "action" => "run",
+          "value" => "select current_timestamp() as ts"
+        })
+
+      assert html =~ "Ran query successfully"
+      assert_patch(view) =~ ~r/current_timestamp/
+    end
+
+    test "formats the current form query value", %{conn: conn} do
+      {:ok, view, _html} = live_with_redirect(conn, "/query")
+
+      html =
+        view
+        |> element("form")
+        |> render_submit(%{
+          "action" => "format",
+          "value" => "select current_timestamp() as ts"
+        })
+
+      assert html =~ "select\n  current_timestamp() as ts"
+    end
+
+    test "renders source, endpoint, and alert completions for the editor", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:source, user: user, name: "Completion Source")
+      insert(:endpoint, user: user, name: "Completion Endpoint")
+      insert(:alert, user: user, name: "Completion Alert")
+
+      {:ok, _view, html} = live_with_redirect(conn, "/query")
+
+      completions =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find("#monaco-hook")
+        |> Floki.attribute("data-completions")
+        |> List.first()
+        |> Jason.decode!()
+
+      assert "Completion Source" in completions
+      assert "Completion Endpoint" in completions
+      assert "Completion Alert" in completions
+    end
+
     test "run a very long query", %{conn: conn} do
       GoogleApi.BigQuery.V2.Api.Jobs
       |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->


### PR DESCRIPTION
Replace the LiveMonacoEditor component in QueryLive with our own component wrapper.

Key differences:
* A simpler functional component instead of a live component
* The editor does not push events to LiveView. Instead, it syncs content with a hidden field that uses regular `phx-*` bindings to interact with the server.
* Expanded JavaScript unit testing of the hook. With no need for a live view process, these tests focus on the DOM interaction.  
* Monaco JavaScript dependencies vendored directly into the repository
* Update Monaco editor to latest version 0.55.1



<img width="2888" height="1310" alt="CleanShot 2026-05-29 at 15 03 58@2x" src="https://github.com/user-attachments/assets/25d0e985-6bbf-47ea-a70e-9869156531ac" />


https://github.com/user-attachments/assets/2f412e08-ad24-4bd1-8fd9-89e807033729



## Monaco editor is independent of LiveView

<img width="1157" height="833" alt="Untitled-2026-05-26-0715" src="https://github.com/user-attachments/assets/4813513e-9061-4f20-a939-211282ebcc7c" />

The key difference in this architecture is that the Monaco editor doesn't send update events to the live view process. 

The Monaco editor updates a hidden textarea field and triggers a form-change event to the live view, matching the standard form-backed LiveView setup. The LiveView can update the form, and the Monaco editor will receive changes from the form field itself.

This simplifies the implementation and makes it much easier to test: we can test the Monaco DOM interactions with JS unit tests, and form interactions in LiveViewTest. 

## PR Stack
This is part of a sequence of PRs that are intended to be merged in order:

* #3505  
* #3525
* Isolated changes, can be merged in any order after the above
  * #3528 
  * #3529 
  * #3527 
* #3530  

or search 🔍  [is:pr O11Y-1543 sort:created-asc ](https://github.com/Logflare/logflare/pulls?q=is%3Apr+O11Y-1543+sort%3Acreated-asc)

Part of O11Y-1684 and O11Y-1543