### PR TITLE
ci: relax pg_cron version requirement

### DIFF
--- a/test/e2e/supabase/features/logs.spec.ts
+++ b/test/e2e/supabase/features/logs.spec.ts
@@ -272,7 +272,7 @@ test.beforeAll(async ({ request, browserName }) => {
   // Cron jobs
   await request.post('/api/platform/pg-meta/default/query?key=extension-create', { data: {
     disable_statement_timeout: false,
-    query: "\nCREATE EXTENSION IF NOT EXISTS pg_cron\n  SCHEMA pg_catalog\n  VERSION '1.6'\n  CASCADE;"
+    query: "\nCREATE EXTENSION IF NOT EXISTS pg_cron\n  SCHEMA pg_catalog\n  CASCADE;"
   }});
 
   await request.post('/api/platform/pg-meta/default/query?key=cron-jobs-create', { data: {


### PR DESCRIPTION
Fixes a CI issue where pg_cron was not installed.  

If the exact version is not available `CREATE EXTENSION` fails   silently.