### PR TITLE
O11Y-982: Move non-interactive BigQuery queries to batch jobs

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -463,6 +463,7 @@ defmodule Logflare.Alerting do
              labels: %{
                "alert_id" => alert_query.id
              },
+             job_priority: :batch,
              query_type: :alerts
            ) do
       {:ok, result}

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -576,6 +576,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       location: user.bigquery_dataset_location,
       use_query_cache: Keyword.get(opts, :use_query_cache, true),
       dryRun: Keyword.get(opts, :dry_run, false),
+      job_priority: Keyword.get(opts, :job_priority),
       query_type: query_type,
       reservation:
         case Keyword.get(opts, :reservation) do

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -68,9 +68,12 @@ defmodule Logflare.BqRepo do
       |> DeepMerge.deep_merge(override)
       |> then(fn map -> struct(QueryRequest, map) end)
 
+    start_time = System.monotonic_time()
+
     result =
       GenUtils.get_conn({:query, user})
       |> execute_query_request(project_id, query_request, opts)
+      |> tap(&emit_query_telemetry(&1, opts, start_time))
       |> warn_if_cost_above_limit(query_request.labels, user)
 
     with {:ok, response} <- result do
@@ -80,7 +83,7 @@ defmodule Logflare.BqRepo do
 
   defp execute_query_request(conn, project_id, query_request, opts) do
     if batch_query?(opts) do
-      execute_batch_query(conn, project_id, query_request)
+      execute_batch_query(conn, project_id, query_request, opts)
     else
       conn
       |> Api.Jobs.bigquery_jobs_query(project_id, body: query_request)
@@ -88,25 +91,30 @@ defmodule Logflare.BqRepo do
     end
   end
 
-  defp execute_batch_query(conn, project_id, %QueryRequest{} = query_request) do
+  defp execute_batch_query(conn, project_id, %QueryRequest{} = query_request, opts) do
     job = build_batch_query_job(query_request)
+    start_time = System.monotonic_time()
 
-    with {:ok, %Job{jobReference: job_reference}} <-
-           Api.Jobs.bigquery_jobs_insert(conn, project_id, body: job) do
-      poll_batch_query_results(
-        conn,
-        project_id,
-        job_reference,
-        query_request,
-        batch_poll_deadline()
-      )
-    else
-      {:ok, %Job{} = job} ->
-        {:error, job}
+    {result, poll_count} =
+      case Api.Jobs.bigquery_jobs_insert(conn, project_id, body: job) do
+        {:ok, %Job{jobReference: job_reference}} ->
+          poll_batch_query_results(
+            conn,
+            project_id,
+            job_reference,
+            query_request,
+            batch_poll_deadline()
+          )
 
-      result ->
-        GenUtils.maybe_parse_google_api_result(result)
-    end
+        {:ok, %Job{} = job} ->
+          {{:error, job}, 0}
+
+        result ->
+          {GenUtils.maybe_parse_google_api_result(result), 0}
+      end
+
+    emit_batch_query_telemetry(result, opts, poll_count, start_time)
+    result
   end
 
   defp build_batch_query_job(%QueryRequest{} = query_request) do
@@ -129,15 +137,14 @@ defmodule Logflare.BqRepo do
   end
 
   defp poll_batch_query_results(_conn, _project_id, nil, _query_request, _deadline) do
-    {:error, :missing_job_reference}
+    {{:error, :missing_job_reference}, 0}
   end
 
   defp poll_batch_query_results(_conn, _project_id, %{jobId: nil}, _query_request, _deadline) do
-    {:error, :missing_job_id}
+    {{:error, :missing_job_id}, 0}
   end
 
   defp poll_batch_query_results(conn, project_id, job_reference, query_request, deadline) do
-    job_id = job_reference.jobId
     location = job_reference.location || query_request.location
 
     opts =
@@ -148,23 +155,46 @@ defmodule Logflare.BqRepo do
       ]
       |> Enum.reject(fn {_key, value} -> is_nil(value) end)
 
+    poll_batch_query_results(conn, project_id, job_reference, query_request, deadline, opts, 0)
+  end
+
+  defp poll_batch_query_results(
+         conn,
+         project_id,
+         job_reference,
+         query_request,
+         deadline,
+         opts,
+         count
+       ) do
+    job_id = job_reference.jobId
+
     case Api.Jobs.bigquery_jobs_get_query_results(conn, project_id, job_id, opts) do
       {:ok, %{jobComplete: true, errors: [_ | _] = errors}} ->
-        {:error, errors}
+        {{:error, errors}, count + 1}
 
       {:ok, %{jobComplete: true} = response} ->
-        {:ok, response}
+        {{:ok, response}, count + 1}
 
       {:ok, %{jobComplete: false}} ->
         if System.monotonic_time(:millisecond) >= deadline do
-          {:error, :timeout}
+          {{:error, :timeout}, count + 1}
         else
           Process.sleep(@batch_poll_interval)
-          poll_batch_query_results(conn, project_id, job_reference, query_request, deadline)
+
+          poll_batch_query_results(
+            conn,
+            project_id,
+            job_reference,
+            query_request,
+            deadline,
+            opts,
+            count + 1
+          )
         end
 
       result ->
