### PR TITLE
perf: reduce user-metrics puller memory spikes

### DIFF
--- a/lib/logflare/backends/user_monitoring.ex
+++ b/lib/logflare/backends/user_monitoring.ex
@@ -41,7 +41,7 @@ defmodule Logflare.Backends.UserMonitoring do
     {pull_interval, export_period} =
       case env do
         :test -> {100, 100}
-        _ -> {10_000, :timer.minutes(8) + :rand.uniform(60_000 * 2)}
+        _ -> {5_000, :timer.seconds(30) + :rand.uniform(15_000)}
       end
 
     exporter_spec =
@@ -61,6 +61,7 @@ defmodule Logflare.Backends.UserMonitoring do
        [
          metric_store_name: @store_name,
          pull_interval: pull_interval,
+         max_demand: 250,
          batch_size: 1_000
        ]}
 

--- a/lib/logflare/backends/user_monitoring/ingest_pipeline.ex
+++ b/lib/logflare/backends/user_monitoring/ingest_pipeline.ex
@@ -14,10 +14,13 @@ defmodule Logflare.Backends.UserMonitoring.IngestPipeline do
     pull_interval = Keyword.get(opts, :pull_interval, 1_000)
     batch_timeout = Keyword.get(opts, :batch_timeout, 500)
     store_name = Keyword.fetch!(opts, :metric_store_name)
-    batch_size = Keyword.get(opts, :batch_size, 10_000)
+    batch_size = Keyword.get(opts, :batch_size, 1_000)
+    max_demand = Keyword.get(opts, :max_demand, 250)
 
     Broadway.start_link(__MODULE__,
       name: __MODULE__,
+      hibernate_after: 5_000,
+      spawn_opt: [fullsweep_after: 100],
       producer: [
         module: {PullProducer, metric_store_name: store_name, pull_interval: pull_interval},
         transformer: {__MODULE__, :transform, []},
@@ -26,7 +29,7 @@ defmodule Logflare.Backends.UserMonitoring.IngestPipeline do
       processors: [
         default: [
           concurrency: System.schedulers_online(),
-          max_demand: Keyword.fetch!(opts, :batch_size)
+          max_demand: max_demand
         ]
       ],
       batchers: [


### PR DESCRIPTION
## Problem

The user-metrics pull pipeline accumulates metrics in an ETS generation and drains a whole sealed generation into the Broadway pipeline in a single step. A generation is only sealed (and the table only trimmed) on rotation, which happens every `export_period` (~8–10 min). With `max_demand` tied to `batch_size`, each drain materializes a large batch of ETS rows into Elixir maps all at once.

Because the `PullProducer` runs at `concurrency: 1`, that materialization lands in one process heap, then is copied to the Broadway processors and pushed through ingestion — none of it GC-tuned. The result is a sharp spike in **process** memory (not ETS) on each drain, scaling with metrics volume. `max_table_memory` does not bound it: it is only checked at rotation and never applies to the generation currently being written.

## Change

Reshape the drain into a smaller, more frequent, GC-friendly flow:

- Shorten `export_period` from ~8–10 min to ~30–45s (with jitter) so each generation — and therefore each drain — is far smaller, trimming runs much more often, and the accumulation window before the first drain after boot shrinks accordingly.
- Lower `pull_interval` from 10s to 5s to detect sealed generations promptly at the shorter period.
- Decouple processor `max_demand` from `batch_size` and set it to `250`, directly bounding the rows materialized per drain step (previously `schedulers × 1_000`).
- Add `hibernate_after: 5_000` and `spawn_opt: [fullsweep_after: 100]` to the Broadway pipeline, matching the other ingest pipelines (`clickhouse_adaptor`, `http_based`, etc.). Broadway carries these to the producer, processors, and batchers, so the idle producer reclaims its transient heap between drains.

## Notes

- The values (`export_period` ~30s, `max_demand` 250, `fullsweep_after` 100) are conservative starting points; the GC values match existing pipelines. They likely want tuning against real cardinality and throughput.
- Trade-off: smaller, more frequent drains and more frequent GC trade a small amount of CPU/run-queue for a much smoother memory profile.
- Does not change which metrics are collected or how they are ingested.

## Testing

- `mix test test/logflare/backends/user_monitoring_test.exs` — 8 tests, 0 failures.
- `mix lint.diff` — no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)