### PR TITLE
fix(http): prevent duplicate transport-owned headers

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/client.ex
+++ b/lib/logflare/backends/adaptor/http_based/client.ex
@@ -6,6 +6,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
 
   alias Logflare.LogEvent
   alias Logflare.Backends.Adaptor.HttpBased.EgressTracer
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Backends.Adaptor.HttpBased.LogEventTransformer
   alias Logflare.Backends.Backend
   alias Logflare.Sources.Source
@@ -50,6 +51,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
   """
   @spec new(opts()) :: t()
   def new(opts \\ []) do
+    headers = Headers.drop_reserved(opts[:headers] || %{}, reserved_header_names(opts))
+
     Tesla.client(
       [
         Tesla.Middleware.Telemetry,
@@ -57,7 +60,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
         opts[:query] && {Tesla.Middleware.Query, opts[:query]},
         opts[:token] && {Tesla.Middleware.BearerAuth, token: opts[:token]},
         opts[:basic_auth] && {Tesla.Middleware.BasicAuth, opts[:basic_auth]},
-        headers_middleware(opts[:headers]),
+        headers_middleware(headers),
         Keyword.get(opts, :formatter, LogEventTransformer),
         Keyword.get(opts, :json, true) && Tesla.Middleware.JSON,
         opts[:gzip] && {Tesla.Middleware.CompressRequest, format: "gzip"},
@@ -66,6 +69,18 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
       |> Enum.filter(& &1),
       adapter_config(Keyword.get(opts, :http2, true), opts[:pool_name])
     )
+  end
+
+  # Header names the middleware will set, so they must be dropped from
+  # user-supplied headers to avoid duplicates (see `Headers.drop_reserved/2`).
+  # `content-type` is intentionally excluded: the request body is not available at
+  # client-build time, so we cannot tell whether `Tesla.Middleware.JSON` will
+  # encode it and own the header — current adaptors never pass a user content-type.
+  @spec reserved_header_names(opts()) :: [String.t()]
+  defp reserved_header_names(opts) do
+    encoding = if opts[:gzip], do: ["content-encoding"], else: []
+    auth = if opts[:token] || opts[:basic_auth], do: ["authorization"], else: []
+    encoding ++ auth
   end
 
   def headers_middleware(nil), do: nil

--- a/lib/logflare/backends/adaptor/http_based/client.ex
+++ b/lib/logflare/backends/adaptor/http_based/client.ex
@@ -73,15 +73,32 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
 
   # Header names the middleware will set, so they must be dropped from
   # user-supplied headers to avoid duplicates (see `Headers.drop_reserved/2`).
-  # `content-type` is intentionally excluded: the request body is not available at
-  # client-build time, so we cannot tell whether `Tesla.Middleware.JSON` will
-  # encode it and own the header — current adaptors never pass a user content-type.
+  #
+  # `content-type` cannot be inferred from `Tesla.Middleware.JSON` here: the request
+  # body is not available at client-build time, so we cannot tell whether the JSON
+  # middleware will encode it and own the header. Instead, a formatter that sets
+  # `content-type` itself (e.g. the protobuf/envelope formatters) declares ownership
+  # via an optional `reserved_headers/0`, and we drop those names regardless of body.
   @spec reserved_header_names(opts()) :: [String.t()]
   defp reserved_header_names(opts) do
     encoding = if opts[:gzip], do: ["content-encoding"], else: []
     auth = if opts[:token] || opts[:basic_auth], do: ["authorization"], else: []
-    encoding ++ auth
+    formatter = formatter_reserved_headers(Keyword.get(opts, :formatter, LogEventTransformer))
+    encoding ++ auth ++ formatter
   end
+
+  @spec formatter_reserved_headers(Tesla.Client.middleware()) :: [String.t()]
+  defp formatter_reserved_headers({module, _opts}), do: formatter_reserved_headers(module)
+
+  defp formatter_reserved_headers(module) when is_atom(module) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :reserved_headers, 0) do
+      module.reserved_headers()
+    else
+      []
+    end
+  end
+
+  defp formatter_reserved_headers(_), do: []
 
   def headers_middleware(nil), do: nil
   def headers_middleware([]), do: nil

--- a/lib/logflare/backends/adaptor/http_based/client.ex
+++ b/lib/logflare/backends/adaptor/http_based/client.ex
@@ -2,6 +2,12 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
   @moduledoc """
   A helper module for building HTTP Based Adaptors based on `Tesla`,
   designed for `Logflare.Backends.Adaptor.HttpBased.Pipeline`.