-        GenUtils.maybe_parse_google_api_result(result)
+        {GenUtils.maybe_parse_google_api_result(result), count + 1}
     end
   end
 
@@ -175,6 +205,51 @@ defmodule Logflare.BqRepo do
   defp batch_query?(opts) do
     Keyword.get(opts, :job_priority) in [:batch, "BATCH"]
   end
+
+  defp emit_query_telemetry(result, opts, start_time) do
+    metadata = query_telemetry_metadata(result, opts)
+
+    measurements = %{
+      count: 1,
+      duration: System.monotonic_time() - start_time,
+      total_bytes_processed: total_bytes_processed(result)
+    }
+
+    :telemetry.execute([:logflare, :bigquery, :query], measurements, metadata)
+  end
+
+  defp emit_batch_query_telemetry(result, opts, poll_count, start_time) do
+    metadata = query_telemetry_metadata(result, opts)
+
+    measurements = %{
+      count: 1,
+      duration: System.monotonic_time() - start_time,
+      poll_count: poll_count
+    }
+
+    :telemetry.execute([:logflare, :bigquery, :batch_query], measurements, metadata)
+  end
+
+  defp query_telemetry_metadata(result, opts) do
+    %{
+      job_priority: query_job_priority(opts),
+      query_type: Keyword.get(opts, :query_type),
+      status: query_status(result)
+    }
+  end
+
+  defp query_job_priority(opts) do
+    if batch_query?(opts), do: :batch, else: :interactive
+  end
+
+  defp query_status({:ok, _response}), do: :ok
+  defp query_status({:error, :timeout}), do: :timeout
+  defp query_status({:error, _reason}), do: :error
+
+  defp total_bytes_processed({:ok, %{totalBytesProcessed: value}}),
+    do: maybe_string_to_integer_or_zero(value)
+
+  defp total_bytes_processed(_result), do: 0
 
   defp transform_response(response) do
     response

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -1,6 +1,9 @@
 defmodule Logflare.BqRepo do
   @moduledoc false
   alias GoogleApi.BigQuery.V2.Api
+  alias GoogleApi.BigQuery.V2.Model.Job
+  alias GoogleApi.BigQuery.V2.Model.JobConfiguration
+  alias GoogleApi.BigQuery.V2.Model.JobConfigurationQuery
   alias GoogleApi.BigQuery.V2.Model.QueryRequest
   alias Logflare.Google.BigQuery.GenUtils
   alias Logflare.Google.BigQuery.SchemaUtils
@@ -11,6 +14,7 @@ defmodule Logflare.BqRepo do
   require Logger
 
   @query_request_timeout 25_000
+  @batch_poll_interval 500
   @use_query_cache true
   @type results :: %{
           :rows => nil | [term()],
@@ -18,7 +22,7 @@ defmodule Logflare.BqRepo do
           optional(atom()) => any()
         }
   @type query_result ::
-          {:ok, results()} | {:error, Tesla.Env.t()}
+          {:ok, results()} | {:error, any()}
 
   @spec query_with_sql_and_params(
           Logflare.User.t(),
@@ -66,13 +70,110 @@ defmodule Logflare.BqRepo do
 
     result =
       GenUtils.get_conn({:query, user})
-      |> Api.Jobs.bigquery_jobs_query(project_id, body: query_request)
-      |> GenUtils.maybe_parse_google_api_result()
+      |> execute_query_request(project_id, query_request, opts)
       |> warn_if_cost_above_limit(query_request.labels, user)
 
     with {:ok, response} <- result do
       {:ok, transform_response(response)}
     end
+  end
+
+  defp execute_query_request(conn, project_id, query_request, opts) do
+    if batch_query?(opts) do
+      execute_batch_query(conn, project_id, query_request)
+    else
+      conn
+      |> Api.Jobs.bigquery_jobs_query(project_id, body: query_request)
+      |> GenUtils.maybe_parse_google_api_result()
+    end
+  end
+
+  defp execute_batch_query(conn, project_id, %QueryRequest{} = query_request) do
+    job = build_batch_query_job(query_request)
+
+    with {:ok, %Job{jobReference: job_reference}} <-
+           Api.Jobs.bigquery_jobs_insert(conn, project_id, body: job) do
+      poll_batch_query_results(
+        conn,
+        project_id,
+        job_reference,
+        query_request,
+        batch_poll_deadline()
+      )
+    else
+      {:ok, %Job{} = job} ->
+        {:error, job}
+
+      result ->
+        GenUtils.maybe_parse_google_api_result(result)
+    end
+  end
+
+  defp build_batch_query_job(%QueryRequest{} = query_request) do
+    query_config =
+      query_request
+      |> Map.from_struct()
+      |> Map.put(:priority, "BATCH")
+      |> then(&struct(JobConfigurationQuery, &1))
+
+    configuration =
+      %JobConfiguration{
+        dryRun: query_request.dryRun,
+        jobTimeoutMs: query_request.jobTimeoutMs,
+        labels: query_request.labels,
+        query: query_config,
+        reservation: query_request.reservation
+      }
+
+    %Job{configuration: configuration}
+  end
+
+  defp poll_batch_query_results(_conn, _project_id, nil, _query_request, _deadline) do
+    {:error, :missing_job_reference}
+  end
+
+  defp poll_batch_query_results(_conn, _project_id, %{jobId: nil}, _query_request, _deadline) do
+    {:error, :missing_job_id}
+  end
+
+  defp poll_batch_query_results(conn, project_id, job_reference, query_request, deadline) do
+    job_id = job_reference.jobId
+    location = job_reference.location || query_request.location
+
+    opts =
+      [
+        location: location,
+        maxResults: query_request.maxResults,
+        timeoutMs: @query_request_timeout
+      ]
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+
+    case Api.Jobs.bigquery_jobs_get_query_results(conn, project_id, job_id, opts) do
+      {:ok, %{jobComplete: true, errors: [_ | _] = errors}} ->
+        {:error, errors}
+
+      {:ok, %{jobComplete: true} = response} ->
+        {:ok, response}
+
+      {:ok, %{jobComplete: false}} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, :timeout}
+        else
+          Process.sleep(@batch_poll_interval)
+          poll_batch_query_results(conn, project_id, job_reference, query_request, deadline)
+        end
+
+      result ->
+        GenUtils.maybe_parse_google_api_result(result)
+    end
+  end
+
+  defp batch_poll_deadline do
+    System.monotonic_time(:millisecond) + @query_request_timeout
+  end
+
+  defp batch_query?(opts) do
+    Keyword.get(opts, :job_priority) in [:batch, "BATCH"]
   end
 
   defp transform_response(response) do

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -103,7 +103,7 @@ defmodule Logflare.BqRepo do
             project_id,
             job_reference,
             query_request,
