### PR TITLE
feat: adds support for otel `kind`

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -436,7 +436,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
         paths: ["$.span_name", "$.name", "$.operationName", "$.event_message"]
       ),
       Field.string("span_kind",
-        paths: ["$.span_kind", "$.kind", "$.spanKind"]
+        paths: ["$.span_kind", "$.kind", "$.spanKind"],
+        default: "Unspecified",
+        value_map: %{
+          "Unspecified" => "Unspecified",
+          "Internal" => "Internal",
+          "Server" => "Server",
+          "Client" => "Client",
+          "Producer" => "Producer",
+          "Consumer" => "Consumer",
+          "SPAN_KIND_UNSPECIFIED" => "Unspecified",
+          "SPAN_KIND_INTERNAL" => "Internal",
+          "SPAN_KIND_SERVER" => "Server",
+          "SPAN_KIND_CLIENT" => "Client",
+          "SPAN_KIND_PRODUCER" => "Producer",
+          "SPAN_KIND_CONSUMER" => "Consumer"
+        }
       ),
       Field.string("service_name",
         paths: [

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -15,7 +15,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
 
   @log_config_id "00000000-0000-0000-0001-000000000003"
   @metric_config_id "00000000-0000-0000-0002-000000000003"
-  @trace_config_id "00000000-0000-0000-0003-000000000003"
+  @trace_config_id "00000000-0000-0000-0003-000000000004"
 
   @spec config_id(TypeDetection.event_type()) :: String.t()
   def config_id(:log), do: @log_config_id

--- a/lib/logflare/logs/otel_trace.ex
+++ b/lib/logflare/logs/otel_trace.ex
@@ -40,6 +40,7 @@ defmodule Logflare.Logs.OtelTrace do
         "span_id" => Base.encode16(span.span_id, case: :lower),
         "parent_span_id" => Base.encode16(span.parent_span_id, case: :lower),
         "trace_id" => Base.encode16(span.trace_id, case: :lower),
+        "kind" => span_kind(span.kind),
         "start_time" => span.start_time_unix_nano,
         "end_time" => span.end_time_unix_nano,
         "attributes" => Otel.handle_attributes(span.attributes),
@@ -64,4 +65,12 @@ defmodule Logflare.Logs.OtelTrace do
       "project" => Otel.resource_project(resource)
     }
   end
+
+  @spec span_kind(Opentelemetry.Proto.Trace.V1.Span.SpanKind.t()) :: String.t()
+  defp span_kind(:SPAN_KIND_INTERNAL), do: "Internal"
+  defp span_kind(:SPAN_KIND_SERVER), do: "Server"
+  defp span_kind(:SPAN_KIND_CLIENT), do: "Client"
+  defp span_kind(:SPAN_KIND_PRODUCER), do: "Producer"
+  defp span_kind(:SPAN_KIND_CONSUMER), do: "Consumer"
+  defp span_kind(_kind), do: "Unspecified"
 end

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -15,11 +15,19 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       input document (e.g. `from_output: "severity_text"`). Fields are resolved in order, so
       the source field must be defined earlier in the config.
     * `:default` — fallback value when no path resolves
-    * `:value_map` — case-insensitive lookup applied to the resolved value. For string
-      fields it is `%{String.t() => String.t()}` and remaps the value (e.g. mapping
-      `"SPAN_KIND_CLIENT"` to `"Client"`); for all other (numeric) fields it is
-      `%{String.t() => integer()}` (e.g. mapping `"ERROR"` to `17` for severity numbers).
-      In both cases, values absent from the map fall back to the field's `:default`.
+    * `:value_map` — case-insensitive lookup applied to the resolved value. The map's
+      value type is dictated by the field's output type and is resolved once at compile
+      time (in the NIF), not per document — so there is no per-event type inference cost:
+
+      * For `string/2` fields it is a `%{String.t() => String.t()}` remap that rewrites
+        one string to another (e.g. mapping `"SPAN_KIND_CLIENT"` to `"Client"`).
+      * For all non-string fields it is a `%{String.t() => integer()}` lookup that
+        derives an integer from a string (e.g. mapping `"ERROR"` to `17` for severity
+        numbers).
+
+      Mixing the two — string values on a non-string field, or integer values on a
+      string field — is rejected at compile time rather than silently mishandled. In
+      both cases, values absent from the map fall back to the field's `:default`.
 
   ## Type-Specific Options
 

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -15,8 +15,11 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       input document (e.g. `from_output: "severity_text"`). Fields are resolved in order, so
       the source field must be defined earlier in the config.
     * `:default` — fallback value when no path resolves
-    * `:value_map` — `%{String.t() => integer()}` lookup applied to the resolved value.
-      Useful for derived fields (e.g. mapping `"ERROR"` to `17` for severity numbers).
+    * `:value_map` — case-insensitive lookup applied to the resolved value. For string
+      fields it is `%{String.t() => String.t()}` and remaps the value (e.g. mapping
+      `"SPAN_KIND_CLIENT"` to `"Client"`); for all other (numeric) fields it is
+      `%{String.t() => integer()}` (e.g. mapping `"ERROR"` to `17` for severity numbers).
+      In both cases, values absent from the map fall back to the field's `:default`.
 
   ## Type-Specific Options
 

--- a/native/mapper_ex/src/coerce.rs
+++ b/native/mapper_ex/src/coerce.rs
@@ -128,6 +128,28 @@ pub fn apply_value_map<'a>(
     nil
 }
 
