### PR TITLE
fix: use a 60s search timeout when a custom BQ   reservation is set

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -42,6 +42,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @managed_service_account_partition_count 5
   @service_account_prefix "logflare-managed"
   @reservation_error_regex ~r/reservation/i
+  @search_reservation_query_timeout_ms 60_000
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = source_backend) do
@@ -571,26 +572,41 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @spec build_base_query_opts(user :: User.t(), opts :: Keyword.t()) :: Keyword.t()
   defp build_base_query_opts(%User{} = user, opts) do
     query_type = Keyword.get(opts, :query_type)
+    reservation = resolve_reservation(user, query_type, Keyword.get(opts, :reservation))
 
     [
       location: user.bigquery_dataset_location,
       use_query_cache: Keyword.get(opts, :use_query_cache, true),
       dryRun: Keyword.get(opts, :dry_run, false),
       query_type: query_type,
-      reservation:
-        case Keyword.get(opts, :reservation) do
-          nil ->
-            case query_type do
-              :search -> user.bigquery_reservation_search
-              :alerts -> user.bigquery_reservation_alerts
-              _ -> nil
-            end
+      reservation: reservation
+    ] ++ query_timeout_opts(query_type, reservation)
+  end
 
-          value ->
-            value
-        end
+  @spec resolve_reservation(
+          user :: User.t(),
+          query_type :: atom() | nil,
+          override :: String.t() | nil
+        ) :: String.t() | nil
+  defp resolve_reservation(%User{bigquery_reservation_search: reservation}, :search, nil),
+    do: reservation
+
+  defp resolve_reservation(%User{bigquery_reservation_alerts: reservation}, :alerts, nil),
+    do: reservation
+
+  defp resolve_reservation(%User{}, _query_type, nil), do: nil
+  defp resolve_reservation(%User{}, _query_type, override), do: override
+
+  @spec query_timeout_opts(query_type :: atom() | nil, reservation :: String.t() | nil) ::
+          Keyword.t()
+  defp query_timeout_opts(:search, reservation) when is_non_empty_binary(reservation) do
+    [
+      jobTimeoutMs: @search_reservation_query_timeout_ms,
+      timeoutMs: @search_reservation_query_timeout_ms
     ]
   end
+
+  defp query_timeout_opts(_query_type, _reservation), do: []
 
   @spec execute_query_with_context(
           user_id :: integer(),

--- a/lib/logflare/google/bigquery/gen_utils.ex
+++ b/lib/logflare/google/bigquery/gen_utils.ex
@@ -319,10 +319,12 @@ defmodule Logflare.Google.BigQuery.GenUtils do
     ).adapter
   end
 
+  # receive_timeout must exceed the longest BigQuery jobs.query `timeoutMs` long-poll (60s
+  # for searches with a custom reservation), otherwise the transport cuts off the response.
   defp build_tesla_adapter_call({:query, _}) do
     Tesla.client(
       [],
-      {Tesla.Adapter.Finch, name: Logflare.FinchQuery, receive_timeout: 60_000}
+      {Tesla.Adapter.Finch, name: Logflare.FinchQuery, receive_timeout: 75_000}
     ).adapter
   end
 

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -275,6 +275,75 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
     end
   end
 
+  describe "search query timeouts" do
+    setup do
+      insert(:plan, name: "Free", type: "standard")
+      pid = self()
+
+      stub(BqJobs, :bigquery_jobs_query, fn _conn, _proj_id, opts ->
+        send(pid, {:timeouts, opts[:body].jobTimeoutMs, opts[:body].timeoutMs})
+        {:ok, TestUtils.gen_bq_response()}
+      end)
+
+      :ok
+    end
+
+    test "uses a 60s timeout for :search queries with a custom reservation" do
+      user =
+        insert(:user,
+          bigquery_dataset_id: "test_dataset",
+          bigquery_reservation_search: "projects/p/locations/l/reservations/search"
+        )
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user.bigquery_dataset_id, user.id},
+        {"select 1", []},
+        query_type: :search
+      )
+
+      assert_received {:timeouts, 60_000, 60_000}
+    end
+
+    test "keeps the default timeout for searches without a reservation and for non-search queries" do
+      user = insert(:user, bigquery_dataset_id: "test_dataset")
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user.bigquery_dataset_id, user.id},
+        {"select 1", []},
+        query_type: :search
+      )
+
+      assert_received {:timeouts, 25_000, 25_000}
+
+      user_with_reservation =
+        insert(:user,
+          bigquery_dataset_id: "test_dataset",
+          bigquery_reservation_alerts: "projects/p/locations/l/reservations/alerts"
+        )
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user_with_reservation.bigquery_dataset_id, user_with_reservation.id},
+        {"select 1", []},
+        query_type: :alerts
+      )
+
+      assert_received {:timeouts, 25_000, 25_000}
+    end
+
+    test "uses a 60s timeout for :search queries with an explicit reservation override" do
+      user = insert(:user, bigquery_dataset_id: "test_dataset")
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user.bigquery_dataset_id, user.id},
+        {"select 1", []},
+        query_type: :search,
+        reservation: "projects/p/locations/l/reservations/override"
+      )
+
+      assert_received {:timeouts, 60_000, 60_000}
+    end
+  end
+
   describe "reservation error logging" do
     setup do
       insert(:plan, name: "Free", type: "standard")


### PR DESCRIPTION
## Why?

Search queries for users with a custom BQ reservation were hitting the default 25s timeout before the reservation had a chance to do its job.


## Key Changes

- `:search` queries that resolve to a custom reservation (_user setting or explicit override_) now set `jobTimeoutMs`/`timeoutMs` to 60s. All other queries keep the 25s default. Alerts intentionally stay as-is per the ticket scope.
- Bumps the Finch `receive_timeout` for query connections from 60s to 75s. The BigQuery `jobs.query` call long-polls for up to `timeoutMs`, so the HTTP receive timeout must outlive the new 60s server-side wait or the transport cuts off the response mid-poll.
- Refactored the reservation resolution in `build_base_query_opts/2` into pattern-matched function heads while adding the timeout opts.