-            batch_poll_deadline()
+            batch_poll_deadline(query_request)
           )
 
         {:ok, %Job{} = job} ->
@@ -151,7 +151,7 @@ defmodule Logflare.BqRepo do
       [
         location: location,
         maxResults: query_request.maxResults,
-        timeoutMs: @query_request_timeout
+        timeoutMs: query_request.timeoutMs || @query_request_timeout
       ]
       |> Enum.reject(fn {_key, value} -> is_nil(value) end)
 
@@ -178,6 +178,7 @@ defmodule Logflare.BqRepo do
 
       {:ok, %{jobComplete: false}} ->
         if System.monotonic_time(:millisecond) >= deadline do
+          cancel_batch_query(conn, project_id, job_id, opts)
           {{:error, :timeout}, count + 1}
         else
           Process.sleep(@batch_poll_interval)
@@ -198,8 +199,17 @@ defmodule Logflare.BqRepo do
     end
   end
 
-  defp batch_poll_deadline do
-    System.monotonic_time(:millisecond) + @query_request_timeout
+  defp cancel_batch_query(conn, project_id, job_id, opts) do
+    cancel_opts = Keyword.take(opts, [:location])
+
+    case Api.Jobs.bigquery_jobs_cancel(conn, project_id, job_id, cancel_opts) do
+      {:ok, _response} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp batch_poll_deadline(%QueryRequest{timeoutMs: timeout_ms}) do
+    System.monotonic_time(:millisecond) + (timeout_ms || @query_request_timeout)
   end
 
   defp batch_query?(opts) do

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -14,6 +14,7 @@ defmodule Logflare.BqRepo do
   require Logger
 
   @query_request_timeout 25_000
+  @background_query_timeout 120_000
   @batch_poll_interval 500
   @use_query_cache true
   @type results :: %{
@@ -51,6 +52,8 @@ defmodule Logflare.BqRepo do
 
     override = Map.put(override, :labels, cleaned_labels)
     use_query_cache = Keyword.get(opts, :use_query_cache, @use_query_cache)
+    timeout_ms = query_timeout_ms(opts)
+    job_timeout_ms = query_job_timeout_ms(opts, timeout_ms)
 
     query_request =
       %{
@@ -61,8 +64,8 @@ defmodule Logflare.BqRepo do
         queryParameters: params,
         jobCreationMode: "JOB_CREATION_OPTIONAL",
         dryRun: false,
-        jobTimeoutMs: @query_request_timeout,
-        timeoutMs: @query_request_timeout,
+        jobTimeoutMs: job_timeout_ms,
+        timeoutMs: timeout_ms,
         labels: cleaned_labels
       }
       |> DeepMerge.deep_merge(override)
@@ -215,6 +218,22 @@ defmodule Logflare.BqRepo do
   defp batch_query?(opts) do
     Keyword.get(opts, :job_priority) in [:batch, "BATCH"]
   end
+
+  defp query_timeout_ms(opts) do
+    Keyword.get(opts, :timeoutMs) ||
+      Keyword.get(opts, :timeout_ms) ||
+      query_type_timeout_ms(Keyword.get(opts, :query_type))
+  end
+
+  defp query_job_timeout_ms(opts, timeout_ms) do
+    Keyword.get(opts, :jobTimeoutMs) || Keyword.get(opts, :job_timeout_ms) || timeout_ms
+  end
+
+  defp query_type_timeout_ms(query_type) when query_type in [:alerts, :endpoint_refresh] do
+    @background_query_timeout
+  end
+
+  defp query_type_timeout_ms(_query_type), do: @query_request_timeout
 
   defp emit_query_telemetry(result, opts, start_time) do
     metadata = query_telemetry_metadata(result, opts)

--- a/lib/logflare/ecto/bigquery/bq_repo.ex
+++ b/lib/logflare/ecto/bigquery/bq_repo.ex
@@ -109,9 +109,6 @@ defmodule Logflare.BqRepo do
             batch_poll_deadline(query_request)
           )
 