+/// Look up a string value in a string value_map, returning the mapped string.
+///
+/// Returns `nil` when the value is absent from the map so callers can decide
+/// whether to pass the original value through unchanged.
+pub fn apply_value_map_str<'a>(
+    env: Env<'a>,
+    value: Term<'a>,
+    map: &HashMap<String, String>,
+    nil: Term<'a>,
+) -> Term<'a> {
+    if value == nil || map.is_empty() {
+        return nil;
+    }
+
+    // Keys are pre-lowercased at compile time
+    if let Some(val) = case_insensitive_get(map, value) {
+        return val.encode(env);
+    }
+
+    nil
+}
+
 /// Coerce a BEAM term to an array of the target element type.
 ///
 /// If the value is not a list, returns an empty list.

--- a/native/mapper_ex/src/coerce.rs
+++ b/native/mapper_ex/src/coerce.rs
@@ -130,8 +130,8 @@ pub fn apply_value_map<'a>(
 
 /// Look up a string value in a string value_map, returning the mapped string.
 ///
-/// Returns `nil` when the value is absent from the map so callers can decide
-/// whether to pass the original value through unchanged.
+/// Returns `nil` when the value is absent from the map; the caller substitutes
+/// the field's default in that case.
 pub fn apply_value_map_str<'a>(
     env: Env<'a>,
     value: Term<'a>,

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -90,8 +90,18 @@ pub fn map_single<'a>(
             value
         };
 
