### PR TITLE
fix: deleting partner from Admin

### DIFF
--- a/priv/repo/migrations/20260618090000_add_cascade_delete_for_partner_users_partner_id.exs
+++ b/priv/repo/migrations/20260618090000_add_cascade_delete_for_partner_users_partner_id.exs
@@ -1,0 +1,15 @@
+defmodule Logflare.Repo.Migrations.AddCascadeDeleteForPartnerUsersPartnerId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:partner_users) do
+      modify :partner_id, references(:partners, on_delete: :delete_all),
+        from: references(:partners)
+    end
+
+    alter table(:users) do
+      modify :partner_id, references(:partners, on_delete: :delete_all),
+        from: references(:partners)
+    end
+  end
+end

--- a/test/logflare_web/live/admin/partner_live_test.exs
+++ b/test/logflare_web/live/admin/partner_live_test.exs
@@ -40,7 +40,8 @@ defmodule LogflareWeb.Admin.PartnerLiveTest do
   end
 
   test "deletes partner on delete button click", %{conn: conn} do
-    [%{token: token, name: name} | _others] = insert_list(5, :partner)
+    [%{token: token, name: name} = partner | _others] = insert_list(5, :partner)
+    user = insert(:user, partner: partner)
 
     {:ok, view, html} = live(conn, "/admin/partner")
 
@@ -52,6 +53,7 @@ defmodule LogflareWeb.Admin.PartnerLiveTest do
       |> render_click()
 
     refute html =~ name
+    refute Logflare.Repo.get(Logflare.User, user.id)
   end
 
   test "creates token on create token button click", %{conn: conn} do


### PR DESCRIPTION
* add cascade delete to partner_users and users.partner_id

`partner_users` appears to be an legacy table. Maybe it can be dropped altogether?

https://github.com/user-attachments/assets/c169b47e-314a-48ed-b633-f200f5abe9ca



Fixes O11Y-1855