### PR TITLE
feat: add metadata to endpoints list

### DIFF
--- a/lib/logflare_web/live/endpoints/actions/index.html.heex
+++ b/lib/logflare_web/live/endpoints/actions/index.html.heex
@@ -26,7 +26,7 @@
 
 <section class="mx-auto container">
   <ul :for={endpoint <- Enum.sort_by(@endpoints, & &1.name)} class="list-group">
-    <li class="list-group-item">
+    <li class="list-group-item ">
       <.team_link team={@team} patch={~p"/endpoints/#{endpoint.id}"} class="tw-text-white">
         {endpoint.name}
       </.team_link>
@@ -34,7 +34,7 @@
       <p :if={endpoint.description} class="tw-pb-0 tw-mb-0 tw-text-sm text-muted">
         {endpoint.description}
       </p>
-      <div class="tw-text-sm">
+      <div class="tw-text-sm ">
         <span :if={endpoint.enable_auth} title="Auth enabled">
           <i class="fas fa-lock"></i>
         </span>
@@ -42,6 +42,10 @@
         <span :if={!endpoint.enable_auth} title="Auth disabled">
           <i class="fas fa-lock-open"></i>
         </span>
+        <span class="badge badge-dark tw-mx-1">{format_query_language(endpoint.language)}</span>
+        <.team_link :if={endpoint.backend} team={@team} patch={~p"/backends/#{endpoint.backend.id}"} title={endpoint.backend.name} class="tw-relative tw-top-1 tw-mx-1 tw-text-sm tw-max-w-56 tw-inline-block tw-truncate">
+          {endpoint.backend.name}
+        </.team_link>
         <span>caches: {endpoint.metrics.cache_count}</span>
       </div>
     </li>

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -4,10 +4,13 @@ defmodule LogflareWeb.EndpointsLive do
   use LogflareWeb, :live_view
   use Phoenix.Component
 
+  import Ecto.Query, only: [from: 2]
+
   require Logger
 
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor
+  alias Logflare.Backends.Backend
   alias Logflare.Endpoints
   alias Logflare.Endpoints.PiiRedactor
   alias LogflareWeb.QueryComponents
@@ -172,18 +175,18 @@ defmodule LogflareWeb.EndpointsLive do
     Logger.debug("Saving endpoint", params: params)
     origin = socket.assigns.team_user || user
 
-    case upsert_query(show_endpoint, user, origin, params) do
-      {:ok, endpoint} ->
-        verb = if show_endpoint, do: "updated", else: "created"
+    with :ok <- authorize_backend_id(origin, params),
+         {:ok, endpoint} <- upsert_query(show_endpoint, user, origin, params) do
+      verb = if show_endpoint, do: "updated", else: "created"
 
-        {:noreply,
-         socket
-         |> put_flash(:info, "Successfully #{verb} endpoint #{endpoint.name}")
-         |> push_patch(to: LogflareWeb.Utils.with_team_param(~p"/endpoints/#{endpoint.id}", team))
-         |> assign(:show_endpoint, endpoint)
-         |> assign(:query_result_rows, nil)
-         |> assign(:total_bytes_processed, nil)}
-
+      {:noreply,
+       socket
+       |> put_flash(:info, "Successfully #{verb} endpoint #{endpoint.name}")
+       |> push_patch(to: LogflareWeb.Utils.with_team_param(~p"/endpoints/#{endpoint.id}", team))
+       |> assign(:show_endpoint, endpoint)
+       |> assign(:query_result_rows, nil)
+       |> assign(:total_bytes_processed, nil)}
+    else
       {:error, %Ecto.Changeset{} = changeset} ->
         verb = if(show_endpoint, do: "update", else: "create")
         message = "Could not #{verb} endpoint. Please fix the errors before trying again."
@@ -195,6 +198,9 @@ defmodule LogflareWeb.EndpointsLive do
           |> assign(:selected_backend_id, changeset.data.backend_id)
 
         {:noreply, socket}
+
+      {:error, :backend_not_found} ->
+        {:noreply, put_flash(socket, :error, "Backend not found")}
     end
   end
 
@@ -418,9 +424,22 @@ defmodule LogflareWeb.EndpointsLive do
   defp refresh_endpoints(%{assigns: assigns} = socket) do
     endpoints =
       Endpoints.list_endpoints_by(user_id: assigns.user_id)
+      |> Logflare.Repo.preload(backend: from(b in Backend, select: struct(b, [:id, :name])))
       |> Endpoints.calculate_endpoint_metrics()
 
     assign(socket, :endpoints, endpoints)