+
+  A module-based formatter that sets request headers should export
+  `reserved_headers/0` with the header names it owns. `new/1` removes
+  user-supplied copies of those headers case-insensitively before building the
+  client. Adaptors that forward user headers must use this contract or remove
+  their transport-owned headers per request.
   """
 
   alias Logflare.LogEvent
@@ -46,6 +52,9 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
   * `:headers` - Sets headers to be added to all requests.
   * `:basic_auth` - Sets basic authentication credentials.
   * `:formatter` - A custom formatter for the request body. Defaults to `#{inspect(LogEventTransformer)}`.
+    Formatters that set request headers should export `reserved_headers/0` so
+    user-supplied copies are removed. In particular, a formatter that owns
+    `content-type` should return `["content-type"]`.
   * `:pool_name` - An override for the name of the Finch pool to use for requests.
   * `:http2` - Whether to use HTTP/2. Defaults to `true`.
   """

--- a/lib/logflare/backends/adaptor/http_based/headers.ex
+++ b/lib/logflare/backends/adaptor/http_based/headers.ex
@@ -1,0 +1,47 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.Headers do
+  @moduledoc """
+  Header normalization shared by the Tesla-based HTTP clients
+  (`Logflare.Backends.Adaptor.WebhookAdaptor.Client` and
+  `Logflare.Backends.Adaptor.HttpBased.Client`).
+
+  Tesla middleware (e.g. `Tesla.Middleware.JSON`, `Tesla.Middleware.CompressRequest`,
+  `Tesla.Middleware.BearerAuth`) set request headers by appending, and
+  `Tesla.put_headers/2` appends rather than replaces. A user-supplied header of the
+  same name therefore survives alongside the middleware's, producing a duplicate that
+  some receivers concatenate into an unparseable value (e.g.
+  "application/jsonapplication/json", yielding an empty parsed body). These helpers
+  ensure such transport-owned headers have a single source.
+  """
+
+  @type header_list :: [{String.t(), term()}]
+  @type headers :: %{optional(String.t()) => term()} | header_list()
+
+  @doc """
+  Drops the client-owned header names from user-supplied headers.
+
+  `reserved` is the set of header names the active middleware will set for the
+  request; dropping them (case-insensitively) leaves the client's value as the only
+  source, so "the server wins" holds by construction rather than by header ordering.
+  Remaining headers keep their original casing and order.
+  """
+  @spec drop_reserved(headers(), [String.t()]) :: header_list()
+  def drop_reserved(headers, reserved) do
+    reserved_set = MapSet.new(reserved, &String.downcase/1)
+
+    for {key, value} <- headers,
+        not MapSet.member?(reserved_set, String.downcase(to_string(key))),
+        do: {key, value}
+  end
+
+  @doc """
+  Canonicalizes user-supplied header names to lower case.
+
+  HTTP header names are case-insensitive, so storing both `Content-Type` and
+  `content-type` represents the same header twice. Downcasing keys collapses such
+  case-variants into a single canonical entry and matches the form used on the wire.
+  """
+  @spec normalize_keys(map()) :: map()
+  def normalize_keys(headers) when is_map(headers) do
+    Map.new(headers, fn {key, value} -> {String.downcase(to_string(key)), value} end)
+  end
+end

--- a/lib/logflare/backends/adaptor/otlp_adaptor.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor.ex
@@ -5,6 +5,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
 
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter
   alias Logflare.Backends.Backend
   alias Logflare.Utils
@@ -48,9 +49,20 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
 
     {existing_config, types}
     |> Ecto.Changeset.cast(params, Map.keys(types))