-        {:ok, %Job{} = job} ->
-          {{:error, job}, 0}
-
         result ->
           {GenUtils.maybe_parse_google_api_result(result), 0}
       end

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -139,7 +139,12 @@ defmodule Logflare.Endpoints.ResultsCache do
   end
 
   def handle_info(:refresh, state) do
-    refresh_state = %{state | opts: Keyword.put(state.opts, :job_priority, :batch)}
+    opts =
+      state.opts
+      |> Keyword.put(:job_priority, :batch)
+      |> Keyword.put(:query_type, :endpoint_refresh)
+
+    refresh_state = %{state | opts: opts}
     task = Tasks.async(__MODULE__, :do_query, [refresh_state])
     tasks = [task | state.query_tasks]
 

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -139,7 +139,8 @@ defmodule Logflare.Endpoints.ResultsCache do
   end
 
   def handle_info(:refresh, state) do
-    task = Tasks.async(__MODULE__, :do_query, [state])
+    refresh_state = %{state | opts: Keyword.put(state.opts, :job_priority, :batch)}
+    task = Tasks.async(__MODULE__, :do_query, [refresh_state])
     tasks = [task | state.query_tasks]
 
     running = Enum.count(tasks)

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -82,8 +82,17 @@ defmodule Logflare.Logs.SearchOperations do
     BigQueryAdaptor.execute_query(
       {bq_project_id, dataset_id, so.source.user.id},
       so.query,
-      query_type: :search
+      bigquery_query_opts(so)
     )
+  end
+
+  @spec bigquery_query_opts(SO.t()) :: Keyword.t()
+  defp bigquery_query_opts(%SO{tailing?: true, tailing_initial?: false}) do
+    [query_type: :search, job_priority: :batch]
+  end
+
+  defp bigquery_query_opts(%SO{}) do
+    [query_type: :search]
   end
 
   @spec put_sql_string(SO.t(), QueryResult.t()) :: SO.t()

--- a/lib/logflare/logs/search_query_executor.ex
+++ b/lib/logflare/logs/search_query_executor.ex
@@ -192,9 +192,11 @@ defmodule Logflare.Logs.SearchQueryExecutor do
     so = SO.new(params)
 
     Tasks.async(fn ->
-      so
-      |> Search.search()
-      |> case do
+      start_time = System.monotonic_time()
+      result = Search.search(so)
+      emit_search_query_telemetry(result, so, :events, start_time)
+
+      case result do
         {:ok, result} ->
           {:search_result, lv_pid, result}
 
@@ -208,9 +210,11 @@ defmodule Logflare.Logs.SearchQueryExecutor do
     so = SO.new(params)
 
     Tasks.async(fn ->
-      so
-      |> Search.aggs()
-      |> case do
+      start_time = System.monotonic_time()
+      result = Search.aggs(so)
+      emit_search_query_telemetry(result, so, :aggregates, start_time)
+
+      case result do
         {:ok, result} ->
           {:search_result, lv_pid, result}
 
@@ -219,4 +223,24 @@ defmodule Logflare.Logs.SearchQueryExecutor do
       end
     end)
   end
+
+  defp emit_search_query_telemetry(result, %SO{} = so, type, start_time) do
+    :telemetry.execute(
+      [:logflare, :logs, :search, :query],
+      %{
+        count: 1,
+        duration: System.monotonic_time() - start_time
+      },
+      %{
+        backend_type: so.backend_type,
+        status: search_query_status(result),
+        tailing: so.tailing?,
+        tailing_initial: so.tailing_initial?,
+        type: type
+      }
+    )
+  end
+
+  defp search_query_status({:ok, _result}), do: :ok
+  defp search_query_status({:error, _result}), do: :error
 end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -219,6 +219,52 @@ defmodule Logflare.Telemetry do
         unit: {:native, :millisecond},
         description: "Endpoint query execution duration"
       ),
