### PR TITLE
refactor: Remove key atomization in `SchemaUtils.to_typemap/2`

### DIFF
--- a/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
+++ b/lib/logflare/google/bigquery/schema_utils/schema_utils.ex
@@ -72,7 +72,9 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
 
   def struct_to_map(struct), do: struct |> Poison.encode!() |> Poison.decode!()
 
-  @spec to_typemap(TS.t() | [TFS.t()], from: :bigquery_schema) :: %{required(atom) => map | atom}
+  @spec to_typemap(TS.t() | [TFS.t()], from: :bigquery_schema) :: %{
+          required(String.t()) => map | atom
+        }
   def to_typemap(%TS{fields: fields} = schema, from: :bigquery_schema) when is_map(schema) do
     to_typemap(fields, from: :bigquery_schema)
   end
@@ -80,7 +82,7 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
   def to_typemap(fields, from: :bigquery_schema) when is_list(fields) do
     Map.new(fields, fn
       %TFS{fields: fields, name: n, type: t, mode: mode} ->
-        k = String.to_atom(n)
+        n = to_string(n)
 
         v =
           cond do
@@ -108,7 +110,7 @@ defmodule Logflare.Google.BigQuery.SchemaUtils do
             v
           end
 
-        {k, v}
+        {n, v}
     end)
   end
 

--- a/lib/logflare/source_schemas.ex
+++ b/lib/logflare/source_schemas.ex
@@ -161,22 +161,22 @@ defmodule Logflare.SourceSchemas do
   end
 
   defp typemap_to_json_schema({key, %{fields: fields, t: :map}}) do
-    {Atom.to_string(key), typemap_to_json_schema(fields)}
+    {to_string(key), typemap_to_json_schema(fields)}
   end
 
   defp typemap_to_json_schema({key, %{t: {:list, type}}}) do
-    {Atom.to_string(key), %{"type" => "array", "items" => %{"type" => Atom.to_string(type)}}}
+    {to_string(key), %{"type" => "array", "items" => %{"type" => Atom.to_string(type)}}}
   end
 
   defp typemap_to_json_schema({key, %{t: :datetime}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: :integer}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: :float}}),
-    do: {Atom.to_string(key), %{"type" => "number"}}
+    do: {to_string(key), %{"type" => "number"}}
 
   defp typemap_to_json_schema({key, %{t: type}}),
-    do: {Atom.to_string(key), %{"type" => Atom.to_string(type)}}
+    do: {to_string(key), %{"type" => Atom.to_string(type)}}
 end

--- a/test/logflare/google/bigquery/schema_utils_test.exs
+++ b/test/logflare/google/bigquery/schema_utils_test.exs
@@ -5,6 +5,38 @@ defmodule Logflare.Google.BigQuery.SchemaUtilsTest do
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.TestUtils
 
+  describe "to_typemap/2" do
+    test "BigQuery schema field names are preserved as strings" do
+      assert %{"user" => %{"address" => %{"city" => "Dublin"}}, "tags" => ["a", "b"]}
+             |> TestUtils.build_bq_schema()
+             |> SchemaUtils.to_typemap(from: :bigquery_schema) == %{
+               "event_message" => %{t: :string},
+               "id" => %{t: :string},
+               "tags" => %{t: {:list, :string}},
+               "timestamp" => %{t: :datetime},
+               "user" => %{
+                 fields: %{"address" => %{fields: %{"city" => %{t: :string}}, t: :map}},
+                 t: :map
+               }
+             }
+    end
+
+    test "atom BigQuery schema field names are converted to strings" do
+      assert %{user: %{address: %{city: "Dublin"}}, tags: ["a", "b"]}
+             |> TestUtils.build_bq_schema()
+             |> SchemaUtils.to_typemap(from: :bigquery_schema) == %{
+               "event_message" => %{t: :string},
+               "id" => %{t: :string},
+               "tags" => %{t: {:list, :string}},
+               "timestamp" => %{t: :datetime},
+               "user" => %{
+                 fields: %{"address" => %{fields: %{"city" => %{t: :string}}, t: :map}},
+                 t: :map
+               }
+             }
+    end
+  end
+
   describe "flatten_typemap/1" do
     test "nil and empty map both return empty map" do
       assert SchemaUtils.flatten_typemap(nil) == %{}

