### PR TITLE
chore: Update ClickHouse docker images to 26.2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,7 +60,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       clickhouse:
-        image: clickhouse/clickhouse-server:25.12
+        image: clickhouse/clickhouse-server:26.2
         ports:
           - 8123:8123
           - 9000:9000

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -81,7 +81,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       clickhouse:
-        image: clickhouse/clickhouse-server:25.12
+        image: clickhouse/clickhouse-server:26.2
         ports:
           - 8123:8123
           - 9000:9000

--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -48,7 +48,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       clickhouse:
-        image: clickhouse/clickhouse-server:25.12
+        image: clickhouse/clickhouse-server:26.2
         ports:
           - 8123:8123
           - 9000:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - 4317:4317 # OTLP gRPC receiver
       - 4318:4318 # OTLP http receiver
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:26.2
     ports:
       - "8123:8123" # HTTP interface
       - "9000:9000" # Native client interface


### PR DESCRIPTION
Updates the `docker-compose.yml` to pull ClickHouse 26.2 along with updates to the various CI yaml files to use the same version.