### PR TITLE
perf(ingest): claim pending events via an atomic claim counter

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -533,20 +533,23 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   # Claim invariant: every `:pending` row has `claim == 0`, and `claim` only goes
-  # `0 -> 1` here (atomically flipping the winner to `:processing`). This holds because:
+  # `0 -> 1` in claim_pending/2. The counter bump is the atomic election (a single
+  # winner); the follow-up `:processing` status write is a separate, non-atomic step
+  # (the row can still vanish between the two — handled below). The invariant holds
+  # because:
   #
-  #   1. The only writers that produce a `:pending` row — `add_to_table/3` (re-insert)
-  #      and the `QueueJanitor` stale reset — set `claim` to 0 atomically with the status.
-  #   2. The off-CAS status writers (`mark_ingested/2`, and `update_status/3` which the
-  #      pipeline only ever calls with `:ingested`) never reset a row to `:pending`, and
-  #      never run on a queue that also claims via `take_pending_ids/2`: a queue is keyed
-  #      by its owning producer pid (`{sid, bid, self()}`, see `BufferProducer.do_fetch/2`)
-  #      and a producer's `id_passing` flag is fixed for life, so the claim (id_passing)
-  #      path and the `mark_ingested`/pop (non-id_passing) path never share a queue.
+  #   1. Every writer that produces a `:pending` row resets `claim` to 0 in the same
+  #      step: `add_to_table/3` (re-insert), the `QueueJanitor` stale reset, and
+  #      `update_status/3` when it sets `:pending`.
+  #   2. No other status writer strands a claimable row: `mark_ingested/2` only sets the
+  #      terminal `:ingested`. And the claim path never shares a queue with the
+  #      `mark_ingested`/pop path — a queue is keyed by its owning producer pid
+  #      (`{sid, bid, self()}`, see `BufferProducer.do_fetch/2`) and a producer's
+  #      `id_passing` flag is fixed for life, so an id_passing producer claims only via
+  #      `take_pending_ids/2` while a non-id_passing one only marks/pops.
   #
-  # Breaking either point — e.g. calling `mark_ingested/2` on an id_passing queue, making
-  # `id_passing` dynamic, or adding a path that sets `:pending` without resetting `claim` —
-  # would invalidate the CAS, so keep those changes in sync with this claim path.
+  # Keep new transitions in sync: any path that returns a row to `:pending` must also
+  # reset `claim` to 0, or the row becomes unclaimable.
   @spec claim_pending(:ets.tid(), term()) :: boolean()
   defp claim_pending(tid, id) do
     # The 0 -> 1 winner owns the claim, but the row can still be deleted between the
@@ -714,7 +717,11 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec update_status(:ets.tid(), term(), :pending | :processing | :ingested) :: :ok
   def update_status(tid, id, status) do
-    :ets.update_element(tid, id, {2, status})
+    # Returning a row to :pending must also reset the claim counter (field 5) to 0, or it
+    # stays unclaimable — the same invariant add_to_table/3 and the QueueJanitor reset
+    # uphold (see claim_pending/2). update_element applies both changes in one atomic op.
+    update = if status == :pending, do: [{2, :pending}, {5, 0}], else: {2, status}
+    :ets.update_element(tid, id, update)
     :ok
   rescue
     ArgumentError ->

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -296,9 +296,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def add_to_table({sid_bid_pid, tid}, batch, _opts) when is_tuple(sid_bid_pid) do
     objects =
       for %{id: id} = event <- batch do
-        # 5th field is the claim counter: 0 = unclaimed. take_pending_ids/2 claims via an
-        # atomic update_counter (0 -> 1 winner), so re-inserting here resets it to 0 and
-        # makes a requeued event claimable again.
+        # New/requeued rows start unclaimed (claim counter 0); see claim_pending/2.
         {id, :pending, event, :erlang.external_size(event.body), 0}
       end
 
@@ -512,17 +510,10 @@ defmodule Logflare.Backends.IngestEventQueue do
         {event_id, :pending, _event, size, _claim} -> {event_id, size}
       end
 
-    # `n` is passed directly as the select limit: `get_tid/1` already confirms the
-    # table is live, the `take_pending_ids(_, 0)` head guarantees `n >= 1`, and
-    # `:ets.select/3` returns fewer rows than the limit when the table is smaller.
-    # This avoids a redundant `:ets.info(tid, :size)` read on the claim hot path.
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {taken_pairs, _cont} <- :ets.select(tid, ms, n) do
-      # Claim each candidate with an atomic CAS on the claim counter (field 5). The
-      # 0 -> 1 winner takes the event; a 2+ result means another consumer — or a
-      # write_concurrency resize duplicate within this select — already claimed it, so
-      # it is rejected. This is multi-consumer safe (matching select_replace) without
-      # compiling a per-id match spec, and needs no dedup pass.
+      # The claim counter's 0 -> 1 winner takes the event; a 2+ result (another consumer,
+      # or a write_concurrency duplicate row within this select) loses, so no dedup needed.
       confirmed = Enum.filter(taken_pairs, fn {id, _size} -> claim_pending(tid, id) end)
 
       {:ok, confirmed, tid}
@@ -532,30 +523,17 @@ defmodule Logflare.Backends.IngestEventQueue do
     end
   end
 
