### PR TITLE
feat(telemetry): emit build commit SHA as OTel resource attribute

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -53,6 +53,10 @@ jobs:
           push: true
           tags: supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
+          # Baked into the image as LOGFLARE_COMMIT_SHA and emitted as an OTel
+          # resource attribute at runtime (see Dockerfile / Logflare.Telemetry).
+          build-args: |
+            COMMIT_SHA=${{ needs.settings.outputs.short_sha }}
           # caching
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Git commit SHA of the build, surfaced as an OTel resource attribute at runtime
+# (see Logflare.Telemetry). Passed in by CI; empty in local/ad-hoc builds.
+ARG COMMIT_SHA
+ENV LOGFLARE_COMMIT_SHA=${COMMIT_SHA}
+
 # Copy required files from builder step
 COPY --from=builder app/_build/prod /opt/app
 COPY --from=builder app/VERSION /opt/app/VERSION

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -40,7 +40,8 @@ defmodule Logflare.Telemetry do
             name: "Logflare",
             service: %{
               name: "Logflare",
-              version: Application.spec(:logflare, :vsn) |> to_string()
+              version: Application.spec(:logflare, :vsn) |> to_string(),
+              commit: System.get_env("LOGFLARE_COMMIT_SHA")
             },
             node: inspect(Node.self()),
             cluster: Application.get_env(:logflare, :metadata)[:cluster]


### PR DESCRIPTION
## What

Emit the build's git commit SHA as a `service.commit` OTel resource attribute on the metrics exporter, so it lands in BigQuery as `resource._service_commit`.

## Why

The Logflare Health dashboard can already show `resource._service_version` (e.g. `1.44.3`), read from the compiled `VERSION` file. That's bumped only at release time, so it can't tell which commit the **continuously-deployed staging `main` cluster** is running — many distinct commits report the same semver. Today the SHA exists only as a Docker image tag in CI and never reaches the running app. This change gives per-build identity.

## Changes

- **`lib/telemetry.ex`** — add `commit: System.get_env("LOGFLARE_COMMIT_SHA")` to the metrics exporter `:resource` `service` map.
- **`Dockerfile`** — `ARG COMMIT_SHA` → `ENV LOGFLARE_COMMIT_SHA` in the runner stage.
- **`.github/workflows/docker-ci-amd-and-arm.yml`** — pass the already-computed `short_sha` as the `COMMIT_SHA` build-arg.

Cloud Build's `secret_setup.Dockerfile` is `FROM` the app image and inherits the `ENV`; versioned/prod images are retags of the same dev image — so the SHA propagates to all clusters with **no Cloud Build changes**.

## Notes

- **Unset is safe.** When `LOGFLARE_COMMIT_SHA` is absent (local/ad-hoc builds), `System.get_env` returns `nil`; the exporter's `to_kv_value/1` matches its `is_atom` clause (`nil` is an atom) → `to_string(nil)` → `""`. No crash — the attribute is just an empty string. Downstream queries should treat `''` like NULL.
- Nested `resource.service.*` arrays are empty in the BigQuery sink; the populated values are the underscore-flattened scalars, so this surfaces as `resource._service_commit`. No schema migration.
- `mix format --check-formatted` passes.

## Follow-up

Separate PR in `o11y-team-tools` to surface version/commit on the Logflare Health dashboard once a build carrying the env var has deployed.

Linear: O11Y-2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)