### PR TITLE
feat(telemetry): emit build commit SHA as OTel resource attribute

### DIFF
--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -53,6 +53,10 @@ jobs:
           push: true
           tags: supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
+          # Baked into the image as LOGFLARE_COMMIT_SHA and emitted as an OTel
+          # resource attribute at runtime (see Dockerfile / Logflare.Telemetry).
+          build-args: |
+            COMMIT_SHA=${{ needs.settings.outputs.short_sha }}
           # caching
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Git commit SHA of the build, surfaced as an OTel resource attribute at runtime
+# (see Logflare.Telemetry). Passed in by CI; empty in local/ad-hoc builds.
+ARG COMMIT_SHA
+ENV LOGFLARE_COMMIT_SHA=${COMMIT_SHA}
+
 # Copy required files from builder step
 COPY --from=builder app/_build/prod /opt/app
 COPY --from=builder app/VERSION /opt/app/VERSION

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -3,6 +3,7 @@ defmodule Logflare.Telemetry do
 
   import Telemetry.Metrics
   import Logflare.Utils, only: [ets_info: 1]
+  import Logflare.Utils.Guards, only: [is_non_empty_binary: 1]
 
   def start_link(arg), do: Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
 
@@ -33,12 +34,7 @@ defmodule Logflare.Telemetry do
 
     otel_exporter =
       if Application.get_env(:logflare, :opentelemetry_enabled?) do
-        service =
-          %{
-            name: "Logflare",
-            version: Application.spec(:logflare, :vsn) |> to_string()
-          }
-          |> maybe_put_commit(System.get_env("LOGFLARE_COMMIT_SHA"))
+        service = service_attributes(System.get_env("LOGFLARE_COMMIT_SHA"))
 
         otel_exporter_opts =
           Application.get_all_env(:opentelemetry_exporter)
@@ -68,9 +64,24 @@ defmodule Logflare.Telemetry do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
+  @spec service_attributes(String.t() | nil) :: map()
+  def service_attributes(commit_sha) do
+    %{
+      name: "Logflare",
+      version: Application.spec(:logflare, :vsn) |> to_string()
+    }
+    |> maybe_put_commit(commit_sha)
+  end
+
   @spec maybe_put_commit(map(), String.t() | nil) :: map()
-  defp maybe_put_commit(service, nil), do: service
-  defp maybe_put_commit(service, commit), do: Map.put(service, :commit, commit)
+  defp maybe_put_commit(service, commit_sha) when is_non_empty_binary(commit_sha) do
+    case String.trim(commit_sha) do
+      "" -> service
+      commit -> Map.put(service, :commit, commit)
+    end
+  end
+
+  defp maybe_put_commit(service, _commit_sha), do: service
 
   defp metrics do
     cache_stats? = Application.get_env(:logflare, :cache_stats, false)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -40,7 +40,8 @@ defmodule Logflare.Telemetry do
             name: "Logflare",
             service: %{
               name: "Logflare",
-              version: Application.spec(:logflare, :vsn) |> to_string()
+              version: Application.spec(:logflare, :vsn) |> to_string(),
+              commit: System.get_env("LOGFLARE_COMMIT_SHA")
             },
             node: inspect(Node.self()),
             cluster: Application.get_env(:logflare, :metadata)[:cluster]

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -33,16 +33,19 @@ defmodule Logflare.Telemetry do
 
     otel_exporter =
       if Application.get_env(:logflare, :opentelemetry_enabled?) do
+        service =
+          %{
+            name: "Logflare",
+            version: Application.spec(:logflare, :vsn) |> to_string()
+          }
+          |> maybe_put_commit(System.get_env("LOGFLARE_COMMIT_SHA"))
+
         otel_exporter_opts =
           Application.get_all_env(:opentelemetry_exporter)
           |> Keyword.put(:metrics, metrics())
           |> Keyword.put(:resource, %{
             name: "Logflare",
-            service: %{
-              name: "Logflare",
-              version: Application.spec(:logflare, :vsn) |> to_string(),
-              commit: System.get_env("LOGFLARE_COMMIT_SHA")
-            },
+            service: service,
             node: inspect(Node.self()),
             cluster: Application.get_env(:logflare, :metadata)[:cluster]
           })
