### PR TITLE
feat: logs application version in logger metadata

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests (with Playwright)
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * SUN'
+    - cron: "0 0 * * SUN"
   pull_request:
     branches: ["**"]
     paths:
@@ -25,9 +25,9 @@ jobs:
     name: Get versions
     runs-on: ubuntu-latest
     outputs:
-      elixir:  ${{ steps.v.outputs.elixir }}
-      erlang:  ${{ steps.v.outputs.erlang }}
-      rust:    ${{ steps.v.outputs.rust }}
+      elixir: ${{ steps.v.outputs.elixir }}
+      erlang: ${{ steps.v.outputs.erlang }}
+      rust: ${{ steps.v.outputs.rust }}
     steps:
       - uses: actions/checkout@v6
       - name: Read versions from .tool-versions
@@ -126,10 +126,10 @@ jobs:
           path: |
             deps
             _build
-          key: mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock') }}
+          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -145,10 +145,10 @@ jobs:
           path: |
             deps
             _build
-          key: mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock') }}
+          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Restore Dialyzer PLT cache
         if: matrix.commands.name == 'Typing check'

--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -110,10 +110,10 @@ jobs:
           path: |
             deps
             _build
-          key: mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock') }}
+          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Install dependencies
         run: mix deps.get

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -193,9 +193,6 @@ config :logflare,
        ]
        |> Enum.filter(&(&1 != nil))
 
-config :logger,
-  metadata: logflare_metadata
-
 log_level =
   case String.downcase(System.get_env("LOGFLARE_LOG_LEVEL") || "") do
     # TODO: remove at v2

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -22,6 +22,7 @@ defmodule Logflare.Application do
     prev = Inspect.Opts.default_inspect_fun()
     Inspect.Opts.default_inspect_fun(&Utils.inspect_fun(prev, &1, &2))
 
+    set_global_logger_metadata()
     start_user_log_interceptor()
     add_logger_backends()
     warn_if_stripe_webhook_secret_unset()
@@ -134,6 +135,24 @@ defmodule Logflare.Application do
         "STRIPE_WEBHOOK_SECRET is not set — all Stripe webhook requests will be rejected"
       )
     end
+  end
+
+  @doc """
+  Global metadata attached to every log event (and the single source for it).
+
+  Combines the Logflare version with the configured `:logflare, :metadata`
+  (e.g. `cluster`). The same `:logflare, :metadata` env feeds OTel resource
+  attributes (see `Logflare.Telemetry`).
+  """
+  @spec global_logger_metadata() :: map()
+  def global_logger_metadata do
+    [logflare_version: Application.spec(:logflare, :vsn) |> to_string()]
+    |> Keyword.merge(Application.get_env(:logflare, :metadata, []))
+    |> Map.new()
+  end
+
+  defp set_global_logger_metadata do
+    :logger.update_primary_config(%{metadata: global_logger_metadata()})
   end
 
   defp start_user_log_interceptor do

--- a/test/logflare/logger_global_metadata_test.exs
+++ b/test/logflare/logger_global_metadata_test.exs
@@ -1,0 +1,60 @@
+defmodule Logflare.LoggerGlobalMetadataTest do
+  use ExUnit.Case, async: false
+
+  require Logger
+
+  alias Logflare.Application, as: App
+
+  defmodule CaptureHandler do
+    def log(event, %{config: %{pid: pid}}), do: send(pid, {:log_event, event})
+  end
+
+  setup do
+    original_primary = :logger.get_primary_config()
+    original_app_meta = Application.get_env(:logflare, :metadata)
+
+    :ok =
+      :logger.add_handler(:global_meta_capture, __MODULE__.CaptureHandler, %{
+        level: :all,
+        config: %{pid: self()}
+      })
+
+    on_exit(fn ->
+      :logger.remove_handler(:global_meta_capture)
+      :logger.set_primary_config(original_primary)
+
+      if original_app_meta,
+        do: Application.put_env(:logflare, :metadata, original_app_meta),
+        else: Application.delete_env(:logflare, :metadata)
+    end)
+
+    :ok
+  end
+
+  test "log events carry the Logflare version in metadata" do
+    expected = Application.spec(:logflare, :vsn) |> to_string()
+    assert expected =~ ~r/\d+\.\d+\.\d+/
+
+    Logger.info("logflare_version metadata probe")
+
+    assert_receive {:log_event, %{meta: %{logflare_version: ^expected}}}
+  end
+
+  test "log events carry the cluster in metadata when configured" do
+    Application.put_env(:logflare, :metadata, cluster: "test-cluster")
+    :logger.update_primary_config(%{metadata: App.global_logger_metadata()})
+
+    Logger.info("cluster metadata probe")
+
+    assert_receive {:log_event, %{meta: %{cluster: "test-cluster"}}}
+  end
+
+  test "global_logger_metadata/0 merges the version with configured :logflare metadata" do
+    Application.put_env(:logflare, :metadata, cluster: "abc")
+
+    meta = App.global_logger_metadata()
+
+    assert meta.cluster == "abc"
+    assert meta.logflare_version == Application.spec(:logflare, :vsn) |> to_string()
+  end
+end


### PR DESCRIPTION
- update logger metadata with version in logflare app start
- move cluster here also so we apply "global" metadata in one place
- cluster log metadata is testable now under mix/dev/test
- adds tests for both

unrelated
- includes Rust stuff in CI cache key