### PR TITLE
perf: Skip BigQuery schema diff for unchanged payloads

### DIFF
--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -41,9 +41,9 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   # planning work without measuring mailbox scheduling or BigQuery side effects.
   @doc false
   def plan_update(body, db_schema, state) do
-    schema = try_schema_update(body, db_schema)
+    {schema, schema_changed?} = try_schema_update(body, db_schema)
 
-    if schema_needs_update?(db_schema, schema, state) do
+    if schema_needs_update?(schema_changed?, state) do
       {:update, schema}
     else
       :noop
@@ -124,8 +124,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     end
   end
 
-  defp schema_needs_update?(db_schema, schema, state) do
-    not same_schemas?(db_schema, schema) and
+  defp schema_needs_update?(schema_changed?, state) do
+    schema_changed? and
       state.next_update <= System.system_time(:millisecond) and
       not SingleTenant.postgres_backend?()
   end
@@ -158,7 +158,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
   defp handle_schema_mismatch(body, state) do
     with {:ok, table} <- BigQuery.get_table(state.source_token),
-         schema <- try_schema_update(body, table.schema),
+         {schema, _schema_changed?} <- try_schema_update(body, table.schema),
          {:ok, _table_info} <- patch_bigquery_table(state, schema) do
       field_count = count_fields(schema)
       persist(state.source_id, schema)
@@ -208,22 +208,13 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     next_update_ts(updates_per_minute)
   end
 
-  defp same_schemas?(old_schema, new_schema) do
-    old_flatmap = SchemaUtils.bq_schema_to_flat_typemap(old_schema)
-    new_flatmap = SchemaUtils.bq_schema_to_flat_typemap(new_schema)
-
-    diff_keys = Map.keys(new_flatmap) -- Map.keys(old_flatmap)
-
-    old_schema == new_schema and Enum.empty?(diff_keys)
-  end
-
   defp try_schema_update(body, schema) do
-    SchemaBuilder.build_table_schema(body, schema)
+    SchemaBuilder.build_table_schema_with_change(body, schema)
   rescue
     e ->
       Logger.warning("Field schema type change error!", error_string: inspect(e))
 
-      schema
+      {schema, false}
   end
 
   # public function for testing

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -8,6 +8,33 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
   alias Model.TableFieldSchema, as: TFS
   alias Model.TableSchema, as: TS
 
+  @initial_table_schema %Model.TableSchema{
+    fields: [
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "REQUIRED",
+        name: "timestamp",
+        type: "TIMESTAMP"
+      },
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "NULLABLE",
+        name: "id",
+        type: "STRING"
+      },
+      %TFS{
+        description: nil,
+        fields: nil,
+        mode: "NULLABLE",
+        name: "event_message",
+        type: "STRING"
+      }
+    ]
+  }
+  @initial_fields_by_name Map.new(@initial_table_schema.fields, &{&1.name, &1})
+
   @doc """
   Builds table schema from event metadata and prev schema.
 
@@ -138,62 +165,96 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
 
   """
   @spec build_table_schema([map()] | map(), TS.t()) :: TS.t()
+  def build_table_schema(params, old_schema) do
+    {schema, _changed?} = build_table_schema_with_change(params, old_schema)
 
-  def build_table_schema(params, %{fields: old_fields}) do
-    protected_keys = Enum.map(initial_table_schema().fields, & &1.name)
+    schema
+  end
+
+  @spec build_table_schema_with_change([map()] | map(), TS.t()) :: {TS.t(), boolean()}
+  def build_table_schema_with_change(params, %{fields: old_fields} = old_schema) do
+    initial_schema = initial_table_schema()
+
+    old_fields_by_name =
+      Enum.reduce(old_fields, %{}, fn field, fields_by_name ->
+        Map.put_new(fields_by_name, field.name, field)
+      end)
+
     is_otel = otel_data?(params)
 
-    new_fields =
-      for param_key <- Map.keys(params),
-          param_key not in protected_keys do
-        prev_field_schema = Enum.find(old_fields, &(&1.name == param_key)) || %{}
-        param_value = Map.get(params, param_key)
+    {new_fields, changed?} =
+      Enum.reduce(
+        params,
+        {[], false},
+        &merge_param(&1, &2, old_fields_by_name, is_otel)
+      )
 