+    |> normalize_header_keys()
     |> Utils.default_field_value(:gzip, true)
     |> Utils.default_field_value(:protocol, "http/protobuf")
     |> Utils.default_field_value(:headers, %{})
+  end
+
+  # Canonicalizes submitted header names to lower case so stored config cannot
+  # hold case-variant duplicates of the same header (e.g. "Content-Type" and
+  # "content-type"), matching the form used on the wire.
+  defp normalize_header_keys(changeset) do
+    case Ecto.Changeset.get_change(changeset, :headers) do
+      nil -> changeset
+      headers -> Ecto.Changeset.put_change(changeset, :headers, Headers.normalize_keys(headers))
+    end
   end
 
   @impl Adaptor

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -46,6 +46,14 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
     Tesla.put_header(%{env | headers: headers}, "content-type", @protobuf_content_type)
   end
 
+  @doc """
+  Header names this formatter sets, so `HttpBased.Client` can drop any
+  user-supplied copies and keep itself the single source (see
+  `Logflare.Backends.Adaptor.HttpBased.Headers.drop_reserved/2`).
+  """
+  @spec reserved_headers() :: [String.t()]
+  def reserved_headers, do: ["content-type"]
+
   defp transform_batch(events, source) do
     %ExportLogsServiceRequest{
       resource_logs: [

--- a/lib/logflare/backends/adaptor/sentry_adaptor/envelope_builder.ex
+++ b/lib/logflare/backends/adaptor/sentry_adaptor/envelope_builder.ex
@@ -22,6 +22,14 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptor.EnvelopeBuilder do
     |> Tesla.run(next)
   end
 
+  @doc """
+  Header names this formatter sets, so `HttpBased.Client` can drop any
+  user-supplied copies and keep itself the single source (see
+  `Logflare.Backends.Adaptor.HttpBased.Headers.drop_reserved/2`).
+  """
+  @spec reserved_headers() :: [String.t()]
+  def reserved_headers, do: ["content-type"]
+
   # Based on https://develop.sentry.dev/sdk/data-model/envelopes/
   defp build_envelope(log_events, original_dsn) do
     sentry_logs = Enum.map(log_events, &translate_log_event/1)

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -85,11 +85,17 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     with headers when not is_nil(headers) <- Ecto.Changeset.get_change(changeset, :headers),
          existing_headers <-
            Map.get(existing_config, :headers) || Map.get(existing_config, "headers") || %{} do
+      # Look up existing values by normalized key: header names are case-insensitive,
+      # and stored config predating normalize_keys/1 may use casing that differs from
+      # the (possibly already normalized) submitted key. An exact match would drop the
+      # stored secret in that case.
+      normalized_existing = Headers.normalize_keys(existing_headers)
+
       restored =
         headers
         |> Enum.reduce(%{}, fn
           {key, @redacted_value}, acc ->
-            replace_header_with_existing(acc, existing_headers, key)
+            replace_header_with_existing(acc, normalized_existing, key)
 
           {key, value}, acc ->
             Map.put(acc, key, value)
@@ -101,8 +107,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     end
   end
 
-  defp replace_header_with_existing(headers, existing_headers, key) do
-    case Map.get(existing_headers, key) do
+  defp replace_header_with_existing(headers, normalized_existing, key) do
+    case Map.get(normalized_existing, String.downcase(to_string(key))) do
       nil -> headers
       value -> Map.put(headers, key, value)
     end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -21,6 +21,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   alias Logflare.Backends
   alias Logflare.Backends.Backend
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Utils
   alias Logflare.Utils.SSRF
 
@@ -56,8 +57,20 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     {existing_config, %{url: :string, headers: :map, http: :string, gzip: :boolean}}
     |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip])
     |> unredact_headers(existing_config)
+    |> normalize_header_keys()
     |> Logflare.Utils.default_field_value(:http, "http2")
     |> Logflare.Utils.default_field_value(:gzip, true)
+  end
+
+  # Canonicalizes submitted header names to lower case so the stored config cannot
+  # hold case-variant duplicates of the same header (e.g. "Content-Type" and
+  # "content-type"). Runs after unredact_headers/2 so the REDACTED-sentinel restore
+  # still matches the keys the client echoed back.
+  defp normalize_header_keys(changeset) do
+    case Ecto.Changeset.get_change(changeset, :headers) do
+      nil -> changeset
+      headers -> Ecto.Changeset.put_change(changeset, :headers, Headers.normalize_keys(headers))
+    end
   end
 
   # Restores secret header values submitted back as the "REDACTED" sentinel.
@@ -210,6 +223,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   defmodule Client do
     @moduledoc false
     alias Logflare.Backends.Adaptor.HttpBased.EgressTracer
+    alias Logflare.Backends.Adaptor.HttpBased.Headers
     alias Logflare.Backends.Adaptor.HttpBased.SSRFProtection
     use Tesla, docs: false
 
@@ -232,10 +246,12 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
             {Tesla.Adapter.Finch, name: Logflare.FinchDefaultHttp1, receive_timeout: 5_000}
         end
 
+      reserved = reserved_header_names(opts)
+
       opts =
         opts
         |> Keyword.put_new(:method, :post)
-        |> Keyword.update(:headers, [], &Map.to_list/1)
+        |> Keyword.update(:headers, [], &Headers.drop_reserved(&1, reserved))
 
       Tesla.client(
         [
@@ -250,6 +266,27 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       )
       |> request(opts)
     end
+
+    # Header names the client's own middleware will set for this request, so they
+    # must be dropped from user-supplied headers to avoid duplicates (see
+    # `Headers.drop_reserved/2`). `content-type` is only owned when the JSON
+    # middleware will actually encode the body — for binary payloads (e.g. NDJSON)
+    # it is skipped, and a custom content-type must survive. `content-encoding` is
+    # owned whenever gzip compression is enabled.
+    @spec reserved_header_names(keyword()) :: [String.t()]
+    defp reserved_header_names(opts) do
+      content_type = if json_encodable?(opts[:body]), do: ["content-type"], else: []
+      content_encoding = if opts[:gzip], do: ["content-encoding"], else: []
+      content_type ++ content_encoding
+    end
+
+    # Mirrors Tesla.Middleware.JSON's encodability check: only non-binary,
+    # non-multipart bodies get JSON-encoded (and thus a content-type header) set.
+    @spec json_encodable?(term()) :: boolean()
+    defp json_encodable?(nil), do: false
+    defp json_encodable?(body) when is_binary(body), do: false
+    defp json_encodable?(%Tesla.Multipart{}), do: false
+    defp json_encodable?(_), do: true
   end
 
   # Broadway Pipeline

--- a/test/logflare/backends/adaptor/http_based/client_test.exs
+++ b/test/logflare/backends/adaptor/http_based/client_test.exs
@@ -1,0 +1,38 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.ClientTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends.Adaptor.HttpBased.Client
+  alias Logflare.Tesla.MockAdapter
+
+  defmodule ContentTypeFormatter do
+    @behaviour Tesla.Middleware
+
+    def reserved_headers, do: ["content-type"]
+
+    @impl true
+    def call(env, next, _opts) do
+      env
+      |> Tesla.put_header("content-type", "application/vnd.logflare.test")
+      |> Tesla.run(next)
+    end
+  end
+
+  test "formatter-owned headers replace user-supplied copies" do
+    client =
+      [
+        headers: [{"Content-Type", "text/plain"}, {"X-Custom", "kept"}],
+        formatter: ContentTypeFormatter,
+        json: false
+      ]
+      |> Client.new()
+      |> MockAdapter.replace(fn env -> {:ok, %{env | status: 204}} end)
+
+    assert {:ok, env} = Tesla.post(client, "https://example.com", "payload")
+
+    assert Enum.filter(env.headers, fn {name, _value} ->
+             String.downcase(name) == "content-type"
+           end) == [{"content-type", "application/vnd.logflare.test"}]
+
+    assert {"X-Custom", "kept"} in env.headers
+  end
+end

--- a/test/logflare/backends/adaptor/http_based/headers_test.exs
+++ b/test/logflare/backends/adaptor/http_based/headers_test.exs
@@ -1,0 +1,44 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.HeadersTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
+
+  describe "drop_reserved/2" do
+    test "drops reserved names case-insensitively and keeps the rest" do
+      headers = %{"Content-Type" => "text/plain", "X-Key" => "v"}
+
+      assert Headers.drop_reserved(headers, ["content-type"]) == [{"X-Key", "v"}]
+    end
+
+    test "matches reserved names regardless of the reserved-list casing" do
+      headers = %{"content-encoding" => "identity"}
+
+      assert Headers.drop_reserved(headers, ["Content-Encoding"]) == []
+    end
+
+    test "preserves order and casing of a header list" do
+      headers = [{"X-A", "1"}, {"Content-Type", "x"}, {"X-B", "2"}]
+
+      assert Headers.drop_reserved(headers, ["content-type"]) == [{"X-A", "1"}, {"X-B", "2"}]
+    end
+
+    test "returns everything when nothing is reserved" do
+      headers = [{"X-A", "1"}]
+
+      assert Headers.drop_reserved(headers, []) == [{"X-A", "1"}]
+    end
+  end
+
+  describe "normalize_keys/1" do
+    test "downcases keys" do
+      assert Headers.normalize_keys(%{"Content-Type" => "x", "X-Key" => "v"}) == %{
+               "content-type" => "x",
+               "x-key" => "v"
+             }
+    end
+
+    test "collapses case-variant keys into one entry" do
+      assert Headers.normalize_keys(%{"X-Foo" => "a", "x-foo" => "b"}) |> Map.keys() == ["x-foo"]
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -74,6 +74,19 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       assert %{gzip: false, headers: %{"x-test" => "true"}} =
                Ecto.Changeset.apply_changes(changeset)
     end
+
+    test "downcases submitted header names" do
+      changeset =
+        Adaptor.cast_and_validate_config(@subject, %{
+          @valid_config_input
+          | "headers" => %{"Content-Type" => "application/json", "X-Custom" => "v"}
+        })
+
+      assert changeset.valid?
+
+      assert %{headers: %{"content-type" => "application/json", "x-custom" => "v"}} =
+               Ecto.Changeset.apply_changes(changeset)
+    end
   end
 
   describe "test_connection/1" do

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -282,6 +282,46 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
     end
   end
 
+  describe "reserved headers" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :otlp,
+          sources: [source],
+          config: %{@valid_config | headers: %{"Content-Type" => "application/json"}}
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+      :timer.sleep(250)
+      [source: source]
+    end
+
+    test "drops a user-supplied content-type so the formatter's is the only one", %{
+      source: source
+    } do
+      this = self()
+      ref = make_ref()
+
+      mock_adapter(fn env ->
+        send(this, {ref, env.headers})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      log_event = build(:log_event, source: source, timestamp: System.system_time(:microsecond))
+
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert_receive {^ref, headers}, 5000
+
+      content_types =
+        for {key, value} <- headers, String.downcase(key) == "content-type", do: value
+
+      assert content_types == ["application/x-protobuf"]
+    end
+  end
+
   describe "redact_config/1" do
     test "redacts sensitive headers" do
       config = %{

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -440,6 +440,20 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
              }
     end
 
+    test "restores the stored secret when stored casing differs from the submitted key" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"authorization" => "REDACTED", "x-custom" => "v"}
+      }
+
+      changeset = @subject.cast_config(params, @existing)
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "authorization" => "Bearer secret-token-123",
+               "x-custom" => "v"
+             }
+    end
+
     test "applies a new Authorization value when the user changes it" do
       params = %{
         url: "https://example.com",

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -9,6 +9,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends.Backend
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Backends.SourceSup
+  alias Tesla.Middleware.JSON
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
   setup do
@@ -332,7 +333,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       ]
 
       for {body, expected_encodable} <- cases do