@@ -64,6 +67,10 @@ defmodule Logflare.Telemetry do
 
     Supervisor.init(children, strategy: :one_for_one)
   end
+
+  @spec maybe_put_commit(map(), String.t() | nil) :: map()
+  defp maybe_put_commit(service, nil), do: service
+  defp maybe_put_commit(service, commit), do: Map.put(service, :commit, commit)
 
   defp metrics do
     cache_stats? = Application.get_env(:logflare, :cache_stats, false)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -34,17 +34,10 @@ defmodule Logflare.Telemetry do
 
     otel_exporter =
       if Application.get_env(:logflare, :opentelemetry_enabled?) do
-        service = service_attributes(System.get_env("LOGFLARE_COMMIT_SHA"))
-
         otel_exporter_opts =
           Application.get_all_env(:opentelemetry_exporter)
           |> Keyword.put(:metrics, metrics())
-          |> Keyword.put(:resource, %{
-            name: "Logflare",
-            service: service,
-            node: inspect(Node.self()),
-            cluster: Application.get_env(:logflare, :metadata)[:cluster]
-          })
+          |> Keyword.put(:resource, resource())
           |> Keyword.update!(:otlp_headers, &Map.new/1)
           # set finch pool to 100 size
           |> Keyword.put(:otlp_concurrent_requests, max(base * 4, 50))
@@ -62,6 +55,16 @@ defmodule Logflare.Telemetry do
       ] ++ otel_exporter
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @spec resource() :: map()
+  def resource do
+    %{
+      name: "Logflare",
+      service: service_attributes(System.get_env("LOGFLARE_COMMIT_SHA")),
+      node: inspect(Node.self()),
+      cluster: Application.get_env(:logflare, :metadata)[:cluster]
+    }
   end
 
   @spec service_attributes(String.t() | nil) :: map()

--- a/test/logflare/telemetry_otel_export_test.exs
+++ b/test/logflare/telemetry_otel_export_test.exs
@@ -7,56 +7,59 @@ defmodule Logflare.TelemetryOtelExportTest do
 
   describe "OTel resource export" do
     test "emits the build commit SHA as a service resource attribute" do
-      test_pid = self()
+      resource = export_resource("deadbeef")
 
-      System.put_env("LOGFLARE_COMMIT_SHA", "deadbeef")
-      on_exit(fn -> System.delete_env("LOGFLARE_COMMIT_SHA") end)
-
-      name = :telemetry_otel_export_test
-
-      start_supervised!(
-        {OtelMetricExporter,
-         name: name,
-         metrics: [counter("logflare.telemetry_otel_export_test.count")],
-         export_period: to_timeout(minute: 5),
-         export_callback: fn {type, _batch}, config ->
-           send(test_pid, {:otel_export, type, config.resource})
-           :ok
-         end,
-         resource: Logflare.Telemetry.resource()}
-      )
-
-      assert :ok = MetricStore.export_sync(name)
-
-      assert_receive {:otel_export, :metrics, resource}
       assert resource["service.name"] == "Logflare"
       assert resource["service.commit"] == "deadbeef"
     end
 
-    test "omits the commit attribute when no SHA is set" do
-      test_pid = self()
+    test "omits the commit attribute when the SHA is an empty string" do
+      # An unset Docker build-arg expands `ENV LOGFLARE_COMMIT_SHA=${COMMIT_SHA}`
+      # to "", so the var is present but empty in real deployments.
+      resource = export_resource("")
 