-        case build_fields_schemas({param_key, param_value}, is_otel) do
-          nil -> nil
-          new_field_schema -> DeepMerge.deep_merge(prev_field_schema, new_field_schema)
-        end
-      end
-      |> Enum.reject(&is_nil/1)
+    missing_initial_field? =
+      Enum.any?(initial_schema.fields, &(not Map.has_key?(old_fields_by_name, &1.name)))
 
+    changed? =
+      changed? or missing_initial_field? or map_size(old_fields_by_name) != length(old_fields) or
+        not fields_deeply_sorted_by_name?(old_fields) or
+        old_schema != %{initial_schema | fields: old_fields}
+
+    if changed? do
+      new_fields = Enum.reverse(new_fields)
+      updated_fields = updated_fields(old_fields, params, new_fields, initial_schema)
+      schema = Map.put(initial_schema, :fields, updated_fields)
+      schema = deep_sort_by_fields_name(schema)
+
+      {schema, true}
+    else
+      {old_schema, false}
+    end
+  end
+
+  defp updated_fields(old_fields, params, new_fields, initial_schema) do
     # reject old fields that are now included in the params
-    unrejected_fields = old_fields |> Enum.reject(&(&1.name in Map.keys(params)))
+    unrejected_fields = Enum.reject(old_fields, &Map.has_key?(params, &1.name))
+    field_names = MapSet.new(unrejected_fields ++ new_fields, & &1.name)
 
-    updated_fields =
-      (unrejected_fields ++ new_fields ++ initial_table_schema().fields)
-      |> Enum.uniq_by(fn f -> f.name end)
+    missing_initial_fields =
+      Enum.reject(initial_schema.fields, &MapSet.member?(field_names, &1.name))
 
-    initial_table_schema()
-    |> Map.put(:fields, updated_fields)
-    |> deep_sort_by_fields_name()
+    Enum.uniq_by(unrejected_fields ++ new_fields ++ missing_initial_fields, & &1.name)
   end
 
   def initial_table_schema do
-    %Model.TableSchema{
-      fields: [
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "REQUIRED",
-          name: "timestamp",
-          type: "TIMESTAMP"
-        },
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "NULLABLE",
-          name: "id",
-          type: "STRING"
-        },
-        %TFS{
-          description: nil,
-          fields: nil,
-          mode: "NULLABLE",
-          name: "event_message",
-          type: "STRING"
-        }
-      ]
-    }
+    @initial_table_schema
+  end
+
+  defp merge_param(
+         {param_key, _param_value},
+         {new_fields, changed?},
+         old_fields_by_name,
+         _is_otel
+       )
+       when param_key in ["event_message", "id", "timestamp"] do
+    initial_field = Map.fetch!(@initial_fields_by_name, param_key)
+    old_field = Map.get(old_fields_by_name, param_key)
+
+    {new_fields, changed? or is_nil(old_field) or old_field != initial_field}
+  end
+
+  defp merge_param(
+         {param_key, param_value},
+         {new_fields, changed?},
+         old_fields_by_name,
+         is_otel
+       ) do
+    prev_field_schema = Map.get(old_fields_by_name, param_key)
+
+    case build_fields_schemas({param_key, param_value}, is_otel) do
+      nil ->
+        {new_fields, changed? or not is_nil(prev_field_schema)}
+
+      new_field_schema ->
+        {merged_field_schema, field_changed?} =
+          merge_field_schema(prev_field_schema, new_field_schema)
+
+        {[merged_field_schema | new_fields], changed? or field_changed?}
+    end
   end
 
   defp build_fields_schemas({params_key, params_val}, _is_otel) when is_map(params_val) do
@@ -268,51 +329,73 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
     Map.has_key?(params, "resource") and Map.has_key?(params, "scope")
   end
 
-  defimpl DeepMerge.Resolver, for: Model.TableFieldSchema do
-    @doc """
-    Implements merge for schema key conflicts.
-    Overwrites fields schemas that are present BOTH in old and new TFS structs and keeps fields schemas present ONLY in old.
-    """
+  defp merge_field_schema(nil, %TFS{} = new), do: {new, true}
 