+  end
+
+  defp authorize_backend_id(user, params) do
+    case params["backend_id"] do
+      v when v in [nil, ""] ->
+        :ok
+
+      backend_id ->
+        if Backends.get_backend_by_user_access(user, backend_id),
+          do: :ok,
+          else: {:error, :backend_not_found}
+    end
   end
 
   defp assign_sources(socket) do

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -29,6 +29,32 @@ defmodule LogflareWeb.EndpointsLiveTest do
 
       assert Logflare.Endpoints.get_endpoint_query(endpoint.id)
     end
+
+    test "attacker cannot attach another user's backend to an endpoint", %{conn: conn} do
+      attacker = insert(:user, endpoints_beta: true)
+      victim = insert(:user, endpoints_beta: true)
+      backend = insert(:postgres_backend, user: victim, name: "Victim Postgres")
+
+      {:ok, view, _html} =
+        conn
+        |> login_user(attacker)
+        |> live_with_redirect(~p"/endpoints/new")
+
+      view
+      |> element("form#endpoint")
+      |> render_submit(%{
+        endpoint: %{
+          backend_id: backend.id,
+          name: "forged endpoint",
+          query: "select 1"
+        }
+      })
+
+      assert render(view) =~ "Backend not found"
+
+      endpoints = Logflare.Endpoints.list_endpoints_by(user_id: attacker.id)
+      refute Enum.any?(endpoints, &(&1.backend_id == backend.id))
+    end
   end
 
   describe "with existing endpoint" do
@@ -36,7 +62,17 @@ defmodule LogflareWeb.EndpointsLiveTest do
       {:ok, endpoint: insert(:endpoint, user: user)}
     end
 
-    test "list endpoints", %{conn: conn, endpoint: endpoint, team: team} do
+    test "list endpoints", %{conn: conn, endpoint: endpoint, team: team, user: user} do
+      backend = insert(:postgres_backend, user: user, name: "Test Postgres")
+
+      postgres_endpoint =
+        insert(:endpoint,
+          user: user,
+          backend: backend,
+          language: :pg_sql,
+          name: "postgres endpoint"
+        )
+
       {:ok, view, _html} = live_with_redirect(conn, "/endpoints")
 
       # intro message and link to docs
@@ -49,6 +85,11 @@ defmodule LogflareWeb.EndpointsLiveTest do
       # description
       assert has_element?(view, "ul li p", endpoint.description)
       assert has_element?(view, "ul li *[title='Auth enabled']")
+      assert has_element?(view, "ul li span", "BigQuery SQL")
+
+      postgres_endpoint_html = view |> element("ul li", postgres_endpoint.name) |> render()
+      assert postgres_endpoint_html =~ "Postgres SQL"
+      assert postgres_endpoint_html =~ backend.name
 
       # link to show
       view
@@ -1274,10 +1315,15 @@ defmodule LogflareWeb.EndpointsLiveTest do
       team_user: team_user,
       endpoint: endpoint
     } do
-      {:ok, _view, html} =
+      backend = insert(:postgres_backend, user: user)
+      insert(:endpoint, user: user, backend: backend)
+
+      {:ok, view, _html} =
         conn |> login_user(user, team_user) |> live_with_redirect(~p"/endpoints")
 
-      for path <- ["endpoints/new", "endpoints/#{endpoint.id}"] do
+      html = render(view)
+
+      for path <- ["endpoints/new", "endpoints/#{endpoint.id}", "backends/#{backend.id}"] do
         assert html =~ ~r/#{path}[^"<]*t=#{team_user.team_id}/
       end
     end


### PR DESCRIPTION
Adds SQL dialect and backend, if set, to endpoints list.


<img width="3306" height="2396" alt="CleanShot 2026-06-11 at 16 09 31@2x" src="https://github.com/user-attachments/assets/1d2c0172-2e04-4db5-81fd-3a066d061f18" />


Long backend name is truncated: 

<img width="804" height="288" alt="CleanShot 2026-06-11 at 15 57 04@2x" src="https://github.com/user-attachments/assets/b2367907-524a-4aed-9f51-cfd5435781e7" />

## Alternate layout

If we want to manage the height of this page we could put them inline after caches:

<img width="2666" height="1992" alt="CleanShot 2026-06-11 at 16 22 39@2x" src="https://github.com/user-attachments/assets/caa1e667-76ed-4950-81b5-83a911b07b1f" />


Closes O11Y-1971