-        {:ok, env} = Tesla.Middleware.JSON.encode(%Tesla.Env{body: body}, [])
+        {:ok, env} = JSON.encode(%Tesla.Env{body: body}, [])
         tesla_set_content_type? = Tesla.get_header(env, "content-type") != nil
 
         assert tesla_set_content_type? == expected_encodable,

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -213,6 +213,108 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "Client.send/1 header handling" do
+    # A literal public IP keeps SSRFProtection happy without a DNS lookup; the
+    # Finch adapter is stubbed so we can inspect the fully-built request headers.
+    @public_url "https://172.32.0.1/"
+
+    defp capture_request_headers do
+      this = self()
+      ref = make_ref()
+
+      Tesla.Adapter.Finch
+      |> expect(:call, fn env, _opts ->
+        send(this, {ref, env.headers})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      ref
+    end
+
+    # Tesla.get_headers/2 matches header names case-sensitively, so it would not
+    # see a user-supplied "Content-Type" alongside the middleware's lowercase
+    # "content-type". Match case-insensitively to detect duplicates.
+    defp header_values(headers, name) do
+      for {key, value} <- headers, String.downcase(key) == name, do: value
+    end
+
+    test "does not emit a duplicate Content-Type when the user supplies one" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"Content-Type" => "application/json"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+    end
+
+    test "drops a user content-type regardless of casing" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"content-TYPE" => "text/plain"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+    end
+
+    test "still sets a single Content-Type when the user supplies none" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"x-key" => "v"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/json"]
+      assert Tesla.get_header(%Tesla.Env{headers: headers}, "x-key") == "v"
+    end
+
+    test "preserves a user content-type for a binary body the JSON middleware skips" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: ~s({"index":{}}\n{"message":"hello"}\n),
+        headers: %{"Content-Type" => "application/x-ndjson"},
+        http: "http1",
+        gzip: false
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-type") == ["application/x-ndjson"]
+    end
+
+    test "does not emit a duplicate Content-Encoding when gzip is enabled" do
+      ref = capture_request_headers()
+
+      @subject.Client.send(
+        url: @public_url,
+        body: [%{"message" => "hello"}],
+        headers: %{"Content-Encoding" => "identity"},
+        http: "http1",
+        gzip: true
+      )
+
+      assert_receive {^ref, headers}, 2000
+      assert header_values(headers, "content-encoding") == ["gzip"]
+    end
+  end
+
   describe "SSRF middleware integration" do
     test "Client.send/1 blocks private IPs at request time" do
       # Call Client.send/1 directly without mocking to verify SSRFProtection is
@@ -311,6 +413,8 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
       changeset = @subject.cast_config(params, @existing)
 
+      # Restored headers equal the stored config, so Ecto records no change and the
+      # stored casing passes through unnormalized (normalization acts on changes).
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
                "Authorization" => "Bearer secret-token-123",
                "Content-Type" => "application/json"
@@ -330,8 +434,8 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, @existing)
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
-               "Authorization" => "Bearer secret-token-123",
-               "Content-Type" => "application/json",
+               "authorization" => "Bearer secret-token-123",
+               "content-type" => "application/json",
                "x-custom" => "new-value"
              }
     end