-    @spec resolve(TFS.t(), TFS.t(), fun) :: TFS.t()
-    def resolve(old, new, _standard_resolver) do
-      resolve(old, new)
+  defp merge_field_schema(%TFS{fields: old_fields} = old, %TFS{fields: new_fields} = new)
+       when is_list(old_fields) and is_list(new_fields) do
+    {merged_fields, children_changed?} = merge_fields(old_fields, new_fields)
+    parent_changed? = %{new | fields: old_fields} != old
+    changed? = parent_changed? or children_changed?
+
+    if changed? do
+      {%{new | fields: merged_fields}, true}
+    else
+      {old, false}
     end
+  end
 
-    @spec resolve(TFS.t(), TFS.t()) :: TFS.t()
-    def resolve(
-          %TFS{fields: old_fields},
-          %TFS{fields: new_fields} = new_tfs
-        )
-        when is_list(old_fields)
-        when is_list(new_fields) do
-      # collect all names for new fields schemas
-      new_fields_names = Enum.map(new_fields || [], & &1.name)
+  defp merge_field_schema(%TFS{fields: old_fields} = old, %TFS{fields: new_fields})
+       when is_list(old_fields) or is_list(new_fields) do
+    raise Protocol.UndefinedError, protocol: DeepMerge.Resolver, value: old
+  end
 
-      # filter field schemas that are present only in old table field schema
-      uniq_old_fs = for fs <- old_fields, fs.name not in new_fields_names, do: fs
+  defp merge_field_schema(old, %TFS{} = new) do
+    if old == new, do: {old, false}, else: {new, true}
+  end
 
-      %{new_tfs | fields: resolve_list(old_fields, new_fields) ++ uniq_old_fs}
-    end
+  defp merge_fields(old_fields, new_fields) do
+    new_fields_by_name = Map.new(new_fields, &{&1.name, &1})
 
-    def resolve(_old, %TFS{} = new) do
-      new
-    end
+    {merged_old_fields, {remaining_new_fields, changed?}} =
+      Enum.map_reduce(old_fields, {new_fields_by_name, false}, fn old_field,
+                                                                  {remaining, changed?} ->
+        case Map.pop(remaining, old_field.name) do
+          {nil, remaining} ->
+            {old_field, {remaining, changed?}}
 
-    @spec resolve_list(list(TFS.t()), list(TFS.t())) :: list(TFS.t())
-    def resolve_list(old_fields, new_fields)
-        when is_list(old_fields)
-        when is_list(new_fields) do
-      for %TFS{} = new_field <- new_fields do
-        old_fields
-        |> maybe_find_with_name(new_field)
-        |> resolve(new_field)
-      end
-    end
+          {new_field, remaining} ->
+            {merged_field, field_changed?} = merge_field_schema(old_field, new_field)
+            {merged_field, {remaining, changed? or field_changed?}}
+        end
+      end)
 
-    @spec maybe_find_with_name(list(TFS.t()), TFS.t()) :: TFS.t() | nil
-    def maybe_find_with_name(enumerable, %TFS{name: name}) do
-      Enum.find(enumerable, &(&1.name === name))
-    end
+    added_fields =
+      Enum.filter(new_fields, &Map.has_key?(remaining_new_fields, &1.name))
+
+    {merged_old_fields ++ added_fields, changed? or added_fields != []}
+  end
+
+  defp fields_sorted_by_name?([]), do: true
+
+  defp fields_sorted_by_name?([first_field | fields]),
+    do: fields_sorted_by_name?(fields, first_field.name)
+
+  defp fields_sorted_by_name?([], _previous_name), do: true
+
+  defp fields_sorted_by_name?([field | fields], previous_name)
+       when previous_name <= field.name,
+       do: fields_sorted_by_name?(fields, field.name)
+
+  defp fields_sorted_by_name?(_fields, _previous_name), do: false
+
+  defp fields_deeply_sorted_by_name?(fields) do
+    fields_sorted_by_name?(fields) and
+      Enum.all?(fields, fn
+        %TFS{fields: nested_fields} when is_list(nested_fields) ->
+          fields_deeply_sorted_by_name?(nested_fields)
+
+        %TFS{} ->
+          true
+      end)
   end
 end

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -19,6 +19,76 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
       assert prev_schema == curr_schema
     end
 