+      counter("logflare.bigquery.query.count",
+        event_name: [:logflare, :bigquery, :query],
+        measurement: :count,
+        tags: [:job_priority, :query_type, :status],
+        description: "BigQuery query count by priority, query type, and status"
+      ),
+      distribution("logflare.bigquery.query.duration",
+        event_name: [:logflare, :bigquery, :query],
+        tags: [:job_priority, :query_type, :status],
+        unit: {:native, :millisecond},
+        description: "BigQuery query duration by priority, query type, and status"
+      ),
+      sum("logflare.bigquery.query.total_bytes_processed",
+        event_name: [:logflare, :bigquery, :query],
+        tags: [:job_priority, :query_type, :status],
+        description: "BigQuery bytes processed by priority, query type, and status"
+      ),
+      counter("logflare.bigquery.batch_query.count",
+        event_name: [:logflare, :bigquery, :batch_query],
+        measurement: :count,
+        tags: [:query_type, :status],
+        description: "BigQuery batch query count by query type and status"
+      ),
+      distribution("logflare.bigquery.batch_query.duration",
+        event_name: [:logflare, :bigquery, :batch_query],
+        tags: [:query_type, :status],
+        unit: {:native, :millisecond},
+        description: "BigQuery batch query submit-to-completion duration"
+      ),
+      distribution("logflare.bigquery.batch_query.poll_count",
+        event_name: [:logflare, :bigquery, :batch_query],
+        tags: [:query_type, :status],
+        description: "Number of getQueryResults polls needed per BigQuery batch query"
+      ),
+      counter("logflare.logs.search.query.count",
+        event_name: [:logflare, :logs, :search, :query],
+        measurement: :count,
+        tags: [:backend_type, :status, :tailing, :tailing_initial, :type],
+        description: "Search query count by backend and tailing state"
+      ),
+      distribution("logflare.logs.search.query.duration",
+        event_name: [:logflare, :logs, :search, :query],
+        tags: [:backend_type, :status, :tailing, :tailing_initial, :type],
+        unit: {:native, :millisecond},
+        description: "Search query duration by backend and tailing state"
+      ),
       last_value("logflare.system.top_processes.message_queue.length",
         tags: [:name],
         description: "Top processes by message queue length"

--- a/test/logflare/alerting/alert_worker_test.exs
+++ b/test/logflare/alerting/alert_worker_test.exs
@@ -15,10 +15,7 @@ defmodule Logflare.Alerting.AlertWorkerTest do
   test "perform/1 executes alert and sends notifications on results", %{user: user} do
     alert = insert(:alert, user: user)
 
-    GoogleApi.BigQuery.V2.Api.Jobs
-    |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
-      {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
-    end)
+    expect_batch_query([%{"testing" => "123"}])
 
     Logflare.Backends.Adaptor.WebhookAdaptor.Client
     |> expect(:send, fn opts ->
@@ -38,15 +35,32 @@ defmodule Logflare.Alerting.AlertWorkerTest do
   test "perform/1 returns :ok when no query results", %{user: user} do
     alert = insert(:alert, user: user)
 
-    GoogleApi.BigQuery.V2.Api.Jobs
-    |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
-      {:ok, TestUtils.gen_bq_response([])}
-    end)
+    expect_batch_query([])
 
     assert :ok = perform_job(AlertWorker, %{alert_query_id: alert.id})
   end
 
   test "perform/1 returns :error when alert not found (deleted)" do
     assert {:error, :not_found} = perform_job(AlertWorker, %{alert_query_id: -1})
+  end
+
+  defp expect_batch_query(results) do
+    response =
+      TestUtils.gen_bq_response(results)
+      |> Map.from_struct()
+      |> then(&struct(GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse, &1))
+
+    GoogleApi.BigQuery.V2.Api.Jobs
+    |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.query.priority == "BATCH"
+
+      {:ok,
+       %GoogleApi.BigQuery.V2.Model.Job{
+         jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{jobId: "batch_job_id"}
+       }}
+    end)
+    |> expect(:bigquery_jobs_get_query_results, 1, fn _conn, _proj_id, "batch_job_id", _opts ->
+      {:ok, response}
+    end)
   end
 end

