### PR TITLE
perf: use Enum.flat_map in OTel log and trace converters

### DIFF
--- a/lib/logflare/logs/otel_log.ex
+++ b/lib/logflare/logs/otel_log.ex
@@ -21,14 +21,12 @@ defmodule Logflare.Logs.OtelLog do
   @behaviour Logflare.Logs.Processor
 
   def handle_batch(resource_logs, _source) when is_list(resource_logs) do
-    resource_logs
-    |> Enum.map(&handle_resource_logs/1)
-    |> List.flatten()
+    Enum.flat_map(resource_logs, &handle_resource_logs/1)
   end
 
   defp handle_resource_logs(%ResourceLogs{resource: resource, scope_logs: scope_logs}) do
     resource = Otel.handle_resource(resource)
-    Enum.map(scope_logs, &handle_scope_logs(&1, resource))
+    Enum.flat_map(scope_logs, &handle_scope_logs(&1, resource))
   end
 
   defp handle_scope_logs(%ScopeLogs{scope: scope, log_records: log_records}, resource) do

--- a/lib/logflare/logs/otel_trace.ex
+++ b/lib/logflare/logs/otel_trace.ex
@@ -14,19 +14,17 @@ defmodule Logflare.Logs.OtelTrace do
   @behaviour Logflare.Logs.Processor
 
   def handle_batch(resource_spans, _source) when is_list(resource_spans) do
-    resource_spans
-    |> Enum.map(&handle_resource_span/1)
-    |> List.flatten()
+    Enum.flat_map(resource_spans, &handle_resource_span/1)
   end
 
   defp handle_resource_span(%ResourceSpans{resource: resource, scope_spans: scope_spans}) do
     resource = Otel.handle_resource(resource)
-    Enum.map(scope_spans, &handle_scope_span(&1, resource))
+    Enum.flat_map(scope_spans, &handle_scope_span(&1, resource))
   end
 
   defp handle_scope_span(%{scope: scope, spans: spans}, resource) do
     scope = Otel.handle_scope(scope)
-    Enum.map(spans, &handle_span(&1, resource, scope))
+    Enum.flat_map(spans, &handle_span(&1, resource, scope))
   end
 
   defp handle_span(span, resource, scope) do

--- a/test/logflare/logs/otel_log_test.exs
+++ b/test/logflare/logs/otel_log_test.exs
@@ -68,5 +68,24 @@ defmodule Logflare.Logs.OtelLogTest do
       assert is_integer(params["timestamp"])
       assert Integer.digits(params["timestamp"]) |> length() == 19
     end
+
+    test "flattens nested resources, scopes, and records into a single list", %{
+      resource_logs: resource_logs,
+      source: source
+    } do
+      [base] = resource_logs
+      [scope_logs] = base.scope_logs
+      [record] = scope_logs.log_records
+
+      duped_scope = %{scope_logs | log_records: [record, record]}
+      duped_resource = %{base | scope_logs: [duped_scope, duped_scope]}
+      nested = [duped_resource, duped_resource]
+
+      batch = OtelLog.handle_batch(nested, source)
+
+      assert length(batch) == 2 * 2 * 2
+      assert Enum.all?(batch, &is_map/1)
+      refute Enum.any?(batch, &is_list/1)
+    end
   end
 end

--- a/test/logflare/logs/otel_trace_test.exs
+++ b/test/logflare/logs/otel_trace_test.exs
@@ -77,6 +77,30 @@ defmodule Logflare.Logs.OtelTraceTest do
       assert Integer.digits(params["end_time"]) |> length() == 19
     end
 
+    test "flattens nested resources, scopes, and spans into a single list", %{
+      resource_spans: resource_spans,
+      source: source
+    } do
+      [base] = resource_spans
+      [scope_spans] = base.scope_spans
+      [span] = scope_spans.spans
+      events_per_span = length(span.events)
+
+      duped_scope = %{scope_spans | spans: [span, span]}
+      duped_resource = %{base | scope_spans: [duped_scope, duped_scope]}
+      nested = [duped_resource, duped_resource]
+
+      batch = OtelTrace.handle_batch(nested, source)
+
+      spans = Enum.filter(batch, fn p -> p["metadata"]["type"] == "span" end)
+      events = Enum.filter(batch, fn p -> p["metadata"]["type"] == "event" end)
+
+      assert length(spans) == 2 * 2 * 2
+      assert length(events) == 2 * 2 * 2 * events_per_span
+      assert length(batch) == length(spans) + length(events)
+      refute Enum.any?(batch, &is_list/1)
+    end
+
     test "correctly parses resource spans", %{
       source: source
     } do


### PR DESCRIPTION
## Summary

- `Logs.OtelLog.handle_batch/2` and `Logs.OtelTrace.handle_batch/2` were walking `resource → scope → record/span` with `Enum.map(...) |> List.flatten()`, allocating deeply nested intermediate lists and then re-walking them to flatten. Replaced with `Enum.flat_map` at each intermediate level, mirroring the pattern already used by `Logs.OtelMetric`.
- Output shape is identical — pure refactor.
- Added unit tests in both `otel_log_test.exs` and `otel_trace_test.exs` that build a 2×2×2 (resources × scopes × records/spans) fixture and assert the returned batch length, guarding the flatten invariant that the existing single-record fixtures could not catch.

## Test plan

- [x] `mix test test/logflare/logs/otel_log_test.exs test/logflare/logs/otel_trace_test.exs` — 11 tests pass (4 OtelLog + 7 OtelTrace, including the 2 new ones)
- [x] New tests pass against the pre-refactor code (baseline) and the post-refactor code (proves equivalence)
- [x] `mix lint.diff` — clean