### PR TITLE
chore: use default options for tprof in bq schema update benchmark

### DIFF
--- a/test/profiling/bq_schema_update_internals_bench.exs
+++ b/test/profiling/bq_schema_update_internals_bench.exs
@@ -171,7 +171,7 @@ inputs =
 profile_after =
   if System.get_env("PROFILE") == "1" do
     type = String.to_existing_atom(System.get_env("TPROF_TYPE") || "time")
-    {:tprof, type: type, warmup: 0, sort: :per_call}
+    {:tprof, type: type}
   else
     false
   end

--- a/test/profiling/bq_schema_update_internals_bench.exs
+++ b/test/profiling/bq_schema_update_internals_bench.exs
@@ -168,12 +168,18 @@ inputs =
       )
   }
 
+profile? = System.get_env("PROFILE") == "1"
+
+tprof_type =
+  if tprof_type = System.get_env("TPROF_TYPE") do
+    String.to_existing_atom(tprof_type)
+  end
+
 profile_after =
-  if System.get_env("PROFILE") == "1" do
-    type = String.to_existing_atom(System.get_env("TPROF_TYPE") || "time")
-    {:tprof, type: type}
-  else
-    false
+  cond do
+    profile? && tprof_type -> {:tprof, type: tprof_type}
+    profile? -> :tprof
+    true -> false
   end
 
 suite =


### PR DESCRIPTION
I prefer the default sorting, and as for `warmup`, whatever the default is, it's probably good enough too (I trust Benchee defaults ...).

This only affects the benchmark added in https://github.com/Logflare/logflare/pull/3540