-        // Apply value_map if configured (e.g., severity_text -> severity_number)
-        let value = if !field.value_map.is_empty() {
+        // Apply value_map if configured.
+        // String fields use a string->string remap; numeric fields use a
+        // string->integer lookup (e.g. severity_text -> severity_number).
+        // Either way, values absent from the map fall back to the default.
+        let value = if !field.value_map_str.is_empty() {
+            let mapped = coerce::apply_value_map_str(env, value, &field.value_map_str, nil);
+            if mapped != nil {
+                mapped
+            } else {
+                coerce::encode_default(env, &field.default, nil)
+            }
+        } else if !field.value_map.is_empty() {
             let mapped = coerce::apply_value_map(env, value, &field.value_map, nil);
             if mapped != nil {
                 mapped

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -90,9 +90,11 @@ pub fn map_single<'a>(
             value
         };
 
-        // Apply value_map if configured.
-        // String fields use a string->string remap; numeric fields use a
-        // string->integer lookup (e.g. severity_text -> severity_number).
+        // Apply value_map if configured. The variant was decided at compile
+        // time (see `decode_field`): string fields populate `value_map_str` (a
+        // string->string remap), all non-string fields populate `value_map` (a
+        // string->integer lookup, e.g. severity_text -> severity_number). At most
+        // one is non-empty, so this is a cheap branch, not per-event inference.
         // Either way, values absent from the map fall back to the default.
         let value = if !field.value_map_str.is_empty() {
             let mapped = coerce::apply_value_map_str(env, value, &field.value_map_str, nil);

--- a/native/mapper_ex/src/mapping.rs
+++ b/native/mapper_ex/src/mapping.rs
@@ -201,8 +201,10 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
     let path_source = decode_path_source(env, field)?;
     let transform = decode_transform(env, field)?;
     let allowed_values = decode_allowed_values(env, field);
-    // For string fields, value_map is a string->string remap; for all other
-    // (numeric) fields it is a string->integer lookup.
+    // Resolve which value_map variant this field uses once, here at compile
+    // time: string fields get a string->string remap, all non-string fields get
+    // a string->integer lookup. The unused variant stays empty so the per-event
+    // path in `map_single` only has to check which map is populated.
     let (value_map, value_map_str) = if matches!(field_type, FieldType::String) {
         (HashMap::new(), decode_value_map_str(env, field)?)
     } else {

--- a/native/mapper_ex/src/mapping.rs
+++ b/native/mapper_ex/src/mapping.rs
@@ -23,6 +23,7 @@ pub struct CompiledField {
     pub transform: Option<FieldTransform>,
     pub allowed_values: HashSet<Vec<u8>>,
     pub value_map: HashMap<String, i64>,
+    pub value_map_str: HashMap<String, String>,
     pub exclude_keys: Vec<Vec<u8>>,
     pub elevate_keys: Vec<Vec<u8>>,
     pub pick: Vec<PickEntry>,
@@ -200,7 +201,13 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
     let path_source = decode_path_source(env, field)?;
     let transform = decode_transform(env, field)?;
     let allowed_values = decode_allowed_values(env, field);
-    let value_map = decode_value_map(env, field)?;
+    // For string fields, value_map is a string->string remap; for all other
+    // (numeric) fields it is a string->integer lookup.
+    let (value_map, value_map_str) = if matches!(field_type, FieldType::String) {
+        (HashMap::new(), decode_value_map_str(env, field)?)
+    } else {
+        (decode_value_map(env, field)?, HashMap::new())
+    };
     let exclude_keys = decode_string_list_bytes(env, field, "exclude_keys");
     let elevate_keys = decode_string_list_bytes(env, field, "elevate_keys");
     let pick = decode_pick(env, field)?;
@@ -223,6 +230,7 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
         transform,
         allowed_values,
         value_map,
+        value_map_str,
         exclude_keys,
         elevate_keys,
         pick,
@@ -405,6 +413,31 @@ fn decode_value_map<'a>(env: Env<'a>, field: Term<'a>) -> Result<HashMap<String,
     };
 
     decode_string_int_map(env, term)
+}
+
+fn decode_value_map_str<'a>(
+    env: Env<'a>,
+    field: Term<'a>,
+) -> Result<HashMap<String, String>, String> {
+    let term = match get_term_key(env, field, "value_map") {
+        Some(t) if t.is_map() => t,
+        _ => return Ok(HashMap::new()),
+    };
+
+    let iter = MapIterator::new(term).ok_or_else(|| "value_map must be a map".to_string())?;
+
+    let mut result = HashMap::new();
+    for (k, v) in iter {
+        let key = k
+            .decode::<String>()
+            .map_err(|_| "value_map keys must be strings".to_string())?;
+        let val = v
+            .decode::<String>()
+            .map_err(|_| "value_map values must be strings".to_string())?;
+        // Pre-normalize keys to lowercase for case-insensitive lookups at map time
+        result.insert(key.to_lowercase(), val);
+    }
+    Ok(result)
 }
 
 fn decode_pick<'a>(env: Env<'a>, field: Term<'a>) -> Result<Vec<PickEntry>, String> {

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -260,7 +260,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
         "span_id" => "span-def",
         "parent_span_id" => "span-parent",
         "span_name" => "GET /api/users",
-        "span_kind" => "server",
+        "span_kind" => "Server",
         "duration" => 1500,
         "status" => %{"code" => "OK", "message" => "success"},
         "project" => "abcdefghijklmnopqrst",
@@ -273,10 +273,53 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       assert result["span_id"] == "span-def"
       assert result["parent_span_id"] == "span-parent"
       assert result["span_name"] == "GET /api/users"
-      assert result["span_kind"] == "server"
+      assert result["span_kind"] == "Server"
       assert result["duration"] == 1500
       assert result["status_code"] == "OK"
       assert result["status_message"] == "success"
+    end
+
+    test "normalizes span_kind to canonical low-cardinality values", %{trace: compiled} do
+      mappings = [
+        # Title-case form emitted by OtelTrace passes through unchanged
+        {"Unspecified", "Unspecified"},
+        {"Internal", "Internal"},
+        {"Server", "Server"},
+        {"Client", "Client"},
+        {"Producer", "Producer"},
+        {"Consumer", "Consumer"},
+        # raw-JSON SPAN_KIND_* aliases normalize to the Title-case form
+        {"SPAN_KIND_SERVER", "Server"},
+        {"SPAN_KIND_CLIENT", "Client"},
+        # case-insensitive
+        {"client", "Client"}
+      ]
+
+      for {raw, expected} <- mappings do
+        payload = %{
+          "event_message" => "fetch POST api.logflare.app",
+          "kind" => raw,
+          "trace_id" => "trace-abc"
+        }
+
+        result = Mapper.map(payload, compiled)
+
+        assert result["span_kind"] == expected
+        assert result["span_name"] == "fetch POST api.logflare.app"
+      end
+    end
+
+    test "falls back to Unspecified for blank or unmapped span_kind values", %{trace: compiled} do
+      # unmapped value
+      assert Mapper.map(%{"kind" => "bogus_kind", "trace_id" => "t1"}, compiled)["span_kind"] ==
+               "Unspecified"
+
+      # blank value
+      assert Mapper.map(%{"kind" => "", "trace_id" => "t1"}, compiled)["span_kind"] ==
+               "Unspecified"
+
+      # missing value
+      assert Mapper.map(%{"trace_id" => "t1"}, compiled)["span_kind"] == "Unspecified"
     end
 
     test "coalesces camelCase trace field names", %{trace: compiled} do
@@ -302,7 +345,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       assert result["span_id"] == ""
       assert result["parent_span_id"] == ""
       assert result["span_name"] == ""
-      assert result["span_kind"] == ""
       assert result["status_code"] == ""
       assert result["status_message"] == ""
       assert result["service_name"] == ""

--- a/test/logflare/logs/otel_trace_test.exs
+++ b/test/logflare/logs/otel_trace_test.exs
@@ -41,7 +41,7 @@ defmodule Logflare.Logs.OtelTraceTest do
       assert le_span["span_id"] == Base.encode16(span.span_id, case: :lower)
       assert le_span["parent_span_id"] == Base.encode16(span.parent_span_id, case: :lower)
       assert le_span["event_message"] == span.name
-      assert le_span["kind"] in ~w(Unspecified Internal Server Client Producer Consumer)
+      assert le_span["kind"] == "Server"
 
       assert le_span["timestamp"] == span.start_time_unix_nano
       assert le_span["start_time"] == span.start_time_unix_nano
@@ -54,6 +54,27 @@ defmodule Logflare.Logs.OtelTraceTest do
       assert le_event["parent_span_id"] == Base.encode16(span.span_id)
 
       assert le_event["timestamp"] == event.time_unix_nano
+    end
+
+    test "maps each OTEL span kind to its canonical low-cardinality value", %{source: source} do
+      kinds = [
+        {:SPAN_KIND_UNSPECIFIED, "Unspecified"},
+        {:SPAN_KIND_INTERNAL, "Internal"},
+        {:SPAN_KIND_SERVER, "Server"},
+        {:SPAN_KIND_CLIENT, "Client"},
+        {:SPAN_KIND_PRODUCER, "Producer"},
+        {:SPAN_KIND_CONSUMER, "Consumer"}
+      ]
+
+      for {kind, expected} <- kinds do
+        le_span =
+          kind
+          |> TestUtilsGrpc.resource_span_with_kind()
+          |> OtelTrace.handle_batch(source)
+          |> Enum.find(fn params -> params["metadata"]["type"] == "span" end)
+
+        assert le_span["kind"] == expected
+      end
     end
 
     test "json parsable log event body", %{

--- a/test/logflare/logs/otel_trace_test.exs
+++ b/test/logflare/logs/otel_trace_test.exs
@@ -41,6 +41,7 @@ defmodule Logflare.Logs.OtelTraceTest do
       assert le_span["span_id"] == Base.encode16(span.span_id, case: :lower)
       assert le_span["parent_span_id"] == Base.encode16(span.parent_span_id, case: :lower)
       assert le_span["event_message"] == span.name
+      assert le_span["kind"] in ~w(Unspecified Internal Server Client Producer Consumer)
 
       assert le_span["timestamp"] == span.start_time_unix_nano
       assert le_span["start_time"] == span.start_time_unix_nano
@@ -311,6 +312,14 @@ defmodule Logflare.Logs.OtelTraceTest do
 
       converted =
         OtelTrace.handle_batch(request.resource_spans, source)
+
+      span_kinds =
+        converted
+        |> Enum.filter(fn p -> p["metadata"]["type"] == "span" end)
+        |> Enum.map(& &1["kind"])
+
+      assert "Client" in span_kinds
+      assert "Server" in span_kinds
 
       assert converted
              |> Iteraptor.each(

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -1192,6 +1192,21 @@ defmodule Logflare.MapperTest do
 
       assert result["span_kind"] == "Unspecified"
     end
+
+    test "empty value_map passes the resolved value through unchanged" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              value_map: %{}
+            )
+          ],
+          %{"kind" => "anything"}
+        )
+
+      assert result["span_kind"] == "anything"
+    end
   end
 
   # ── Allowed values ──────────────────────────────────────────────────

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -1113,6 +1113,87 @@ defmodule Logflare.MapperTest do
     end
   end
 
+  # ── String value_map ────────────────────────────────────────────────
+
+  describe "string value_map" do
+    test "remaps a matched value to its string replacement" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              value_map: %{"SPAN_KIND_CLIENT" => "Client", "SPAN_KIND_SERVER" => "Server"}
+            )
+          ],
+          %{"kind" => "SPAN_KIND_CLIENT"}
+        )
+
+      assert result["span_kind"] == "Client"
+    end
+
+    test "lookup is case-insensitive" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              value_map: %{"SPAN_KIND_SERVER" => "Server"}
+            )
+          ],
+          %{"kind" => "span_kind_server"}
+        )
+
+      assert result["span_kind"] == "Server"
+    end
+
+    test "unmapped values fall back to the default" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              default: "Unspecified",
+              value_map: %{"SPAN_KIND_CLIENT" => "Client"}
+            )
+          ],
+          %{"kind" => "something_else"}
+        )
+
+      assert result["span_kind"] == "Unspecified"
+    end
+
+    test "unmapped values with no explicit default fall back to empty string" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              value_map: %{"SPAN_KIND_CLIENT" => "Client"}
+            )
+          ],
+          %{"kind" => "something_else"}
+        )
+
+      assert result["span_kind"] == ""
+    end
+
+    test "missing path falls back to default, not remapped" do
+      result =
+        compile_and_map(
+          [
+            Field.string("span_kind",
+              path: "$.kind",
+              default: "Unspecified",
+              value_map: %{"SPAN_KIND_CLIENT" => "Client"}
+            )
+          ],
+          %{}
+        )
+
+      assert result["span_kind"] == "Unspecified"
+    end
+  end
+
   # ── Allowed values ──────────────────────────────────────────────────
 
   describe "allowed_values" do

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -1377,6 +1377,26 @@ defmodule Logflare.MapperTest do
       assert {:error, reason} = Mapper.compile(config)
       assert reason =~ "duplicate field name: 'name'"
     end
