### PR TITLE
feat: exclude quick filter in search

### DIFF
--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -1,11 +1,11 @@
 defmodule LogflareWeb.QueryComponents do
   use Phoenix.Component
+  use LogflareWeb, :html
   use LogflareWeb, :routes
 
   alias Logflare.Logs.SearchOperations.Helpers
   alias Logflare.Lql
   alias Logflare.Lql.Rules.FilterRule
-  alias Logflare.Teams.Team
   alias LogflareWeb.Utils
   alias Phoenix.LiveView.JS
 
@@ -34,35 +34,32 @@ defmodule LogflareWeb.QueryComponents do
   attr :search_params, :map, default: %{}
   attr :team, :any, default: nil
 
-  def quick_filter(%{node: %{path: [path]}} = assigns)
-      when path in ["id", "event_message", "timestamp"] and not is_map_key(assigns, :class) do
-    assigns
-    |> assign(:class, nil)
-    |> quick_filter()
-  end
-
   def quick_filter(assigns) do
+    include_path = append_to_query(assigns)
+    exclude_path = append_to_query(assigns, :exclude)
+
     assigns =
       assigns
-      |> assign(
-        :path,
-        append_to_query(
-          assigns.lql,
-          assigns.node,
-          assigns.source,
-          assigns.source_schema_flat_map,
-          assigns.lql_schema,
-          assigns.search_params,
-          assigns.team
-        )
-      )
+      |> assign(:include_path, include_path)
+      |> assign(:exclude_path, exclude_path)
       |> assign(:value_ok?, quick_filter_value_ok?(assigns.node))
-      |> assign_new(:class, fn -> "tw-hidden group-hover:tw-inline" end)
+      |> assign_new(:class, fn %{node: %{path: [path | _]}} ->
+        if path in ~w(id event_message timestamp) do
+          "tw-visible"
+        end
+      end)
 
     ~H"""
-    <.link :if={@path && @value_ok?} title="Append to query" class={@class} patch={@path}>
-      <i class="fas fa-search tw-text-xs tw-mr-1 tw-w-2"></i>
-    </.link>
+    <div class="tw-inline-block tw-space-x-1">
+      <.team_link :if={@include_path && @value_ok?} team={@team} title="Append to query" class="tw-no-underline tw-invisible group-hover:tw-visible" patch={@include_path}>
+        <i class={["fas fa-search tw-text-xs", @class]}></i>
+        <span>Include</span>
+      </.team_link>
+      <.team_link :if={@exclude_path && @value_ok?} team={@team} title="Exclude from query" class="tw-no-underline tw-invisible group-hover:tw-visible" patch={@exclude_path}>
+        <i class="fa fa-ban tw-text-xs"></i>
+        <span>Exclude</span>
+      </.team_link>
+    </div>
     """
   end
 
@@ -115,25 +112,20 @@ defmodule LogflareWeb.QueryComponents do
     )
   end
 
-  @spec append_to_query(
-          String.t(),
-          map(),
-          Logflare.Sources.Source.t(),
-          map(),
-          map(),
-          map(),
-          Team.t() | nil
-        ) ::
-          String.t() | nil
+  @spec append_to_query(map(), :include | :exclude) :: String.t() | nil
   def append_to_query(
-        lql,
-        %{path: path, value: value},
-        source,
-        flat_map,
-        lql_schema,
-        search_params,
-        team \\ nil
+        %{
+          lql: lql,
+          node: %{path: path, value: value},
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: lql_schema,
+          search_params: search_params
+        } = assigns,
+        action \\ :include
       ) do
+    team = Map.get(assigns, :team)
+
     case lookup_schema_path(path, flat_map) do
       {normalized_key, list_includes?} ->
         resolved_path = resolve_lql_path(normalized_key, flat_map)
@@ -141,7 +133,7 @@ defmodule LogflareWeb.QueryComponents do
         updated_lql =
           lql
           |> Lql.decode!(lql_schema)
-          |> upsert_filter_rule(resolved_path, value, list_includes?)
+          |> upsert_filter_rule(resolved_path, value, list_includes?, action)
           |> Lql.encode!()
 
         params =
@@ -157,17 +149,18 @@ defmodule LogflareWeb.QueryComponents do
     end
   end
 