--- a/test/logflare/alerting/alert_worker_test.exs
+++ b/test/logflare/alerting/alert_worker_test.exs
@@ -52,6 +52,7 @@ defmodule Logflare.Alerting.AlertWorkerTest do
 
     GoogleApi.BigQuery.V2.Api.Jobs
     |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.jobTimeoutMs == 120_000
       assert opts[:body].configuration.query.priority == "BATCH"
 
       {:ok,

--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -410,6 +410,7 @@ defmodule Logflare.AlertingTest do
 
     GoogleApi.BigQuery.V2.Api.Jobs
     |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.jobTimeoutMs == 120_000
       assert opts[:body].configuration.query.priority == "BATCH"
       assert_fun.(opts)
 

--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -231,9 +231,8 @@ defmodule Logflare.AlertingTest do
 
       pid = self()
 
-      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
-        send(pid, {:reservation, opts[:body].reservation})
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      expect_batch_query(fn opts ->
+        send(pid, {:reservation, opts[:body].configuration.reservation})
       end)
 
       assert {:ok,
@@ -254,9 +253,8 @@ defmodule Logflare.AlertingTest do
       alert_query = insert(:alert, user: user) |> Logflare.Repo.preload([:user])
       pid = self()
 
-      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
-        send(pid, {:reservation, opts[:body].reservation})
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      expect_batch_query(fn opts ->
+        send(pid, {:reservation, opts[:body].configuration.reservation})
       end)
 
       assert {:ok,
@@ -271,9 +269,8 @@ defmodule Logflare.AlertingTest do
     end
 
     test "execute_alert_query with query composition" do
-      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
-        assert opts[:body].query =~ "current_datetime"
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      expect_batch_query(fn opts ->
+        assert opts[:body].configuration.query.query =~ "current_datetime"
       end)
 
       user = insert(:user)
@@ -295,10 +292,7 @@ defmodule Logflare.AlertingTest do
     test "run_alert_query/1 runs the entire alert", %{user: user} do
       alert_query = insert(:alert, user: user)
 
-      GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
-      end)
+      expect_batch_query()
 
       Logflare.Backends.Adaptor.WebhookAdaptor.Client
       |> expect(:send, fn opts ->
@@ -324,10 +318,7 @@ defmodule Logflare.AlertingTest do
     test "run_alert_query/1 does not send notifications if no results", %{user: user} do
       alert_query = insert(:alert, user: user)
 
-      GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
-        {:ok, TestUtils.gen_bq_response([])}
-      end)
+      expect_batch_query(fn _opts -> :ok end, [])
 
       Logflare.Backends.Adaptor.WebhookAdaptor.Client
       |> reject(:send, 1)
@@ -363,9 +354,8 @@ defmodule Logflare.AlertingTest do
       {:ok, _updated_alert} =
         Alerting.update_alert_query(alert, %{query: "select 'unique_fresh_data_check'"})
 
-      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
-        assert opts[:body].query =~ "unique_fresh_data_check"
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      expect_batch_query(fn opts ->
+        assert opts[:body].configuration.query.query =~ "unique_fresh_data_check"
       end)
 
       assert {:ok,
@@ -390,7 +380,7 @@ defmodule Logflare.AlertingTest do
 
       # expect NO BQ execution
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> reject(:bigquery_jobs_query, 3)
+      |> reject(:bigquery_jobs_insert, 3)
 
       # verify job is NOT run by stale run_alert
       assert {:error, :not_found} = Alerting.run_alert(alert.id, :scheduled)
@@ -410,6 +400,31 @@ defmodule Logflare.AlertingTest do
       alert = insert(:alert, user: user)
       assert [] = Alerting.list_execution_history(alert.id)
     end
+  end
+
+  defp expect_batch_query(assert_fun \\ fn _opts -> :ok end, results \\ [%{"testing" => "123"}]) do
+    response =
+      TestUtils.gen_bq_response(results)
+      |> Map.from_struct()
+      |> then(&struct(GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse, &1))
+
+    GoogleApi.BigQuery.V2.Api.Jobs
+    |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.query.priority == "BATCH"
+      assert_fun.(opts)
+
+      {:ok,
+       %GoogleApi.BigQuery.V2.Model.Job{
+         jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{
+           jobId: "batch_job_id",
+           location: "US",
+           projectId: "project-id"
+         }
+       }}
+    end)
+    |> expect(:bigquery_jobs_get_query_results, 1, fn _conn, _proj_id, "batch_job_id", _opts ->
+      {:ok, response}
+    end)
   end
 
   defp insert_oban_job(alert_query, attrs) do

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -189,9 +189,22 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
           name: "test name"
         )
 
+      response =
+        TestUtils.gen_bq_response([%{"testing" => "123"}])
+        |> Map.from_struct()
+        |> then(&struct(GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse, &1))
+
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
-        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+        assert opts[:body].configuration.query.priority == "BATCH"
+
+        {:ok,
+         %GoogleApi.BigQuery.V2.Model.Job{
+           jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{jobId: "batch_job_id"}
+         }}
+      end)
+      |> expect(:bigquery_jobs_get_query_results, 1, fn _conn, _proj_id, "batch_job_id", _opts ->
+        {:ok, response}
       end)
 
       @client

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -196,6 +196,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
 
       GoogleApi.BigQuery.V2.Api.Jobs
       |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+        assert opts[:body].configuration.jobTimeoutMs == 120_000
         assert opts[:body].configuration.query.priority == "BATCH"
 
         {:ok,

--- a/test/logflare/bigquery/bq_repo_test.exs
+++ b/test/logflare/bigquery/bq_repo_test.exs
@@ -60,6 +60,43 @@ defmodule Logflare.BigQuery.BqRepoTest do
       }
     end
 
+    test "query_with_sql_and_params applies query-type timeout defaults and overrides", %{
+      user: user
+    } do
+      pid = self()
+
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_query, 4, fn _conn, _project_id, opts ->
+        send(pid, {:timeouts, opts[:body].jobTimeoutMs, opts[:body].timeoutMs})
+        {:ok, TestUtils.gen_bq_response([])}
+      end)
+
+      assert {:ok, _response} =
+               BqRepo.query_with_sql_and_params(user, "project-id", "select 1", [])
+
+      assert {:ok, _response} =
+               BqRepo.query_with_sql_and_params(user, "project-id", "select 1", [],
+                 query_type: :alerts
+               )
+
+      assert {:ok, _response} =
+               BqRepo.query_with_sql_and_params(user, "project-id", "select 1", [],
+                 query_type: :endpoint_refresh
+               )
+
+      assert {:ok, _response} =
+               BqRepo.query_with_sql_and_params(user, "project-id", "select 1", [],
+                 query_type: :alerts,
+                 timeoutMs: 10_000,
+                 jobTimeoutMs: 11_000
+               )
+
+      assert_received {:timeouts, 25_000, 25_000}
+      assert_received {:timeouts, 120_000, 120_000}
+      assert_received {:timeouts, 120_000, 120_000}
+      assert_received {:timeouts, 11_000, 10_000}
+    end
+
     test "query_with_sql_and_params executes batch jobs when requested", %{user: user} do
       pid = self()
 

