### PR TITLE
ui: min height for all chart bars

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -175,10 +175,8 @@ const chartSettings = (type) => {
   }
 };
 
-const minPointSizeForValue = (value) => {
-  if (Number(value) <= 0) return 0;
-  return minBarHeight;
-};
+const minPointSizeForDataKey = (chartData, dataKey) => (_value, index) =>
+  Number(chartData[index]?.[dataKey]) > 0 ? minBarHeight : 0;
 
 const barTotal = (entry, keys) =>
   keys.reduce((sum, key) => sum + Math.max(Number(entry?.[key]) || 0, 0), 0);
@@ -238,7 +236,6 @@ const LogEventsChart = ({
   const TooltipContent = tooltipFactory(chartDataShapeId);
   const settings = chartSettings(chartDataShapeId);
   const topStackKey = settings.keys[settings.keys.length - 1];
-  const useMinPointSize = settings.keys.length === 1;
   const chartData = React.useMemo(
     () =>
       data.map((entry) => {
@@ -341,7 +338,7 @@ const LogEventsChart = ({
                 stackId="stack"
                 fill={settings.colors[key]}
                 isAnimationActive={false}
-                minPointSize={useMinPointSize ? minPointSizeForValue : undefined}
+                minPointSize={minPointSizeForDataKey(chartData, key)}
                 shape={key === topStackKey ? renderBarWithHighlight : undefined}
                 onClick={handleBarClick}
               />


### PR DESCRIPTION
Enforce a minimum chart height for any chart interval with data. 

We looked at this previously and decided to shade the background of the chart for any bar with data. This was intended to indicate to users a segment of the chart which might have data but was too small to see due to the scale used for rendering. 

For example, the arrows indicates segments with data but too small to render:


<img width="2516" height="1860" alt="CleanShot 2026-06-22 at 14 57 29@2x" src="https://github.com/user-attachments/assets/6487cf8e-789d-46ba-ae69-6868b917b8a5" />

Based on O11Y-1790 this doesn't seem to be obvious enough. This PR ensures any chart segment with data will show a bar. 

<img width="2508" height="1856" alt="CleanShot 2026-06-22 at 15 02 58@2x" src="https://github.com/user-attachments/assets/4091395c-bf3a-4baa-80c5-ce8b7cb95cc5" />


Hopefully is this is clearer for users.


Fixes O11Y-1790