### PR TITLE
Internalize image mirror workflow

### DIFF
--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -11,8 +11,8 @@ jobs:
     outputs:
       docker_tag: ${{ steps.docker-image.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,22 +40,22 @@ jobs:
       id-token: write
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
       - name: Login to ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: public.ecr.aws
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Mirror image
-        uses: akhilerm/tag-push-action@v2.2.0
+        uses: akhilerm/tag-push-action@f35ff2cb99d407368b5c727adbcc14a2ed81d509 # v2.2.0
         with:
           src: docker.io/${{ needs.retag.outputs.docker_tag }}
           dst: |

--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -34,20 +34,30 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - retag
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v5
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: supabase
-          repositories: cli
-          skip-token-revoke: true
-      - name: Dispatch event to CLI repository
-        uses: peter-evans/repository-dispatch@v2
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: us-east-1
+      - name: Login to ECR
+        uses: docker/login-action@v3
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: supabase/cli
-          event-type: mirror-image
-          client-payload: '{"image":"${{ needs.retag.outputs.docker_tag }}"}'
+          registry: public.ecr.aws
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mirror image
+        uses: akhilerm/tag-push-action@v2.2.0
+        with:
+          src: docker.io/${{ needs.retag.outputs.docker_tag }}
+          dst: |
+            public.ecr.aws/${{ needs.retag.outputs.docker_tag }}
+            ghcr.io/${{ needs.retag.outputs.docker_tag }}


### PR DESCRIPTION
## Summary
- replace the cross-repo repository dispatch to `supabase/cli` with an in-repo mirror job
- mirror `docker.io/supabase/logflare:<version>` to `public.ecr.aws/supabase/logflare:<version>` and `ghcr.io/supabase/logflare:<version>` after retagging
- grant the mirror job `packages: write` and `id-token: write` so it can push GHCR and assume the AWS role

## Notes
This internalizes the image mirror behavior in the service repo, matching the Realtime release pattern. The repository will need a `PROD_AWS_ROLE` Actions secret configured for ECR auth.

## Validation
- parsed `.github/workflows/docker-retag-versioned.yml` as YAML
- ran `git diff --check`
