### PR TITLE
fix: stop returning 500 from OTLP ingest when validation rejects events

### DIFF
--- a/lib/logflare/logs/validators/bq_schema_change_validator.ex
+++ b/lib/logflare/logs/validators/bq_schema_change_validator.ex
@@ -106,16 +106,22 @@ defmodule Logflare.Logs.Validators.BigQuerySchemaChange do
 
   defp enforce_type(incoming, key, schema_flat_map) do
     case Map.fetch(schema_flat_map, key) do
-      {:ok, ^incoming} ->
-        :ok
-
-      {:ok, _existing} ->
-        raise("Type error! Field `#{key}` has an unexpected type.")
-
-      :error ->
-        :ok
+      {:ok, expected} -> check_type(incoming, expected, key)
+      :error -> :ok
     end
   end
+
+  defp check_type(same, same, _key), do: :ok
+
+  # BigQuery implicitly coerces INT64 -> FLOAT64 on insert, so integer values
+  # against a FLOAT column are valid even though :integer != :float as Erlang
+  # terms. Mirrors that coercion at validation time. Same for REPEATED FLOAT
+  # columns receiving a list of integers.
+  defp check_type(:integer, :float, _key), do: :ok
+  defp check_type({:list, :integer}, {:list, :float}, _key), do: :ok
+
+  defp check_type(_incoming, _expected, key),
+    do: raise("Type error! Field `#{key}` has an unexpected type.")
 
   defp join_key("", key), do: to_string(key)
   defp join_key(prefix, key), do: prefix <> "." <> to_string(key)

--- a/lib/logflare_grpc/logs/server.ex
+++ b/lib/logflare_grpc/logs/server.ex
@@ -3,6 +3,8 @@ defmodule LogflareGrpc.Logs.Server do
   GRPC Server for the Logflare Otel Logs Service
   """
 
+  require Logger
+
   alias Logflare.Logs.Processor
   alias Logflare.Logs.OtelLog
 
@@ -15,7 +17,20 @@ defmodule LogflareGrpc.Logs.Server do
     http_transcode: true
 
   def export(%ExportLogsServiceRequest{resource_logs: logs}, stream) do
-    Processor.ingest(logs, OtelLog, stream.local.source)
+    source = stream.local.source
+
+    case Processor.ingest(logs, OtelLog, source) do
+      {:error, errors} when is_list(errors) ->
+        Logger.warning("OTLP gRPC ingest rejected #{length(errors)} event(s) at validation",
+          source_token: source.token,
+          source_id: source.id,
+          sample_errors: errors |> Enum.uniq() |> Enum.take(3)
+        )
+
+      _ ->
+        :ok
+    end
+
     GRPC.Server.set_trailers(stream, %{"grpc-status" => "0"})
     %ExportLogsServiceResponse{}
   end

--- a/lib/logflare_grpc/metrics/server.ex
+++ b/lib/logflare_grpc/metrics/server.ex
@@ -3,6 +3,8 @@ defmodule LogflareGrpc.Metrics.Server do
   GRPC Server for the Logflare Metrics Service
   """
 
+  require Logger
+
   alias Logflare.Logs.Processor
   alias Logflare.Logs.OtelMetric
 
@@ -15,7 +17,20 @@ defmodule LogflareGrpc.Metrics.Server do
     http_transcode: true
 
   def export(%ExportMetricsServiceRequest{resource_metrics: metrics}, stream) do
-    Processor.ingest(metrics, OtelMetric, stream.local.source)
+    source = stream.local.source
+
+    case Processor.ingest(metrics, OtelMetric, source) do
+      {:error, errors} when is_list(errors) ->
+        Logger.warning("OTLP gRPC ingest rejected #{length(errors)} event(s) at validation",
+          source_token: source.token,
+          source_id: source.id,
+          sample_errors: errors |> Enum.uniq() |> Enum.take(3)
+        )
+
+      _ ->
+        :ok
+    end
+
     GRPC.Server.set_trailers(stream, %{"grpc-status" => "0"})
     %ExportMetricsServiceResponse{}
   end