-      System.delete_env("LOGFLARE_COMMIT_SHA")
-
-      name = :telemetry_otel_export_no_sha_test
-
-      start_supervised!(
-        {OtelMetricExporter,
-         name: name,
-         metrics: [counter("logflare.telemetry_otel_export_no_sha_test.count")],
-         export_period: to_timeout(minute: 5),
-         export_callback: fn {type, _batch}, config ->
-           send(test_pid, {:otel_export, type, config.resource})
-           :ok
-         end,
-         resource: Logflare.Telemetry.resource()}
-      )
-
-      assert :ok = MetricStore.export_sync(name)
-
-      assert_receive {:otel_export, :metrics, resource}
       assert resource["service.name"] == "Logflare"
       refute Map.has_key?(resource, "service.commit")
     end
+
+    test "omits the commit attribute when no SHA is set" do
+      resource = export_resource(nil)
+
+      assert resource["service.name"] == "Logflare"
+      refute Map.has_key?(resource, "service.commit")
+    end
+  end
+
+  # Builds the OTel resource via Telemetry.resource/0, runs it through a real
+  # exporter, and returns the resource as it would be emitted downstream.
+  defp export_resource(commit_sha) do
+    test_pid = self()
+
+    if commit_sha do
+      System.put_env("LOGFLARE_COMMIT_SHA", commit_sha)
+    else
+      System.delete_env("LOGFLARE_COMMIT_SHA")
+    end
+
+    on_exit(fn -> System.delete_env("LOGFLARE_COMMIT_SHA") end)
+
+    name = :"telemetry_otel_export_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      {OtelMetricExporter,
+       name: name,
+       metrics: [counter("#{name}.count")],
+       export_period: to_timeout(minute: 5),
+       export_callback: fn {type, _batch}, config ->
+         send(test_pid, {:otel_export, type, config.resource})
+         :ok
+       end,
+       resource: Logflare.Telemetry.resource()}
+    )
+
+    assert :ok = MetricStore.export_sync(name)
+    assert_receive {:otel_export, :metrics, resource}
+
+    resource
   end
 end

--- a/test/logflare/telemetry_otel_export_test.exs
+++ b/test/logflare/telemetry_otel_export_test.exs
@@ -1,0 +1,62 @@
+defmodule Logflare.TelemetryOtelExportTest do
+  use ExUnit.Case, async: false
+
+  import Telemetry.Metrics, only: [counter: 1]
+
+  alias OtelMetricExporter.MetricStore
+
+  describe "OTel resource export" do
+    test "emits the build commit SHA as a service resource attribute" do
+      test_pid = self()
+
+      System.put_env("LOGFLARE_COMMIT_SHA", "deadbeef")
+      on_exit(fn -> System.delete_env("LOGFLARE_COMMIT_SHA") end)
+
+      name = :telemetry_otel_export_test
+
+      start_supervised!(
+        {OtelMetricExporter,
+         name: name,
+         metrics: [counter("logflare.telemetry_otel_export_test.count")],
+         export_period: to_timeout(minute: 5),
+         export_callback: fn {type, _batch}, config ->
+           send(test_pid, {:otel_export, type, config.resource})
+           :ok
+         end,
+         resource: Logflare.Telemetry.resource()}
+      )
+
+      assert :ok = MetricStore.export_sync(name)
+
+      assert_receive {:otel_export, :metrics, resource}
+      assert resource["service.name"] == "Logflare"
+      assert resource["service.commit"] == "deadbeef"
+    end
+
+    test "omits the commit attribute when no SHA is set" do
+      test_pid = self()
+
+      System.delete_env("LOGFLARE_COMMIT_SHA")
+
+      name = :telemetry_otel_export_no_sha_test
+
+      start_supervised!(
+        {OtelMetricExporter,
+         name: name,
+         metrics: [counter("logflare.telemetry_otel_export_no_sha_test.count")],
+         export_period: to_timeout(minute: 5),
+         export_callback: fn {type, _batch}, config ->
+           send(test_pid, {:otel_export, type, config.resource})
+           :ok
+         end,
+         resource: Logflare.Telemetry.resource()}
+      )
+
+      assert :ok = MetricStore.export_sync(name)
+
+      assert_receive {:otel_export, :metrics, resource}
+      assert resource["service.name"] == "Logflare"
+      refute Map.has_key?(resource, "service.commit")
+    end
+  end
+end

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -6,6 +6,31 @@ defmodule Logflare.TelemetryTest do
   alias Logflare.Telemetry
   alias Logflare.TestUtils
 