--- a/test/logflare/bigquery/bq_repo_test.exs
+++ b/test/logflare/bigquery/bq_repo_test.exs
@@ -106,6 +106,41 @@ defmodule Logflare.BigQuery.BqRepoTest do
       assert_received {:poll_opts, [location: "US", timeoutMs: 25_000]}
     end
 
+    test "query_with_sql_and_params cancels batch jobs on poll timeout", %{user: user} do
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_insert, 1, fn _conn, "project-id", _opts ->
+        {:ok,
+         %GoogleApi.BigQuery.V2.Model.Job{
+           jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{
+             jobId: "batch_job_id",
+             location: "US",
+             projectId: "project-id"
+           }
+         }}
+      end)
+      |> expect(:bigquery_jobs_get_query_results, 1, fn _conn,
+                                                        "project-id",
+                                                        "batch_job_id",
+                                                        opts ->
+        assert opts == [location: "US", timeoutMs: 0]
+        {:ok, %GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse{jobComplete: false}}
+      end)
+      |> expect(:bigquery_jobs_cancel, 1, fn _conn, "project-id", "batch_job_id", opts ->
+        assert opts == [location: "US"]
+        {:ok, %GoogleApi.BigQuery.V2.Model.JobCancelResponse{}}
+      end)
+
+      assert {:error, :timeout} =
+               BqRepo.query_with_sql_and_params(
+                 user,
+                 "project-id",
+                 "select timestamp from `my_table`",
+                 [],
+                 job_priority: :batch,
+                 timeoutMs: 0
+               )
+    end
+
     test "query_with_sql_and_params respects use_query_cache option", %{user: user} do
       pid = self()
 

--- a/test/logflare/bigquery/bq_repo_test.exs
+++ b/test/logflare/bigquery/bq_repo_test.exs
@@ -60,6 +60,52 @@ defmodule Logflare.BigQuery.BqRepoTest do
       }
     end
 
+    test "query_with_sql_and_params executes batch jobs when requested", %{user: user} do
+      pid = self()
+
+      response =
+        TestUtils.gen_bq_response([])
+        |> Map.from_struct()
+        |> then(&struct(GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse, &1))
+
+      GoogleApi.BigQuery.V2.Api.Jobs
+      |> expect(:bigquery_jobs_insert, 1, fn _conn, "project-id", opts ->
+        send(pid, {:priority, opts[:body].configuration.query.priority})
+        send(pid, {:labels, opts[:body].configuration.labels})
+
+        {:ok,
+         %GoogleApi.BigQuery.V2.Model.Job{
+           jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{
+             jobId: "batch_job_id",
+             location: "US",
+             projectId: "project-id"
+           }
+         }}
+      end)
+      |> expect(:bigquery_jobs_get_query_results, 1, fn _conn,
+                                                        "project-id",
+                                                        "batch_job_id",
+                                                        opts ->
+        send(pid, {:poll_opts, opts})
+        {:ok, response}
+      end)
+
+      assert {:ok, response} =
+               BqRepo.query_with_sql_and_params(
+                 user,
+                 "project-id",
+                 "select timestamp from `my_table`",
+                 [],
+                 job_priority: :batch,
+                 labels: %{"custom_tag" => "custom_value"}
+               )
+
+      assert response.rows == []
+      assert_received {:priority, "BATCH"}
+      assert_received {:labels, %{"managed_by" => "logflare", "custom_tag" => "custom_value"}}
+      assert_received {:poll_opts, [location: "US", timeoutMs: 25_000]}
+    end
+
     test "query_with_sql_and_params respects use_query_cache option", %{user: user} do
       pid = self()
 

--- a/test/logflare/endpoints/cache_test.exs
+++ b/test/logflare/endpoints/cache_test.exs
@@ -83,6 +83,7 @@ defmodule Logflare.Endpoints.CacheTest do
       # Mock error response for refresh task
       GoogleApi.BigQuery.V2.Api.Jobs
       |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+        assert opts[:body].configuration.jobTimeoutMs == 120_000
         assert opts[:body].configuration.query.priority == "BATCH"
         {:error, :timeout}
       end)