@@ -345,7 +449,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, @existing)
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{
-               "Authorization" => "Bearer new-token-456"
+               "authorization" => "Bearer new-token-456"
              }
     end
 
@@ -374,6 +478,33 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, %{url: "https://example.com", headers: %{}})
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{}
+    end
+  end
+
+  describe "cast_config/2 header key normalization" do
+    test "downcases submitted header names" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"Content-Type" => "application/json", "X-Custom" => "v"}
+      }
+
+      changeset = @subject.cast_config(params, %{})
+
+      assert Ecto.Changeset.get_field(changeset, :headers) == %{
+               "content-type" => "application/json",
+               "x-custom" => "v"
+             }
+    end
+
+    test "collapses case-variant duplicates into a single entry" do
+      params = %{
+        url: "https://example.com",
+        headers: %{"X-Foo" => "a", "x-foo" => "b"}
+      }
+
+      changeset = @subject.cast_config(params, %{})
+
+      assert Ecto.Changeset.get_field(changeset, :headers) |> Map.keys() == ["x-foo"]
     end
   end
 

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -315,6 +315,32 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "json_encodable?/1 mirrors Tesla.Middleware.JSON" do
+    # Client.reserved_header_names/1 predicts whether the JSON middleware will
+    # encode the body (and thus own content-type) via a private json_encodable?/1
+    # that mirrors Tesla.Middleware.JSON's own encodable? clauses. Tesla exposes no
+    # public predicate, so this pins Tesla's actual encode/2 behavior: if an upgrade
+    # changes which bodies get a content-type, this fails and we update the mirror,
+    # rather than silently regressing the duplicate-header fix.
+    test "encode/2 sets content-type for exactly the bodies the mirror treats as encodable" do
+      cases = [
+        {nil, false},
+        {"already-a-binary", false},
+        {%Tesla.Multipart{}, false},
+        {[%{"message" => "hello"}], true},
+        {%{"message" => "hello"}, true}
+      ]
+
+      for {body, expected_encodable} <- cases do
+        {:ok, env} = Tesla.Middleware.JSON.encode(%Tesla.Env{body: body}, [])
+        tesla_set_content_type? = Tesla.get_header(env, "content-type") != nil
+
+        assert tesla_set_content_type? == expected_encodable,
+               "Tesla content-type behavior for #{inspect(body)} diverged from json_encodable?/1"
+      end
+    end
+  end
+
   describe "SSRF middleware integration" do
     test "Client.send/1 blocks private IPs at request time" do
       # Call Client.send/1 directly without mocking to verify SSRFProtection is