+  describe "service_attributes/1" do
+    test "always includes name and version" do
+      service = Telemetry.service_attributes(nil)
+      assert service.name == "Logflare"
+      assert is_binary(service.version)
+    end
+
+    test "includes commit when a SHA is set" do
+      assert %{commit: "abc123"} = Telemetry.service_attributes("abc123")
+    end
+
+    test "trims surrounding whitespace from the commit" do
+      assert %{commit: "abc123"} = Telemetry.service_attributes("  abc123\n")
+    end
+
+    test "omits commit when the SHA is nil" do
+      refute Map.has_key?(Telemetry.service_attributes(nil), :commit)
+    end
+
+    test "omits commit when the SHA is empty or whitespace-only" do
+      refute Map.has_key?(Telemetry.service_attributes(""), :commit)
+      refute Map.has_key?(Telemetry.service_attributes("   "), :commit)
+    end
+  end
+
   describe "process metrics" do
     test "retrieves and emits top 10 by memory" do
       event = [:logflare, :system, :top_processes, :memory]

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -6,23 +6,9 @@ defmodule Logflare.TelemetryTest do
   alias Logflare.Telemetry
   alias Logflare.TestUtils
 
-  describe "service_attributes/1" do
-    test "always includes name and version" do
-      service = Telemetry.service_attributes(nil)
-      assert service.name == "Logflare"
-      assert is_binary(service.version)
-    end
-
-    test "includes commit when a SHA is set" do
-      assert %{commit: "abc123"} = Telemetry.service_attributes("abc123")
-    end
-
+  describe "service_attributes/1 commit normalization" do
     test "trims surrounding whitespace from the commit" do
       assert %{commit: "abc123"} = Telemetry.service_attributes("  abc123\n")
-    end
-
-    test "omits commit when the SHA is nil" do
-      refute Map.has_key?(Telemetry.service_attributes(nil), :commit)
     end
 
     test "omits commit when the SHA is empty or whitespace-only" do


### PR DESCRIPTION
## What

Emit the build's git commit SHA as a `service.commit` OTel resource attribute on the metrics exporter, so it lands in BigQuery as `resource._service_commit`.

## Why

OTel telemetry can already report `resource._service_version` (e.g. `1.44.3`), read from the compiled `VERSION` file. That's bumped only at release time, so it can't distinguish which commit a continuously-deployed build is actually running — many distinct commits report the same semver. Today the SHA exists only as a Docker image tag in CI and never reaches the running app. This change gives per-build identity.

## Changes

- **`lib/telemetry.ex`** — add a `commit` entry to the metrics exporter `:resource` `service` map, populated from `LOGFLARE_COMMIT_SHA`. The key is only added when the env var is set (see Notes).
- **`Dockerfile`** — `ARG COMMIT_SHA` → `ENV LOGFLARE_COMMIT_SHA` in the runner stage.
- **`.github/workflows/docker-ci-amd-and-arm.yml`** — pass the already-computed `short_sha` as the `COMMIT_SHA` build-arg.

Cloud Build's `secret_setup.Dockerfile` is `FROM` the app image and inherits the `ENV`; versioned/prod images are retags of the same dev image — so the SHA propagates everywhere with no Cloud Build changes.

## Notes

- **Unset is safe.** When `LOGFLARE_COMMIT_SHA` is absent (local/ad-hoc builds), the `commit` key is omitted from the resource `service` map entirely, rather than emitted as an empty string. In OTel terms an unknown attribute should be absent, not present-but-empty — so downstream queries see the attribute missing rather than `''`. CI always sets it, so real deployments are unaffected.