+
+    test "returns {:error, reason} on a string field whose value_map has non-string values" do
+      config =
+        MappingConfig.new([
+          Field.string("span_kind", path: "$.kind", value_map: %{"SPAN_KIND_CLIENT" => 3})
+        ])
+
+      assert {:error, reason} = Mapper.compile(config)
+      assert reason =~ "value_map values must be strings"
+    end
+
+    test "returns {:error, reason} on a string field whose value_map has non-string keys" do
+      config =
+        MappingConfig.new([
+          Field.string("span_kind", path: "$.kind", value_map: %{1 => "Client"})
+        ])
+
+      assert {:error, reason} = Mapper.compile(config)
+      assert reason =~ "value_map keys must be strings"
+    end
   end
 
   describe "error handling" do

--- a/test/support/test_utils_grpc.ex
+++ b/test/support/test_utils_grpc.ex
@@ -84,10 +84,41 @@ defmodule Logflare.TestUtilsGrpc do
         span_id: :crypto.strong_rand_bytes(8),
         parent_span_id: :crypto.strong_rand_bytes(8),
         trace_id: :crypto.strong_rand_bytes(16),
+        kind: :SPAN_KIND_SERVER,
         start_time_unix_nano: System.os_time(:nanosecond),
         end_time_unix_nano: System.os_time(:nanosecond),
         events: random_event(),
         attributes: random_attributes()
