### PR TITLE
feat: hide null values for selected fields

### DIFF
--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -39,8 +39,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
         <.log_event :for={log <- @search_op_log_events.rows} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)} source_schema_flat_map={@source_schema_flat_map}>
           {log.body["event_message"]}
           <:actions phx-no-format>
-          <div class={if(Enum.any?(@select_fields), do: "tw-ml-[13rem] tw-pb-1.5", else: "tw-inline")}>
-          <.modal_link
+          <div class="group-has-[.log-event-selected-field]:tw-ml-[13rem] group-has-[.log-event-selected-field]:tw-pb-1.5 tw-inline-block">
+            <.modal_link
                    component={LogEventViewerComponent}
                    class="tw-text-[0.65rem]"
                    modal_id={:log_event_viewer}
@@ -217,9 +217,9 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
   def selected_fields(assigns) do
     ~H"""
-    <div id={["log-", @log_event.id, "-selected-fields"]}>
+    <div id={["log-", @log_event.id, "-selected-fields"]} class="has-[.log-event-selected-field]:tw-block tw-hidden">
       <%= for field <- @select_fields do %>
-        <div class="tw-text-neutral-200 tw-flex tw-leading-6">
+        <div :if={not is_nil(@log_event.body[field.key])} class="tw-text-neutral-200 tw-flex tw-leading-6 log-event-selected-field">
           <div class="tw-w-[13rem] tw-text-right ">
             <span class="tw-whitespace-nowrap tw-w-fit tw-px-1 tw-py-0.5 tw-bg-neutral-600 tw-text-white tw-mr-2">{truncate_display(field.display)}</span>
           </div>

--- a/test/logflare_web/live/search_live/log_event_components_test.exs
+++ b/test/logflare_web/live/search_live/log_event_components_test.exs
@@ -251,7 +251,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
              ]
     end
 
-    test "handles null values" do
+    test "does not render null values" do
       log_event = build(:log_event, metadata_user_id: nil)
 
       select_fields = [
@@ -268,8 +268,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         <LogEventComponents.selected_fields log_event={@log_event} select_fields={@select_fields} />
         """)
 
-      assert html =~ "metadata.user_id"
-      assert html =~ "null"
+      refute html =~ "metadata.user_id"
+      refute html =~ "null"
     end
   end
 
@@ -308,13 +308,15 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
           metadata_user_id: "user_123",
           city: "San Francisco",
           timestamp: 1_234_567_890_000,
-          long_field: String.duplicate("a", 80)
+          long_field: String.duplicate("a", 80),
+          plan_id: nil
         )
 
       lql_rules = [
         %SelectRule{path: "metadata.user_id", alias: nil},
         %SelectRule{path: "metadata.store.city", alias: "city"},
-        %SelectRule{path: "long_field", alias: nil}
+        %SelectRule{path: "long_field", alias: nil},
+        %SelectRule{path: "metadata.plan_id", alias: nil}
       ]
 
       search_op = %{
@@ -331,6 +333,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
 
              long_field:
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+             plan_id: null
 
              """
     end


### PR DESCRIPTION
Hides selected fields in search results if the value is NULL to reduce unnecessary space.

I've left NULL value select fields in the copy-to-clipboard event text. This seemed like the better tradeoff but can be removed if we want.

Closes O11Y-1817

<img width="5308" height="1528" alt="CleanShot 2026-06-11 at 14 55 59@2x" src="https://github.com/user-attachments/assets/822c1ab0-3ca0-4d42-b9fc-4d909f25be35" />
 
 
Clipboard contents will include all fields, including null values for selected fields:
 
 ```
Thu Jun 11 2026 11:42:32+08:00    {"application_name":null,"name":null,"qty":12,"store":{"address":"123 W Main St","city":"Phoenix","state":"AZ","zip":85016},"tags":["popular, tropical, organic"],"type":"fruit","yellow":true}

application_name: null

name: null


```