### PR TITLE
fix(webhook): restore redacted secret headers on config update

### DIFF
--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   # still set to the sentinel we swap in the existing stored value (dropping it if
   # there is nothing to restore). Headers the user actually changed pass through.
   defp unredact_headers(changeset, existing_config) do
-    with headers when not is_nil(changeset) <- Ecto.Changeset.get_change(changeset, :headers),
+    with headers when not is_nil(headers) <- Ecto.Changeset.get_change(changeset, :headers),
          existing_headers <-
            Map.get(existing_config, :headers) || Map.get(existing_config, "headers") || %{} do
       restored =

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -26,6 +26,9 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   @behaviour Logflare.Backends.Adaptor
 
+  # Sentinel value substituted for secret header values by redact_config/1.
+  @redacted_value "REDACTED"
+
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = args) do
     GenServer.start_link(__MODULE__, args, name: Backends.via_source(source, __MODULE__, backend))
@@ -47,8 +50,43 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   def cast_config(params, existing_config \\ %{}) do
     {existing_config, %{url: :string, headers: :map, http: :string, gzip: :boolean}}
     |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip])
+    |> unredact_headers(existing_config)
     |> Logflare.Utils.default_field_value(:http, "http2")
     |> Logflare.Utils.default_field_value(:gzip, true)
+  end
+
+  # Restores secret header values submitted back as the "REDACTED" sentinel.
+  #
+  # redact_config/1 masks secret headers (e.g. Authorization) when serializing a
+  # backend, so clients never receive the real value. On update the client echoes
+  # the sentinel back for unchanged headers; without this, casting would overwrite
+  # the stored secret with the literal string "REDACTED". For each submitted header
+  # still set to the sentinel we swap in the existing stored value (dropping it if
+  # there is nothing to restore). Headers the user actually changed pass through.
+  defp unredact_headers(changeset, existing_config) do
+    case Ecto.Changeset.get_change(changeset, :headers) do
+      nil ->
+        changeset
+
+      headers ->
+        existing_headers =
+          Map.get(existing_config, :headers) || Map.get(existing_config, "headers") || %{}
+
+        restored =
+          headers
+          |> Enum.reduce(%{}, fn
+            {key, @redacted_value}, acc ->
+              case Map.get(existing_headers, key) do
+                nil -> acc
+                value -> Map.put(acc, key, value)
+              end
+
+            {key, value}, acc ->
+              Map.put(acc, key, value)
+          end)
+
+        Ecto.Changeset.put_change(changeset, :headers, restored)
+    end
   end
 
   @impl Logflare.Backends.Adaptor
@@ -87,7 +125,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   defp redact_header(key, value) do
     if String.downcase(key) == "authorization" do
-      {key, "REDACTED"}
+      {key, @redacted_value}
     else
       {key, value}
     end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -64,28 +64,29 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   # still set to the sentinel we swap in the existing stored value (dropping it if
   # there is nothing to restore). Headers the user actually changed pass through.
   defp unredact_headers(changeset, existing_config) do
-    case Ecto.Changeset.get_change(changeset, :headers) do
-      nil ->
-        changeset
+    with headers when not is_nil(changeset) <- Ecto.Changeset.get_change(changeset, :headers),
+         existing_headers <-
+           Map.get(existing_config, :headers) || Map.get(existing_config, "headers") || %{} do
+      restored =
+        headers
+        |> Enum.reduce(%{}, fn
+          {key, @redacted_value}, acc ->
+            replace_header_with_existing(acc, existing_headers, key)
 
-      headers ->
-        existing_headers =
-          Map.get(existing_config, :headers) || Map.get(existing_config, "headers") || %{}
+          {key, value}, acc ->
+            Map.put(acc, key, value)
+        end)
 
