### PR TITLE
fix(webhook): prevent duplicate transport-owned headers in HTTP backends

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/client.ex
+++ b/lib/logflare/backends/adaptor/http_based/client.ex
@@ -6,6 +6,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
 
   alias Logflare.LogEvent
   alias Logflare.Backends.Adaptor.HttpBased.EgressTracer
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Backends.Adaptor.HttpBased.LogEventTransformer
   alias Logflare.Backends.Backend
   alias Logflare.Sources.Source
@@ -50,6 +51,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
   """
   @spec new(opts()) :: t()
   def new(opts \\ []) do
+    headers = Headers.drop_reserved(opts[:headers] || %{}, reserved_header_names(opts))
+
     Tesla.client(
       [
         Tesla.Middleware.Telemetry,
@@ -57,7 +60,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
         opts[:query] && {Tesla.Middleware.Query, opts[:query]},
         opts[:token] && {Tesla.Middleware.BearerAuth, token: opts[:token]},
         opts[:basic_auth] && {Tesla.Middleware.BasicAuth, opts[:basic_auth]},
-        headers_middleware(opts[:headers]),
+        headers_middleware(headers),
         Keyword.get(opts, :formatter, LogEventTransformer),
         Keyword.get(opts, :json, true) && Tesla.Middleware.JSON,
         opts[:gzip] && {Tesla.Middleware.CompressRequest, format: "gzip"},
@@ -66,6 +69,18 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
       |> Enum.filter(& &1),
       adapter_config(Keyword.get(opts, :http2, true), opts[:pool_name])
     )
+  end
+
+  # Header names the middleware will set, so they must be dropped from
+  # user-supplied headers to avoid duplicates (see `Headers.drop_reserved/2`).
+  # `content-type` is intentionally excluded: the request body is not available at
+  # client-build time, so we cannot tell whether `Tesla.Middleware.JSON` will
+  # encode it and own the header — current adaptors never pass a user content-type.
+  @spec reserved_header_names(opts()) :: [String.t()]
+  defp reserved_header_names(opts) do
+    encoding = if opts[:gzip], do: ["content-encoding"], else: []
+    auth = if opts[:token] || opts[:basic_auth], do: ["authorization"], else: []
+    encoding ++ auth
   end
 
   def headers_middleware(nil), do: nil

--- a/lib/logflare/backends/adaptor/http_based/headers.ex
+++ b/lib/logflare/backends/adaptor/http_based/headers.ex
@@ -1,0 +1,47 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.Headers do
+  @moduledoc """
+  Header normalization shared by the Tesla-based HTTP clients
+  (`Logflare.Backends.Adaptor.WebhookAdaptor.Client` and
+  `Logflare.Backends.Adaptor.HttpBased.Client`).
+
+  Tesla middleware (e.g. `Tesla.Middleware.JSON`, `Tesla.Middleware.CompressRequest`,
+  `Tesla.Middleware.BearerAuth`) set request headers by appending, and
+  `Tesla.put_headers/2` appends rather than replaces. A user-supplied header of the
+  same name therefore survives alongside the middleware's, producing a duplicate that
+  some receivers concatenate into an unparseable value (e.g.
+  "application/jsonapplication/json", yielding an empty parsed body). These helpers
+  ensure such transport-owned headers have a single source.
+  """
+
+  @type header_list :: [{String.t(), term()}]
+  @type headers :: %{optional(String.t()) => term()} | header_list()
+
+  @doc """
+  Drops the client-owned header names from user-supplied headers.
+
+  `reserved` is the set of header names the active middleware will set for the
+  request; dropping them (case-insensitively) leaves the client's value as the only
+  source, so "the server wins" holds by construction rather than by header ordering.
+  Remaining headers keep their original casing and order.
+  """
+  @spec drop_reserved(headers(), [String.t()]) :: header_list()
+  def drop_reserved(headers, reserved) do
+    reserved_set = MapSet.new(reserved, &String.downcase/1)
+
+    for {key, value} <- headers,
+        not MapSet.member?(reserved_set, String.downcase(to_string(key))),
+        do: {key, value}
+  end
+
+  @doc """
+  Canonicalizes user-supplied header names to lower case.
+
+  HTTP header names are case-insensitive, so storing both `Content-Type` and
+  `content-type` represents the same header twice. Downcasing keys collapses such
+  case-variants into a single canonical entry and matches the form used on the wire.
+  """
+  @spec normalize_keys(map()) :: map()
+  def normalize_keys(headers) when is_map(headers) do
+    Map.new(headers, fn {key, value} -> {String.downcase(to_string(key)), value} end)
+  end
+end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -21,6 +21,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   alias Logflare.Backends
   alias Logflare.Backends.Backend
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Utils
   alias Logflare.Utils.SSRF
 
@@ -51,8 +52,20 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     {existing_config, %{url: :string, headers: :map, http: :string, gzip: :boolean}}
     |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip])
     |> unredact_headers(existing_config)
+    |> normalize_header_keys()
     |> Logflare.Utils.default_field_value(:http, "http2")
     |> Logflare.Utils.default_field_value(:gzip, true)
+  end
+
+  # Canonicalizes submitted header names to lower case so the stored config cannot
+  # hold case-variant duplicates of the same header (e.g. "Content-Type" and
+  # "content-type"). Runs after unredact_headers/2 so the REDACTED-sentinel restore
+  # still matches the keys the client echoed back.
+  defp normalize_header_keys(changeset) do
+    case Ecto.Changeset.get_change(changeset, :headers) do
+      nil -> changeset
+      headers -> Ecto.Changeset.put_change(changeset, :headers, Headers.normalize_keys(headers))
+    end
   end
 
   # Restores secret header values submitted back as the "REDACTED" sentinel.
@@ -172,6 +185,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   defmodule Client do
     @moduledoc false
     alias Logflare.Backends.Adaptor.HttpBased.EgressTracer
+    alias Logflare.Backends.Adaptor.HttpBased.Headers
     alias Logflare.Backends.Adaptor.HttpBased.SSRFProtection
     use Tesla, docs: false
 
@@ -194,10 +208,12 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
             {Tesla.Adapter.Finch, name: Logflare.FinchDefaultHttp1, receive_timeout: 5_000}
         end
 
+      reserved = reserved_header_names(opts)
+
       opts =
         opts
         |> Keyword.put_new(:method, :post)
-        |> Keyword.update(:headers, [], &Map.to_list/1)
+        |> Keyword.update(:headers, [], &Headers.drop_reserved(&1, reserved))
 
       Tesla.client(
         [
@@ -212,6 +228,27 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       )
       |> request(opts)
     end
+
+    # Header names the client's own middleware will set for this request, so they
+    # must be dropped from user-supplied headers to avoid duplicates (see
+    # `Headers.drop_reserved/2`). `content-type` is only owned when the JSON
+    # middleware will actually encode the body — for binary payloads (e.g. NDJSON)
+    # it is skipped, and a custom content-type must survive. `content-encoding` is
+    # owned whenever gzip compression is enabled.
+    @spec reserved_header_names(keyword()) :: [String.t()]
+    defp reserved_header_names(opts) do
+      content_type = if json_encodable?(opts[:body]), do: ["content-type"], else: []
+      content_encoding = if opts[:gzip], do: ["content-encoding"], else: []
+      content_type ++ content_encoding
+    end
+
+    # Mirrors Tesla.Middleware.JSON's encodability check: only non-binary,
+    # non-multipart bodies get JSON-encoded (and thus a content-type header) set.
+    @spec json_encodable?(term()) :: boolean()
+    defp json_encodable?(nil), do: false
+    defp json_encodable?(body) when is_binary(body), do: false
+    defp json_encodable?(%Tesla.Multipart{}), do: false
+    defp json_encodable?(_), do: true
   end
 
   # Broadway Pipeline

--- a/test/logflare/backends/adaptor/http_based/headers_test.exs
+++ b/test/logflare/backends/adaptor/http_based/headers_test.exs
@@ -1,0 +1,44 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.HeadersTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
+
+  describe "drop_reserved/2" do
+    test "drops reserved names case-insensitively and keeps the rest" do
+      headers = %{"Content-Type" => "text/plain", "X-Key" => "v"}
+
+      assert Headers.drop_reserved(headers, ["content-type"]) == [{"X-Key", "v"}]
+    end
+
+    test "matches reserved names regardless of the reserved-list casing" do
+      headers = %{"content-encoding" => "identity"}
+
+      assert Headers.drop_reserved(headers, ["Content-Encoding"]) == []
+    end
+
+    test "preserves order and casing of a header list" do
+      headers = [{"X-A", "1"}, {"Content-Type", "x"}, {"X-B", "2"}]
+
+      assert Headers.drop_reserved(headers, ["content-type"]) == [{"X-A", "1"}, {"X-B", "2"}]
+    end
+
+    test "returns everything when nothing is reserved" do
+      headers = [{"X-A", "1"}]
+
+      assert Headers.drop_reserved(headers, []) == [{"X-A", "1"}]
+    end
+  end
+
+  describe "normalize_keys/1" do
+    test "downcases keys" do
+      assert Headers.normalize_keys(%{"Content-Type" => "x", "X-Key" => "v"}) == %{
+               "content-type" => "x",
+               "x-key" => "v"
+             }
+    end
+
+    test "collapses case-variant keys into one entry" do
+      assert Headers.normalize_keys(%{"X-Foo" => "a", "x-foo" => "b"}) |> Map.keys() == ["x-foo"]
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -215,6 +215,108 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "Client.send/1 header handling" do
+    # A literal public IP keeps SSRFProtection happy without a DNS lookup; the
+    # Finch adapter is stubbed so we can inspect the fully-built request headers.
+    @public_url "https://172.32.0.1/"
+
+    defp capture_request_headers do
+      this = self()
+      ref = make_ref()
+
+      Tesla.Adapter.Finch
+      |> expect(:call, fn env, _opts ->
+        send(this, {ref, env.headers})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      ref
+    end
+
+    # Tesla.get_headers/2 matches header names case-sensitively, so it would not
+    # see a user-supplied "Content-Type" alongside the middleware's lowercase
+    # "content-type". Match case-insensitively to detect duplicates.
+    defp header_values(headers, name) do
+      for {key, value} <- headers, String.downcase(key) == name, do: value
+    end
+
+    test "does not emit a duplicate Content-Type when the user supplies one" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"Content-Type" => "application/json"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+    end
+
+    test "drops a user content-type regardless of casing" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"content-TYPE" => "text/plain"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+    end
+
+    test "still sets a single Content-Type when the user supplies none" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"x-key" => "v"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+      assert Tesla.get_header(%Tesla.Env{headers: headers}, "x-key") == "v"
+    end
+
+    test "preserves a user content-type for a binary body the JSON middleware skips" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: ~s({"index":{}}\n{"message":"hello"}\n),
+        headers: %{"Content-Type" => "application/x-ndjson"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/x-ndjson"]
+    end
+
+    test "does not emit a duplicate Content-Encoding when gzip is enabled" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"Content-Encoding" => "identity"},
+        http: "http1",
+        gzip: true
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-encoding") == ["gzip"]
+    end
+  end
+
   describe "SSRF middleware integration" do
     test "Client.send/1 blocks private IPs at request time" do
       # Call Client.send/1 directly without mocking to verify SSRFProtection is
@@ -313,6 +415,8 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
       changeset = @subject.cast_config(params, @existing)
 
+      # Restored headers equal the stored config, so Ecto records no change and the
+      # stored casing passes through unnormalized (normalization acts on changes).
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
                "Authorization" => "Bearer secret-token-123",
                "Content-Type" => "application/json"
@@ -332,8 +436,8 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, @existing)
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
-               "Authorization" => "Bearer secret-token-123",
-               "Content-Type" => "application/json",
+               "authorization" => "Bearer secret-token-123",
+               "content-type" => "application/json",
                "x-custom" => "new-value"
              }
     end
@@ -347,7 +451,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, @existing)
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
-               "Authorization" => "Bearer new-token-456"
+               "authorization" => "Bearer new-token-456"
              }
     end
 
@@ -376,6 +480,33 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, %{url: "https://example.com", headers: %{}})
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{}
+    end
+  end
+
+  describe "cast_config/2 header key normalization" do
+    test "downcases submitted header names" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"Content-Type" => "application/json", "X-Custom" => "v"}
+      }
+
+      changeset = @subject.cast_config(params, %{})
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "content-type" => "application/json",
+               "x-custom" => "v"
+             }
+    end
+
+    test "collapses case-variant duplicates into a single entry" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"X-Foo" => "a", "x-foo" => "b"}
+      }
+
+      changeset = @subject.cast_config(params, %{})
+
+      assert Ecto.Changeset.get_field(changeset, :headers) |> Map.keys() == ["x-foo"]
     end
   end
 


### PR DESCRIPTION
## Problem

When a webhook/log-drain backend is configured with a user-supplied `Content-Type` header, requests went out with **two** `Content-Type` headers (e.g. `application/jsonapplication/json`). `Tesla.Middleware.JSON` appends a `content-type` when it encodes the body, and `Tesla.put_headers/2` appends rather than de-duplicates, so the user's header survived alongside the middleware's. Receivers concatenated the two values, failed to parse the body, and delivered an empty body.

This affects any webhook-derived backend (Datadog, Loki, Elastic, Incident.io, …) where the user sets a header the transport also manages.

## Fix

Give transport-owned headers a single source rather than de-duplicating by header order (which is non-deterministic):

- New `Logflare.Backends.Adaptor.HttpBased.Headers` with `drop_reserved/2` (case-insensitive strip) and `normalize_keys/1`.
- `WebhookAdaptor.Client.send/1` strips the reserved set per request: `content-type` only when the JSON middleware will actually encode the body — binary payloads (e.g. NDJSON) keep a custom content-type — and `content-encoding` when gzip is enabled. `authorization` is intentionally not reserved here, since several adaptors set it directly.
- `HttpBased.Client.new/1` strips `content-encoding` (gzip) and `authorization` (token/basic auth).
- `WebhookAdaptor.cast_config/2` lowercases header keys so stored config cannot hold case-variant duplicates of the same header.

## Tests

- Unit tests for the shared `Headers` module.
- Webhook client tests covering duplicate content-type, casing, a binary body that keeps its custom content-type, and content-encoding under gzip.
- Cast-time header-key normalization tests.

All touched adaptor suites pass; lint and dialyzer are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