-  defp upsert_filter_rule(rules, "timestamp", value, _list_includes?) do
+  defp upsert_filter_rule(rules, "timestamp", value, _list_includes?, action) do
     chart_period = Lql.Rules.get_chart_period(rules, :minute)
 
     ts_rule =
       normalize_filter_rule_value("timestamp", value)
       |> build_timestamp_filter_rule(chart_period)
+      |> maybe_negate_filter_rule(action)
 
     Lql.Rules.upsert_filter_rule_by_path(rules, ts_rule)
   end
 
-  defp upsert_filter_rule(rules, path, value, list_includes?) do
+  defp upsert_filter_rule(rules, path, value, list_includes?, action) do
     filter_rule =
       FilterRule.build(
         path: path,
@@ -175,9 +168,16 @@ defmodule LogflareWeb.QueryComponents do
         value: value,
         modifiers: if(is_binary(value), do: %{quoted_string: true}, else: %{})
       )
+      |> maybe_negate_filter_rule(action)
 
     Lql.Rules.upsert_filter_rule_by_path(rules, filter_rule)
   end
+
+  defp maybe_negate_filter_rule(%FilterRule{} = rule, :exclude) do
+    %{rule | modifiers: Map.put(rule.modifiers, :negate, true)}
+  end
+
+  defp maybe_negate_filter_rule(%FilterRule{} = rule, :include), do: rule
 
   @doc """
   Looks up the path in the schema flat map and returns whether it's a list type.

--- a/test/logflare_web/components/query_components_test.exs
+++ b/test/logflare_web/components/query_components_test.exs
@@ -137,10 +137,7 @@ defmodule LogflareWeb.QueryComponentsTest do
           lql_schema: schema
         })
 
-      [href] =
-        html
-        |> Floki.parse_document!()
-        |> Floki.attribute("a", "href")
+      href = quick_filter_href(html, "Append to query")
 
       %URI{query: query} = URI.parse(href)
 
@@ -167,10 +164,7 @@ defmodule LogflareWeb.QueryComponentsTest do
           lql_schema: schema
         })
 
-      [href] =
-        html
-        |> Floki.parse_document!()
-        |> Floki.attribute("a", "href")
+      href = quick_filter_href(html, "Append to query")
 
       %URI{query: query} = URI.parse(href)
 
@@ -197,10 +191,33 @@ defmodule LogflareWeb.QueryComponentsTest do
           lql_schema: schema
         })
 
-      expected_href = ~p"/sources/#{source}/search?#{%{querystring: lql, tailing?: false}}"
+      inlcude_href = ~p"/sources/#{source}/search?#{%{querystring: lql, tailing?: false}}"
+      exclude_href = ~p"/sources/#{source}/search?#{%{querystring: "-" <> lql, tailing?: false}}"
 
-      doc = Floki.parse_document!(html)
-      assert Floki.attribute(doc, "a", "href") == [expected_href]
+      assert quick_filter_href(html, "Append to query") == inlcude_href
+      assert quick_filter_href(html, "Exclude from query") == exclude_href
+    end
+
+    test "renders a metadata exclude quick filter link", %{
+      source: source,
+      schema: schema,
+      source_schema_flat_map: flat_map
+    } do
+      html =
+        render_component(&QueryComponents.quick_filter/1, %{
+          lql: "",
+          node: %{key: "status", path: ["metadata", "status"], value: "error"},
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: schema
+        })
+
+      href = quick_filter_href(html, "Exclude from query")
+
+      %URI{query: query} = URI.parse(href)
+
+      assert %{"querystring" => ~s|-m.status:"error"|, "tailing?" => "false"} =
+               URI.decode_query(query)
     end
 
     test "renders a metadata array quick filter link", %{
@@ -217,10 +234,7 @@ defmodule LogflareWeb.QueryComponentsTest do
           lql_schema: schema
         })
 
-      [href] =
-        html
-        |> Floki.parse_document!()
-        |> Floki.attribute("a", "href")
+      href = quick_filter_href(html, "Append to query")
 
       %URI{query: query} = URI.parse(href)
 
@@ -231,6 +245,36 @@ defmodule LogflareWeb.QueryComponentsTest do
                  path: "metadata.tags",
                  operator: :list_includes,
                  value: "popular, tropical, organic"
+               }
+             ] = Lql.decode!(querystring, schema)
+    end
+
+    test "renders a metadata array exclude quick filter link", %{
+      source: source,
+      schema: schema,
+      source_schema_flat_map: flat_map
+    } do
+      html =
+        render_component(&QueryComponents.quick_filter/1, %{
+          lql: "",
+          node: %{key: "", path: ["metadata", "tags"], value: "popular, tropical, organic"},
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: schema
+        })
+
+      href = quick_filter_href(html, "Exclude from query")
+
+      %URI{query: query} = URI.parse(href)
+
+      assert %{"querystring" => querystring, "tailing?" => "false"} = URI.decode_query(query)
+
+      assert [
+               %FilterRule{
+                 path: "metadata.tags",
+                 operator: :list_includes,
+                 value: "popular, tropical, organic",
+                 modifiers: %{negate: true}
                }
              ] = Lql.decode!(querystring, schema)
     end
@@ -250,10 +294,7 @@ defmodule LogflareWeb.QueryComponentsTest do
           search_params: %{"tz" => "Australia/Brisbane"}
         })
 
-      [href] =
-        html
-        |> Floki.parse_document!()
-        |> Floki.attribute("a", "href")
+      href = quick_filter_href(html, "Append to query")
 
       %URI{query: query} = URI.parse(href)
 
@@ -269,29 +310,30 @@ defmodule LogflareWeb.QueryComponentsTest do
       schema: schema,
       source_schema_flat_map: flat_map
     } do
-      [
-        {%{key: "timestamp", path: ["timestamp"], value: NaiveDateTime.utc_now()}, []},
-        {%{key: "event_message", path: ["event_message"], value: "error"}, []},
-        {%{key: "status", path: ["metadata", "status"], value: "error"},
-         ["tw-hidden group-hover:tw-inline"]}
-      ]
-      |> Enum.each(fn {node, class} ->
-        html =
-          render_component(&QueryComponents.quick_filter/1, %{
-            lql: "",
-            node: node,
-            source: source,
-            source_schema_flat_map: flat_map,
-            lql_schema: schema
-          })
+      render = fn node ->
+        render_component(&QueryComponents.quick_filter/1, %{
+          lql: "",
+          node: node,
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: schema
+        })
+      end
 
-        doc = Floki.parse_document!(html)
+      assert %{key: "timestamp", path: ["timestamp"], value: NaiveDateTime.utc_now()}
+             |> render.()
+             |> String.contains?("tw-visible")
 
-        assert Floki.attribute(doc, "a", "class") == class
-      end)
+      assert %{key: "event_message", path: ["event_message"], value: "error"}
+             |> render.()
+             |> String.contains?("tw-visible")
+
+      assert %{key: "status", path: ["metadata", "status"], value: "error"}
+             |> render.()
+             |> String.contains?("tw-invisible")
     end
 
-    test "omits the quick filter link when value is too long", %{
+    test "omits quick filter links when value is too long", %{
       source: source,
       schema: schema,
       source_schema_flat_map: flat_map
@@ -330,5 +372,14 @@ defmodule LogflareWeb.QueryComponentsTest do
       doc = Floki.parse_document!(html)
       assert Floki.find(doc, "a") == []
     end
+  end
+
+  defp quick_filter_href(html, title) do
+    [href] =
+      html
+      |> Floki.parse_document!()
+      |> Floki.attribute("a[title='#{title}']", "href")
+
+    href
   end
 end


### PR DESCRIPTION
Add an exclude quick filter action to event view in search results. 

The quick filter links are hidden until the cursor hovers over the field value.`id`, `timestamp`, and `event_message` have a permanent filter icon and reveal the full links on hover. We could show both filter and exclude links permanently for these three but adds some visual clutter.

<img width="2398" height="1574" alt="CleanShot 2026-06-16 at 15 46 22@2x" src="https://github.com/user-attachments/assets/3167afb8-bdce-49c7-a2d7-8f1691aae6ba" />


## Demo

https://github.com/user-attachments/assets/61639f79-fa7d-4c60-9455-ffe61abba7ed



Closes O11Y-1595