-        restored =
-          headers
-          |> Enum.reduce(%{}, fn
-            {key, @redacted_value}, acc ->
-              case Map.get(existing_headers, key) do
-                nil -> acc
-                value -> Map.put(acc, key, value)
-              end
+      Ecto.Changeset.put_change(changeset, :headers, restored)
+    else
+      _ -> changeset
+    end
+  end
 
-            {key, value}, acc ->
-              Map.put(acc, key, value)
-          end)
-
-        Ecto.Changeset.put_change(changeset, :headers, restored)
+  defp replace_header_with_existing(headers, existing_headers, key) do
+    case Map.get(existing_headers, key) do
+      nil -> headers
+      value -> Map.put(headers, key, value)
     end
   end
 

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -299,7 +299,10 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   describe "cast_config/2 header redaction round-trip" do
     @existing %{
       url: "https://example.com",
-      headers: %{"Authorization" => "Bearer secret-token-123", "Content-Type" => "application/json"}
+      headers: %{
+        "Authorization" => "Bearer secret-token-123",
+        "Content-Type" => "application/json"
+      }
     }
 
     test "restores the stored secret when the REDACTED sentinel is submitted back" do

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -296,6 +296,86 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "cast_config/2 header redaction round-trip" do
+    @existing %{
+      url: "https://example.com",
+      headers: %{"Authorization" => "Bearer secret-token-123", "Content-Type" => "application/json"}
+    }
+
+    test "restores the stored secret when the REDACTED sentinel is submitted back" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"Authorization" => "REDACTED", "Content-Type" => "application/json"}
+      }
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "Authorization" => "Bearer secret-token-123",
+               "Content-Type" => "application/json"
+             }
+    end
+
+    test "preserves the stored secret while adding a new header" do
+      params = %{
+        url: "https://example.com",
+        headers: %{
+          "Authorization" => "REDACTED",
+          "Content-Type" => "application/json",
+          "x-custom" => "new-value"
+        }
+      }
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "Authorization" => "Bearer secret-token-123",
+               "Content-Type" => "application/json",
+               "x-custom" => "new-value"
+             }
+    end
+
+    test "applies a new Authorization value when the user changes it" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"Authorization" => "Bearer new-token-456"}
+      }
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "Authorization" => "Bearer new-token-456"
+             }
+    end
+
+    test "clears headers when an empty map is submitted" do
+      params = %{url: "https://example.com", headers: %{}}
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{}
+    end
+
+    test "keeps existing headers when none are submitted" do
+      params = %{url: "https://example.com"}
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == @existing.headers
+    end
+
+    test "drops a sentinel with no stored value to restore" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"Authorization" => "REDACTED"}
+      }
+
+      changeset = @subject.cast_config(params, %{url: "https://example.com", headers: %{}})
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{}
+    end
+  end
+
   describe "benchmark" do
     @describetag :benchmark
 


### PR DESCRIPTION
## Problem

`redact_config/1` masks secret webhook headers (e.g. `Authorization`) as the literal string `"REDACTED"` when a backend is serialized, so API clients never receive the real value.

On update, the client echoes that sentinel back for unchanged headers. Because `cast_config/2` casts `headers` as a plain `:map`, the whole map is replaced with whatever is submitted — there is no within-map merge and no un-redaction. The result, depending on the client:

- echo `"REDACTED"` back → the stored secret is overwritten with the literal string `"REDACTED"`, silently breaking auth.
- strip the sentinel before sending → the header is dropped entirely.

Either way, editing any other header (or adding a new one) destroys the existing `Authorization` secret on a webhook / log drain destination.

## Fix

`cast_config/2` now un-redacts after casting: for each submitted header still set to the `"REDACTED"` sentinel, the existing stored value is swapped back in (and dropped if there is nothing to restore). This makes redaction symmetric with `redact_config/1`:

- unchanged secret (sentinel submitted) → original value preserved
- new value typed in → applied
- header added → added, secret preserved
- empty map submitted → headers cleared
- headers omitted → existing kept (unchanged)

## Tests

Added a `cast_config/2 header redaction round-trip` describe block covering the cases above.

Note: opened as a draft — I don't have an Elixir toolchain on this machine to run the suite locally, so leaving it for CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)