### PR TITLE
Fix/take pending ids race

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -518,7 +518,6 @@ defmodule Logflare.Backends.IngestEventQueue do
       # so already-taken events are correctly rejected.
       confirmed =
         taken_pairs
-        |> Enum.uniq_by(fn {id, _size} -> id end)
         |> Enum.filter(fn {id, _size} ->
           replace_ms = [{{id, :pending, :"$1", :"$2"}, [], [{{id, :processing, :"$1", :"$2"}}]}]
           :ets.select_replace(tid, replace_ms) == 1

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -512,15 +512,19 @@ defmodule Logflare.Backends.IngestEventQueue do
     with tid when tid != nil <- get_tid(sid_bid_pid),
          size when is_integer(size) <- :ets.info(tid, :size),
          {taken_pairs, _cont} <- :ets.select(tid, ms, min(n, max(size, 1))) do
-      # Deduplicate first — ets.select with write_concurrency can return the same
-      # element more than once, which would create duplicate Broadway messages.
-      # Filter out events concurrently deleted between select and update_element.
-      # update_element returns false when the key no longer exists (e.g. janitor drop race).
+      # ets.select with write_concurrency + read_concurrency can return the same
+      # element multiple times across calls (stale read). select_replace is a
+      # conditional atomic update: only replaces when status is still :pending,
+      # so already-taken events are correctly rejected.
+      # Note: result term uses {{:const, id}, :processing, :"$1", :"$2"} (not
+      # {:const, {id, :processing, :"$1", :"$2"}}) so that $1/$2 are substituted
+      # with the captured event and size values, not stored as literal atoms.
       confirmed =
         taken_pairs
         |> Enum.uniq_by(fn {id, _size} -> id end)
         |> Enum.filter(fn {id, _size} ->
-          :ets.update_element(tid, id, {2, :processing})
+          replace_ms = [{{id, :pending, :"$1", :"$2"}, [], [{{id, :processing, :"$1", :"$2"}}]}]
+          :ets.select_replace(tid, replace_ms) == 1
         end)
 
       {:ok, confirmed, tid}

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -516,9 +516,6 @@ defmodule Logflare.Backends.IngestEventQueue do
       # element multiple times across calls (stale read). select_replace is a
       # conditional atomic update: only replaces when status is still :pending,
       # so already-taken events are correctly rejected.
-      # Note: result term uses {{:const, id}, :processing, :"$1", :"$2"} (not
-      # {:const, {id, :processing, :"$1", :"$2"}}) so that $1/$2 are substituted
-      # with the captured event and size values, not stored as literal atoms.
       confirmed =
         taken_pairs
         |> Enum.uniq_by(fn {id, _size} -> id end)


### PR DESCRIPTION
ETS select traversals on tables with write_concurrency and read_concurrency enabled are unsafe when concurrent inserts occur — the same key can be returned more than once across successive calls. In take_pending_ids, this caused the same event id to be emitted as multiple Broadway messages. The first message succeeded and deleted the event from ETS; subsequent duplicates hit ets:lookup and found nothing, incrementing the missing_ids metric.

The fix replaces update_element with select_replace, which atomically matches :pending and replaces with :processing in a single operation. If a stale read returns an already-taken id, select_replace returns 0 (no match) and it's filtered out. No data was lost — events still made it to BigQuery — but the metric was noisy and the duplicate processing was wasteful.