+    test "reports whether schema changed" do
+      {prev_schema, true} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"b" => 1.0}}, @default_schema)
+
+      {same_schema, false} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"b" => 1.0}}, prev_schema)
+
+      {changed_schema, true} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"c" => 1.0}}, same_schema)
+
+      assert same_schema == prev_schema
+
+      assert %TFS{name: "c", type: "FLOAT", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(changed_schema, "a.c")
+    end
+
+    test "does not report a change when a nested payload omits existing fields" do
+      old_schema =
+        SchemaBuilder.build_table_schema(%{"a" => %{"b" => 1, "c" => 2}}, @default_schema)
+
+      {same_schema, false} =
+        SchemaBuilder.build_table_schema_with_change(%{"a" => %{"c" => 2}}, old_schema)
+
+      assert same_schema === old_schema
+    end
+
+    test "normalizes untouched nested field ordering" do
+      old_schema =
+        SchemaBuilder.build_table_schema(%{"a" => %{"b" => 1, "c" => 2}}, @default_schema)
+
+      a_field = TestUtils.get_bq_field_schema(old_schema, "a")
+
+      old_schema = %{
+        old_schema
+        | fields:
+            List.replace_at(old_schema.fields, 0, %{
+              a_field
+              | fields: Enum.reverse(a_field.fields)
+            })
+      }
+
+      {schema, true} =
+        SchemaBuilder.build_table_schema_with_change(
+          %{"event_message" => "same shape"},
+          old_schema
+        )
+
+      assert Enum.map(TestUtils.get_bq_field_schema(schema, "a").fields, & &1.name) == ["b", "c"]
+    end
+
+    test "restores missing initial fields" do
+      old_schema = %TS{fields: []}
+
+      {schema, true} = SchemaBuilder.build_table_schema_with_change(%{}, old_schema)
+
+      assert Enum.map(schema.fields, & &1.name) == ["event_message", "id", "timestamp"]
+      assert SchemaBuilder.build_table_schema(%{}, old_schema) == schema
+    end
+
+    test "preserves first-value precedence when merging arrays of maps" do
+      schema =
+        SchemaBuilder.build_table_schema(
+          %{"a" => [%{"value" => 1}, %{"value" => "later"}]},
+          @default_schema
+        )
+
+      assert %TFS{name: "value", type: "INTEGER", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(schema, "a.value")
+    end
+
     test "adding new field schemas" do
       prev_schema = SchemaBuilder.build_table_schema(%{"a" => %{"b" => 1.0}}, @default_schema)
       curr_schema = SchemaBuilder.build_table_schema(%{"a" => [%{"c" => 1.0}]}, prev_schema)

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -2,8 +2,9 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
   @moduledoc false
   use Logflare.DataCase
 
-  alias Logflare.Sources.Source.BigQuery.Schema
   alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Sources.Source.BigQuery.SchemaBuilder
 
   setup do
     insert(:plan)
@@ -16,6 +17,19 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     seconds = (next_update - System.system_time(:millisecond)) / 1000
     assert seconds <= 10
     assert seconds > 9
+  end
+
+  test "plans updates only when the payload changes the schema" do
+    body = %{"metadata" => %{"existing" => 1}}
+    schema = SchemaBuilder.build_table_schema(body, SchemaBuilder.initial_table_schema())
+
+    assert :noop = Schema.plan_update(body, schema, %{next_update: 0})
+
+    assert {:update, updated_schema} =
+             Schema.plan_update(%{"metadata" => %{"added" => true}}, schema, %{next_update: 0})
+
+    assert %_{name: "added", type: "BOOL"} =
+             TestUtils.get_bq_field_schema(updated_schema, "metadata.added")
   end
 
   test "updates correctly" do


### PR DESCRIPTION
NOT YET READY FOR REVIEW

---

Adds `SchemaBuilder.build_table_schema_with_change/2` so callers can reuse the existing schema and know whether a payload changed it. BigQuery schema planning uses that flag instead of rebuilding and then doing a full schema equality diff for unchanged payloads. `build_table_schema/2` keeps its public return behavior, including schema normalization, with focused changed, unchanged, and planning tests.