### PR TITLE
perf(ingest): update_counter claim + BigQuery pipeline allocation cleanups

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -296,7 +296,10 @@ defmodule Logflare.Backends.IngestEventQueue do
   def add_to_table({sid_bid_pid, tid}, batch, _opts) when is_tuple(sid_bid_pid) do
     objects =
       for %{id: id} = event <- batch do
-        {id, :pending, event, :erlang.external_size(event.body)}
+        # 5th field is the claim counter: 0 = unclaimed. take_pending_ids/2 claims via an
+        # atomic update_counter (0 -> 1 winner), so re-inserting here resets it to 0 and
+        # makes a requeued event claimable again.
+        {id, :pending, event, :erlang.external_size(event.body), 0}
       end
 
     :ets.insert(tid, objects)
@@ -436,7 +439,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def total_pending({_sid, _bid, _pid} = sid_bid_pid) do
     ms =
       Ex2ms.fun do
-        {_event_id, :pending, _event, _size} -> true
+        {_event_id, :pending, _event, _size, _claim} -> true
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -454,7 +457,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def total_by_status({_, _} = sid_bid, status) do
     ms =
       Ex2ms.fun do
-        {_event_id, event_status, _event, _size} when event_status == ^status -> true
+        {_event_id, event_status, _event, _size, _claim} when event_status == ^status -> true
       end
 
     traverse_queues(
@@ -478,7 +481,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def take_pending(sid_bid_pid, n) when is_integer(n) do
     ms =
       Ex2ms.fun do
-        {_event_id, :pending, event, _size} -> event
+        {_event_id, :pending, event, _size, _claim} -> event
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -506,28 +509,41 @@ defmodule Logflare.Backends.IngestEventQueue do
   def take_pending_ids(sid_bid_pid, n) when is_integer(n) do
     ms =
       Ex2ms.fun do
-        {event_id, :pending, _event, size} -> {event_id, size}
+        {event_id, :pending, _event, size, _claim} -> {event_id, size}
       end
 
+    # `n` is passed directly as the select limit: `get_tid/1` already confirms the
+    # table is live, the `take_pending_ids(_, 0)` head guarantees `n >= 1`, and
+    # `:ets.select/3` returns fewer rows than the limit when the table is smaller.
+    # This avoids a redundant `:ets.info(tid, :size)` read on the claim hot path.
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         size when is_integer(size) <- :ets.info(tid, :size),
-         {taken_pairs, _cont} <- :ets.select(tid, ms, min(n, max(size, 1))) do
-      # ets.select with write_concurrency + read_concurrency can return the same
-      # element multiple times across calls (stale read). select_replace is a
-      # conditional atomic update: only replaces when status is still :pending,
-      # so already-taken events are correctly rejected.
-      confirmed =
-        taken_pairs
-        |> Enum.filter(fn {id, _size} ->
-          replace_ms = [{{id, :pending, :"$1", :"$2"}, [], [{{id, :processing, :"$1", :"$2"}}]}]
-          :ets.select_replace(tid, replace_ms) == 1
-        end)
+         {taken_pairs, _cont} <- :ets.select(tid, ms, n) do
+      # Claim each candidate with an atomic CAS on the claim counter (field 5). The
+      # 0 -> 1 winner takes the event; a 2+ result means another consumer — or a
+      # write_concurrency resize duplicate within this select — already claimed it, so
+      # it is rejected. This is multi-consumer safe (matching select_replace) without
+      # compiling a per-id match spec, and needs no dedup pass.
+      confirmed = Enum.filter(taken_pairs, fn {id, _size} -> claim_pending(tid, id) end)
 
       {:ok, confirmed, tid}
     else
       nil -> {:error, :not_initialized}
       :"$end_of_table" -> {:ok, [], nil}
     end
+  end
+
+  @spec claim_pending(:ets.tid(), term()) :: boolean()
+  defp claim_pending(tid, id) do
+    if :ets.update_counter(tid, id, {5, 1}) == 1 do
+      :ets.update_element(tid, id, {2, :processing})
+      true
+    else
+      false
+    end
+  rescue
+    # The row was deleted (e.g. janitor drop) between the select and the claim;
+    # mirrors `update_element` returning false for a missing key.
+    ArgumentError -> false
   end
 
   @doc """
@@ -544,7 +560,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending(sid_bid_pid, n) when is_integer(n) do
     select_ms =
       Ex2ms.fun do
-        {event_id, :pending, event, _size} -> {event_id, event}
+        {event_id, :pending, event, _size, _claim} -> {event_id, event}
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -568,7 +584,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def fetch_events({_, _, _} = sid_bid_pid, n) do
     ms =
       Ex2ms.fun do
-        {_event_id, _, event, _size} -> event
+        {_event_id, _, event, _size, _claim} -> event
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -637,14 +653,17 @@ defmodule Logflare.Backends.IngestEventQueue do
   defp do_truncate_table(key, status, n) do
     ms =
       Ex2ms.fun do
-        {_event_id, _event_status, event, _size} = obj when ^status == :all -> obj
-        {_event_id, event_status, event, _size} = obj when event_status == ^status -> obj
+        {_event_id, _event_status, event, _size, _claim} = obj when ^status == :all -> obj
+        {_event_id, event_status, event, _size, _claim} = obj when event_status == ^status -> obj
       end
 
     del_ms =
       Ex2ms.fun do
-        {_event_id, _event_status, _event, _size} = _obj when ^status == :all -> true
-        {_event_id, event_status, _event, _size} = _obj when event_status == ^status -> true
+        {_event_id, _event_status, _event, _size, _claim} = _obj when ^status == :all ->
+          true
+
+        {_event_id, event_status, _event, _size, _claim} = _obj when event_status == ^status ->
+          true
       end
 
     with tid when tid != nil <- get_tid(key),
@@ -694,7 +713,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def list_processing_ids(key) do
     ms =
       Ex2ms.fun do
-        {id, :processing, _event, _size} -> id
+        {id, :processing, _event, _size, _claim} -> id
       end
 
     with tid when tid != nil <- get_tid(key),
@@ -799,8 +818,8 @@ defmodule Logflare.Backends.IngestEventQueue do
     # chunk over table and drop
     ms =
       Ex2ms.fun do
-        {event_id, _status, _event, _size} = _obj when ^filter == :all -> event_id
-        {event_id, status, _event, _size} = _obj when status == ^filter -> event_id
+        {event_id, _status, _event, _size, _claim} = _obj when ^filter == :all -> event_id
+        {event_id, status, _event, _size, _claim} = _obj when status == ^filter -> event_id
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -180,15 +180,17 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
   defp act_on_stale_event(tid, id) do
     case :ets.lookup(tid, id) do
-      [{^id, :processing, %{retries: retries}, _size}] when retries >= @max_stale_retries - 1 ->
-        :ets.select_delete(tid, [{{id, :processing, :_, :_}, [], [true]}])
+      [{^id, :processing, %{retries: retries}, _size, _claim}]
+      when retries >= @max_stale_retries - 1 ->
+        :ets.select_delete(tid, [{{id, :processing, :_, :_, :_}, [], [true]}])
         :drop
 
-      [{^id, :processing, %{retries: retries} = le, size}] ->
+      [{^id, :processing, %{retries: retries} = le, size, _claim}] ->
         new_le = %{le | retries: (retries || 0) + 1}
 
+        # Reset the claim counter (field 5) to 0 so the requeued event can be claimed again.
         case :ets.select_replace(tid, [
-               {{id, :processing, le, size}, [], [{:const, {id, :pending, new_le, size}}]}
+               {{id, :processing, le, size, :_}, [], [{:const, {id, :pending, new_le, size, 0}}]}
              ]) do
           1 -> :reset
           0 -> :skip

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -594,8 +594,18 @@ defmodule Logflare.Sources do
   """
   @spec get_labels_from_event(Source.t(), LogEvent.t()) :: map()
   def get_labels_from_event(source, log_event) do
-    mapping = get_labels_mapping(source)
+    source
+    |> get_labels_mapping()
+    |> extract_labels(log_event)
+  end
 
+  @doc """
+  Extracts label values from a log event using a precomputed label mapping
+  (see `get_labels_mapping/1`). Useful when the mapping is resolved once and
+  reused across many events, avoiding re-parsing the source's label config.
+  """
+  @spec extract_labels(map(), LogEvent.t()) :: map()
+  def extract_labels(mapping, log_event) do
     for {label, path} <- mapping, into: %{} do
       {label, get_in(log_event.body, path)}
     end

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -231,7 +231,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
       # Fetch full LogEvents from ETS. Sizes were computed in the producer and are
       # carried on each message — no recomputation needed here. The batch is already
       # byte-bounded by bq_batch_size_splitter/0 in the batcher config.
-      {triples, missing} = fetch_events_from_messages(messages, context)
+      {triples, missing} = fetch_events_from_messages(messages, context, source)
 
       if missing != [] do
         :telemetry.execute(
@@ -286,12 +286,12 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     Enum.map(log_events, &le_to_bq_row/1)
   end
 
-  defp fetch_events_from_messages(messages, context) do
+  defp fetch_events_from_messages(messages, context, source) do
     Enum.reduce(messages, {[], []}, fn
       %{data: {id, tid, size}} = message, {out, missing} ->
         case :ets.lookup(tid, id) do
           [{^id, _status, log_event, _byte_size, _claim}] ->
-            {[{message, process_data(log_event, context), size} | out], missing}
+            {[{message, process_data(log_event, context, source), size} | out], missing}
 
           [] ->
             {out, [message | missing]}
@@ -418,8 +418,9 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     {log_events, %{}}
   end
 
-  def process_data(%LE{source_id: source_id} = log_event, context) do
-    source = Sources.Cache.get_by_id(source_id)
+  def process_data(%LE{} = log_event, context, source) do
+    # `source` is resolved once per batch in handle_batch/4 and threaded in, rather
+    # than re-fetched from the cache per event (a Source struct copy per event).
 
     # TODO ... We use `ignoreUnknownValues: true` when we do `stream_batch!`. If we set that to `true`
     # then this makes BigQuery check the payloads for new fields. In the response we'll get a list of events that

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -241,9 +241,13 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
         )
       end
 
-      log_events = Enum.map(triples, fn {_msg, le, _size} -> le end)
-      batch_count = length(log_events)
-      batch_size = Enum.sum_by(triples, fn {_msg, _le, size} -> size end)
+      # Single pass over triples to collect the log events and batch metrics, rather
+      # than a separate map, length, and sum_by. Row order within a batch insert does
+      # not matter (each BQ row carries its own insertId).
+      {log_events, batch_count, batch_size} =
+        Enum.reduce(triples, {[], 0, 0}, fn {_msg, le, size}, {les, count, bytes} ->
+          {[le | les], count + 1, bytes + size}
+        end)
 
       if source && source.bq_storage_write_api do
         batch_attrs = compute_batch_attrs(batch_count, batch_size, :bq_storage_write)

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -142,15 +142,21 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
       source ->
         metrics = Sources.get_source_metrics_for_ingest(source.token)
+        # Resolve the label mapping once per ack rather than re-parsing source.labels
+        # per event. When empty, the event body is never read, so we skip the ETS
+        # lookup entirely (the full LogEvent does not need to be copied out).
+        label_mapping = Sources.get_labels_mapping(source)
 
         for %{data: {id, tid, size}} <- successful do
-          case :ets.lookup(tid, id) do
-            [{^id, _status, le, _byte_size, _claim}] ->
-              emit_event_telemetry(queue, source, le, size, backend_metadata)
-
-            [] ->
-              :ok
-          end
+          maybe_emit_event_telemetry(
+            queue,
+            source,
+            tid,
+            id,
+            size,
+            label_mapping,
+            backend_metadata
+          )
 
           if metrics.avg > 100 do
             IngestEventQueue.delete_id(tid, id)
@@ -553,10 +559,25 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     IngestEventQueue.add_to_table(sid_bid, events)
   end
 
-  defp emit_event_telemetry({sid, bid, _}, source, le, size, backend_metadata) do
-    # emit telemetry on event
-    event_labels = Sources.get_labels_from_event(source, le)
+  # No labels configured: emit without reading the event from ETS.
+  defp maybe_emit_event_telemetry(queue, source, _tid, _id, size, mapping, backend_metadata)
+       when map_size(mapping) == 0 do
+    emit_event_telemetry(queue, source, %{}, size, backend_metadata)
+  end
 
+  # Labels configured: the event body is required to resolve label values.
+  defp maybe_emit_event_telemetry(queue, source, tid, id, size, mapping, backend_metadata) do
+    case :ets.lookup(tid, id) do
+      [{^id, _status, le, _byte_size, _claim}] ->
+        event_labels = Sources.extract_labels(mapping, le)
+        emit_event_telemetry(queue, source, event_labels, size, backend_metadata)
+
+      [] ->
+        :ok
+    end
+  end
+
+  defp emit_event_telemetry({sid, bid, _}, source, event_labels, size, backend_metadata) do
     metrics = %{ingested_bytes: size}
 
     metadata =

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -259,10 +259,9 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
         end
       else
         batch_attrs = compute_batch_attrs(batch_count, batch_size, :bq_streaming_insert)
-        event_size_pairs = Enum.map(triples, fn {_msg, le, size} -> {le, size} end)
 
         OpenTelemetry.Tracer.with_span "ingest.bq_insert", %{attributes: batch_attrs} do
-          stream_batch(context, event_size_pairs)
+          stream_batch(context, log_events)
         end
       end
 
@@ -345,7 +344,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
   def stream_batch(
         %{source_token: source_token, user_id: user_id, system_source: system_source} = context,
-        event_size_pairs
+        log_events
       ) do
     Logger.metadata(
       source_id: source_token,
@@ -357,13 +356,11 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     :telemetry.span(
       [:logflare, :ingest, :pipeline, :stream_batch],
       %{source_token: source_token},
-      fn -> execute_bigquery_stream_batch(context, event_size_pairs) end
+      fn -> execute_bigquery_stream_batch(context, log_events) end
     )
   end
 
-  defp execute_bigquery_stream_batch(%{source_token: source_token} = context, event_size_pairs) do
-    log_events = Enum.map(event_size_pairs, &elem(&1, 0))
-
+  defp execute_bigquery_stream_batch(%{source_token: source_token} = context, log_events) do
     rows =
       OpenTelemetry.Tracer.with_span "ingest.bq_serialize", %{
         attributes: %{insert_method: :bq_streaming_insert}
@@ -418,7 +415,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
       end
     end
 
-    {event_size_pairs, %{}}
+    {log_events, %{}}
   end
 
   def process_data(%LE{source_id: source_id} = log_event, context) do

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -145,7 +145,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
         for %{data: {id, tid, size}} <- successful do
           case :ets.lookup(tid, id) do
-            [{^id, _status, le, _byte_size}] ->
+            [{^id, _status, le, _byte_size, _claim}] ->
               emit_event_telemetry(queue, source, le, size, backend_metadata)
 
             [] ->
@@ -291,7 +291,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     Enum.reduce(messages, {[], []}, fn
       %{data: {id, tid, size}} = message, {out, missing} ->
         case :ets.lookup(tid, id) do
-          [{^id, _status, log_event, _byte_size}] ->
+          [{^id, _status, log_event, _byte_size, _claim}] ->
             {[{message, process_data(log_event, context), size} | out], missing}
 
           [] ->
@@ -526,11 +526,11 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     to_requeue =
       Enum.reduce(failed, [], fn %{data: {id, tid, _size}}, acc ->
         case :ets.lookup(tid, id) do
-          [{^id, _status, %LE{retries: retries} = le, _byte_size} | _]
+          [{^id, _status, %LE{retries: retries} = le, _byte_size, _claim} | _]
           when retries < max_retries ->
             [%LE{le | retries: (retries || 0) + 1} | acc]
 
-          [{^id, _status, _le, _byte_size} | _] ->
+          [{^id, _status, _le, _byte_size, _claim} | _] ->
             IngestEventQueue.delete_id(tid, id)
             acc
 

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -125,13 +125,9 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
     maybe_requeue_failed({sid, bid}, failed, config)
 
-    backend_metadata =
-      if bid do
-        Backends.Cache.get_backend(bid).metadata || %{}
-      else
-        %{}
-      end
-
+    # Per-event ingest telemetry is emitted in handle_batch/4, where the full
+    # LogEvent is already in hand — ack only needs each event's id to finalize
+    # queue state, so it never re-fetches the event from ETS.
     case Sources.Cache.get_by_id(sid) do
       nil ->
         Logger.warning("Source not found for ack!", source_id: sid)
@@ -142,22 +138,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
       source ->
         metrics = Sources.get_source_metrics_for_ingest(source.token)
-        # Resolve the label mapping once per ack rather than re-parsing source.labels
-        # per event. When empty, the event body is never read, so we skip the ETS
-        # lookup entirely (the full LogEvent does not need to be copied out).
-        label_mapping = Sources.get_labels_mapping(source)
 
-        for %{data: {id, tid, size}} <- successful do
-          maybe_emit_event_telemetry(
-            queue,
-            source,
-            tid,
-            id,
-            size,
-            label_mapping,
-            backend_metadata
-          )
-
+        for %{data: {id, tid, _size}} <- successful do
           if metrics.avg > 100 do
             IngestEventQueue.delete_id(tid, id)
           else
@@ -274,6 +256,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
           stream_batch(context, log_events)
         end
       end
+
+      emit_ingest_telemetry(context, source, triples)
 
       succeeded = Enum.map(triples, fn {msg, _le, _size} -> msg end)
 
@@ -559,23 +543,24 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     IngestEventQueue.add_to_table(sid_bid, events)
   end
 
-  # No labels configured: emit without reading the event from ETS.
-  defp maybe_emit_event_telemetry(queue, source, _tid, _id, size, mapping, backend_metadata)
-       when map_size(mapping) == 0 do
-    emit_event_telemetry(queue, source, %{}, size, backend_metadata)
-  end
+  # Emit per-event ingest telemetry from handle_batch, where the full LogEvent is
+  # already in hand (no extra ETS lookup in ack). The label mapping and backend
+  # metadata are resolved once per batch rather than per event.
+  defp emit_ingest_telemetry(_context, nil, _triples), do: :ok
 
-  # Labels configured: the event body is required to resolve label values.
-  defp maybe_emit_event_telemetry(queue, source, tid, id, size, mapping, backend_metadata) do
-    case :ets.lookup(tid, id) do
-      [{^id, _status, le, _byte_size, _claim}] ->
-        event_labels = Sources.extract_labels(mapping, le)
-        emit_event_telemetry(queue, source, event_labels, size, backend_metadata)
+  defp emit_ingest_telemetry(context, source, triples) do
+    label_mapping = Sources.get_labels_mapping(source)
+    backend_metadata = backend_metadata(context.backend_id)
+    queue = {context.source_id, context.backend_id, nil}
 
-      [] ->
-        :ok
+    for {_msg, le, size} <- triples do
+      event_labels = Sources.extract_labels(label_mapping, le)
+      emit_event_telemetry(queue, source, event_labels, size, backend_metadata)
     end
   end
+
+  defp backend_metadata(nil), do: %{}
+  defp backend_metadata(bid), do: Backends.Cache.get_backend(bid).metadata || %{}
 
   defp emit_event_telemetry({sid, bid, _}, source, event_labels, size, backend_metadata) do
     metrics = %{ingested_bytes: size}

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -370,6 +370,24 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert MapSet.size(second_ids) == 6
     end
 
+    test "re-claims an event after it is re-added to the queue (claim counter resets)", %{
+      sbp: sbp
+    } do
+      [event] = events = [build(:log_event)]
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+      event_id = event.id
+
+      # first claim takes it and marks it :processing (claim counter -> 1)
+      assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+      # nothing left pending to claim
+      assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)
+
+      # re-adding (as the BigQuery requeue path does) overwrites with a fresh
+      # :pending row whose claim counter is reset to 0, so it is claimable again
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+      assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+    end
+
     # Regression artifact for #3609: the per-id select_replace CAS guards against two
     # consumers claiming the same queue concurrently. Reverting to an unconditional
     # update_element should make this fail (the same id claimed by two tasks). It is
@@ -1076,6 +1094,29 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert is_integer(size)
       # claim counter reset to 0 so the requeued event can be claimed again
       assert claim == 0
+    end
+
+    test "stale event reset by the janitor can be re-claimed by take_pending_ids" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      backend = insert(:backend, user: user)
+      sbp = {source.id, backend.id, self()}
+      IngestEventQueue.upsert_tid(sbp)
+      le = build(:log_event, source: source)
+      IngestEventQueue.add_to_table(sbp, [le])
+
+      # claim via the real path: marks :processing and sets the claim counter to 1
+      le_id = le.id
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+      assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)
+
+      # two cycles: the stuck :processing event is detected and reset to :pending
+      state = make_janitor_state(source, backend)
+      state = QueueJanitor.do_cleanup_stale_processing(state)
+      _state = QueueJanitor.do_cleanup_stale_processing(state)
+
+      # the reset event is claimable again — only true if the claim counter was reset
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
     end
 
     test "max retries exceeded: stale event is deleted" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -322,6 +322,83 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     end
   end
 
+  describe "take_pending_ids/2" do
+    setup do
+      user = insert(:user)
+      sbp = {insert(:source, user: user).id, insert(:backend, user: user).id, self()}
+      IngestEventQueue.upsert_tid(sbp)
+      [sbp: sbp]
+    end
+
+    test "claims pending events, marking them :processing and returning {id, size} pairs", %{
+      sbp: sbp
+    } do
+      events = for _ <- 1..5, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, pairs, tid} = IngestEventQueue.take_pending_ids(sbp, 5)
+      assert tid != nil
+      assert length(pairs) == 5
+
+      taken_ids = for {id, _size} <- pairs, do: id
+      assert Enum.sort(taken_ids) == Enum.sort(for e <- events, do: e.id)
+      # claimed events are no longer pending
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+
+    test "respects the requested count and leaves the remainder pending", %{sbp: sbp} do
+      events = for _ <- 1..10, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, pairs, _tid} = IngestEventQueue.take_pending_ids(sbp, 4)
+      assert length(pairs) == 4
+      assert IngestEventQueue.total_pending(sbp) == 6
+    end
+
+    test "does not re-claim events already taken across sequential calls", %{sbp: sbp} do
+      events = for _ <- 1..10, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, first, _} = IngestEventQueue.take_pending_ids(sbp, 4)
+      assert {:ok, second, _} = IngestEventQueue.take_pending_ids(sbp, 10)
+
+      first_ids = MapSet.new(first, fn {id, _} -> id end)
+      second_ids = MapSet.new(second, fn {id, _} -> id end)
+
+      assert MapSet.disjoint?(first_ids, second_ids)
+      assert MapSet.size(first_ids) == 4
+      assert MapSet.size(second_ids) == 6
+    end
+
+    # Regression artifact for #3609: the per-id select_replace CAS guards against two
+    # consumers claiming the same queue concurrently. Reverting to an unconditional
+    # update_element should make this fail (the same id claimed by two tasks). It is
+    # probabilistic — the race window must actually be hit — so it uses a large batch
+    # and several concurrent claimers to make a double-claim likely if the guard is lost.
+    @tag :race
+    test "concurrent claims on the same queue never claim an event twice", %{sbp: sbp} do
+      count = 1_000
+      events = for _ <- 1..count, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      claimed =
+        for _ <- 1..8 do
+          Task.async(fn ->
+            {:ok, pairs, _tid} = IngestEventQueue.take_pending_ids(sbp, count)
+            for {id, _size} <- pairs, do: id
+          end)
+        end
+        |> Task.await_many(10_000)
+        |> List.flatten()
+
+      # No event claimed by more than one consumer.
+      assert length(claimed) == length(Enum.uniq(claimed))
+      # Every event was claimed exactly once.
+      assert length(claimed) == count
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+  end
+
   describe "`add_to_table/3` distribution with queues_key" do
     setup do
       user = insert(:user)
@@ -863,7 +940,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       tid = IngestEventQueue.get_tid(sbp)
 
       assert :ok = IngestEventQueue.update_status(tid, le.id, :processing)
-      assert [{_id, :processing, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_id, :processing, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
     test "returns :ok silently when ETS table is stale/deleted" do
@@ -968,7 +1045,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       new_state = QueueJanitor.do_cleanup_stale_processing(state)
 
       # Still :processing — first cycle only builds snapshot
-      assert [{_, :processing, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_, :processing, _, _, _}] = :ets.lookup(tid, le.id)
       # Snapshot now populated
       assert map_size(new_state.processing_snapshot) == 1
     end
@@ -990,13 +1067,15 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       _state = QueueJanitor.do_cleanup_stale_processing(state)
 
       le_id = le.id
-      assert [{^le_id, :pending, reset_le, size}] = :ets.lookup(tid, le.id)
+      assert [{^le_id, :pending, reset_le, size, claim}] = :ets.lookup(tid, le.id)
       # retries incremented
       assert reset_le.retries == 1
       # rest of the LogEvent is intact — not corrupted by select_replace
       assert reset_le.id == le.id
       assert reset_le.body == le.body
       assert is_integer(size)
+      # claim counter reset to 0 so the requeued event can be claimed again
+      assert claim == 0
     end
 
     test "max retries exceeded: stale event is deleted" do

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -247,7 +247,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       log =
         capture_log([level: :warning], fn ->
-          Pipeline.stream_batch(context, [{build(:log_event, source: source), 0}])
+          Pipeline.stream_batch(context, [build(:log_event, source: source)])
         end)
 
       assert log =~ "user audit: BigQuery backend auto-disconnect triggered"
@@ -285,7 +285,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       log =
         capture_log([level: :warning], fn ->
-          Pipeline.stream_batch(context, [{build(:log_event, source: source), 0}])
+          Pipeline.stream_batch(context, [build(:log_event, source: source)])
         end)
 
       assert log =~ "user audit: BigQuery backend auto-disconnect triggered"

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -111,6 +111,75 @@ defmodule Logflare.BigQuery.PipelineTest do
       assert [{_id, :ingested, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
+    test "ack emits ingest telemetry with resolved labels when source has labels", %{
+      source: source
+    } do
+      source = insert(:source, user_id: source.user_id, labels: "lvl=m.level")
+      sid_bid_pid = {source.id, nil, self()}
+      IngestEventQueue.upsert_tid(sid_bid_pid)
+      le = build(:log_event, source: source, metadata: %{"level" => "error"})
+      IngestEventQueue.add_to_table(sid_bid_pid, [le])
+      tid = IngestEventQueue.get_tid(sid_bid_pid)
+
+      ref = {sid_bid_pid, %{max_retries: 0}}
+      message = Pipeline.transform({le.id, tid, 123}, ref: ref)
+      {mod, ref, _} = message.acknowledger
+
+      test_pid = self()
+      handler = "test-ingest-labels-#{inspect(make_ref())}"
+
+      :telemetry.attach(
+        handler,
+        [:logflare, :backends, :ingest],
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:ingest, measurements, metadata})
+        end,
+        nil
+      )
+
+      mod.ack(ref, [message], [])
+
+      assert_receive {:ingest, %{ingested_bytes: 123}, metadata}
+      assert metadata["lvl"] == "error"
+
+      :telemetry.detach(handler)
+    end
+
+    test "ack emits ingest telemetry without reading the event when source has no labels", %{
+      source: source
+    } do
+      sid_bid_pid = {source.id, nil, self()}
+      IngestEventQueue.upsert_tid(sid_bid_pid)
+      le = build(:log_event, source: source)
+      IngestEventQueue.add_to_table(sid_bid_pid, [le])
+      tid = IngestEventQueue.get_tid(sid_bid_pid)
+      # Delete from ETS so a per-event lookup would find nothing — telemetry must
+      # still be emitted, proving the lookup is skipped when there are no labels.
+      :ets.delete(tid, le.id)
+
+      ref = {sid_bid_pid, %{max_retries: 0}}
+      message = Pipeline.transform({le.id, tid, 123}, ref: ref)
+      {mod, ref, _} = message.acknowledger
+
+      test_pid = self()
+      handler = "test-ingest-nolabels-#{inspect(make_ref())}"
+
+      :telemetry.attach(
+        handler,
+        [:logflare, :backends, :ingest],
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:ingest, measurements, metadata})
+        end,
+        nil
+      )
+
+      mod.ack(ref, [message], [])
+
+      assert_receive {:ingest, %{ingested_bytes: 123}, _metadata}
+
+      :telemetry.detach(handler)
+    end
+
     test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{
       source: source
     } do

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -111,19 +111,19 @@ defmodule Logflare.BigQuery.PipelineTest do
       assert [{_id, :ingested, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
-    test "ack emits ingest telemetry with resolved labels when source has labels", %{
+    test "handle_batch emits ingest telemetry with resolved labels when source has labels", %{
       source: source
     } do
       source = insert(:source, user_id: source.user_id, labels: "lvl=m.level")
-      sid_bid_pid = {source.id, nil, self()}
-      IngestEventQueue.upsert_tid(sid_bid_pid)
-      le = build(:log_event, source: source, metadata: %{"level" => "error"})
-      IngestEventQueue.add_to_table(sid_bid_pid, [le])
-      tid = IngestEventQueue.get_tid(sid_bid_pid)
+      context = bq_context(source)
+      batch_info = %Broadway.BatchInfo{batcher: :bq, batch_key: :bq, size: 1, trigger: :flush}
 
-      ref = {sid_bid_pid, %{max_retries: 0}}
-      message = Pipeline.transform({le.id, tid, 123}, ref: ref)
-      {mod, ref, _} = message.acknowledger
+      stub(Logflare.Google.BigQuery, :stream_batch!, fn _ctx, _rows ->
+        {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      le = build(:log_event, source: source, metadata: %{"level" => "error"})
+      {messages, _tid} = setup_queue(source, [le])
 
       test_pid = self()
       handler = "test-ingest-labels-#{inspect(make_ref())}"
@@ -137,29 +137,28 @@ defmodule Logflare.BigQuery.PipelineTest do
         nil
       )
 
-      mod.ack(ref, [message], [])
+      Pipeline.handle_batch(:bq, messages, batch_info, context)
 
-      assert_receive {:ingest, %{ingested_bytes: 123}, metadata}
+      assert_receive {:ingest, %{ingested_bytes: bytes}, metadata}
+      assert bytes > 0
+      # labels resolved from the event body, no per-event ETS lookup in ack
       assert metadata["lvl"] == "error"
 
       :telemetry.detach(handler)
     end
 
-    test "ack emits ingest telemetry without reading the event when source has no labels", %{
+    test "handle_batch emits ingest telemetry with no labels when source has none", %{
       source: source
     } do
-      sid_bid_pid = {source.id, nil, self()}
-      IngestEventQueue.upsert_tid(sid_bid_pid)
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(sid_bid_pid, [le])
-      tid = IngestEventQueue.get_tid(sid_bid_pid)
-      # Delete from ETS so a per-event lookup would find nothing — telemetry must
-      # still be emitted, proving the lookup is skipped when there are no labels.
-      :ets.delete(tid, le.id)
+      context = bq_context(source)
+      batch_info = %Broadway.BatchInfo{batcher: :bq, batch_key: :bq, size: 1, trigger: :flush}
 
-      ref = {sid_bid_pid, %{max_retries: 0}}
-      message = Pipeline.transform({le.id, tid, 123}, ref: ref)
-      {mod, ref, _} = message.acknowledger
+      stub(Logflare.Google.BigQuery, :stream_batch!, fn _ctx, _rows ->
+        {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      le = build(:log_event, source: source)
+      {messages, _tid} = setup_queue(source, [le])
 
       test_pid = self()
       handler = "test-ingest-nolabels-#{inspect(make_ref())}"
@@ -173,9 +172,11 @@ defmodule Logflare.BigQuery.PipelineTest do
         nil
       )
 
-      mod.ack(ref, [message], [])
+      Pipeline.handle_batch(:bq, messages, batch_info, context)
 
-      assert_receive {:ingest, %{ingested_bytes: 123}, _metadata}
+      source_id = source.id
+      assert_receive {:ingest, %{ingested_bytes: bytes}, %{"source_id" => ^source_id}}
+      assert bytes > 0
 
       :telemetry.detach(handler)
     end
@@ -520,6 +521,18 @@ defmodule Logflare.BigQuery.PipelineTest do
         end)
 
       {messages, tid}
+    end
+
+    defp bq_context(source) do
+      %{
+        source_id: source.id,
+        source_token: source.token,
+        backend_id: nil,
+        bigquery_project_id: nil,
+        bigquery_dataset_id: nil,
+        user_id: source.user_id,
+        system_source: false
+      }
     end
 
     test "passes {id, tid, size} messages through with correct size", %{

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -15,6 +15,7 @@ defmodule Logflare.BigQuery.PipelineTest do
   alias Logflare.LogEvent
   alias Logflare.Repo
   alias Logflare.Sources.Source.BigQuery.Pipeline
+  alias Logflare.Sources.Source.BigQuery.Schema
   alias Logflare.User
 
   @pipeline_name :test_pipeline
@@ -564,6 +565,51 @@ defmodule Logflare.BigQuery.PipelineTest do
       end)
 
       Pipeline.handle_batch(:bq, messages, batch_info, context)
+    end
+  end
+
+  describe "process_data/3" do
+    setup do
+      insert(:plan)
+      user = insert(:user)
+      [user: user, context: %{backend_id: nil}]
+    end
+
+    test "skips schema update when the passed source has lock_schema set", %{
+      user: user,
+      context: context
+    } do
+      source = insert(:source, user_id: user.id, lock_schema: true)
+      le = build(:log_event, source: source)
+
+      # the lock decision must come from the threaded source, not a per-event re-fetch
+      reject(&Schema.update/3)
+
+      assert ^le = Pipeline.process_data(le, context, source)
+    end
+
+    test "runs schema update using the passed source when not locked", %{
+      user: user,
+      context: context
+    } do
+      source = insert(:source, user_id: user.id, lock_schema: false)
+      le = build(:log_event, source: source)
+      test_pid = self()
+
+      expect(Schema, :update, fn _via, ^le, ^source ->
+        send(test_pid, :schema_updated)
+        :ok
+      end)
+
+      assert ^le = Pipeline.process_data(le, context, source)
+      assert_received :schema_updated
+    end
+
+    test "does not crash when the passed source is nil", %{context: context} do
+      le = build(:log_event)
+      reject(&Schema.update/3)
+
+      assert ^le = Pipeline.process_data(le, context, nil)
     end
   end
 

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -107,7 +107,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       assert IngestEventQueue.get_table_size(sid_bid_pid) == 1
       assert IngestEventQueue.total_pending(sid_bid_pid) == 0
-      assert [{_id, :ingested, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_id, :ingested, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
     test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{

--- a/test/profiling/ingest_event_queue_take_pending_ids_bench.exs
+++ b/test/profiling/ingest_event_queue_take_pending_ids_bench.exs
@@ -1,0 +1,211 @@
+alias Logflare.Backends.IngestEventQueue
+
+# Create a test user and source
+user = Logflare.Factory.insert(:user)
+source = Logflare.Factory.insert(:source, user: user)
+
+# Single-consumer queue, keyed by an owner pid (mirrors BufferProducer's {sid, bid, self()}).
+owner = spawn(fn -> :timer.sleep(:infinity) end)
+key = {source.id, nil, owner}
+IngestEventQueue.upsert_tid(key)
+tid = IngestEventQueue.get_tid(key)
+
+# The row tuple is now 5 elements: {event_id, status, event, size, claim}. This match spec
+# selects pending rows as {event_id, size}, mirroring the module's take_pending_ids/2.
+select_ms = [{{:"$1", :pending, :"$2", :"$3", :"$4"}, [], [{{:"$1", :"$3"}}]}]
+
+# Strategy A — per-id conditional CAS (the pre-update_counter implementation, #3609).
+take_via_select_replace = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      Enum.filter(taken_pairs, fn {id, _size} ->
+        replace_ms = [
+          {{id, :pending, :"$1", :"$2", :"$3"}, [], [{{id, :processing, :"$1", :"$2", :"$3"}}]}
+        ]
+
+        :ets.select_replace(tid, replace_ms) == 1
+      end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy B — dedup + unconditional update_element (the #3600 form; valid only for
+# single-consumer queues). Cheaper: no per-id match-spec compilation.
+take_via_update_element = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      taken_pairs
+      |> Enum.uniq_by(fn {id, _size} -> id end)
+      |> Enum.filter(fn {id, _size} -> :ets.update_element(tid, id, {2, :processing}) end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy D — single select_replace compiled once: one match spec with one literal-key
+# clause per id, so ETS compiles the whole spec a single time (vs once per id) while
+# keeping the set-table key index. No schema change, still multi-consumer safe. Caveat:
+# select_replace returns only a count, so it cannot say *which* ids it won — the fast path
+# assumes count == candidates (true with no contention). The single-threaded bench never
+# hits the contention fallback. NOTE: this measures table_size == n; if ETS full-scans an
+# N-clause spec instead of doing N keyed lookups, a large-table/small-n sweep would expose it.
+take_via_batched_select_replace = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      candidates = Enum.uniq_by(taken_pairs, fn {id, _size} -> id end)
+
+      replace_ms =
+        for {id, _size} <- candidates do
+          {{id, :pending, :"$1", :"$2", :"$3"}, [], [{{id, :processing, :"$1", :"$2", :"$3"}}]}
+        end
+
+      case replace_ms do
+        [] ->
+          []
+
+        _ ->
+          # In production, count < length(candidates) needs a per-id fallback to identify
+          # the winners; never triggered single-threaded, so we return candidates directly.
+          _claimed = :ets.select_replace(tid, replace_ms)
+          candidates
+      end
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy C — per-id update_counter (CAS-lite). Atomic and isolated under write_concurrency,
+# but uses a direct integer op rather than a per-id match spec. The `0 -> 1` winner claims;
+# `2+` means another consumer (or a resize-duplicate) already took it. No uniq_by needed.
+# `update_counter` raises on a missing key (janitor delete race), so claim losses on that
+# path surface as ArgumentError -> not won, mirroring update_element returning false.
+take_via_update_counter = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      Enum.filter(taken_pairs, fn {id, _size} ->
+        try do
+          if :ets.update_counter(tid, id, {5, 1}) == 1 do
+            :ets.update_element(tid, id, {2, :processing})
+            true
+          else
+            false
+          end
+        rescue
+          ArgumentError -> false
+        end
+      end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+inputs = %{
+  "250 events" => for(_ <- 1..250, do: Logflare.Factory.build(:log_event)),
+  "1000 events" => for(_ <- 1..1_000, do: Logflare.Factory.build(:log_event))
+}
+
+Benchee.run(
+  %{
+    "take_pending_ids/2 (current, end-to-end)" => fn events ->
+      IngestEventQueue.take_pending_ids(key, length(events))
+    end,
+    "inline: select + per-id select_replace (CAS)" => fn events ->
+      take_via_select_replace.(tid, length(events))
+    end,
+    "inline: select + uniq_by + update_element" => fn events ->
+      take_via_update_element.(tid, length(events))
+    end,
+    "inline: select + per-id update_counter (CAS-lite)" => fn events ->
+      take_via_update_counter.(tid, length(events))
+    end,
+    "inline: select + single compiled select_replace" => fn events ->
+      take_via_batched_select_replace.(tid, length(events))
+    end
+  },
+  inputs: inputs,
+  before_each: fn events ->
+    # Reset the queue to a fully-pending state before each claim.
+    IngestEventQueue.truncate_table(key, :all, 0)
+    IngestEventQueue.add_to_table(key, events)
+    events
+  end,
+  time: 5,
+  warmup: 2,
+  memory_time: 3,
+  reduction_time: 3
+)
+
+# credo:disable-for-this-file Credo.Check.Readability.MaxLineLength
+# Run with: mix run test/profiling/ingest_event_queue_take_pending_ids_bench.exs
+#
+# Compares the claim strategy in take_pending_ids/2. The module now uses update_counter
+# (the "current, end-to-end" line), so the inline strategies below are the alternatives:
+#   - update_counter (current): per-id atomic CAS on the claim counter; no match-spec compile.
+#   - select_replace (prior, #3609): per-id conditional CAS, compiles a match spec per id.
+#   - update_element: dedup + unconditional write; correct only for single-consumer queues.
+#   - single compiled select_replace: REJECTED (ETS scans an N-clause spec; see below).
+#
+# Historical results (indicative, local dev machine — capture formal snapshots against
+# a committed SHA per the profiling workflow):
+#
+## 2026-06-19  Baseline: select_replace (current) vs update_element ##
+# ##### With input 1000 events #####
+# Name                                                   ips        average         99th %
+# inline: select + uniq_by + update_element           5.13 K      194.86 μs      265.96 μs
+# take_pending_ids/2 (current, end-to-end)            1.64 K      608.62 μs      670.72 μs
+# inline: select + per-id select_replace (CAS)        1.63 K      613.49 μs      737.88 μs
+# -> update_element ~3.15x faster (+413 μs/claim saved vs current)
+#
+# ##### With input 250 events #####
+# Name                                                   ips        average         99th %
+# inline: select + uniq_by + update_element          19.50 K       51.29 μs       68.45 μs
+# take_pending_ids/2 (current, end-to-end)            6.58 K      151.96 μs      185.61 μs
+# inline: select + per-id select_replace (CAS)        6.47 K      154.61 μs      183.41 μs
+# -> update_element ~3.0x faster
+#
+# Note: update_element shows higher BEAM memory/reductions (the uniq_by set), but lower
+# wall-clock — select_replace's per-id match-spec compilation happens in the BIF layer
+# and does not surface as reductions. update_element is only safe for single-consumer
+# queues (see the concurrent-claim regression test in ingest_event_queue_test.exs).
+#
+## 2026-06-19  Add update_counter (CAS-lite) variant ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %    memory
+# inline: select + per-id update_counter (CAS-lite)        7.38 K    135.57 μs    175.71 μs    109 KB
+# inline: select + uniq_by + update_element                5.27 K    189.59 μs    222.08 μs    378 KB
+# take_pending_ids/2 (current, end-to-end)                 1.67 K    599.56 μs    725.01 μs    266 KB
+# inline: select + per-id select_replace (CAS)             1.51 K    660.62 μs    824.71 μs    266 KB
+# -> update_counter ~4.4x faster than current AND multi-consumer safe (the 0->1 winner
+#    claims; 2+ means another consumer/resize-dup already took it, so no uniq_by needed,
+#    hence the lowest memory/reductions too). Requires a 5th integer "claim" field on the
+#    row tuple ({id, status, event, size, claim}), which touches the module's match specs.
+#
+## 2026-06-19  Single compiled select_replace variant — REJECTED ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %    memory
+# inline: select + per-id update_counter (CAS-lite)        7.21 K    138.63 μs    166.44 μs    109 KB
+# inline: select + per-id select_replace (CAS)             1.61 K    620.37 μs    712.39 μs    266 KB
+# inline: select + single compiled select_replace          0.27 K   3678.24 μs   6588.41 μs    537 KB
+# -> "compile once" is a trap: one match spec with N literal-key clauses is ~26x slower than
+#    update_counter and ~6x slower than per-id select_replace. ETS does NOT index a
+#    multi-clause literal-key spec into N keyed lookups — it SCANS, testing each row against
+#    the clause list (~O(rows * clauses)), and compiling the giant spec is itself costly.
+#    The per-id structure is what preserves the set-table key index; you cannot have both
+#    "one compilation" and "keyed lookups" with select_replace. Do not revisit this approach.
+#
+## 2026-06-19  update_counter shipped in take_pending_ids/2 (5-tuple row) ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %
+# inline: select + per-id update_counter (CAS-lite)        7.87 K    127.04 μs    165.20 μs
+# take_pending_ids/2 (current, end-to-end)                 7.57 K    132.08 μs    280.76 μs
+# inline: select + uniq_by + update_element                5.24 K    190.97 μs    214.75 μs
+# inline: select + per-id select_replace (CAS)             1.53 K    651.72 μs    714.56 μs
+# inline: select + single compiled select_replace          0.28 K   3519.09 μs   3880.80 μs
+# -> The real end-to-end function (now update_counter) tracks the inline CAS-lite line and
+#    is ~4.9x faster than the prior per-id select_replace, while keeping multi-consumer
+#    safety. Row tuple is now {event_id, status, event, size, claim}.


### PR DESCRIPTION
## Summary

Two related ingest-path performance changes:

1. **`IngestEventQueue.take_pending_ids/2`** — replace the per-id `:ets.select_replace` claim with an atomic claim counter (`update_counter`). ~4.9x faster claims, same multi-consumer safety.
2. **BigQuery Broadway pipeline** — remove several sources of unnecessary per-batch and per-event allocation in `handle_batch/4`, the streaming insert path, and `ack/3`.

> ⚠️ **Draft / prototype.** Opening for design feedback. See "Status & open questions" before reviewing for merge.

---

## Part 1 — `take_pending_ids/2` claim via update_counter

`take_pending_ids/2` is the BigQuery pipeline's claim hot path. It claimed each event with a per-id `:ets.select_replace`, which **compiles a match spec per id** in the BIF layer — benchmarked as the dominant cost. This swaps that for an atomic claim counter, keeping the multi-consumer safety that #3609 added while running **~4.9x faster** (652 → 132 µs per 1000-event batch).

### Approach

The row tuple gains a 5th integer field — `{event_id, status, event, size, claim}`. A claim succeeds when `:ets.update_counter/3` transitions `claim` from `0 → 1`:

- **Multi-consumer safe** — only the `0 → 1` winner takes the event; a `2+` result means another consumer (or a `write_concurrency` resize-duplicate within the same select) already claimed it. Same guarantee as `select_replace`.
- **Cheap** — a direct integer op, no per-id match-spec compilation, and no `uniq_by` dedup pass (duplicates lose the CAS naturally).
- **Re-insertion resets the counter to 0**, so both requeue paths keep events claimable: `BufferProducer` failure requeue (via `add_to_table`) and the `QueueJanitor` stale `:processing → :pending` reset.

Also drops a redundant `:ets.info(:size)` read in `take_pending_ids` (`get_tid/1` already confirms the table is live).

### Why not the alternatives

| Strategy (1000-event claim) | avg | multi-consumer safe? |
|---|---|---|
| **update_counter (this PR)** | **132 µs** | ✅ |
| update_element + uniq_by | 191 µs | ❌ single-consumer only |
| select_replace per-id (prior) | 652 µs | ✅ |
| single compiled select_replace | 3519 µs | ✅ but ETS scans an N-clause spec |

`update_element` is faster than the old code but only safe if each queue has exactly one consumer. A single multi-clause `select_replace` (one compilation) is **rejected** — ETS does not index an N-clause literal-key spec into N keyed lookups; it scans, making it ~26x slower. See the benchmark file's recorded history for details.

### Blast radius

The tuple shape is a shared contract. Updated:

- `ingest_event_queue.ex` — construction + all match specs, new `claim_pending/2` helper.
- `queue_janitor.ex` — stale-reset path (**resets `claim` to 0** so requeued events stay claimable).
- `bigquery/pipeline.ex` — external raw `:ets.lookup` patterns.
- Tests updated to the 5-tuple; new `take_pending_ids/2` describe block incl. a concurrent-claim race test.

---

## Part 2 — BigQuery pipeline allocation cleanups

Per-batch and per-event allocations removed from the BQ Broadway pipeline. Batches are up to 500 events, so each scales with batch size and runs on every batch.

1. **Drop dead `event_size_pairs` in the streaming insert path.** The streaming path built a list of `{log_event, size}` tuples, passed it through `stream_batch/2`, and immediately re-extracted the `log_events` — discarding every size. Sizes are read exactly once (computing `batch_size` for telemetry); nothing downstream uses them, and the function's return value is discarded. Now passes the already-built `log_events` directly. Removes two O(n) traversals + ~2N tuple allocations per streaming batch.

2. **Reuse the batch source instead of a per-event cache fetch.** `process_data` called `Sources.Cache.get_by_id/1` for every event, copying the full `Source` struct out of the cache into the process heap once per event. `handle_batch/4` already resolves the identical source once (a BQ pipeline serves a single source), so it's threaded through `fetch_events_from_messages/3` into `process_data/3` and the per-event fetch is dropped.

3. **Collect batch events and metrics in a single pass.** `handle_batch/4` traversed the batch three times (`Enum.map` for log events, `length` for the count, `Enum.sum_by` for byte total). Folded into one `Enum.reduce`. Log events come out reversed, which is fine — each BQ row carries its own `insertId` and order within a batch insert is irrelevant.

4. **Drop the per-event ETS lookup in `ack/3`.** `ack` re-fetched the full `LogEvent` from ETS for every successful event solely to resolve telemetry labels — a second copy of an event `handle_batch/4` had already pulled out of ETS. The per-event ingest telemetry now emits in `handle_batch/4`, where the event is already in hand via `triples`, resolving the label mapping and backend metadata once per batch. `ack/3` now only needs each event's id to finalize queue state and never touches the event body. Adds `Sources.extract_labels/2` (mapping-aware extraction) with `get_labels_from_event/2` delegating to it.

The storage-write path was already clean (takes `log_events` directly).

### Behavior note for #4 (telemetry timing)

`[:logflare, :backends, :ingest]` now fires at batch-insert time rather than at ack. The emitted set is identical (`handle_batch`'s `succeeded` == ack's `successful`) except on the exceptional path where `handle_batch` raises after emitting — consistent with the pipeline already emitting regardless of BigQuery insert errors (insert errors are logged, not propagated to fail messages). Events missing from ETS are not in `triples`, so they emit no ingest telemetry (unchanged from original behavior).

---

## Verification

- `mix test` on `ingest_event_queue_test.exs`, `bigquery/pipeline_test.exs`, `opentelemetry_test.exs`, `buffer_producer_test.exs`, `bigquery_adaptor_test.exs`, `dynamic_pipeline_test.exs`, `sources_test.exs` — all pass (incl. the `@tag :race` concurrent-claim test, the janitor stale-reset/reclaim test, `process_data/3` source-threading tests, and `handle_batch` ingest-telemetry tests).
- `mix lint.diff` clean, `mix test.typings` (Dialyzer) clean.
- Benchmark: `test/profiling/ingest_event_queue_take_pending_ids_bench.exs`.

## Status & open questions

- [ ] **Confirm the original incident behind #3609** — the `update_counter` CAS preserves multi-consumer safety regardless, but understanding what was observed would validate the regression test actually reproduces it.
- [ ] Run the **full** `test/logflare/backends/` tree + a real BQ ingest path (only the directly-affected files were run here).
- [ ] Consider a module-level doc / constructor for the 5-tuple shape to prevent future drift.
- [ ] `test/profiling/ingest_event_queue_trunc.exs` already used a stale 3-tuple spec (pre-existing, CI-excluded) — now two arities behind.
- [ ] Sanity-check the Part 2 #4 telemetry-timing change against any downstream consumer that treats `[:logflare, :backends, :ingest]` as a strictly-acked signal (e.g. billing/accounting).