### PR TITLE
feat: json_viewer_component renders whitespace

### DIFF
--- a/lib/logflare_web/components/json_viewer_component.ex
+++ b/lib/logflare_web/components/json_viewer_component.ex
@@ -112,14 +112,19 @@ defmodule LogflareWeb.JSONViewerComponent do
     """
   end
 
-  defp tree_node_value(%{value: "http" <> _url} = assigns) do
-    assigns =
-      assigns
-      |> assign(class: "tw-text-json-tree-string")
-
+  defp tree_node_value(%{href: _, formatted_value: _, class: _class} = assigns) do
     ~H"""
-    <span class={@class}>"</span><.link href={@value} target="_blank" class={@class}>{@value}</.link><span class={@class}>"</span>
+    <span class={@class}>"</span><.link href={@href} target="_blank" class={@class}>{@formatted_value}</.link><span class={@class}>"</span>
     {render_slot(@action, %{key: @key, value: @value, path: @key_path})}
+    """
+  end
+
+  defp tree_node_value(%{formatted_value: _, class: "tw-text-json-tree-string"} = assigns) do
+    ~H"""
+    <span class={@class}>
+      <span class="tw-whitespace-pre-wrap">{@formatted_value}</span>
+      {render_slot(@action, %{key: @key, value: @value, path: @key_path})}
+    </span>
     """
   end
 
@@ -161,11 +166,19 @@ defmodule LogflareWeb.JSONViewerComponent do
 
   defp tree_node_value(%{value: value, path: _path} = assigns) when is_binary(value) do
     assigns
-    |> assign(
-      formatted_value: ["\"", value, "\""],
-      class: "tw-text-json-tree-string"
-    )
-    |> tree_node_value()
+    |> assign(:class, "tw-text-json-tree-string")
+    |> then(fn assigns ->
+      if linkable_https_string?(value) do
+        assigns
+        |> assign(:formatted_value, value)
+        |> assign(:href, value)
+        |> tree_node_value()
+      else
+        assigns
+        |> assign(:formatted_value, ["\"", render_whitespace(value), "\""])
+        |> tree_node_value()
+      end
+    end)
   end
 
   defp tree_node_value(%{children: children, path: _path, key_path: _key_path} = assigns)
@@ -180,6 +193,19 @@ defmodule LogflareWeb.JSONViewerComponent do
     ~H"""
     <.tree_node :for={{k, v} <- @children} value={v} key={k} label={k} path={@path} key_path={@key_path} id={@id} action={@action} />
     """
+  end
+
+  defp render_whitespace(value) do
+    value
+    |> String.replace("\\r\\n", "\n")
+    |> String.replace("\\n", "\n")
+    |> String.replace("\\t", "\t")
+    |> String.replace("\\r", "\r")
+  end
+
+  defp linkable_https_string?(value) do
+    String.starts_with?(value, "https://") and
+      not String.contains?(value, [" ", "\t", "\n", "\r"])
   end
 
   defp append_path(path, nil), do: path

--- a/test/logflare_web/components/json_viewer_component_test.exs
+++ b/test/logflare_web/components/json_viewer_component_test.exs
@@ -2,6 +2,7 @@ defmodule LogflareWeb.JSONViewerComponentTest do
   use LogflareWeb.ConnCase, async: true
   use ExUnitProperties
 
+  import Phoenix.Component
   import Phoenix.LiveViewTest
   import LogflareWeb.JSONViewerComponent
   import StreamData
@@ -205,12 +206,49 @@ defmodule LogflareWeb.JSONViewerComponentTest do
       assert html =~ ~s(tw-text-json-tree-label)
     end
 
-    test "renders URL as link" do
-      data = %{"website" => "https://example.com"}
-      html = render_component(&json_viewer/1, data: data)
+    test "renders decoded and literal whitespace escapes as whitespace" do
+      data = %{
+        "decoded" => "SELECT\n\t*\rFROM logs",
+        "literal" => ~S(SELECT\n\t*\rFROM logs)
+      }
 
-      assert html =~ ~s(href="https://example.com")
-      assert html =~ ~s(target="_blank")
+      doc = render_component(&json_viewer/1, data: data) |> Floki.parse_document!()
+
+      assert doc
+             |> Floki.find("#decoded")
+             |> Floki.text() =~ "SELECT\n\t*\rFROM logs"
+
+      assert doc
+             |> Floki.find("#literal")
+             |> Floki.text() =~ "SELECT\n\t*\rFROM logs"
+    end
+
+    test "exact https strings are renwered as link" do
+      assert render_component(&json_viewer/1, data: %{"https" => "https://example.com"}) =~ "href"
+
+      refute render_component(&json_viewer/1, data: %{"insecure_http" => "http://example.com"}) =~
+               "href"
+
+      refute render_component(&json_viewer/1,
+               data: %{"trailing white space" => "https://example.com and some text"}
+             ) =~ "href"
+
+      refute render_component(&json_viewer/1,
+               data: %{"escaped white space" => ~S(https://example.com\nnext line)}
+             ) =~ "href"
+    end
+
+    test "action slots receive original string" do
+      assigns = %{data: %{"query" => ~S(SELECT\n1)}}
+
+      assert rendered_to_string(~H"""
+             <.json_viewer data={@data}>
+               <:action :let={node}>
+                 <span class="slot-value">{node.value}</span>
+               </:action>
+             </.json_viewer>
+             """) =~
+               ~S(<span class="slot-value">SELECT\n1</span>)
     end
   end
 

--- a/test/logflare_web/components/json_viewer_component_test.exs
+++ b/test/logflare_web/components/json_viewer_component_test.exs
@@ -223,7 +223,7 @@ defmodule LogflareWeb.JSONViewerComponentTest do
              |> Floki.text() =~ "SELECT\n\t*\rFROM logs"
     end
 
-    test "exact https strings are renwered as link" do
+    test "exact https strings are rendered as link" do
       assert render_component(&json_viewer/1, data: %{"https" => "https://example.com"}) =~ "href"
 
       refute render_component(&json_viewer/1, data: %{"insecure_http" => "http://example.com"}) =~

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1115,7 +1115,9 @@ defmodule LogflareWeb.Source.SearchLVTest do
             %TFS{name: "deployment_time", type: "TIMESTAMP", mode: "NULLABLE"}
           ]
         }
-        |> then(&SchemaBuilder.build_table_schema(%{"testing" => "string"}, &1))
+        |> then(
+          &SchemaBuilder.build_table_schema(%{"query" => "string", "testing" => "string"}, &1)
+        )
 
       response_schema =
         %TS{
@@ -1123,9 +1125,17 @@ defmodule LogflareWeb.Source.SearchLVTest do
             %TFS{name: "deployment_time", type: "TIMESTAMP"}
           ]
         }
-        |> then(&SchemaBuilder.build_table_schema(%{"testing" => "string"}, &1))
+        |> then(
+          &SchemaBuilder.build_table_schema(%{"query" => "string", "testing" => "string"}, &1)
+        )
 
-      deployment_time = TestUtils.gen_bq_timestamp(~U[2026-04-27 04:22:46.765189Z])
+      respone_body = %{
+        "event_message" => "some modal message",
+        "testing" => "modal123",
+        "query" => "SELECT\\n1",
+        "deployment_time" => TestUtils.gen_bq_timestamp(~U[2026-04-27 04:22:46.765189Z]),
+        "id" => "some-uuid"
+      }
 
       {:ok, _user} =
         Logflare.Users.update_user_with_preferences(user, %{
@@ -1143,16 +1153,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # TODO: use expect, remove UDFs creation query
       stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, _opts ->
-        {:ok,
-         TestUtils.gen_bq_response(
-           %{
-             "event_message" => "some modal message",
-             "testing" => "modal123",
-             "deployment_time" => deployment_time,
-             "id" => "some-uuid"
-           },
-           response_schema
-         )}
+        {:ok, TestUtils.gen_bq_response(respone_body, response_schema)}
       end)
 
       {:ok, view, _html} =
@@ -1174,16 +1175,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
         query = opts[:body].query
         send(pid, {:query, query})
 
-        {:ok,
-         TestUtils.gen_bq_response(
-           %{
-             "event_message" => "some modal message",
-             "testing" => "modal123",
-             "deployment_time" => deployment_time,
-             "id" => "some-uuid"
-           },
-           response_schema
-         )}
+        {:ok, TestUtils.gen_bq_response(respone_body, response_schema)}
       end)
 
       TestUtils.retry_assert(fn ->
@@ -1195,9 +1187,15 @@ defmodule LogflareWeb.Source.SearchLVTest do
       TestUtils.retry_assert(fn ->
         html = render(view)
 
+        assert html
+               |> Floki.parse_document!()
+               |> Floki.find("#metadata-raw-json-code")
+               |> Floki.text() =~ "SELECT\\\\n1"
+
         assert html =~ "Raw JSON"
         assert html =~ "modal123"
         assert html =~ "some modal message"
+        assert html =~ "SELECT\n1"
         assert html =~ "deployment_time"
         assert html =~ "1777263766765189"
         assert html =~ "2026-04-27 14:22:46"


### PR DESCRIPTION
JSON event viewer renders whitespace in strings

All white space in a string is rendered. Should we special case `event_message` and **not** render whitespace (see screenshot)?

<img width="2280" height="1714" alt="CleanShot 2026-06-19 at 14 30 32@2x" src="https://github.com/user-attachments/assets/b2b24fa0-136e-4ab0-99b4-c83dd015d789" />


## Demo



https://github.com/user-attachments/assets/ab27f8ad-d2f2-4f0e-8278-72383e859b86





Fixes O11Y-1207