### PR TITLE
perf(bq pipeline): delete non-default acked rows immediately

### DIFF
--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -152,7 +152,12 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
               :ok
           end
 
-          if metrics.avg > 100 do
+          # Non-default queues ({sid, bid} with bid != nil) never serve recent logs
+          # (list_recent_logs_local always reads {sid, nil}) and the janitor truncates
+          # all their :ingested rows every cycle anyway, so delete at ack instead of
+          # leaving the intermediate :ingested state for the janitor to reap. The default
+          # queue keeps the :ingested remainder that backs recent local logs.
+          if bid != nil or metrics.avg > 100 do
             IngestEventQueue.delete_id(tid, id)
           else
             IngestEventQueue.update_status(tid, id, :ingested)

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -111,6 +111,28 @@ defmodule Logflare.BigQuery.PipelineTest do
       assert [{_id, :ingested, _, _, _}] = :ets.lookup(tid, le.id)
     end
 
+    test "ack deletes events directly for non-default backend even when avg <= 100", %{
+      source: source
+    } do
+      stub(Logflare.Sources, :get_source_metrics_for_ingest, fn _ -> %{avg: 50} end)
+
+      backend = insert(:backend, type: :bigquery, sources: [source])
+      sid_bid_pid = {source.id, backend.id, self()}
+      IngestEventQueue.upsert_tid(sid_bid_pid)
+      le = build(:log_event, source: source)
+      IngestEventQueue.add_to_table(sid_bid_pid, [le])
+      tid = IngestEventQueue.get_tid(sid_bid_pid)
+      :ets.update_element(tid, le.id, {2, :processing})
+
+      ref = {sid_bid_pid, %{max_retries: 0}}
+      message = Pipeline.transform({le.id, tid, 0}, ref: ref)
+      {mod, ref, _} = message.acknowledger
+
+      mod.ack(ref, [message], [])
+
+      assert IngestEventQueue.get_table_size(sid_bid_pid) == 0
+    end
+
     test "le_to_bq_row/1 generates TableDataInsertAllRequestRows struct correctly", %{
       source: source
     } do


### PR DESCRIPTION
For non-default BigQuery queues (`{sid, bid}` with `bid != nil`), the `:ingested` status is effectively write-only: recent logs only ever reads the default queue (`list_recent_logs_local` reads `{sid, nil}`), and the `QueueJanitor` already truncates *all* `:ingested` rows for non-default backends every cycle (`truncate_all? = metrics.avg > 100 or bid != nil`).

This changes the BQ pipeline ack to delete those rows immediately instead of marking them `:ingested` and waiting for the next janitor pass. End-state is identical; it just skips the intermediate `:ingested` dwell (up to one scaled janitor interval) and removes the janitor truncation work, reducing ETS residency for backend queues.

The default queue (`{sid, nil}`) is unchanged — it keeps the `:ingested` remainder that backs recent local logs.

## Change

`if metrics.avg > 100` → `if bid != nil or metrics.avg > 100` in the ack delete/status branch.

## Notes

- The janitor’s `or bid != nil` clause is retained as a safety net for any `:ingested` rows that still appear (lookup-miss path, claim races, other writers).
- Telemetry is unaffected — the lookup that emits per-event telemetry runs before the delete branch.