+      }
+    ]
+  end
+
+  @doc """
+  Builds a ResourceSpans containing a single Span with the given `kind`.
+  """
+  @spec resource_span_with_kind(Span.SpanKind.t()) :: [ResourceSpans.t()]
+  def resource_span_with_kind(kind) do
+    [
+      %ResourceSpans{
+        resource: %Resource{attributes: random_attributes()},
+        scope_spans: [
+          %ScopeSpans{
+            scope: random_scope(),
+            spans: [
+              %Span{
+                name: TestUtils.random_string(),
+                span_id: :crypto.strong_rand_bytes(8),
+                parent_span_id: :crypto.strong_rand_bytes(8),
+                trace_id: :crypto.strong_rand_bytes(16),
+                kind: kind,
+                start_time_unix_nano: System.os_time(:nanosecond),
+                end_time_unix_nano: System.os_time(:nanosecond),
+                events: [],
+                attributes: random_attributes()
+              }
+            ]
+          }
+        ]
       }
     ]
   end


### PR DESCRIPTION
- added string to string serializer in rust mapper
- rust mapper enforces low cardinality of span_kind
- encodes `:SPAN_KIND_SERVER` to `Server` et al in Logs.OtelTrace module
- encoding it here so `kind` value is the same in BigQuery and Clickhouse (more human readable)
- confirmed HyperDX does expect `Server` et al for values for service mapping view

Closes O11Y-1978