### PR TITLE
feat(clickhouse): log host on connection and query errors

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -283,6 +283,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   def clickhouse_cloud_url?(_url), do: false
 
+  @spec config_host(Backend.t()) :: String.t() | nil
+  defp config_host(%Backend{config: %{url: url}}), do: url_host(url)
+  defp config_host(_backend), do: nil
+
+  @spec read_host(Backend.t()) :: String.t() | nil
+  defp read_host(%Backend{config: %{read_only_url: url}}) when is_non_empty_binary(url),
+    do: url_host(url)
+
+  defp read_host(%Backend{} = backend), do: config_host(backend)
+
+  @spec url_host(term()) :: String.t() | nil
+  defp url_host(url) when is_non_empty_binary(url) do
+    case URI.new(url) do
+      {:ok, %URI{host: host}} when is_binary(host) -> host
+      _ -> nil
+    end
+  end
+
+  defp url_host(_url), do: nil
+
   @doc """
   Produces a type-specific ingest table name for ClickHouse.
 
@@ -341,7 +361,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
         {:error, %Ch.Error{message: error_msg}} when is_non_empty_binary(error_msg) ->
           Logger.warning(
             "ClickHouse query failed: #{inspect(error_msg)}",
-            backend_id: backend.id
+            backend_id: backend.id,
+            host: read_host(backend)
           )
 
           {:error, "Error executing ClickHouse query"}
@@ -349,7 +370,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
         {:error, %{message: message}} when is_non_empty_binary(message) ->
           Logger.warning(
             "ClickHouse query failed: #{inspect(message)}",
-            backend_id: backend.id
+            backend_id: backend.id,
+            host: read_host(backend)
           )
 
           {:error, "Error executing ClickHouse query"}
@@ -427,6 +449,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     else
       {:error, reason} ->
         Logger.warning("ClickHouse native insert error.",
+          host: config_host(backend),
           error_string: inspect(reason)
         )
 
@@ -446,6 +469,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
       {:error, reason} ->
         Logger.warning("ClickHouse http insert error.",
+          host: config_host(backend),
           error_string: inspect(reason)
         )
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
@@ -311,8 +311,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
   end
 
   @spec start_pool(__MODULE__.t()) :: {:ok, __MODULE__.t()} | {:error, any()}
-  defp start_pool(%__MODULE__{} = state) do
-    with {:ok, ch_opts} <- build_ch_opts(state),
+  defp start_pool(%__MODULE__{backend_id: backend_id} = state) do
+    backend = Backends.Cache.get_backend(backend_id)
+
+    with {:ok, ch_opts} <- build_ch_opts(backend),
          {:ok, pid} <- Ch.start_link(ch_opts) do
       Process.monitor(pid)
 
@@ -330,8 +332,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
       {:error, reason} ->
         Logger.error(
           "Failed to start ClickHouse connection pool",
-          backend_id: state.backend_id,
-          host: connection_host(state.backend_id),
+          backend_id: backend_id,
+          host: host_from_backend(backend),
           reason: reason
         )
 
@@ -423,46 +425,41 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
     Application.get_env(:logflare, __MODULE__)[:recycle_spread] || @recycle_spread
   end
 
-  @spec build_ch_opts(__MODULE__.t()) :: {:ok, Keyword.t()} | {:error, term()}
-  defp build_ch_opts(%__MODULE__{backend_id: backend_id}) do
-    # Fetch fresh backend from cache
-    backend = Backends.Cache.get_backend(backend_id)
+  @spec build_ch_opts(Backend.t() | nil) :: {:ok, Keyword.t()} | {:error, term()}
+  defp build_ch_opts(nil), do: {:error, :backend_not_found}
 
-    if is_nil(backend) do
-      {:error, :backend_not_found}
-    else
-      config = backend.config
+  defp build_ch_opts(%Backend{} = backend) do
+    config = backend.config
 
-      default_pool_size =
-        Application.fetch_env!(:logflare, :clickhouse_backend_adaptor)[:pool_size]
+    default_pool_size =
+      Application.fetch_env!(:logflare, :clickhouse_backend_adaptor)[:pool_size]
 
-      pool_size =
-        config
-        |> Map.get(:pool_size, default_pool_size)
-        |> div(2)
-        |> max(default_pool_size)
+    pool_size =
+      config
+      |> Map.get(:pool_size, default_pool_size)
+      |> div(2)
+      |> max(default_pool_size)
 
-      url = read_url(config)
+    url = read_url(config)
 
-      with {:ok, {scheme, hostname, url_port}} <- extract_url_components(url) do
-        pool_via = connection_pool_via(backend)
-        port = get_read_port(config, url_port)
+    with {:ok, {scheme, hostname, url_port}} <- extract_url_components(url) do
+      pool_via = connection_pool_via(backend)
+      port = get_read_port(config, url_port)
 
-        ch_opts = [
-          name: pool_via,
-          scheme: scheme,
-          hostname: hostname,
-          port: port,
-          database: config.database,
-          username: config.username,
-          password: config.password,
-          pool_size: pool_size,
-          settings: [],
-          timeout: @ch_query_conn_timeout
-        ]
+      ch_opts = [
+        name: pool_via,
+        scheme: scheme,
+        hostname: hostname,
+        port: port,
+        database: config.database,
+        username: config.username,
+        password: config.password,
+        pool_size: pool_size,
+        settings: [],
+        timeout: @ch_query_conn_timeout
+      ]
 
-        {:ok, ch_opts}
-      end
+      {:ok, ch_opts}
     end
   end
 
@@ -474,13 +471,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
 
   @spec connection_host(pos_integer()) :: String.t() | nil
   defp connection_host(backend_id) do
-    with %Backend{config: config} <- Backends.Cache.get_backend(backend_id),
-         {:ok, {_scheme, hostname, _port}} <- extract_url_components(read_url(config)) do
-      hostname
-    else
+    backend_id
+    |> Backends.Cache.get_backend()
+    |> host_from_backend()
+  end
+
+  @spec host_from_backend(Backend.t() | nil) :: String.t() | nil
+  defp host_from_backend(%Backend{config: config}) do
+    case extract_url_components(read_url(config)) do
+      {:ok, {_scheme, hostname, _port}} -> hostname
       _ -> nil
     end
   end
+
+  defp host_from_backend(_backend), do: nil
 
   @spec extract_url_components(String.t()) ::
           {:ok, {String.t(), String.t(), non_neg_integer() | nil}} | {:error, String.t()}

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
@@ -294,7 +294,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
   def handle_info({:DOWN, _ref, :process, pid, _reason}, %__MODULE__{pool_pid: pid} = state)
       when is_pid(pid) do
     Logger.warning("ClickHouse connection pool died",
-      backend_id: state.backend_id
+      backend_id: state.backend_id,
+      host: connection_host(state.backend_id)
     )
 
     {:noreply, %{state | pool_pid: nil, next_recycle_at: nil}}
@@ -330,6 +331,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
         Logger.error(
           "Failed to start ClickHouse connection pool",
           backend_id: state.backend_id,
+          host: connection_host(state.backend_id),
           reason: reason
         )
 
@@ -440,8 +442,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
         |> div(2)
         |> max(default_pool_size)
 
-      read_only_url = Map.get(config, :read_only_url)
-      url = if is_non_empty_binary(read_only_url), do: read_only_url, else: Map.get(config, :url)
+      url = read_url(config)
 
       with {:ok, {scheme, hostname, url_port}} <- extract_url_components(url) do
         pool_via = connection_pool_via(backend)
@@ -462,6 +463,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
 
         {:ok, ch_opts}
       end
+    end
+  end
+
+  @spec read_url(map()) :: String.t() | nil
+  defp read_url(config) do
+    read_only_url = Map.get(config, :read_only_url)
+    if is_non_empty_binary(read_only_url), do: read_only_url, else: Map.get(config, :url)
+  end
+
+  @spec connection_host(pos_integer()) :: String.t() | nil
+  defp connection_host(backend_id) do
+    with %Backend{config: config} <- Backends.Cache.get_backend(backend_id),
+         {:ok, {_scheme, hostname, _port}} <- extract_url_components(read_url(config)) do
+      hostname
+    else
+      _ -> nil
     end
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester.ex
@@ -165,7 +165,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester do
         {:error, {:exception, code, message}} = error ->
           Logger.error(
             "ClickHouse NativeIngester: exception during insert into #{table}, " <>
-              "code=#{code} message=#{inspect(message)}, removing connection"
+              "code=#{code} message=#{inspect(message)}, removing connection",
+            host: conn.host
           )
 
           {error, :remove}
@@ -173,7 +174,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester do
         {:error, {:column_mismatch, _} = detail} = error ->
           Logger.error(
             "ClickHouse NativeIngester: column mismatch during insert into #{table}, " <>
-              "detail=#{inspect(detail)}, removing connection"
+              "detail=#{inspect(detail)}, removing connection",
+            host: conn.host
           )
 
           {error, :remove}
@@ -181,7 +183,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester do
         {:error, reason} = error ->
           Logger.error(
             "ClickHouse NativeIngester: error during insert into #{table}, " <>
-              "reason=#{inspect(reason)}, removing connection"
+              "reason=#{inspect(reason)}, removing connection",
+            host: conn.host
           )
 
           {error, :remove}
@@ -189,9 +192,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester do
     end)
   catch
     :exit, {:timeout, _} ->
-      Logger.warning("ClickHouse NativeIngester: pool checkout timeout for insert into #{table}")
+      Logger.warning("ClickHouse NativeIngester: pool checkout timeout for insert into #{table}",
+        host: config_host(backend)
+      )
+
       {:error, :checkout_timeout}
   end
+
+  @spec config_host(Backend.t()) :: String.t() | nil
+  defp config_host(%Backend{config: %{url: url}}) when is_binary(url), do: URI.parse(url).host
+  defp config_host(_backend), do: nil
 
   @spec do_cached_insert(
           Connection.t(),

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester/pool.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester/pool.ex
@@ -140,7 +140,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester.Pool do
            transfer_or_close!(conn, pool_pid)
 
          {:error, reason} ->
-           Logger.warning("ClickHouse NativeIngester.Pool: failed to connect: #{inspect(reason)}")
+           Logger.warning(
+             "ClickHouse NativeIngester.Pool: failed to connect: #{inspect(reason)}",
+             host: Keyword.get(connect_opts, :host)
+           )
 
            exit({:connect_failed, reason})
        end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester/pool_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/native_ingester/pool_manager.ex
@@ -134,7 +134,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester.PoolManager
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, %__MODULE__{pool_pid: pid} = state)
       when is_pid(pid) do
-    Logger.warning("ClickHouse native TCP pool died", backend_id: state.backend_id)
+    Logger.warning("ClickHouse native TCP pool died",
+      backend_id: state.backend_id,
+      host: backend_host(state.backend_id)
+    )
 
     {:noreply, %{state | pool_pid: nil}}
   end
@@ -147,6 +150,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester.PoolManager
   defp record_activity(%__MODULE__{} = state) do
     %{state | last_activity: System.system_time(:millisecond)}
   end
+
+  @spec backend_host(pos_integer()) :: String.t() | nil
+  defp backend_host(backend_id) do
+    case Backends.Cache.get_backend(backend_id) do
+      %Backend{} = backend -> config_host(backend)
+      _ -> nil
+    end
+  end
+
+  @spec config_host(Backend.t()) :: String.t() | nil
+  defp config_host(%Backend{config: %{url: url}}) when is_binary(url), do: URI.parse(url).host
+  defp config_host(_backend), do: nil
 
   @spec start_pool(__MODULE__.t()) :: {:ok, __MODULE__.t()} | {{:error, term()}, __MODULE__.t()}
   defp start_pool(%__MODULE__{backend_id: backend_id} = state) do
@@ -176,6 +191,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester.PoolManager
       {:error, reason} ->
         Logger.error("Failed to start ClickHouse native TCP pool",
           backend_id: backend_id,
+          host: config_host(backend),
           reason: reason
         )
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/provisioner.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/provisioner.ex
@@ -45,6 +45,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Provisioner do
       {:error, reason} = error ->
         Logger.warning("ClickHouse test connection failed",
           backend_id: backend.id,
+          host: config_host(backend),
           error_string: inspect(reason)
         )
 
@@ -60,6 +61,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Provisioner do
       {:error, reason} = error ->
         Logger.warning("ClickHouse provisioning failed",
           backend_id: backend.id,
+          host: config_host(backend),
           error_string: inspect(reason)
         )
 
@@ -68,6 +70,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Provisioner do
   end
 
   def handle_continue(:close_process, state), do: {:stop, :normal, state}
+
+  @spec config_host(Backend.t()) :: String.t() | nil
+  defp config_host(%Backend{config: %{url: url}}) when is_binary(url), do: URI.parse(url).host
+  defp config_host(_backend), do: nil
 
   @doc false
   @impl GenServer

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/native_ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/native_ingester_test.exs
@@ -358,7 +358,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngesterTest do
       end)
 
       Mimic.expect(Pool, :checkout, fn _backend, fun ->
-        fun.(%{database: backend.config.database})
+        fun.(%{database: backend.config.database, host: "localhost"})
         {:error, :stop}
       end)
 
@@ -384,7 +384,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngesterTest do
       end)
 
       Mimic.expect(Pool, :checkout, fn _backend, fun ->
-        fun.(%{database: backend.config.database})
+        fun.(%{database: backend.config.database, host: "localhost"})
         {:error, :stop}
       end)
 


### PR DESCRIPTION
## What

Adds the ClickHouse host to the metadata of connection, query, insert, and provisioning error/warning logs.

## Why

When a ClickHouse backend has errors, the logs previously carried only `backend_id` and the failure `reason`. It was hard to figure out which cluster/host was actually failing — you had to separately look up the backend's config. The host was already parsed from the config URL at each connection-setup site but never threaded into the logs.

## Changes

Each error/warning log below now includes a `host` metadata field. Read-path logs derive the host from `read_only_url` (falling back to `url`); ingest-path logs use `url`.

- `connection_manager.ex` — "Failed to start ClickHouse connection pool", "ClickHouse connection pool died". `start_pool` now fetches the backend once and passes it to both `build_ch_opts` and host derivation; the pool-died handler resolves the host from `backend_id` via the cache (no backend in scope there).
- `native_ingester/pool.ex` — "failed to connect" (host pulled from the connect opts)
- `native_ingester/pool_manager.ex` — "Failed to start ClickHouse native TCP pool", "native TCP pool died"
- `native_ingester.ex` — insert exception / column-mismatch / generic errors (host from the live `Connection` struct) and pool checkout timeout
- `clickhouse_adaptor.ex` — "ClickHouse query failed" (read host), native/http insert errors (ingest host)
- `provisioner.ex` — "test connection failed", "provisioning failed"

## Performance

All host derivations sit on error/warning branches — none runs on the success path, so steady-state ingestion is unaffected. The cost per error is a struct/keyword access or a short `URI.parse`; the two pool-died handlers additionally do a single `Backends.Cache` read (only path with `backend_id` alone).

## Testing

No unit tests added. The change is additive log metadata on error paths; the only branching logic (host selection) is the standard library plus a one-line fallback, and the `read_only_url`-precedence path is already exercised by `build_ch_opts` on the live connection path. Asserting on log metadata in tests requires fighting the test formatter (it drops metadata) for negligible signal.