-  # Claim invariant: every `:pending` row has `claim == 0`, and `claim` only goes
-  # `0 -> 1` in claim_pending/2. The counter bump is the atomic election (a single
-  # winner); the follow-up `:processing` status write is a separate, non-atomic step
-  # (the row can still vanish between the two — handled below). The invariant holds
-  # because:
-  #
-  #   1. Every writer that produces a `:pending` row resets `claim` to 0 in the same
-  #      step: `add_to_table/3` (re-insert), the `QueueJanitor` stale reset, and
-  #      `update_status/3` when it sets `:pending`.
-  #   2. No other status writer strands a claimable row: `mark_ingested/2` only sets the
-  #      terminal `:ingested`. And the claim path never shares a queue with the
-  #      `mark_ingested`/pop path — a queue is keyed by its owning producer pid
-  #      (`{sid, bid, self()}`, see `BufferProducer.do_fetch/2`) and a producer's
-  #      `id_passing` flag is fixed for life, so an id_passing producer claims only via
-  #      `take_pending_ids/2` while a non-id_passing one only marks/pops.
-  #
-  # Keep new transitions in sync: any path that returns a row to `:pending` must also
-  # reset `claim` to 0, or the row becomes unclaimable.
+  # Claim invariant:
+  #   * every `:pending` row has `claim == 0`
+  #   * `update_counter` is the atomic election; the `:processing` write is a separate step
+  #   * any transition back to `:pending` must reset `claim` (add_to_table/3, the
+  #     QueueJanitor reset, and update_status/3 all do)
+  #   * id_passing and non-id_passing producers never share a pid-keyed queue, so the
+  #     claim path and the mark_ingested/pop path never touch the same rows
   @spec claim_pending(:ets.tid(), term()) :: boolean()
   defp claim_pending(tid, id) do
-    # The 0 -> 1 winner owns the claim, but the row can still be deleted between the
-    # counter bump and the status write. `update_element` returns false for a missing
-    # key, so returning its result rejects a row that vanished mid-claim — matching the
-    # old select_replace, which returned 0 (not claimed) for a row deleted in its window.
+    # Return update_element/3's result: it is false for a missing key, so a row deleted
+    # between the counter bump and the status write is rejected rather than claimed.
     if :ets.update_counter(tid, id, {5, 1}) == 1 do
       :ets.update_element(tid, id, {2, :processing})
     else
@@ -717,9 +695,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec update_status(:ets.tid(), term(), :pending | :processing | :ingested) :: :ok
   def update_status(tid, id, status) do
-    # Returning a row to :pending must also reset the claim counter (field 5) to 0, or it
-    # stays unclaimable — the same invariant add_to_table/3 and the QueueJanitor reset
-    # uphold (see claim_pending/2). update_element applies both changes in one atomic op.
+    # When returning to :pending, reset claim in the same ETS update so the row stays claimable.
     update = if status == :pending, do: [{2, :pending}, {5, 0}], else: {2, status}
     :ets.update_element(tid, id, update)
     :ok

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -296,7 +296,10 @@ defmodule Logflare.Backends.IngestEventQueue do
   def add_to_table({sid_bid_pid, tid}, batch, _opts) when is_tuple(sid_bid_pid) do
     objects =
       for %{id: id} = event <- batch do
-        {id, :pending, event, :erlang.external_size(event.body)}
+        # 5th field is the claim counter: 0 = unclaimed. take_pending_ids/2 claims via an
+        # atomic update_counter (0 -> 1 winner), so re-inserting here resets it to 0 and
+        # makes a requeued event claimable again.
+        {id, :pending, event, :erlang.external_size(event.body), 0}
       end
 
     :ets.insert(tid, objects)
@@ -436,7 +439,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def total_pending({_sid, _bid, _pid} = sid_bid_pid) do
     ms =
       Ex2ms.fun do
-        {_event_id, :pending, _event, _size} -> true
+        {_event_id, :pending, _event, _size, _claim} -> true
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -454,7 +457,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def total_by_status({_, _} = sid_bid, status) do
     ms =
       Ex2ms.fun do
