### PR TITLE
Fix GHCR app token login

### DIFF
--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: x-access-token
           password: ${{ steps.app-token.outputs.token }}
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4


### PR DESCRIPTION
## Summary

- Use `x-access-token` as the GHCR username when authenticating with the GitHub App installation token.

## Why

The `mirror_image` job creates a GitHub App token, but the GHCR login used `${{ github.actor }}` as the username. In the failing workflow run, the login succeeded as the triggering user, then the image push failed with `permission_denied: installation not allowed to Write organization package`.

Using `x-access-token` matches token-based registry authentication and ensures the token identity is used for the GHCR push.

## Validation

- Parsed `.github/workflows/docker-retag-versioned.yml` as YAML with Ruby.
- Ran `git diff --check` for the workflow file.

`actionlint` was not installed locally, so full GitHub Actions linting was not run.