### PR TITLE
perf: Prefer read replicas on KeyValue Cache reads

### DIFF
--- a/lib/logflare/key_values/cache.ex
+++ b/lib/logflare/key_values/cache.ex
@@ -3,6 +3,7 @@ defmodule Logflare.KeyValues.Cache do
 
   alias Logflare.ContextCache
   alias Logflare.KeyValues
+  alias Logflare.Repo
   alias Logflare.Utils
 
   import Cachex.Spec
@@ -47,7 +48,7 @@ defmodule Logflare.KeyValues.Cache do
     cache_key = {:count, user_id}
 
     Cachex.fetch(__MODULE__, cache_key, fn _key ->
-      {:commit, {:cached, KeyValues.count_key_values(user_id)}}
+      {:commit, {:cached, Repo.apply_with_replica(KeyValues, :count_key_values, [user_id])}}
     end)
     |> case do
       {:commit, {:cached, v}} -> v
@@ -65,7 +66,8 @@ defmodule Logflare.KeyValues.Cache do
     cache_key = {:lookup, [user_id, key, accessor_path]}
 
     Cachex.fetch(__MODULE__, cache_key, fn _key ->
-      {:commit, {:cached, KeyValues.lookup(user_id, key, accessor_path)}}
+      {:commit,
+       {:cached, Repo.apply_with_replica(KeyValues, :lookup, [user_id, key, accessor_path])}}
     end)
     |> case do
       {:commit, {:cached, v}} -> v

--- a/lib/logflare/key_values/cache_warmer.ex
+++ b/lib/logflare/key_values/cache_warmer.ex
@@ -15,10 +15,10 @@ defmodule Logflare.KeyValues.CacheWarmer do
   @impl true
   def execute(_state) do
     if initialized?() do
-      warm_recent()
+      Repo.apply_with_replica(__MODULE__, :warm_recent, [])
     else
       try do
-        __MODULE__.warm_full()
+        Repo.apply_with_replica(__MODULE__, :warm_full, [])
         :persistent_term.put(@pt_key, true)
       rescue
         e ->

--- a/lib/logflare/repo.ex
+++ b/lib/logflare/repo.ex
@@ -34,22 +34,41 @@ defmodule Logflare.Repo do
   @doc """
   Applies the given MFA using a randomly selected repo (primary or read replica).
   """
+  @spec apply_with_random_repo(module(), atom(), list()) :: term()
   def apply_with_random_repo(m, f, a) do
-    choices = [__MODULE__ | Application.fetch_env!(:logflare, :read_replicas)]
+    [__MODULE__ | Application.fetch_env!(:logflare, :read_replicas)]
+    |> Enum.random()
+    |> resolve_repo()
+    |> with_dynamic_repo(fn -> apply(m, f, a) end)
+  end
 
-    new_repo =
-      case Enum.random(choices) do
-        repo when is_atom(repo) -> repo
-        hostname when is_binary(hostname) -> Replicas.lookup!(hostname)
-      end
+  @doc """
+  Applies the given MFA on a randomly selected read replica when replicas are
+  configured. Always uses a replica when any are set; falls back to the primary
+  repo only when no replicas are configured.
+  """
+  @spec apply_with_replica(module(), atom(), list()) :: term()
+  def apply_with_replica(m, f, a) do
+    :logflare
+    |> Application.fetch_env!(:read_replicas)
+    |> pick_replica_repo()
+    |> with_dynamic_repo(fn -> apply(m, f, a) end)
+  end
 
-    prev_repo = Logflare.Repo.get_dynamic_repo()
-    Logflare.Repo.put_dynamic_repo(new_repo)
+  defp pick_replica_repo([]), do: __MODULE__
+  defp pick_replica_repo(replicas), do: replicas |> Enum.random() |> resolve_repo()
+
+  defp resolve_repo(repo) when is_atom(repo), do: repo
+  defp resolve_repo(hostname) when is_binary(hostname), do: Replicas.lookup!(hostname)
+
+  defp with_dynamic_repo(new_repo, fun) do
+    prev_repo = get_dynamic_repo()
+    put_dynamic_repo(new_repo)
 
     try do
-      apply(m, f, a)
+      fun.()
     after
-      Logflare.Repo.put_dynamic_repo(prev_repo)
+      put_dynamic_repo(prev_repo)
     end
   end
 end

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -64,4 +64,35 @@ defmodule Logflare.RepoTest do
       assert Repo.get_dynamic_repo() == Repo
     end
   end
+
+  describe "apply_with_replica/3" do
+    test "uses default repo when replicas list is empty" do
+      start_read_replicas(_no_replicas = [])
+
+      assert Repo.get_dynamic_repo() == Repo
+      assert Repo.apply_with_replica(Repo, :get_dynamic_repo, []) == Repo
+    end
+
+    test "always uses a replica when replicas are configured" do
+      start_read_replicas(["127.0.0.1", "::1"])
+
+      repos = for _ <- 1..30, do: Repo.apply_with_replica(Repo, :get_dynamic_repo, [])
+
+      refute Enum.any?(repos, fn repo -> repo == Repo end),
+             "expected every call to use a replica, never the primary"
+
+      # verify that after the call, we're back to the default repo
+      assert Repo.get_dynamic_repo() == Repo
+    end
+
+    test "reverts repo if function raises" do
+      start_read_replicas(["127.0.0.1"])
+
+      assert_raise ArithmeticError, fn ->
+        Repo.apply_with_replica(Kernel, :/, [1, 0])
+      end
+
+      assert Repo.get_dynamic_repo() == Repo
+    end
+  end
 end


### PR DESCRIPTION
* Adds a new helper in Repo, allowing to prefer read replicas for DB fetches
* Introduces the helpers to KyValue.Cache warming, count and lookup calls