--- a/lib/logflare_grpc/trace/server.ex
+++ b/lib/logflare_grpc/trace/server.ex
@@ -3,6 +3,8 @@ defmodule LogflareGrpc.Trace.Server do
   GRPC Server for the Logflare Trace Service
   """
 
+  require Logger
+
   alias Logflare.Logs.Processor
   alias Logflare.Logs.OtelTrace
 
@@ -15,7 +17,20 @@ defmodule LogflareGrpc.Trace.Server do
     http_transcode: true
 
   def export(%ExportTraceServiceRequest{resource_spans: spans}, stream) do
-    Processor.ingest(spans, OtelTrace, stream.local.source)
+    source = stream.local.source
+
+    case Processor.ingest(spans, OtelTrace, source) do
+      {:error, errors} when is_list(errors) ->
+        Logger.warning("OTLP gRPC ingest rejected #{length(errors)} event(s) at validation",
+          source_token: source.token,
+          source_id: source.id,
+          sample_errors: errors |> Enum.uniq() |> Enum.take(3)
+        )
+
+      _ ->
+        :ok
+    end
+
     GRPC.Server.set_trailers(stream, %{"grpc-status" => "0"})
     %ExportTraceServiceResponse{}
   end

--- a/lib/logflare_web/controllers/log_controller.ex
+++ b/lib/logflare_web/controllers/log_controller.ex
@@ -2,6 +2,8 @@ defmodule LogflareWeb.LogController do
   use LogflareWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  require Logger
+
   alias Logflare.Logs
   alias Logflare.Logs.Processor
   alias Opentelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest
@@ -299,8 +301,16 @@ defmodule LogflareWeb.LogController do
       reraise exception, __STACKTRACE__
   end
 
-  defp protobuf_response({:error, _}, conn, _success_response) do
-    send_proto_error(conn, 500, "Internal server error")
+  defp protobuf_response({:error, errors}, conn, success_response) when is_list(errors) do
+    source = conn.assigns.source
+
+    Logger.warning("OTLP ingest rejected #{length(errors)} event(s) at validation",
+      source_token: source.token,
+      source_id: source.id,
+      sample_errors: errors |> Enum.uniq() |> Enum.take(3)
+    )
+
+    send_proto_resp(conn, success_response)
   end
 
   defp protobuf_response(_, conn, success_response) do

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -154,6 +154,33 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
       assert message =~ "items"
       refute message =~ "expected a map"
     end
+
+    test "accepts integer value against :float schema (BQ INT64 -> FLOAT64 coercion)" do
+      source = source_with_flat_map(%{"metadata" => :map, "metadata.value" => :float})
+
+      le = LE.make(%{"metadata" => %{"value" => 42}}, %{source: source})
+
+      assert validate(le, source) == :ok
+    end
+
+    test "accepts list of integers against {:list, :float} schema" do
+      source =
+        source_with_flat_map(%{"metadata" => :map, "metadata.bounds" => {:list, :float}})
+
+      le = LE.make(%{"metadata" => %{"bounds" => [1, 2, 3]}}, %{source: source})
+
+      assert validate(le, source) == :ok
+    end
+
+    test "still rejects :float incoming against :integer schema (no reverse coercion)" do
+      source = source_with_flat_map(%{"metadata" => :map, "metadata.count" => :integer})
+
+      le = LE.make(%{"metadata" => %{"count" => 1.5}}, %{source: source})
+
+      assert {:error, message} = validate(le, source)
+      assert message =~ "Type error"
+      assert message =~ "metadata.count"
+    end
   end
 
   describe "valid?/2" do

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -172,6 +172,26 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
       assert validate(le, source) == :ok
     end
 
+    test "accepts mixed int/float list against {:list, :float} schema" do
+      source =
+        source_with_flat_map(%{"metadata" => :map, "metadata.bounds" => {:list, :float}})
+
+      le = LE.make(%{"metadata" => %{"bounds" => [1, 2.5, 3]}}, %{source: source})
+
+      assert validate(le, source) == :ok
+    end
+
+    test "rejects mixed int/float list against {:list, :integer} schema" do
+      source =
+        source_with_flat_map(%{"metadata" => :map, "metadata.bounds" => {:list, :integer}})
+
+      le = LE.make(%{"metadata" => %{"bounds" => [1, 2.5, 3]}}, %{source: source})
+
+      assert {:error, message} = validate(le, source)
+      assert message =~ "Type error"
+      assert message =~ "metadata.bounds"
+    end
+
     test "still rejects :float incoming against :integer schema (no reverse coercion)" do
       source = source_with_flat_map(%{"metadata" => :map, "metadata.count" => :integer})
 

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -127,6 +127,45 @@ defmodule LogflareWeb.LogControllerTest do
       end)
     end
 
+    for {path, request_module, response_module} <- [
+          {:otel_metrics, ExportMetricsServiceRequest, ExportMetricsServiceResponse},
+          {:otel_traces, ExportTraceServiceRequest, ExportTraceServiceResponse},
+          {:otel_logs, ExportLogsServiceRequest, ExportLogsServiceResponse}
+        ] do
+      test "#{path} returns 200 (not 500) when validation rejects events", %{
+        conn: conn,
+        source: source,
+        user: user
+      } do
+        Mimic.stub(Logflare.Backends, :ingest_logs, fn _batch, _source ->
+          {:error, ["Type error! Field `value` has an unexpected type."]}
+        end)
+
+        body =
+          case unquote(path) do
+            :otel_metrics -> TestUtilsGrpc.random_otel_metrics_request()
+            :otel_traces -> TestUtilsGrpc.random_export_service_request()
+            :otel_logs -> TestUtilsGrpc.random_otel_logs_request()
+          end
+          |> unquote(request_module).encode()
+
+        log =
+          capture_log(fn ->
+            conn =
+              conn
+              |> put_req_header("x-api-key", user.api_key)
+              |> put_req_header("x-source", Atom.to_string(source.token))
+              |> put_req_header("content-type", "application/x-protobuf")
+              |> post(Routes.log_path(conn, unquote(path)), body)
+
+            assert protobuf_response(conn, 200, unquote(response_module)) ==
+                     struct!(unquote(response_module), partial_success: nil)
+          end)
+
+        assert log =~ "OTLP ingest rejected"
+      end
+    end
+
     test ":otel_logs ingestion", %{conn: conn, source: source, user: user} do
       {_this, ref} = expect_webhook_with_body()
 


### PR DESCRIPTION
## Summary

POST `/v1/metrics` (and `/v1/traces`, `/v1/logs`) returns 500 when any event in the batch fails schema validation. Exporters retry on 500, which makes the problem worse. This PR makes OTLP ingest ack invalid events into the rejected stream instead of failing the batch, and relaxes one validator class that was rejecting events BigQuery would have accepted.

## Root cause

`Backends.ingest_logs/3` returns `{:error, errors}` when *any* event in a batch fails validation — `split_valid_events` accumulates the pipeline-error message from each invalid event into a list. The OTEL HTTP controllers piped that through `protobuf_response({:error, _}, ...)` which mapped it to a 500.

This was dormant until the recent `BigQuerySchemaChange.validate` rewrite (62aaa6ef0). Previously the validator silently swallowed mismatches due to a struct-vs-flat-map key bug, so `errors` was effectively always empty and the controller's strict mapping never fired. Once the validator started returning `{:error, _}` correctly, the existing controller behavior turned into customer-visible 5xx storms — especially on metrics, where the OTLP `as_int`/`as_double` oneof routinely drifts numeric fields between integer and float across data points.

Confirmed by tracing: `Processor.ingest` -> `Backends.ingest_logs` (`backends.ex:586` `if Enum.empty?(errors), do: {:ok, count}, else: {:error, errors}`) -> `protobuf_response({:error, _}, ...)` -> 500. A single bad data point in the batch fails the entire POST.

## Changes

**`lib/logflare_web/controllers/log_controller.ex`** — `protobuf_response/3` on `{:error, errors}` now logs a sampled warning and acks with 200 instead of returning 500. The rescue clause for genuine uncaught exceptions still 500s (those are real server errors); only validation rejections are treated as non-fatal. This matches the spirit of the non-OTEL `handle/2` path's intent — invalid events go to the rejected stream, not the response code.

**`lib/logflare_grpc/{metrics,trace,logs}/server.ex`** — same warn-and-ack pattern. Previously these ignored `Processor.ingest`'s return entirely, so silent drops had zero observability. Now there's a sampled warning when validation rejects events, matching the HTTP path.

**`lib/logflare/logs/validators/bq_schema_change_validator.ex`** — relax `enforce_type/3` so `:integer` satisfies a `:float` schema slot (and `{:list, :integer}` satisfies `{:list, :float}`). BigQuery implicitly coerces INT64 -> FLOAT64 on streaming inserts, so events that *would have succeeded* downstream were being rejected at validation. This is the dominant drift axis for OTEL metrics where gauges/sums alternate between whole-number and float observations.

## Coercion audit

Reviewed other type-coercion classes BQ accepts in streaming inserts and found no other safe additions for Logflare's auto-built schemas. INT64 -> TIMESTAMP and STRING -> TIMESTAMP only arise on manually-imported schemas with explicit DATETIME/TIMESTAMP columns, and they involve unit assumptions (nanos vs micros vs seconds) where being permissive risks masking real bad-data signals. INT64 -> FLOAT64 is the one universally-safe coercion and the only one applied here.

## Test plan

- [x] `mix test test/logflare/validator/bq_schema_change_validator_test.exs` (added 3 cases: int->float accepted, list-of-int -> list-of-float accepted, float->int still rejected)
- [x] `mix test test/logflare_web/controllers/log_controller_test.exs` (added regression test asserting all three OTEL endpoints return 200 + log when `Backends.ingest_logs` returns `{:error, _}`)
- [x] `mix test test/logflare_grpc/{metrics,trace,logs}/server_test.exs` (existing tests still pass; no new test added since the gRPC change is structurally identical to the HTTP one already covered)
- [x] `mix lint.diff` (clean — 0 added issues)
- [x] `mix format` (clean on changed files)
- [ ] Manual: POST `/v1/metrics` with payload containing int/float drift against a source with a cached schema, confirm 200 + sampled warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)