### PR TITLE
chore: gate BigQuery schema verification behind a config flag (default off)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,11 @@ config :logflare,
 
 config :logflare, Logflare.Alerting, enabled: true
 
+# Schema type verification on the ingest path. The verification logic was
+# silently broken for years (see #3489) and is being re-enabled gradually:
+# disabled by default until validated in production.
+config :logflare, Logflare.Logs.Validators.BigQuerySchemaChange, enabled: false
+
 config :logflare, Logflare.Google, dataset_id_append: "_default"
 
 config :logflare, :postgres_backend_adapter, pool_size: 3

--- a/lib/logflare/logs/validators/bq_schema_change_validator.ex
+++ b/lib/logflare/logs/validators/bq_schema_change_validator.ex
@@ -26,14 +26,21 @@ defmodule Logflare.Logs.Validators.BigQuerySchemaChange do
   def validate(%LE{body: _body}, %Source{validate_schema: false}), do: :ok
 
   def validate(%LE{body: body}, %Source{} = source) do
-    schema_flat_map =
-      case source.id && SourceSchemas.Cache.get_source_schema_by(source_id: source.id) do
-        %_{schema_flat_map: flat_map} when is_map(flat_map) -> flat_map
-        _ -> %{}
-      end
+    if enabled?() do
+      schema_flat_map =
+        case source.id && SourceSchemas.Cache.get_source_schema_by(source_id: source.id) do
+          %_{schema_flat_map: flat_map} when is_map(flat_map) -> flat_map
+          _ -> %{}
+        end
 
-    check_body(body, schema_flat_map)
+      check_body(body, schema_flat_map)
+    else
+      :ok
+    end
   end
+
+  @spec enabled?() :: boolean()
+  def enabled?, do: Application.get_env(:logflare, __MODULE__, [])[:enabled] == true
 
   @spec valid?(map, map) :: boolean
   def valid?(body, schema) do

--- a/lib/logflare/logs/validators/bq_schema_change_validator.ex
+++ b/lib/logflare/logs/validators/bq_schema_change_validator.ex
@@ -40,7 +40,7 @@ defmodule Logflare.Logs.Validators.BigQuerySchemaChange do
   end
 
   @spec enabled?() :: boolean()
-  def enabled?, do: Application.get_env(:logflare, __MODULE__, [])[:enabled] == true
+  defp enabled?, do: Application.get_env(:logflare, __MODULE__, [])[:enabled] == true
 
   @spec valid?(map, map) :: boolean
   def valid?(body, schema) do

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -10,6 +10,7 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
   alias Logflare.Google.BigQuery.SchemaFactory
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.LogEvent, as: LE
+  alias Logflare.Logs.Validators.BigQuerySchemaChange
   alias Logflare.SourceSchemas
   alias Logflare.Sources
   alias Logflare.Sources.Source
@@ -17,6 +18,10 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
 
   describe "validate/2" do
     setup do
+      previous = Application.get_env(:logflare, BigQuerySchemaChange, [])
+      Application.put_env(:logflare, BigQuerySchemaChange, Keyword.put(previous, :enabled, true))
+      on_exit(fn -> Application.put_env(:logflare, BigQuerySchemaChange, previous) end)
+
       Factory.insert(:plan)
       :ok
     end


### PR DESCRIPTION
PR #3489 re-enabled on-ingest BigQuery schema type verification, which had been a silent no-op for years — string-keyed body maps were merged against the `%SourceSchema{}` struct’s atom keys, so type conflicts were never detected and no event was ever rejected. Since we don’t yet know how the now-working verification behaves under production traffic, this disables it by default. We can turn it back on in a later release after more testing.

## What changed

- **`config/config.exs`** — new flag, defaulting off: `config :logflare, Logflare.Logs.Validators.BigQuerySchemaChange, enabled: false`
- **`bq_schema_change_validator.ex`** — `validate/2` gates the real work behind a runtime `enabled?()` check. When off it returns `:ok` immediately. Using a runtime `Application.get_env` (not a compile-time attribute) keeps `check_body/4` and friends reachable, so there are no unused-function / unreachable-clause warnings.
- **validator test** — the `validate/2` block enables the flag in `setup` (with `on_exit` restore) so the dormant-in-prod logic stays fully covered. The `valid?/2` block is unaffected.

## Behavior

When disabled, `validate/2` returns `:ok` for every event — observably identical to the pre-#3489 broken state (zero rejections), but with strictly less per-event work: it skips the schema-cache lookup and the typemap build/flatten/merge the old broken code performed pointlessly on every event.

The flag default lives in `config.exs`, which is compiled into every release (prod, docker, single-tenant), so no operator config is required now or when re-enabling — flipping the line to `true` and rebuilding is enough. The per-source `validate_schema` toggle is untouched and now sits below this global switch.

## Re-enabling later

Set `enabled: true` in config (or enable per-env first to canary in staging/test before prod).

## Verification

- `bq_schema_change_validator_test.exs` — 21 tests, 0 failures
- `log_event_test.exs` + `log_controller_test.exs` — 93 tests / 6 properties, 0 failures
- `mix lint.diff` — no new issues
- `mix test.typings` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)