--- a/test/profiling/bq_schema_update_internals_bench.history.exs
+++ b/test/profiling/bq_schema_update_internals_bench.history.exs
@@ -1,6 +1,64 @@
 [
   %{
     meta: %{
+      captured_at: "2026-06-02T13:02:23.013962Z",
+      git_sha: "14d2094d0",
+      label: nil,
+      machine: "Apple M2"
+    },
+    results: %{
+      "noop / edge log" => %{
+        ips: 34_180,
+        memory_avg_bytes: 36_576,
+        reductions_avg: 2921,
+        wall_avg_us: 29.26,
+        wall_median_us: 26.58,
+        wall_p99_us: 41.92
+      },
+      "noop / lists" => %{
+        ips: 120_619,
+        memory_avg_bytes: 13_672,
+        reductions_avg: 1331,
+        wall_avg_us: 8.29,
+        wall_median_us: 7.42,
+        wall_p99_us: 22.13
+      },
+      "noop / scalars" => %{
+        ips: 83_208,
+        memory_avg_bytes: 17_640,
+        reductions_avg: 1539,
+        wall_avg_us: 12.02,
+        wall_median_us: 10.54,
+        wall_p99_us: 24.04
+      },
+      "update / edge log" => %{
+        ips: 29_910,
+        memory_avg_bytes: 41_648,
+        reductions_avg: 3204,
+        wall_avg_us: 33.43,
+        wall_median_us: 32.08,
+        wall_p99_us: 46.04
+      },
+      "update / lists" => %{
+        ips: 109_082,
+        memory_avg_bytes: 14_872,
+        reductions_avg: 1427,
+        wall_avg_us: 9.17,
+        wall_median_us: 8.17,
+        wall_p99_us: 21.33
+      },
+      "update / scalars" => %{
+        ips: 75_031,
+        memory_avg_bytes: 18_896,
+        reductions_avg: 1583,
+        wall_avg_us: 13.33,
+        wall_median_us: 11.83,
+        wall_p99_us: 27.42
+      }
+    }
+  },
+  %{
+    meta: %{
       captured_at: "2026-05-29T02:32:23.449726Z",
       git_sha: "7b2d6c250",
       label: "main-plan-update",


### PR DESCRIPTION
Sort of related: https://erlef.org/blog/eef/atom-exhaustion -- but I'll also check if it helps perf.

<details><summary>Perf</summary>

```
Delta vs 7b2d6c250 (main-plan-update):
  noop / edge log
    ips:  10.5K ips → 34.2K ips  (+226.1%)
    wall: 67.13 → 26.58 µs  (-60.4%)
    mem:  37.7 KB → 35.7 KB  (-5.3%)
    reds: 3.5K → 2.9K  (-15.8%)
  noop / lists
    ips:  40.8K ips → 120.6K ips  (+195.4%)
    wall: 11.96 → 7.42 µs  (-38.0%)
    mem:  13.9 KB → 13.4 KB  (-3.7%)
    reds: 1.6K → 1.3K  (-14.1%)
  noop / scalars
    ips:  40.7K ips → 83.2K ips  (+104.3%)
    wall: 16.79 → 10.54 µs  (-37.2%)
    mem:  17.7 KB → 17.2 KB  (-2.9%)
    reds: 1.8K → 1.5K  (-16.4%)
  update / edge log
    ips:  16.2K ips → 29.9K ips  (+84.8%)
    wall: 49.13 → 32.08 µs  (-34.7%)
    mem:  42.3 KB → 40.7 KB  (-3.8%)
    reds: 3.8K → 3.2K  (-15.7%)
  update / lists
    ips:  56.6K ips → 109.1K ips  (+92.8%)
    wall: 12.08 → 8.17 µs  (-32.4%)
    mem:  15.1 KB → 14.5 KB  (-3.6%)
    reds: 1.7K → 1.4K  (-13.8%)
  update / scalars
    ips:  55.5K ips → 75.0K ips  (+35.3%)
    wall: 15.46 → 11.83 µs  (-23.5%)
    mem:  18.9 KB → 18.5 KB  (-2.3%)
    reds: 1.9K → 1.6K  (-16.7%)
```

</details>