@@ -253,6 +254,7 @@ defmodule Logflare.Endpoints.CacheTest do
 
     GoogleApi.BigQuery.V2.Api.Jobs
     |> stub(:bigquery_jobs_insert, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.jobTimeoutMs == 120_000
       assert opts[:body].configuration.query.priority == "BATCH"
 
       {:ok,

--- a/test/logflare/endpoints/cache_test.exs
+++ b/test/logflare/endpoints/cache_test.exs
@@ -11,6 +11,8 @@ defmodule Logflare.Endpoints.CacheTest do
         insert(:endpoint,
           user: user,
           query: "select current_datetime() as testing",
+          source_mapping: %{},
+          parsed_labels: %{},
           proactive_requerying_seconds: 1,
           cache_duration_seconds: 3
         )
@@ -19,6 +21,8 @@ defmodule Logflare.Endpoints.CacheTest do
         insert(:endpoint,
           user: user,
           query: "select current_datetime() as testing",
+          source_mapping: %{},
+          parsed_labels: %{},
           proactive_requerying_seconds: 3,
           cache_duration_seconds: 1
         )
@@ -78,7 +82,8 @@ defmodule Logflare.Endpoints.CacheTest do
 
       # Mock error response for refresh task
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_insert, 1, fn _conn, _proj_id, opts ->
+        assert opts[:body].configuration.query.priority == "BATCH"
         {:error, :timeout}
       end)
 
@@ -105,13 +110,12 @@ defmodule Logflare.Endpoints.CacheTest do
     test "cache dies after cache_duration_seconds", %{endpoint: endpoint} do
       test_response = [%{"testing" => "123"}]
 
-      expected_calls =
-        (endpoint.cache_duration_seconds / endpoint.proactive_requerying_seconds) |> floor()
-
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, expected_calls, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
+
+      stub_batch_query(test_response)
 
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
       assert Process.alive?(cache_pid)
@@ -132,9 +136,11 @@ defmodule Logflare.Endpoints.CacheTest do
       test_response = [%{"testing" => "123"}]
 
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 2, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
+
+      stub_batch_query(test_response)
 
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
       assert Process.alive?(cache_pid)
@@ -173,10 +179,7 @@ defmodule Logflare.Endpoints.CacheTest do
 
       test_response = [%{"testing" => "456"}]
 
-      GoogleApi.BigQuery.V2.Api.Jobs
-      |> stub(:bigquery_jobs_query, fn _conn, _proj_id, _opts ->
-        {:ok, TestUtils.gen_bq_response(test_response)}
-      end)
+      stub_batch_query(test_response)
 
       # After proactive_requerying_seconds, should return updated response
       Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
@@ -192,15 +195,19 @@ defmodule Logflare.Endpoints.CacheTest do
         insert(:endpoint,
           user: user,
           query: "select current_datetime() as testing",
+          source_mapping: %{},
+          parsed_labels: %{},
           proactive_requerying_seconds: 1,
           cache_duration_seconds: 3
         )
 
-      # perform at most 2 queries before dying
+      # perform initial interactive query, then proactive refreshes as batch jobs
       GoogleApi.BigQuery.V2.Api.Jobs
-      |> expect(:bigquery_jobs_query, 3, fn _conn, _proj_id, _opts ->
+      |> expect(:bigquery_jobs_query, 1, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response()}
       end)
+
+      stub_batch_query([%{}])
 
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
       assert Process.alive?(cache_pid)
@@ -229,11 +236,32 @@ defmodule Logflare.Endpoints.CacheTest do
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       reject(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 4)
+      reject(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_insert, 3)
 
       # should be larger than :proactive_requerying_seconds
       Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
 
       refute Process.alive?(cache_pid)
     end
+  end
+
+  defp stub_batch_query(results) do
+    response =
+      TestUtils.gen_bq_response(results)
+      |> Map.from_struct()
+      |> then(&struct(GoogleApi.BigQuery.V2.Model.GetQueryResultsResponse, &1))
+
+    GoogleApi.BigQuery.V2.Api.Jobs
+    |> stub(:bigquery_jobs_insert, fn _conn, _proj_id, opts ->
+      assert opts[:body].configuration.query.priority == "BATCH"
+
+      {:ok,
+       %GoogleApi.BigQuery.V2.Model.Job{
+         jobReference: %GoogleApi.BigQuery.V2.Model.JobReference{jobId: "batch_job_id"}
+       }}
+    end)
+    |> stub(:bigquery_jobs_get_query_results, fn _conn, _proj_id, "batch_job_id", _opts ->
+      {:ok, response}
+    end)
   end
 end

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -871,6 +871,26 @@ defmodule Logflare.Logs.SearchOperationsTest do
       [base_so: base_so]
     end
 
+    test "do_query/1 batches BigQuery tailing polling queries", %{base_so: base_so} do
+      Mimic.stub(BigQueryAdaptor, :execute_query, fn _identifier, _query, opts ->
+        Process.put(:captured_opts, opts)
+
+        {:ok,
+         QueryResult.new([%{"test" => "data"}], %{
+           total_rows: 1,
+           query_string: "",
+           bq_params: []
+         })}
+      end)
+
+      base_so
+      |> Map.put(:tailing?, true)
+      |> Map.put(:tailing_initial?, false)
+      |> SearchOperations.do_query()
+
+      assert Process.get(:captured_opts) == [query_type: :search, job_priority: :batch]
+    end
+
     test "do_query/1 uses BigQuery backend adaptor", %{base_so: base_so} do
       Mimic.stub(BigQueryAdaptor, :execute_query, fn identifier, query, opts ->
         Process.put(:captured_identifier, identifier)


### PR DESCRIPTION
## Summary
- add a BigQuery batch query path using jobs.insert with BATCH priority and polling via getQueryResults
- route alert queries, endpoint proactive refreshes, and UI tailing polling queries through batch jobs
- update tests for batch execution paths

## Tests
- mix test test/logflare/bigquery/bq_repo_test.exs test/logflare/alerting_test.exs test/logflare/alerting/alert_worker_test.exs test/logflare/backends/adaptor/incidentio_adaptor_test.exs test/logflare/logs/search_operations_test.exs test/logflare/endpoints/cache_test.exs

Linear: O11Y-982