-        {_event_id, event_status, _event, _size} when event_status == ^status -> true
+        {_event_id, event_status, _event, _size, _claim} when event_status == ^status -> true
       end
 
     traverse_queues(
@@ -478,7 +481,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def take_pending(sid_bid_pid, n) when is_integer(n) do
     ms =
       Ex2ms.fun do
-        {_event_id, :pending, event, _size} -> event
+        {_event_id, :pending, event, _size, _claim} -> event
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -506,28 +509,41 @@ defmodule Logflare.Backends.IngestEventQueue do
   def take_pending_ids(sid_bid_pid, n) when is_integer(n) do
     ms =
       Ex2ms.fun do
-        {event_id, :pending, _event, size} -> {event_id, size}
+        {event_id, :pending, _event, size, _claim} -> {event_id, size}
       end
 
+    # `n` is passed directly as the select limit: `get_tid/1` already confirms the
+    # table is live, the `take_pending_ids(_, 0)` head guarantees `n >= 1`, and
+    # `:ets.select/3` returns fewer rows than the limit when the table is smaller.
+    # This avoids a redundant `:ets.info(tid, :size)` read on the claim hot path.
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         size when is_integer(size) <- :ets.info(tid, :size),
-         {taken_pairs, _cont} <- :ets.select(tid, ms, min(n, max(size, 1))) do
-      # ets.select with write_concurrency + read_concurrency can return the same
-      # element multiple times across calls (stale read). select_replace is a
-      # conditional atomic update: only replaces when status is still :pending,
-      # so already-taken events are correctly rejected.
-      confirmed =
-        taken_pairs
-        |> Enum.filter(fn {id, _size} ->
-          replace_ms = [{{id, :pending, :"$1", :"$2"}, [], [{{id, :processing, :"$1", :"$2"}}]}]
-          :ets.select_replace(tid, replace_ms) == 1
-        end)
+         {taken_pairs, _cont} <- :ets.select(tid, ms, n) do
+      # Claim each candidate with an atomic CAS on the claim counter (field 5). The
+      # 0 -> 1 winner takes the event; a 2+ result means another consumer — or a
+      # write_concurrency resize duplicate within this select — already claimed it, so
+      # it is rejected. This is multi-consumer safe (matching select_replace) without
+      # compiling a per-id match spec, and needs no dedup pass.
+      confirmed = Enum.filter(taken_pairs, fn {id, _size} -> claim_pending(tid, id) end)
 
       {:ok, confirmed, tid}
     else
       nil -> {:error, :not_initialized}
       :"$end_of_table" -> {:ok, [], nil}
     end
+  end
+
+  @spec claim_pending(:ets.tid(), term()) :: boolean()
+  defp claim_pending(tid, id) do
+    if :ets.update_counter(tid, id, {5, 1}) == 1 do
+      :ets.update_element(tid, id, {2, :processing})
+      true
+    else
+      false
+    end
+  rescue
+    # The row was deleted (e.g. janitor drop) between the select and the claim;
+    # mirrors `update_element` returning false for a missing key.
+    ArgumentError -> false
   end
 
   @doc """
@@ -544,7 +560,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending(sid_bid_pid, n) when is_integer(n) do
     select_ms =
       Ex2ms.fun do
-        {event_id, :pending, event, _size} -> {event_id, event}
+        {event_id, :pending, event, _size, _claim} -> {event_id, event}
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -568,7 +584,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def fetch_events({_, _, _} = sid_bid_pid, n) do
     ms =
       Ex2ms.fun do
-        {_event_id, _, event, _size} -> event
+        {_event_id, _, event, _size, _claim} -> event
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
@@ -637,14 +653,17 @@ defmodule Logflare.Backends.IngestEventQueue do
   defp do_truncate_table(key, status, n) do
     ms =
       Ex2ms.fun do
-        {_event_id, _event_status, event, _size} = obj when ^status == :all -> obj
-        {_event_id, event_status, event, _size} = obj when event_status == ^status -> obj
+        {_event_id, _event_status, event, _size, _claim} = obj when ^status == :all -> obj
+        {_event_id, event_status, event, _size, _claim} = obj when event_status == ^status -> obj
       end
 
     del_ms =
       Ex2ms.fun do
-        {_event_id, _event_status, _event, _size} = _obj when ^status == :all -> true
-        {_event_id, event_status, _event, _size} = _obj when event_status == ^status -> true
+        {_event_id, _event_status, _event, _size, _claim} = _obj when ^status == :all ->
+          true
+
+        {_event_id, event_status, _event, _size, _claim} = _obj when event_status == ^status ->
+          true
       end
 
     with tid when tid != nil <- get_tid(key),
@@ -694,7 +713,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def list_processing_ids(key) do
     ms =
       Ex2ms.fun do
-        {id, :processing, _event, _size} -> id
+        {id, :processing, _event, _size, _claim} -> id
       end
 
     with tid when tid != nil <- get_tid(key),
@@ -799,8 +818,8 @@ defmodule Logflare.Backends.IngestEventQueue do
     # chunk over table and drop
     ms =
       Ex2ms.fun do
-        {event_id, _status, _event, _size} = _obj when ^filter == :all -> event_id
-        {event_id, status, _event, _size} = _obj when status == ^filter -> event_id
+        {event_id, _status, _event, _size, _claim} = _obj when ^filter == :all -> event_id
+        {event_id, status, _event, _size, _claim} = _obj when status == ^filter -> event_id
       end
 
     with tid when tid != nil <- get_tid(sid_bid_pid),

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -532,6 +532,21 @@ defmodule Logflare.Backends.IngestEventQueue do
     end
   end
 
+  # Claim invariant: every `:pending` row has `claim == 0`, and `claim` only goes
+  # `0 -> 1` here (atomically flipping the winner to `:processing`). This holds because:
+  #
+  #   1. The only writers that produce a `:pending` row — `add_to_table/3` (re-insert)
+  #      and the `QueueJanitor` stale reset — set `claim` to 0 atomically with the status.
+  #   2. The off-CAS status writers (`mark_ingested/2`, and `update_status/3` which the
+  #      pipeline only ever calls with `:ingested`) never reset a row to `:pending`, and
+  #      never run on a queue that also claims via `take_pending_ids/2`: a queue is keyed
+  #      by its owning producer pid (`{sid, bid, self()}`, see `BufferProducer.do_fetch/2`)
+  #      and a producer's `id_passing` flag is fixed for life, so the claim (id_passing)
+  #      path and the `mark_ingested`/pop (non-id_passing) path never share a queue.
+  #
+  # Breaking either point — e.g. calling `mark_ingested/2` on an id_passing queue, making
+  # `id_passing` dynamic, or adding a path that sets `:pending` without resetting `claim` —
+  # would invalidate the CAS, so keep those changes in sync with this claim path.
   @spec claim_pending(:ets.tid(), term()) :: boolean()
   defp claim_pending(tid, id) do
     # The 0 -> 1 winner owns the claim, but the row can still be deleted between the

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -534,15 +534,17 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   @spec claim_pending(:ets.tid(), term()) :: boolean()
   defp claim_pending(tid, id) do
+    # The 0 -> 1 winner owns the claim, but the row can still be deleted between the
+    # counter bump and the status write. `update_element` returns false for a missing
+    # key, so returning its result rejects a row that vanished mid-claim — matching the
+    # old select_replace, which returned 0 (not claimed) for a row deleted in its window.
     if :ets.update_counter(tid, id, {5, 1}) == 1 do
       :ets.update_element(tid, id, {2, :processing})
-      true
     else
       false
     end
   rescue
-    # The row was deleted (e.g. janitor drop) between the select and the claim;
-    # mirrors `update_element` returning false for a missing key.
+    # The row was deleted before the counter bump; update_counter raises on a missing key.
     ArgumentError -> false
   end
 

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -180,15 +180,17 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
 
   defp act_on_stale_event(tid, id) do
     case :ets.lookup(tid, id) do
-      [{^id, :processing, %{retries: retries}, _size}] when retries >= @max_stale_retries - 1 ->
-        :ets.select_delete(tid, [{{id, :processing, :_, :_}, [], [true]}])
+      [{^id, :processing, %{retries: retries}, _size, _claim}]
+      when retries >= @max_stale_retries - 1 ->
+        :ets.select_delete(tid, [{{id, :processing, :_, :_, :_}, [], [true]}])
         :drop
 
-      [{^id, :processing, %{retries: retries} = le, size}] ->
+      [{^id, :processing, %{retries: retries} = le, size, _claim}] ->
         new_le = %{le | retries: (retries || 0) + 1}
 
+        # Reset the claim counter (field 5) to 0 so the requeued event can be claimed again.
         case :ets.select_replace(tid, [
-               {{id, :processing, le, size}, [], [{:const, {id, :pending, new_le, size}}]}
+               {{id, :processing, le, size, :_}, [], [{:const, {id, :pending, new_le, size, 0}}]}
              ]) do
           1 -> :reset
           0 -> :skip

--- a/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/queue_janitor.ex
@@ -188,7 +188,7 @@ defmodule Logflare.Backends.IngestEventQueue.QueueJanitor do
       [{^id, :processing, %{retries: retries} = le, size, _claim}] ->
         new_le = %{le | retries: (retries || 0) + 1}
 
-        # Reset the claim counter (field 5) to 0 so the requeued event can be claimed again.
+        # Reset to :pending with claim 0 so the requeued event is claimable (see claim_pending/2).
         case :ets.select_replace(tid, [
                {{id, :processing, le, size, :_}, [], [{:const, {id, :pending, new_le, size, 0}}]}
              ]) do

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -145,7 +145,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
         for %{data: {id, tid, size}} <- successful do
           case :ets.lookup(tid, id) do
-            [{^id, _status, le, _byte_size}] ->
+            [{^id, _status, le, _byte_size, _claim}] ->
               emit_event_telemetry(queue, source, le, size, backend_metadata)
 
             [] ->
@@ -291,7 +291,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     Enum.reduce(messages, {[], []}, fn
       %{data: {id, tid, size}} = message, {out, missing} ->
         case :ets.lookup(tid, id) do
-          [{^id, _status, log_event, _byte_size}] ->
+          [{^id, _status, log_event, _byte_size, _claim}] ->
             {[{message, process_data(log_event, context), size} | out], missing}
 
           [] ->
@@ -526,11 +526,11 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     to_requeue =
       Enum.reduce(failed, [], fn %{data: {id, tid, _size}}, acc ->
         case :ets.lookup(tid, id) do
-          [{^id, _status, %LE{retries: retries} = le, _byte_size} | _]
+          [{^id, _status, %LE{retries: retries} = le, _byte_size, _claim} | _]
           when retries < max_retries ->
             [%LE{le | retries: (retries || 0) + 1} | acc]
 
-          [{^id, _status, _le, _byte_size} | _] ->
+          [{^id, _status, _le, _byte_size, _claim} | _] ->
             IngestEventQueue.delete_id(tid, id)
             acc
 

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -370,6 +370,24 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert MapSet.size(second_ids) == 6
     end
 
+    test "re-claims an event after it is re-added to the queue (claim counter resets)", %{
+      sbp: sbp
+    } do
+      [event] = events = [build(:log_event)]
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+      event_id = event.id
+
+      # first claim takes it and marks it :processing (claim counter -> 1)
+      assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+      # nothing left pending to claim
+      assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)
+
+      # re-adding (as the BigQuery requeue path does) overwrites with a fresh
+      # :pending row whose claim counter is reset to 0, so it is claimable again
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+      assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+    end
+
     # Regression artifact for #3609: the per-id select_replace CAS guards against two
     # consumers claiming the same queue concurrently. Reverting to an unconditional
     # update_element should make this fail (the same id claimed by two tasks). It is
@@ -1076,6 +1094,29 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert is_integer(size)
       # claim counter reset to 0 so the requeued event can be claimed again
       assert claim == 0
+    end
+
+    test "stale event reset by the janitor can be re-claimed by take_pending_ids" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      backend = insert(:backend, user: user)
+      sbp = {source.id, backend.id, self()}
+      IngestEventQueue.upsert_tid(sbp)
+      le = build(:log_event, source: source)
+      IngestEventQueue.add_to_table(sbp, [le])
+
+      # claim via the real path: marks :processing and sets the claim counter to 1
+      le_id = le.id
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+      assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)
+
+      # two cycles: the stuck :processing event is detected and reset to :pending
+      state = make_janitor_state(source, backend)
+      state = QueueJanitor.do_cleanup_stale_processing(state)
+      _state = QueueJanitor.do_cleanup_stale_processing(state)
+
+      # the reset event is claimable again — only true if the claim counter was reset
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
     end
 
     test "max retries exceeded: stale event is deleted" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -962,6 +962,27 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert [{_id, :processing, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
+    test "setting :pending resets the claim counter so the row is claimable again" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      backend = insert(:backend, user: user)
+      sbp = {source.id, backend.id, self()}
+      IngestEventQueue.upsert_tid(sbp)
+      le = build(:log_event, source: source)
+      IngestEventQueue.add_to_table(sbp, [le])
+      tid = IngestEventQueue.get_tid(sbp)
+
+      # claim it (claim counter -> 1, status :processing)
+      le_id = le.id
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+      assert [{^le_id, :processing, _, _, 1}] = :ets.lookup(tid, le.id)
+
+      # returning to :pending must also reset the claim counter, or it stays unclaimable
+      assert :ok = IngestEventQueue.update_status(tid, le.id, :pending)
+      assert [{^le_id, :pending, _, _, 0}] = :ets.lookup(tid, le.id)
+      assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
+    end
+
     test "returns :ok silently when ETS table is stale/deleted" do
       assert :ok = IngestEventQueue.update_status(:stale_tid, "any-id", :processing)
     end

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -388,11 +388,12 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
     end
 
-    # Regression artifact for #3609: the per-id select_replace CAS guards against two
-    # consumers claiming the same queue concurrently. Reverting to an unconditional
-    # update_element should make this fail (the same id claimed by two tasks). It is
-    # probabilistic — the race window must actually be hit — so it uses a large batch
-    # and several concurrent claimers to make a double-claim likely if the guard is lost.
+    # Regression guard for the concurrent-claim CAS. For correct code this passes
+    # deterministically — the update_counter 0 -> 1 winner is the sole claimer, so no
+    # event is ever taken twice regardless of scheduling. The large batch and several
+    # concurrent claimers exist to make a *regression* (e.g. reverting to an
+    # unconditional update_element) actually hit the race window and fail, rather than
+    # slip through. Tagged :race so it can be isolated, but it is safe to run by default.
     @tag :race
     test "concurrent claims on the same queue never claim an event twice", %{sbp: sbp} do
       count = 1_000

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -322,6 +322,83 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     end
   end
 
+  describe "take_pending_ids/2" do
+    setup do
+      user = insert(:user)
+      sbp = {insert(:source, user: user).id, insert(:backend, user: user).id, self()}
+      IngestEventQueue.upsert_tid(sbp)
+      [sbp: sbp]
+    end
+
+    test "claims pending events, marking them :processing and returning {id, size} pairs", %{
+      sbp: sbp
+    } do
+      events = for _ <- 1..5, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, pairs, tid} = IngestEventQueue.take_pending_ids(sbp, 5)
+      assert tid != nil
+      assert length(pairs) == 5
+
+      taken_ids = for {id, _size} <- pairs, do: id
+      assert Enum.sort(taken_ids) == Enum.sort(for e <- events, do: e.id)
+      # claimed events are no longer pending
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+
+    test "respects the requested count and leaves the remainder pending", %{sbp: sbp} do
+      events = for _ <- 1..10, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, pairs, _tid} = IngestEventQueue.take_pending_ids(sbp, 4)
+      assert length(pairs) == 4
+      assert IngestEventQueue.total_pending(sbp) == 6
+    end
+
+    test "does not re-claim events already taken across sequential calls", %{sbp: sbp} do
+      events = for _ <- 1..10, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert {:ok, first, _} = IngestEventQueue.take_pending_ids(sbp, 4)
+      assert {:ok, second, _} = IngestEventQueue.take_pending_ids(sbp, 10)
+
+      first_ids = MapSet.new(first, fn {id, _} -> id end)
+      second_ids = MapSet.new(second, fn {id, _} -> id end)
+
+      assert MapSet.disjoint?(first_ids, second_ids)
+      assert MapSet.size(first_ids) == 4
+      assert MapSet.size(second_ids) == 6
+    end
+
+    # Regression artifact for #3609: the per-id select_replace CAS guards against two
+    # consumers claiming the same queue concurrently. Reverting to an unconditional
+    # update_element should make this fail (the same id claimed by two tasks). It is
+    # probabilistic — the race window must actually be hit — so it uses a large batch
+    # and several concurrent claimers to make a double-claim likely if the guard is lost.
+    @tag :race
+    test "concurrent claims on the same queue never claim an event twice", %{sbp: sbp} do
+      count = 1_000
+      events = for _ <- 1..count, do: build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      claimed =
+        for _ <- 1..8 do
+          Task.async(fn ->
+            {:ok, pairs, _tid} = IngestEventQueue.take_pending_ids(sbp, count)
+            for {id, _size} <- pairs, do: id
+          end)
+        end
+        |> Task.await_many(10_000)
+        |> List.flatten()
+
+      # No event claimed by more than one consumer.
+      assert length(claimed) == length(Enum.uniq(claimed))
+      # Every event was claimed exactly once.
+      assert length(claimed) == count
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+  end
+
   describe "`add_to_table/3` distribution with queues_key" do
     setup do
       user = insert(:user)
@@ -863,7 +940,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       tid = IngestEventQueue.get_tid(sbp)
 
       assert :ok = IngestEventQueue.update_status(tid, le.id, :processing)
-      assert [{_id, :processing, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_id, :processing, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
     test "returns :ok silently when ETS table is stale/deleted" do
@@ -968,7 +1045,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       new_state = QueueJanitor.do_cleanup_stale_processing(state)
 
       # Still :processing — first cycle only builds snapshot
-      assert [{_, :processing, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_, :processing, _, _, _}] = :ets.lookup(tid, le.id)
       # Snapshot now populated
       assert map_size(new_state.processing_snapshot) == 1
     end
@@ -990,13 +1067,15 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       _state = QueueJanitor.do_cleanup_stale_processing(state)
 
       le_id = le.id
-      assert [{^le_id, :pending, reset_le, size}] = :ets.lookup(tid, le.id)
+      assert [{^le_id, :pending, reset_le, size, claim}] = :ets.lookup(tid, le.id)
       # retries incremented
       assert reset_le.retries == 1
       # rest of the LogEvent is intact — not corrupted by select_replace
       assert reset_le.id == le.id
       assert reset_le.body == le.body
       assert is_integer(size)
+      # claim counter reset to 0 so the requeued event can be claimed again
+      assert claim == 0
     end
 
     test "max retries exceeded: stale event is deleted" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -342,7 +342,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       taken_ids = for {id, _size} <- pairs, do: id
       assert Enum.sort(taken_ids) == Enum.sort(for e <- events, do: e.id)
-      # claimed events are no longer pending
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
@@ -377,13 +376,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert :ok = IngestEventQueue.add_to_table(sbp, events)
       event_id = event.id
 
-      # first claim takes it and marks it :processing (claim counter -> 1)
       assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
-      # nothing left pending to claim
       assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)
 
-      # re-adding (as the BigQuery requeue path does) overwrites with a fresh
-      # :pending row whose claim counter is reset to 0, so it is claimable again
+      # re-adding (the BigQuery requeue path) resets the claim counter, making it claimable
       assert :ok = IngestEventQueue.add_to_table(sbp, events)
       assert {:ok, [{^event_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
     end
@@ -410,9 +406,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         |> Task.await_many(10_000)
         |> List.flatten()
 
-      # No event claimed by more than one consumer.
       assert length(claimed) == length(Enum.uniq(claimed))
-      # Every event was claimed exactly once.
       assert length(claimed) == count
       assert IngestEventQueue.total_pending(sbp) == 0
     end
@@ -972,7 +966,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.add_to_table(sbp, [le])
       tid = IngestEventQueue.get_tid(sbp)
 
-      # claim it (claim counter -> 1, status :processing)
       le_id = le.id
       assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
       assert [{^le_id, :processing, _, _, 1}] = :ets.lookup(tid, le.id)
@@ -1114,7 +1107,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert reset_le.id == le.id
       assert reset_le.body == le.body
       assert is_integer(size)
-      # claim counter reset to 0 so the requeued event can be claimed again
       assert claim == 0
     end
 
@@ -1127,7 +1119,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       le = build(:log_event, source: source)
       IngestEventQueue.add_to_table(sbp, [le])
 
-      # claim via the real path: marks :processing and sets the claim counter to 1
       le_id = le.id
       assert {:ok, [{^le_id, _size}], _tid} = IngestEventQueue.take_pending_ids(sbp, 1)
       assert {:ok, [], _} = IngestEventQueue.take_pending_ids(sbp, 1)

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -107,7 +107,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       assert IngestEventQueue.get_table_size(sid_bid_pid) == 1
       assert IngestEventQueue.total_pending(sid_bid_pid) == 0
-      assert [{_id, :ingested, _, _}] = :ets.lookup(tid, le.id)
+      assert [{_id, :ingested, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
     test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{

--- a/test/profiling/ingest_event_queue_take_pending_ids_bench.exs
+++ b/test/profiling/ingest_event_queue_take_pending_ids_bench.exs
@@ -1,0 +1,211 @@
+alias Logflare.Backends.IngestEventQueue
+
+# Create a test user and source
+user = Logflare.Factory.insert(:user)
+source = Logflare.Factory.insert(:source, user: user)
+
+# Single-consumer queue, keyed by an owner pid (mirrors BufferProducer's {sid, bid, self()}).
+owner = spawn(fn -> :timer.sleep(:infinity) end)
+key = {source.id, nil, owner}
+IngestEventQueue.upsert_tid(key)
+tid = IngestEventQueue.get_tid(key)
+
+# The row tuple is now 5 elements: {event_id, status, event, size, claim}. This match spec
+# selects pending rows as {event_id, size}, mirroring the module's take_pending_ids/2.
+select_ms = [{{:"$1", :pending, :"$2", :"$3", :"$4"}, [], [{{:"$1", :"$3"}}]}]
+
+# Strategy A — per-id conditional CAS (the pre-update_counter implementation, #3609).
+take_via_select_replace = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      Enum.filter(taken_pairs, fn {id, _size} ->
+        replace_ms = [
+          {{id, :pending, :"$1", :"$2", :"$3"}, [], [{{id, :processing, :"$1", :"$2", :"$3"}}]}
+        ]
+
+        :ets.select_replace(tid, replace_ms) == 1
+      end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy B — dedup + unconditional update_element (the #3600 form; valid only for
+# single-consumer queues). Cheaper: no per-id match-spec compilation.
+take_via_update_element = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      taken_pairs
+      |> Enum.uniq_by(fn {id, _size} -> id end)
+      |> Enum.filter(fn {id, _size} -> :ets.update_element(tid, id, {2, :processing}) end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy D — single select_replace compiled once: one match spec with one literal-key
+# clause per id, so ETS compiles the whole spec a single time (vs once per id) while
+# keeping the set-table key index. No schema change, still multi-consumer safe. Caveat:
+# select_replace returns only a count, so it cannot say *which* ids it won — the fast path
+# assumes count == candidates (true with no contention). The single-threaded bench never
+# hits the contention fallback. NOTE: this measures table_size == n; if ETS full-scans an
+# N-clause spec instead of doing N keyed lookups, a large-table/small-n sweep would expose it.
+take_via_batched_select_replace = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      candidates = Enum.uniq_by(taken_pairs, fn {id, _size} -> id end)
+
+      replace_ms =
+        for {id, _size} <- candidates do
+          {{id, :pending, :"$1", :"$2", :"$3"}, [], [{{id, :processing, :"$1", :"$2", :"$3"}}]}
+        end
+
+      case replace_ms do
+        [] ->
+          []
+
+        _ ->
+          # In production, count < length(candidates) needs a per-id fallback to identify
+          # the winners; never triggered single-threaded, so we return candidates directly.
+          _claimed = :ets.select_replace(tid, replace_ms)
+          candidates
+      end
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+# Strategy C — per-id update_counter (CAS-lite). Atomic and isolated under write_concurrency,
+# but uses a direct integer op rather than a per-id match spec. The `0 -> 1` winner claims;
+# `2+` means another consumer (or a resize-duplicate) already took it. No uniq_by needed.
+# `update_counter` raises on a missing key (janitor delete race), so claim losses on that
+# path surface as ArgumentError -> not won, mirroring update_element returning false.
+take_via_update_counter = fn tid, n ->
+  case :ets.select(tid, select_ms, n) do
+    {taken_pairs, _cont} ->
+      Enum.filter(taken_pairs, fn {id, _size} ->
+        try do
+          if :ets.update_counter(tid, id, {5, 1}) == 1 do
+            :ets.update_element(tid, id, {2, :processing})
+            true
+          else
+            false
+          end
+        rescue
+          ArgumentError -> false
+        end
+      end)
+
+    :"$end_of_table" ->
+      []
+  end
+end
+
+inputs = %{
+  "250 events" => for(_ <- 1..250, do: Logflare.Factory.build(:log_event)),
+  "1000 events" => for(_ <- 1..1_000, do: Logflare.Factory.build(:log_event))
+}
+
+Benchee.run(
+  %{
+    "take_pending_ids/2 (current, end-to-end)" => fn events ->
+      IngestEventQueue.take_pending_ids(key, length(events))
+    end,
+    "inline: select + per-id select_replace (CAS)" => fn events ->
+      take_via_select_replace.(tid, length(events))
+    end,
+    "inline: select + uniq_by + update_element" => fn events ->
+      take_via_update_element.(tid, length(events))
+    end,
+    "inline: select + per-id update_counter (CAS-lite)" => fn events ->
+      take_via_update_counter.(tid, length(events))
+    end,
+    "inline: select + single compiled select_replace" => fn events ->
+      take_via_batched_select_replace.(tid, length(events))
+    end
+  },
+  inputs: inputs,
+  before_each: fn events ->
+    # Reset the queue to a fully-pending state before each claim.
+    IngestEventQueue.truncate_table(key, :all, 0)
+    IngestEventQueue.add_to_table(key, events)
+    events
+  end,
+  time: 5,
+  warmup: 2,
+  memory_time: 3,
+  reduction_time: 3
+)
+
+# credo:disable-for-this-file Credo.Check.Readability.MaxLineLength
+# Run with: mix run test/profiling/ingest_event_queue_take_pending_ids_bench.exs
+#
+# Compares the claim strategy in take_pending_ids/2. The module now uses update_counter
+# (the "current, end-to-end" line), so the inline strategies below are the alternatives:
+#   - update_counter (current): per-id atomic CAS on the claim counter; no match-spec compile.
+#   - select_replace (prior, #3609): per-id conditional CAS, compiles a match spec per id.
+#   - update_element: dedup + unconditional write; correct only for single-consumer queues.
+#   - single compiled select_replace: REJECTED (ETS scans an N-clause spec; see below).
+#
+# Historical results (indicative, local dev machine — capture formal snapshots against
+# a committed SHA per the profiling workflow):
+#
+## 2026-06-19  Baseline: select_replace (current) vs update_element ##
+# ##### With input 1000 events #####
+# Name                                                   ips        average         99th %
+# inline: select + uniq_by + update_element           5.13 K      194.86 μs      265.96 μs
+# take_pending_ids/2 (current, end-to-end)            1.64 K      608.62 μs      670.72 μs
+# inline: select + per-id select_replace (CAS)        1.63 K      613.49 μs      737.88 μs
+# -> update_element ~3.15x faster (+413 μs/claim saved vs current)
+#
+# ##### With input 250 events #####
+# Name                                                   ips        average         99th %
+# inline: select + uniq_by + update_element          19.50 K       51.29 μs       68.45 μs
+# take_pending_ids/2 (current, end-to-end)            6.58 K      151.96 μs      185.61 μs
+# inline: select + per-id select_replace (CAS)        6.47 K      154.61 μs      183.41 μs
+# -> update_element ~3.0x faster
+#
+# Note: update_element shows higher BEAM memory/reductions (the uniq_by set), but lower
+# wall-clock — select_replace's per-id match-spec compilation happens in the BIF layer
+# and does not surface as reductions. update_element is only safe for single-consumer
+# queues (see the concurrent-claim regression test in ingest_event_queue_test.exs).
+#
+## 2026-06-19  Add update_counter (CAS-lite) variant ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %    memory
+# inline: select + per-id update_counter (CAS-lite)        7.38 K    135.57 μs    175.71 μs    109 KB
+# inline: select + uniq_by + update_element                5.27 K    189.59 μs    222.08 μs    378 KB
+# take_pending_ids/2 (current, end-to-end)                 1.67 K    599.56 μs    725.01 μs    266 KB
+# inline: select + per-id select_replace (CAS)             1.51 K    660.62 μs    824.71 μs    266 KB
+# -> update_counter ~4.4x faster than current AND multi-consumer safe (the 0->1 winner
+#    claims; 2+ means another consumer/resize-dup already took it, so no uniq_by needed,
+#    hence the lowest memory/reductions too). Requires a 5th integer "claim" field on the
+#    row tuple ({id, status, event, size, claim}), which touches the module's match specs.
+#
+## 2026-06-19  Single compiled select_replace variant — REJECTED ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %    memory
+# inline: select + per-id update_counter (CAS-lite)        7.21 K    138.63 μs    166.44 μs    109 KB
+# inline: select + per-id select_replace (CAS)             1.61 K    620.37 μs    712.39 μs    266 KB
+# inline: select + single compiled select_replace          0.27 K   3678.24 μs   6588.41 μs    537 KB
+# -> "compile once" is a trap: one match spec with N literal-key clauses is ~26x slower than
+#    update_counter and ~6x slower than per-id select_replace. ETS does NOT index a
+#    multi-clause literal-key spec into N keyed lookups — it SCANS, testing each row against
+#    the clause list (~O(rows * clauses)), and compiling the giant spec is itself costly.
+#    The per-id structure is what preserves the set-table key index; you cannot have both
+#    "one compilation" and "keyed lookups" with select_replace. Do not revisit this approach.
+#
+## 2026-06-19  update_counter shipped in take_pending_ids/2 (5-tuple row) ##
+# ##### With input 1000 events #####
+# Name                                                        ips      average       99th %
+# inline: select + per-id update_counter (CAS-lite)        7.87 K    127.04 μs    165.20 μs
+# take_pending_ids/2 (current, end-to-end)                 7.57 K    132.08 μs    280.76 μs
+# inline: select + uniq_by + update_element                5.24 K    190.97 μs    214.75 μs
+# inline: select + per-id select_replace (CAS)             1.53 K    651.72 μs    714.56 μs
+# inline: select + single compiled select_replace          0.28 K   3519.09 μs   3880.80 μs
+# -> The real end-to-end function (now update_counter) tracks the inline CAS-lite line and
+#    is ~4.9x faster than the prior per-id select_replace, while keeping multi-consumer
+#    safety. Row tuple is now {event_id, status, event, size, claim}.


### PR DESCRIPTION
## Summary

PR 1 of 3 splitting #3616. Replaces the per-id `:ets.select_replace` claim in `IngestEventQueue.take_pending_ids/2` — the BigQuery pipeline's claim hot path — with an atomic claim counter. ~4.9x faster claims (652 → 132 µs per 1000-event batch) while keeping the multi-consumer safety that `select_replace` provided.

This is the foundational PR. The other two are stacked on it:

- PR 2 — BigQuery pipeline allocation cleanups (no behavior change)
- PR 3 — telemetry/ack relocation

## Approach

`take_pending_ids/2` claimed each event with a per-id `:ets.select_replace`, which compiles a match spec per id in the BIF layer — benchmarked as the dominant cost. The row tuple gains a 5th integer field — `{event_id, status, event, size, claim}` — and a claim now succeeds when `:ets.update_counter/3` transitions `claim` from `0 → 1`:

- **Atomic election, separate status write** — `update_counter` is the atomic election: only the `0 → 1` winner takes the event, and a `2+` result means another consumer (or a `write_concurrency` resize-duplicate within the same select) already claimed it. The follow-up `:processing` status write is a separate step via `:ets.update_element/3`, which returns `false` for a key that vanished between the two ops — so a row deleted mid-claim is rejected rather than claimed. Same multi-consumer guarantee as `select_replace`.
- **Cheap** — a direct integer op, no per-id match-spec compilation, and no `uniq_by` dedup pass (duplicate reads lose the election naturally).
- **Transitions back to `:pending` reset the counter to 0**, so requeued events stay claimable. All three paths do it: the failure requeue (`add_to_table/3`), the `QueueJanitor` stale `:processing → :pending` reset, and `update_status/3` when it sets `:pending`.

Also drops a redundant `:ets.info(:size)` read in `take_pending_ids` — `get_tid/1` already confirms the table is live.

## Why not the alternatives

| Strategy (1000-event claim) | avg | multi-consumer safe? |
|---|---|---|
| **update_counter (this PR)** | **132 µs** | ✅ |
| update_element + uniq_by | 191 µs | ❌ single-consumer only |
| select_replace per-id (prior) | 652 µs | ✅ |
| single compiled select_replace | 3519 µs | ✅ but ETS scans an N-clause spec |

`update_element` is faster than the old code but only safe if each queue has exactly one consumer. A single multi-clause `select_replace` (one compilation) is rejected — ETS does not index an N-clause literal-key spec into N keyed lookups; it scans, making it ~26x slower. The benchmark file records the full history.

## Blast radius

The tuple shape is a shared contract. Updated:

- `ingest_event_queue.ex` — construction + all match specs, new `claim_pending/2` helper, and `update_status/3` now resets `claim` to 0 when it sets `:pending`.
- `queue_janitor.ex` — stale-reset path resets `claim` to 0 so requeued events stay claimable.
- `bigquery/pipeline.ex` — raw `:ets.lookup` patterns updated to the 5-tuple.
- `test/profiling/ingest_event_queue_take_pending_ids_bench.exs` — new claim-strategy benchmark recording the full strategy comparison and history.
- Tests updated to the 5-tuple; new `take_pending_ids/2` describe block incl. a concurrent-claim race test (tagged `:race`), and an `update_status/3` test covering the `:pending` claim-counter reset.