### PR DESCRIPTION
## Problem

When an HTTP backend is configured with a user-supplied `Content-Type` header, requests went out with **two** `Content-Type` headers (e.g. `application/jsonapplication/json`). Tesla middleware set the header by appending, and `Tesla.put_headers/2` appends rather than de-duplicates, so the user's header survived alongside the transport's. Receivers concatenated the two values, failed to parse the body, and delivered an empty body.

Two paths exhibited this:

- **Webhook-derived backends** (Datadog, Loki, Elastic, Incident.io, …): `Tesla.Middleware.JSON` appends `content-type` when it encodes the body.
- **OTLP backends**: `OtlpAdaptor` passes user-configured headers alongside `ProtobufFormatter`, which always sets `content-type` to `application/x-protobuf`. A user-supplied `content-type` survived next to the formatter's.

## Fix

Give transport-owned headers a single source rather than de-duplicating by header order (which is non-deterministic).

Shared plumbing:

- New `Logflare.Backends.Adaptor.HttpBased.Headers` with `drop_reserved/2` (case-insensitive strip) and `normalize_keys/1`.

Webhook path:

- `WebhookAdaptor.Client.send/1` strips the reserved set per request: `content-type` only when the JSON middleware will actually encode the body — binary payloads (e.g. NDJSON) keep a custom content-type — and `content-encoding` when gzip is enabled. `authorization` is intentionally not reserved here, since several adaptors set it directly.
- `WebhookAdaptor.cast_config/2` lowercases header keys so stored config cannot hold case-variant duplicates of the same header.
- The redacted-secret restore path looks up existing values by normalized key, so a stored secret is not dropped when its casing differs from the submitted (possibly normalized) key.

HTTP-based / OTLP path:

- `HttpBased.Client.new/1` strips `content-encoding` (gzip) and `authorization` (token/basic auth).
- The body is not known at client-build time, so the client cannot infer whether the JSON middleware will own `content-type`. Instead, a formatter that sets `content-type` itself declares ownership via an optional `reserved_headers/0`, and the client drops those names from user headers regardless of body. `OtlpAdaptor.ProtobufFormatter` and `SentryAdaptor.EnvelopeBuilder` declare `["content-type"]`.
- `OtlpAdaptor.cast_config/2` lowercases header keys, matching the webhook path.