### PR TITLE
perf: timeouts tweaking

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -38,6 +38,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @scaling_threshold 15_000
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
+  @ch_slow_pool_checkout_ms 1_000
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 
@@ -351,8 +352,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     with :ok <- ensure_query_connection_manager_started(backend) do
       pool_via = connection_pool_via(backend)
 
-      timeout = if Application.get_env(:logflare, :env) == :test, do: 1_000, else: 30_000
-      opts = opts |> Keyword.put(:decode, false) |> Keyword.put(:timeout, timeout)
+      timeout = if Application.get_env(:logflare, :env) == :test, do: 1_000, else: 60_000
+
+      backend_id = backend.id
+      log_fun = fn entry -> log_slow_checkout(entry, backend_id) end
+
+      opts =
+        opts
+        |> Keyword.put(:decode, false)
+        |> Keyword.put(:timeout, timeout)
+        |> Keyword.put(:log, log_fun)
 
       case Ch.query(pool_via, statement, params, opts) do
         {:ok, %Ch.Result{} = result} ->
@@ -380,6 +389,28 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
           {:error, "Error executing ClickHouse query"}
       end
     end
+  end
+
+  @spec log_slow_checkout(DBConnection.LogEntry.t(), pos_integer()) :: :ok
+  defp log_slow_checkout(%DBConnection.LogEntry{pool_time: pool_time}, backend_id)
+       when is_integer(pool_time) do
+    pool_ms = System.convert_time_unit(pool_time, :native, :millisecond)
+
+    if pool_ms >= slow_pool_checkout_ms() do
+      Logger.warning(
+        "ClickHouse slow connection checkout: waited #{pool_ms}ms for a pool connection",
+        backend_id: backend_id
+      )
+    end
+
+    :ok
+  end
+
+  defp log_slow_checkout(_entry, _backend_id), do: :ok
+
+  @spec slow_pool_checkout_ms() :: non_neg_integer()
+  defp slow_pool_checkout_ms do
+    Application.get_env(:logflare, __MODULE__)[:slow_pool_checkout_ms] || @ch_slow_pool_checkout_ms
   end
 
   @spec execute_direct_query(url :: String.t(), config :: map(), statement :: String.t()) ::

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -410,7 +410,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @spec slow_pool_checkout_ms() :: non_neg_integer()
   defp slow_pool_checkout_ms do
-    Application.get_env(:logflare, __MODULE__)[:slow_pool_checkout_ms] || @ch_slow_pool_checkout_ms
+    Application.get_env(:logflare, __MODULE__)[:slow_pool_checkout_ms] ||
+      @ch_slow_pool_checkout_ms
   end
 
   @spec execute_direct_query(url :: String.t(), config :: map(), statement :: String.t()) ::

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
@@ -26,6 +26,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
   @inactivity_timeout :timer.minutes(5)
   @resolve_interval :timer.seconds(30)
   @ch_query_conn_timeout :timer.minutes(1)
+  @ch_queue_target :timer.seconds(5)
   @recycle_interval :timer.minutes(10)
   @recycle_spread :timer.seconds(60)
 
@@ -456,7 +457,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
         password: config.password,
         pool_size: pool_size,
         settings: [],
-        timeout: @ch_query_conn_timeout
+        timeout: @ch_query_conn_timeout,
+        queue_target: @ch_queue_target
       ]
 
       {:ok, ch_opts}

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -43,7 +43,7 @@ defmodule Logflare.Endpoints.ResultsCache do
   We have a %GoogleApi.BigQuery.V2.Model.ErrorProto{} model but it's missing fields we see in error responses.
   """
   def query(cache) when is_pid(cache) do
-    GenServer.call(cache, :query, 30_000)
+    GenServer.call(cache, :query, 60_000)
   catch
     :exit, {:timeout, _call} ->
       Logger.warning("Endpoint query timeout")

--- a/lib/logflare/endpoints/results_cache.ex
+++ b/lib/logflare/endpoints/results_cache.ex
@@ -43,7 +43,7 @@ defmodule Logflare.Endpoints.ResultsCache do
   We have a %GoogleApi.BigQuery.V2.Model.ErrorProto{} model but it's missing fields we see in error responses.
   """
   def query(cache) when is_pid(cache) do
-    GenServer.call(cache, :query, 60_000)
+    GenServer.call(cache, :query, 65_000)
   catch
     :exit, {:timeout, _call} ->
       Logger.warning("Endpoint query timeout")

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -90,6 +90,49 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert {:error, _} = result
     end
 
+    test "logs a warning when connection checkout is slow", %{backend: backend} do
+      original = Application.get_env(:logflare, ClickHouseAdaptor)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:logflare, ClickHouseAdaptor, original)
+        else
+          Application.delete_env(:logflare, ClickHouseAdaptor)
+        end
+      end)
+
+      Application.put_env(:logflare, ClickHouseAdaptor, slow_pool_checkout_ms: 0)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, _} = ClickHouseAdaptor.execute_ch_query(backend, "SELECT 1 as test")
+        end)
+
+      assert log =~ "ClickHouse slow connection checkout"
+      assert log =~ "for a pool connection"
+    end
+
+    test "does not log when connection checkout is within threshold", %{backend: backend} do
+      original = Application.get_env(:logflare, ClickHouseAdaptor)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:logflare, ClickHouseAdaptor, original)
+        else
+          Application.delete_env(:logflare, ClickHouseAdaptor)
+        end
+      end)
+
+      Application.put_env(:logflare, ClickHouseAdaptor, slow_pool_checkout_ms: 60_000)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, _} = ClickHouseAdaptor.execute_ch_query(backend, "SELECT 1 as test")
+        end)
+
+      refute log =~ "ClickHouse slow connection checkout"
+    end
+
     test "preserves 16-byte strings while converting UUID columns", %{backend: backend} do
       # A 16-byte string that could be mistaken for a UUID binary
       sixteen_byte_str = "exactly16bytesXX"


### PR DESCRIPTION

- tweaks timeouts for Ch to 60s
- bumps queue_target to 5s to handle load spikes
- logs slow queue checkouts for early warning signals.