### PR TITLE
chore: update logs playwright tests

### DIFF
--- a/test/e2e/supabase/bin/compose
+++ b/test/e2e/supabase/bin/compose
@@ -7,6 +7,6 @@ BASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)
 source "$BASE_DIR/config.sh"
 
 cd "$BASE_DIR/$SUPABASE_DIR/$SPARSE_PATH"
-docker compose -f docker-compose.yml -f ../../docker-compose.e2e.yml "$@"
+docker compose -f docker-compose.yml -f docker-compose.logs.yml -f ../../docker-compose.e2e.yml "$@"
 cd ../..
 

--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -253,11 +253,15 @@ test.beforeAll(async ({ request, browserName }) => {
   await supabase.functions.invoke(`function_${uniqueId}`)
   await supabase.functions.invoke('hello')
 
-  // Realtime
+  // Realtime: the "Billing metrics" log we assert on is emitted by realtime's
+  // PromEx tenant poller (every ~5s) but ONLY while a tenant has a live
+  // connection. A short-lived 2s subscription almost never overlaps a poll
+  // tick, so it produced zero emissions and the realtime_logs wait below timed
+  // out. Keep the channel subscribed through the ingestion polling instead, so
+  // emissions occur continuously; it's torn down after Promise.all resolves.
   const channel = supabase.channel(`test_${uniqueId}`)
   channel.subscribe()
   await new Promise(r => setTimeout(r, 2000))
-  await supabase.removeChannel(channel)
 
   // PostgRest
   await request.post('/api/platform/pg-meta/default/query?key=table-create-with-columns', { data: {
@@ -282,10 +286,11 @@ test.beforeAll(async ({ request, browserName }) => {
   //
   // - edge_logs / auth_logs / storage_logs poll for uniqueId-tagged events from
   //   the setup above.
-  // - realtime_logs / postgrest_logs poll for periodic infra emissions
-  //   ("Billing" and "Config reloaded"). The corresponding test bodies assert
-  //   on those strings with a 15s expect timeout, but the emissions are
-  //   sparse, so without this wait the tests race the gap between emissions.
+  // - realtime_logs polls for "Billing" emissions, produced every ~5s while the
+  //   channel opened above stays subscribed.
+  // - postgrest_logs polls for the periodic "Config reloaded" infra emission.
+  //   The corresponding test bodies assert on these strings with a 15s expect
+  //   timeout, so without this wait the tests race the gap between emissions.
   //
   // edge functions /home/deno/functions/hello and the cron job reliably hit
   // historical entries via the test bodies' date-windowed searches, so we
@@ -297,6 +302,8 @@ test.beforeAll(async ({ request, browserName }) => {
     waitForLogs(request, 'realtime_logs', 'Billing'),
     waitForLogs(request, 'postgrest_logs', 'Config reloaded'),
   ]);
+
+  await supabase.removeChannel(channel)
 });
 
 test.afterAll(async ({ request }) => {

--- a/test/e2e/supabase/features/schema_modal.spec.ts
+++ b/test/e2e/supabase/features/schema_modal.spec.ts
@@ -39,6 +39,16 @@ test('verifies clipboard functionality for log detail fields (id, status, timest
 
   const expandButton = page.getByRole('button', { name: 'Expand' });
 
+  // Studio renders a dismissible promo notice (e.g. "We've updated our Terms of
+  // Service") pinned to the bottom-right corner that overlaps the Expand button
+  // and intercepts the click. It shows in CI's fresh environment but not always
+  // locally, so close it if present before clicking.
+  const closeBanner = page.getByRole('button', { name: 'Close banner' });
+  if (await closeBanner.isVisible().catch(() => false)) {
+    await closeBanner.click();
+    await expect(closeBanner).toBeHidden();
+  }
+
   await expandButton.click();
 
   const metadata = page.getByText('[ { "request": [ { "headers').first();

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -50,10 +50,20 @@ fi
 cp .env.example .env
 endgroup
 
-log "add logs config..."
-sh .run.sh config add logs
+cd ../..
 
+[ ! "$GITHUB_ACTIONS" = "true" ] && log "Build logflare image..." && compose build analytics
+
+log "Pulling docker images..."
+compose pull
 endgroup
+
+log "Starting Supabase stack (inside docker containers)..."
+if ! compose up -d --wait --wait-timeout 180; then
+  if [ "$GITHUB_ACTIONS" = "true" ]; then
+    endgroup
+    echo -n "::group::"
+  fi
 
   exited=$(compose ps --all --format '{{.Service}} {{.State}}' | awk '$2 == "exited" || $2 == "dead" {print $1}')
 

--- a/test/e2e/supabase/setup-supabase-services.sh
+++ b/test/e2e/supabase/setup-supabase-services.sh
@@ -50,20 +50,10 @@ fi
 cp .env.example .env
 endgroup
 
-cd ../..
+log "add logs config..."
+sh .run.sh config add logs
 
-[ ! "$GITHUB_ACTIONS" = "true" ] && log "Build logflare image..." && compose build analytics
-
-log "Pulling docker images..."
-compose pull
 endgroup
-
-log "Starting Supabase stack (inside docker containers)..."
-if ! compose up -d --wait --wait-timeout 180; then
-  if [ "$GITHUB_ACTIONS" = "true" ]; then
-    endgroup
-    echo -n "::group::"
-  fi
 
   exited=$(compose ps --all --format '{{.Service}} {{.State}}' | awk '$2 == "exited" || $2 == "dead" {print $1}')
 


### PR DESCRIPTION
Updates playwright tests for e2e against supabase self-hosted due to logs components getting split out to separate compose file.

https://github.com/supabase/supabase/blob/master/docker/docker-compose.logs.yml

and also uses run.sh to add the separate override to the config file
https://github.com/supabase/supabase/blob/master/docker/run.sh