### PR TITLE
test: silence BigQuery IAM/schema noise from background mocks

### DIFF
--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -500,6 +500,11 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
     test "update_iam_policy/0" do
       pid = self()
+
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       # Mock IAM API calls for listing existing service accounts
       expect(GoogleApi.IAM.V1.Api.Projects, :iam_projects_service_accounts_list, fn
         _conn, "projects/" <> _project_id, _opts ->
@@ -567,6 +572,11 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
     test "update_iam_policy/0 should not update iam policy with service accounts" do
       pid = self()
+
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       reject(&GoogleApi.IAM.V1.Api.Projects.iam_projects_service_accounts_list/3)
       reject(&GoogleApi.IAM.V1.Api.Projects.iam_projects_service_accounts_create/3)
 

--- a/test/logflare/partners_test.exs
+++ b/test/logflare/partners_test.exs
@@ -78,6 +78,10 @@ defmodule Logflare.PartnerTest do
 
   describe "delete_user/2" do
     test "deletes user and removes association with partner" do
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       expect(
         GoogleApi.CloudResourceManager.V1.Api.Projects,
         :cloudresourcemanager_projects_set_iam_policy,

--- a/test/logflare/single_tenant_test.exs
+++ b/test/logflare/single_tenant_test.exs
@@ -1,19 +1,19 @@
 defmodule Logflare.SingleTenantTest do
   @moduledoc false
   use Logflare.DataCase
-  alias Logflare.SingleTenant
-  alias Logflare.Billing
-  alias Logflare.Users
-  alias Logflare.User
-  alias Logflare.Billing.Plan
-  alias Logflare.Sources
-  alias Logflare.Endpoints
-  alias Logflare.Sources.Source.BigQuery.Schema
-  alias Logflare.Sources.Source
+
   alias Logflare.Auth
-  alias Logflare.Backends.Backend
   alias Logflare.Backends
-  alias Logflare.Backends.Adaptor.BigQueryAdaptor
+  alias Logflare.Backends.Backend
+  alias Logflare.Billing
+  alias Logflare.Billing.Plan
+  alias Logflare.Endpoints
+  alias Logflare.SingleTenant
+  alias Logflare.Sources
+  alias Logflare.Sources.Source
+  alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.User
+  alias Logflare.Users
 
   describe "single tenant mode using Big Query" do
     TestUtils.setup_single_tenant()
@@ -85,8 +85,6 @@ defmodule Logflare.SingleTenantTest do
     end
 
     test "Logflare.Application.startup_tasks/0 should insert plan and user" do
-      expect(BigQueryAdaptor, :update_iam_policy, fn -> :ok end)
-
       Logflare.Application.startup_tasks()
 
       assert [_] = Billing.list_plans()

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -19,6 +19,10 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
   end
 
   test "updates correctly" do
+    prev_config = Application.get_env(:logflare, Schema)
+    Application.put_env(:logflare, Schema, updates_per_minute: 1)
+    on_exit(fn -> Application.put_env(:logflare, Schema, prev_config) end)
+
     user = insert(:user)
     source = insert(:source, user: user)
     schema = TestUtils.default_bq_schema()

--- a/test/logflare/users/users_test.exs
+++ b/test/logflare/users/users_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.UsersTest do
   use Logflare.DataCase, async: true
   use ExUnitProperties
 
-  alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.Mailer
   alias Logflare.Sources
   alias Logflare.User
@@ -50,6 +49,10 @@ defmodule Logflare.UsersTest do
     alert = insert(:alert, user: user)
     source = insert(:source, user: user)
     endpoint = insert(:endpoint, user: user)
+
+    stub(BigQueryAdaptor, :update_iam_policy, fn ->
+      Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+    end)
 
     expect(
       GoogleApi.CloudResourceManager.V1.Api.Projects,
@@ -323,8 +326,6 @@ defmodule Logflare.UsersTest do
 
   defp expect_post_insert_user_side_effects do
     expect(Mailer, :deliver, fn _email -> {:ok, %{}} end)
-    expect(BigQueryAdaptor, :update_iam_policy, fn _user -> :ok end)
-    expect(BigQueryAdaptor, :patch_dataset_access, fn _user -> {:ok, :patch_attempted} end)
 
     :ok
   end

--- a/test/logflare_web/controllers/auth/auth_controller_test.exs
+++ b/test/logflare_web/controllers/auth/auth_controller_test.exs
@@ -3,15 +3,10 @@ defmodule LogflareWeb.AuthControllerTest do
   use Mimic
 
   alias Logflare.Auth
-  alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.SingleTenant
 
   setup do
     insert(:plan)
-
-    stub(BigQueryAdaptor, :update_iam_policy, fn -> :ok end)
-    stub(BigQueryAdaptor, :update_iam_policy, fn _user -> :ok end)
-    stub(BigQueryAdaptor, :patch_dataset_access, fn _user -> {:ok, :patch_attempted} end)
 
     :ok
   end

--- a/test/logflare_web/controllers/team_user_controller_test.exs
+++ b/test/logflare_web/controllers/team_user_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule LogflareWeb.TeamUserControllerTest do
   use LogflareWeb.ConnCase
 
+  alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.TeamUsers
 
   setup do
@@ -49,6 +50,10 @@ defmodule LogflareWeb.TeamUserControllerTest do
     team = insert(:team, user: owner)
     team_user = insert(:team_user, team: team)
 
+    stub(BigQueryAdaptor, :update_iam_policy, fn ->
+      Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+    end)
+
     expect(
       GoogleApi.CloudResourceManager.V1.Api.Projects,
       :cloudresourcemanager_projects_set_iam_policy,
@@ -70,6 +75,10 @@ defmodule LogflareWeb.TeamUserControllerTest do
     team = insert(:team, user: owner)
     member_user = insert(:user)
     member_team_user = insert(:team_user, team: team, email: member_user.email)
+
+    stub(BigQueryAdaptor, :update_iam_policy, fn ->
+      Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+    end)
 
     expect(
       GoogleApi.CloudResourceManager.V1.Api.Projects,

--- a/test/logflare_web/controllers/user_controller_test.exs
+++ b/test/logflare_web/controllers/user_controller_test.exs
@@ -3,6 +3,7 @@ defmodule LogflareWeb.UserControllerTest do
 
   import ExUnit.CaptureLog
 
+  alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.Users
 
   setup do
@@ -160,6 +161,10 @@ defmodule LogflareWeb.UserControllerTest do
     end
 
     test "succeeds", %{conn: conn} do
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       expect(
         GoogleApi.CloudResourceManager.V1.Api.Projects,
         :cloudresourcemanager_projects_set_iam_policy,
@@ -276,6 +281,10 @@ defmodule LogflareWeb.UserControllerTest do
     end
 
     test "logs when user account is deleted", %{conn: conn, user: user} do
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       expect(
         GoogleApi.CloudResourceManager.V1.Api.Projects,
         :cloudresourcemanager_projects_set_iam_policy,
@@ -349,6 +358,10 @@ defmodule LogflareWeb.UserControllerTest do
     end
 
     test "bug: should be able to delete a partner-provisioned account", %{conn: conn} do
+      stub(BigQueryAdaptor, :update_iam_policy, fn ->
+        Mimic.call_original(BigQueryAdaptor, :update_iam_policy, [])
+      end)
+
       expect(
         GoogleApi.CloudResourceManager.V1.Api.Projects,
         :cloudresourcemanager_projects_set_iam_policy,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,6 +39,7 @@ defmodule LogflareWeb.ConnCase do
       import Plug.Conn
       import unquote(__MODULE__)
 
+      alias Logflare.Backends.Adaptor.BigQueryAdaptor
       alias Logflare.Backends.Adaptor.ClickHouseAdaptor
       alias Logflare.Backends.IngestEventQueue
       alias Logflare.PubSubRates
@@ -60,6 +61,10 @@ defmodule LogflareWeb.ConnCase do
         stub(Logflare.Cluster.Utils, :rpc_call, fn _node, func ->
           func.()
         end)
+
+        stub(BigQueryAdaptor, :update_iam_policy, fn -> :ok end)
+        stub(BigQueryAdaptor, :update_iam_policy, fn _user -> :ok end)
+        stub(BigQueryAdaptor, :patch_dataset_access, fn _user -> {:ok, :patch_attempted} end)
 
         caches = Logflare.ContextCache.Supervisor.list_caches()
         Enum.each(caches, &Cachex.reset(&1, hooks: [Cachex.Stats]))

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -20,20 +20,23 @@ defmodule Logflare.DataCase do
 
   using do
     quote do
-      alias Logflare.Repo
-      alias Logflare.TestUtils
-      alias Logflare.TestUtilsGrpc
-      alias Logflare.Backends.Adaptor.ClickHouseAdaptor
-      alias Logflare.Backends.IngestEventQueue
-      alias Logflare.PubSubRates
-      require TestUtils
+      use Mimic
+
+      require Logflare.TestUtils
 
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
       import Logflare.DataCase
       import Logflare.Factory
-      use Mimic
+
+      alias Logflare.Backends.Adaptor.BigQueryAdaptor
+      alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+      alias Logflare.Backends.IngestEventQueue
+      alias Logflare.PubSubRates
+      alias Logflare.Repo
+      alias Logflare.TestUtils
+      alias Logflare.TestUtilsGrpc
 
       setup context do
         Mimic.verify_on_exit!(context)
@@ -43,6 +46,10 @@ defmodule Logflare.DataCase do
         stub(Logflare.Cluster.Utils, :rpc_call, fn _node, func ->
           func.()
         end)
+
+        stub(BigQueryAdaptor, :update_iam_policy, fn -> :ok end)
+        stub(BigQueryAdaptor, :update_iam_policy, fn _user -> :ok end)
+        stub(BigQueryAdaptor, :patch_dataset_access, fn _user -> {:ok, :patch_attempted} end)
 
         caches = Logflare.ContextCache.Supervisor.list_caches()
         Enum.each(caches, &Cachex.reset(&1, hooks: [Cachex.Stats]))


### PR DESCRIPTION
Tests were logging (and occasionally failing on) Mimic errors caused by BigQuery calls. By globally stubbing `BigQueryAdaptor` calls to update_iam_policy/0,1 and patch_dataset_access/1 we reduce the noise.