### PR TITLE
perf(clickhouse): reduce allocations in RowBinary row encoding

### DIFF
--- a/bench/clickhouse_encode_e2e.exs
+++ b/bench/clickhouse_encode_e2e.exs
@@ -1,0 +1,212 @@
+# Usage: TAG=before mix run --no-start bench/clickhouse_encode_e2e.exs
+#
+# End-to-end encode-stage benchmark for the ClickHouse ingester. Exercises the
+# real production function `Ingester.encode_batch/2` (NOT hand-replicated
+# baselines) over realistic log / metric / trace batches, then forces the
+# resulting iodata to a binary so the full encode cost is measured.
+#
+# Run once per checkout via bench/run_encode_e2e.sh, which tags each run
+# (before/after) and saves Benchee results for cross-SHA comparison.
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.LogEvent
+
+tag = System.get_env("TAG", "untagged")
+save_dir = System.get_env("BENCH_SAVE_DIR", "/tmp")
+File.mkdir_p!(save_dir)
+
+batch_size = String.to_integer(System.get_env("BATCH_SIZE", "500"))
+
+mapping_config_id = "00000000-0000-0000-0001-000000000003"
+source_uuid = String.to_atom("550e8400-e29b-41d4-a716-446655440000")
+
+# Realistic, *varied* resource attributes: ~12 keys spanning the typical OTEL
+# service/host/k8s/cloud namespaces. Key set and value lengths vary by event so
+# the map encoder isn't fed an artificially uniform batch.
+resource_attributes = fn i ->
+  base = %{
+    "service.name" => "checkout-service",
+    "service.version" => "2.#{rem(i, 20)}.1",
+    "service.namespace" => "ecommerce",
+    "service.instance.id" => "i-0#{rem(i, 64)}a1b2c3d4e5f6",
+    "host.name" => "ip-10-0-#{rem(i, 256)}-#{rem(i * 7, 256)}.ec2.internal",
+    "host.arch" => "amd64",
+    "cloud.provider" => "aws",
+    "cloud.region" => "us-east-1",
+    "telemetry.sdk.name" => "opentelemetry",
+    "telemetry.sdk.language" => "erlang",
+    "telemetry.sdk.version" => "1.4.0"
+  }
+
+  cond do
+    rem(i, 3) == 0 ->
+      Map.merge(base, %{
+        "k8s.pod.name" => "checkout-service-#{rem(i, 9999)}-abcde",
+        "k8s.namespace.name" => "production",
+        "k8s.node.name" => "gke-prod-pool-#{rem(i, 16)}"
+      })
+
+    rem(i, 3) == 1 ->
+      Map.put(base, "deployment.environment", "production")
+
+    true ->
+      base
+  end
+end
+
+log_attributes = fn i ->
+  base = %{
+    "http.method" => Enum.at(~w(GET POST PUT DELETE), rem(i, 4)),
+    "http.status_code" => "#{Enum.at([200, 201, 400, 404, 500], rem(i, 5))}",
+    "http.route" => "/api/v1/orders/:id/line_items",
+    "user.id" => "user_#{rem(i, 100_000)}",
+    "request.id" => "req_#{i}"
+  }
+
+  if rem(i, 4) == 0,
+    do: Map.put(base, "error.stack", "** (RuntimeError) boom\n" <> String.duplicate("    at foo/bar:42\n", 6)),
+    else: base
+end
+
+# Event messages span short access-log lines and larger structured blobs.
+event_message = fn i ->
+  if rem(i, 5) == 0 do
+    ~s({"event":"order.created","order_id":#{i},"items":#{rem(i, 12) + 1},"total_cents":#{i * 137},"currency":"USD","customer":"user_#{rem(i, 100_000)}","note":"#{String.duplicate("x", rem(i, 200))}"})
+  else
+    "GET /api/v1/orders/#{i}/line_items 200 in #{rem(i, 800)}ms"
+  end
+end
+
+base_event = fn type, body ->
+  %LogEvent{
+    id: Ecto.UUID.generate(),
+    source_uuid: source_uuid,
+    source_name: "bench source",
+    event_type: type,
+    ingested_at: DateTime.utc_now(),
+    body: Map.merge(body, %{"mapping_config_id" => mapping_config_id})
+  }
+end
+
+log_event = fn i ->
+  base_event.(:log, %{
+    "project" => "bench-project",
+    "trace_id" => Base.encode16(<<i::128>>, case: :lower),
+    "span_id" => Base.encode16(<<i::64>>, case: :lower),
+    "trace_flags" => 1,
+    "severity_text" => Enum.at(~w(DEBUG INFO WARN ERROR), rem(i, 4)),
+    "severity_number" => Enum.at([5, 9, 13, 17], rem(i, 4)),
+    "service_name" => "checkout-service",
+    "event_message" => event_message.(i),
+    "scope_name" => "logflare.instrumentation",
+    "scope_version" => "1.0.0",
+    "scope_schema_url" => "",
+    "resource_schema_url" => "https://opentelemetry.io/schemas/1.21.0",
+    "resource_attributes" => resource_attributes.(i),
+    "scope_attributes" => %{"library.language" => "elixir"},
+    "log_attributes" => log_attributes.(i),
+    "timestamp" => 1_700_000_000_000_000 + i
+  })
+end
+
+metric_event = fn i ->
+  base_event.(:metric, %{
+    "project" => "bench-project",
+    "time_unix" => 1_700_000_000_000_000 + i,
+    "start_time_unix" => 1_700_000_000_000_000,
+    "metric_name" => "http.server.duration",
+    "metric_description" => "Duration of inbound HTTP requests",
+    "metric_unit" => "ms",
+    "metric_type" => rem(i, 3) + 1,
+    "service_name" => "checkout-service",
+    "event_message" => "",
+    "scope_name" => "logflare.instrumentation",
+    "scope_version" => "1.0.0",
+    "scope_schema_url" => "",
+    "resource_schema_url" => "https://opentelemetry.io/schemas/1.21.0",
+    "resource_attributes" => resource_attributes.(i),
+    "scope_attributes" => %{"library.language" => "elixir"},
+    "attributes" => log_attributes.(i),
+    "aggregation_temporality" => "cumulative",
+    "is_monotonic" => true,
+    "flags" => 0,
+    "value" => i * 1.5,
+    "count" => i,
+    "sum" => i * 12.3,
+    "min" => 0.5,
+    "max" => i * 1.0,
+    "scale" => 0,
+    "zero_count" => 0,
+    "positive_offset" => 0,
+    "negative_offset" => 0,
+    "bucket_counts" => Enum.map(0..9, &(&1 + rem(i, 3))),
+    "explicit_bounds" => [0.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0],
+    "positive_bucket_counts" => [],
+    "negative_bucket_counts" => [],
+    "quantile_values" => [],
+    "quantiles" => [],
+    "exemplars.filtered_attributes" => [%{"trace_id" => "abc"}],
+    "exemplars.time_unix" => [1_700_000_000_000_000 + i],
+    "exemplars.value" => [i * 1.0],
+    "exemplars.span_id" => [Base.encode16(<<i::64>>, case: :lower)],
+    "exemplars.trace_id" => [Base.encode16(<<i::128>>, case: :lower)],
+    "timestamp" => 1_700_000_000_000_000 + i
+  })
+end
+
+trace_event = fn i ->
+  event_count = rem(i, 4)
+
+  base_event.(:trace, %{
+    "project" => "bench-project",
+    "trace_id" => Base.encode16(<<i::128>>, case: :lower),
+    "span_id" => Base.encode16(<<i::64>>, case: :lower),
+    "parent_span_id" => Base.encode16(<<i + 1::64>>, case: :lower),
+    "trace_state" => "",
+    "span_name" => "POST /api/v1/orders",
+    "span_kind" => "SPAN_KIND_SERVER",
+    "service_name" => "checkout-service",
+    "event_message" => "",
+    "duration" => rem(i, 800) * 1_000_000,
+    "status_code" => Enum.at(~w(STATUS_CODE_OK STATUS_CODE_ERROR), rem(i, 2)),
+    "status_message" => "",
+    "scope_name" => "logflare.instrumentation",
+    "scope_version" => "1.0.0",
+    "resource_attributes" => resource_attributes.(i),
+    "span_attributes" => log_attributes.(i),
+    "events.timestamp" => Enum.map(1..event_count//1, &(1_700_000_000_000_000 + i + &1)),
+    "events.name" => Enum.map(1..event_count//1, &"event.#{&1}"),
+    "events.attributes" => Enum.map(1..event_count//1, fn n -> %{"exception.type" => "Error#{n}", "exception.message" => "boom #{n}"} end),
+    "links.trace_id" => [Base.encode16(<<i + 2::128>>, case: :lower)],
+    "links.span_id" => [Base.encode16(<<i + 2::64>>, case: :lower)],
+    "links.trace_state" => [""],
+    "links.attributes" => [%{"link.kind" => "child"}],
+    "timestamp" => 1_700_000_000_000_000 + i
+  })
+end
+
+log_batch = Enum.map(1..batch_size, log_event)
+metric_batch = Enum.map(1..batch_size, metric_event)
+trace_batch = Enum.map(1..batch_size, trace_event)
+
+# Encode once and report the produced byte sizes so before/after runs are
+# confirmed to be encoding the same volume of data.
+for {label, batch, type} <- [{"log", log_batch, :log}, {"metric", metric_batch, :metric}, {"trace", trace_batch, :trace}] do
+  bytes = batch |> Ingester.encode_batch(type) |> IO.iodata_to_binary() |> byte_size()
+  IO.puts("#{label}: #{batch_size} events -> #{bytes} bytes (#{Float.round(bytes / batch_size, 1)} bytes/event)")
+end
+
+IO.puts("")
+
+Benchee.run(
+  %{
+    "log" => fn -> log_batch |> Ingester.encode_batch(:log) |> IO.iodata_to_binary() end,
+    "metric" => fn -> metric_batch |> Ingester.encode_batch(:metric) |> IO.iodata_to_binary() end,
+    "trace" => fn -> trace_batch |> Ingester.encode_batch(:trace) |> IO.iodata_to_binary() end
+  },
+  time: 5,
+  warmup: 2,
+  memory_time: 2,
+  save: [path: Path.join(save_dir, "encode_e2e_#{tag}.benchee"), tag: tag],
+  print: [configuration: false]
+)

--- a/bench/clickhouse_encoder_primitives.exs
+++ b/bench/clickhouse_encoder_primitives.exs
@@ -1,0 +1,119 @@
+# Usage: mix run --no-start bench/clickhouse_encoder_primitives.exs
+#
+# Exploratory micro-benchmarks for candidate RowBinaryEncoder optimizations
+# identified while reviewing encode_batch. Each candidate is compared against
+# the current production implementation, replicated locally as the baseline,
+# with a byte-equality assertion first.
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder
+
+varint = &RowBinaryEncoder.varint/1
+string = fn v when is_binary(v) -> [varint.(byte_size(v)), v] end
+
+# ---------------------------------------------------------------------------
+# Candidate 1: empty-array / empty-map sentinel  [<<0>>]  vs  <<0>>
+#
+# A metric/trace row contains many optional array columns that are empty in
+# practice. The current code returns a fresh single-element list [<<0>>] each
+# time; a shared <<0>> binary literal allocates nothing. Measured by building
+# a row-shaped iolist with N empty arrays interspersed with real values.
+# ---------------------------------------------------------------------------
+
+empty_list = fn -> [<<0>>] end
+empty_bin = fn -> <<0>> end
+
+# Simulate the empty-array slots of a metric row (~10 empties is realistic for
+# a gauge/sum metric where histogram buckets/quantiles/exemplars are unused).
+build_row_list = fn ->
+  for _ <- 1..10, do: empty_list.()
+end
+
+build_row_bin = fn ->
+  for _ <- 1..10, do: empty_bin.()
+end
+
+IO.puts("== Candidate 1: empty sentinel [<<0>>] vs <<0>> (10 empty arrays/row) ==")
+
+l = IO.iodata_to_binary(build_row_list.())
+b = IO.iodata_to_binary(build_row_bin.())
+IO.puts(if l == b, do: "outputs match (#{byte_size(l)} bytes)", else: "MISMATCH")
+
+Benchee.run(
+  %{
+    "[<<0>>] list sentinel" => build_row_list,
+    "<<0>> binary sentinel" => build_row_bin
+  },
+  time: 2,
+  warmup: 1,
+  memory_time: 1,
+  print: [configuration: false]
+)
+
+# ---------------------------------------------------------------------------
+# Candidate 2: map_string_string fold variants
+#
+#   baseline  : :maps.fold building [acc, string(k), string(v)]  (current)
+#   inlined   : :maps.fold building [acc, varint(byte_size(k)), k, varint(byte_size(v)), v]
+#               -- drops the two intermediate [varint, str] lists from string/1
+# ---------------------------------------------------------------------------
+
+baseline_map = fn items ->
+  :maps.fold(
+    fn k, v, acc -> [acc, string.(k), string.(v)] end,
+    [varint.(map_size(items))],
+    items
+  )
+end
+
+inlined_map = fn items ->
+  :maps.fold(
+    fn k, v, acc ->
+      [acc, varint.(byte_size(k)), k, varint.(byte_size(v)), v]
+    end,
+    [varint.(map_size(items))],
+    items
+  )
+end
+
+# Guarded: fast path for binary k/v, falls back to string/1 for iodata values
+# (preserves the current map/3 capability of accepting iodata-list values).
+guarded_map = fn items ->
+  fun = fn
+    k, v, acc when is_binary(k) and is_binary(v) ->
+      [acc, varint.(byte_size(k)), k, varint.(byte_size(v)), v]
+
+    k, v, acc ->
+      [acc, string.(k), string.(v)]
+  end
+
+  :maps.fold(fun, [varint.(map_size(items))], items)
+end
+
+small = %{"host" => "node-3", "region" => "us-east-1", "status" => "200"}
+
+medium =
+  for i <- 1..15, into: %{}, do: {"attribute_key_#{i}", "some attribute value number #{i}"}
+
+large =
+  for i <- 1..100, into: %{}, do: {"attribute_key_#{i}", "some attribute value number #{i}"}
+
+for {label, m} <- [{"small (3 keys)", small}, {"medium (15 keys)", medium}, {"large (100 keys)", large}] do
+  IO.puts("\n== Candidate 2: map_string_string fold -- #{label} ==")
+
+  a = IO.iodata_to_binary(baseline_map.(m))
+  c = IO.iodata_to_binary(inlined_map.(m))
+  g = IO.iodata_to_binary(guarded_map.(m))
+  IO.puts(if a == c and c == g, do: "outputs match (#{byte_size(a)} bytes)", else: "MISMATCH")
+
+  Benchee.run(
+    %{
+      "baseline (string/1 per k,v)" => fn -> baseline_map.(m) end,
+      "inlined (byte_size in fold)" => fn -> inlined_map.(m) end,
+      "guarded (binary fast path)" => fn -> guarded_map.(m) end
+    },
+    time: 2,
+    warmup: 1,
+    memory_time: 1,
+    print: [configuration: false]
+  )
+end

--- a/bench/clickhouse_map_encoding.exs
+++ b/bench/clickhouse_map_encoding.exs
@@ -1,0 +1,72 @@
+# Usage: mix run bench/clickhouse_map_encoding.exs
+#
+# Compares candidate implementations of the String->String Map encoder used
+# for ClickHouse attribute columns (resource/scope/log attributes).
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder
+
+string = fn value when is_binary(value) -> [RowBinaryEncoder.varint(byte_size(value)), value] end
+
+# Baseline: current source impl (Map.to_list + length + Enum.flat_map).
+baseline = fn items ->
+  pairs = Map.to_list(items)
+
+  [
+    RowBinaryEncoder.varint(length(pairs))
+    | Enum.flat_map(pairs, fn {k, v} -> [string.(k), string.(v)] end)
+  ]
+end
+
+# Candidate A: map_size + comprehension, nested iodata (no flat_map flatten).
+cand_a = fn items ->
+  [
+    RowBinaryEncoder.varint(map_size(items))
+    | for({k, v} <- items, do: [string.(k), string.(v)])
+  ]
+end
+
+# Candidate B: :maps.fold, no to_list materialization.
+cand_b = fn items ->
+  :maps.fold(
+    fn k, v, acc -> [acc, string.(k), string.(v)] end,
+    [RowBinaryEncoder.varint(map_size(items))],
+    items
+  )
+end
+
+small = %{"host" => "node-3", "region" => "us-east-1", "status" => "200"}
+
+medium =
+  for i <- 1..15, into: %{}, do: {"attribute_key_#{i}", "some attribute value number #{i}"}
+
+large =
+  for i <- 1..100, into: %{}, do: {"attribute_key_#{i}", "some attribute value number #{i}"}
+
+# Sanity: all three must produce identical bytes.
+for {name, m} <- [small: small, medium: medium, large: large] do
+  a = IO.iodata_to_binary(baseline.(m))
+  b = IO.iodata_to_binary(cand_a.(m))
+  c = IO.iodata_to_binary(cand_b.(m))
+
+  if a == b and b == c do
+    IO.puts("#{name}: outputs match (#{byte_size(a)} bytes)")
+  else
+    IO.puts("#{name}: MISMATCH baseline=#{byte_size(a)} A=#{byte_size(b)} B=#{byte_size(c)}")
+  end
+end
+
+for {label, m} <- [{"small (3 keys)", small}, {"medium (15 keys)", medium}, {"large (100 keys)", large}] do
+  IO.puts("\n== #{label} ==")
+
+  Benchee.run(
+    %{
+      "baseline (to_list+length+flat_map)" => fn -> baseline.(m) end,
+      "A: map_size + comprehension" => fn -> cand_a.(m) end,
+      "B: :maps.fold" => fn -> cand_b.(m) end
+    },
+    time: 2,
+    warmup: 1,
+    memory_time: 1,
+    print: [configuration: false]
+  )
+end

--- a/bench/clickhouse_row_encoding.exs
+++ b/bench/clickhouse_row_encoding.exs
@@ -1,0 +1,83 @@
+# Usage: mix run bench/clickhouse_row_encoding.exs
+#
+# Measures two row-encoding optimizations for the ClickHouse ingester:
+#   #1 hoisting the batch-constant mapping_config_id UUID encode out of the
+#      per-row loop (encode_batch vs per-row encode_row)
+#   #2 the binary-pattern-match fast path in RowBinaryEncoder.uuid/1 vs the
+#      old String.replace |> Base.decode16! approach.
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder
+alias Logflare.LogEvent
+
+mapping_config_id = "00000000-0000-0000-0001-000000000003"
+source_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+# Old uuid/1 implementation, replicated locally as the #2 baseline.
+old_uuid = fn uuid_string ->
+  <<u1::64, u2::64>> =
+    uuid_string
+    |> String.replace("-", "")
+    |> Base.decode16!(case: :mixed)
+
+  <<u1::64-little, u2::64-little>>
+end
+
+build_event = fn i ->
+  %LogEvent{
+    id: Ecto.UUID.generate(),
+    source_uuid: String.to_atom(source_uuid),
+    source_name: "bench source",
+    event_type: :log,
+    ingested_at: DateTime.utc_now(),
+    body: %{
+      "mapping_config_id" => mapping_config_id,
+      "project" => "bench-project",
+      "trace_id" => "abc123",
+      "span_id" => "def456",
+      "trace_flags" => 1,
+      "severity_text" => "INFO",
+      "severity_number" => 9,
+      "service_name" => "bench-service",
+      "event_message" => "an example log line number #{i}",
+      "scope_name" => "bench.scope",
+      "scope_version" => "1.0.0",
+      "scope_schema_url" => "",
+      "resource_schema_url" => "",
+      "resource_attributes" => %{"host" => "node-#{rem(i, 8)}", "region" => "us-east-1"},
+      "scope_attributes" => %{"lib" => "logflare"},
+      "log_attributes" => %{"user_id" => "#{i}", "path" => "/api/v1/resource", "status" => "200"},
+      "timestamp" => 1_700_000_000_000_000 + i
+    }
+  }
+end
+
+batch = Enum.map(1..500, build_event)
+
+IO.puts("Batch size: #{length(batch)} log events\n")
+
+IO.puts("== #1: batch encode (hoisted) vs per-row encode (re-parses uuid per row) ==")
+
+Benchee.run(
+  %{
+    "per-row encode_row/2 (baseline)" =>
+      fn -> Enum.map(batch, &Ingester.encode_row(&1, :log)) end,
+    "encode_batch/2 (hoisted uuid)" =>
+      fn -> Ingester.encode_batch(batch, :log) end
+  },
+  time: 3,
+  warmup: 1,
+  memory_time: 1
+)
+
+IO.puts("\n== #2: uuid/1 fast path vs old String.replace approach ==")
+
+Benchee.run(
+  %{
+    "old uuid (String.replace)" => fn -> old_uuid.(mapping_config_id) end,
+    "new uuid (binary match)" => fn -> RowBinaryEncoder.uuid(mapping_config_id) end
+  },
+  time: 3,
+  warmup: 1,
+  memory_time: 1
+)

--- a/bench/compare_encode_e2e.exs
+++ b/bench/compare_encode_e2e.exs
@@ -1,0 +1,13 @@
+# Usage: mix run --no-start bench/compare_encode_e2e.exs
+#
+# Loads the saved before/after Benchee results produced by
+# bench/clickhouse_encode_e2e.exs and prints a per-job comparison
+# (after is shown relative to before, the slowest tag).
+
+save_dir = System.get_env("BENCH_SAVE_DIR", "/tmp")
+
+Benchee.run(
+  %{},
+  load: Path.join(save_dir, "encode_e2e_*.benchee"),
+  print: [configuration: false]
+)

--- a/bench/run_encode_e2e.sh
+++ b/bench/run_encode_e2e.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Before/after end-to-end encode-stage benchmark for the ClickHouse ingester.
+#
+# Runs bench/clickhouse_encode_e2e.exs against the baseline SHA and the current
+# branch HEAD, then prints a per-job comparison. The bench scripts are untracked,
+# so they survive `git checkout` and run unmodified against both revisions.
+#
+# Usage: bench/run_encode_e2e.sh [baseline_sha]
+set -euo pipefail
+
+BASELINE="${1:-e38c122ac}"
+# Results are transient comparison artifacts — keep them out of the repo tree,
+# consistent with the other benches here (which persist nothing).
+SAVE_DIR="${BENCH_SAVE_DIR:-${TMPDIR:-/tmp}/logflare_encode_e2e}"
+export BENCH_SAVE_DIR="$SAVE_DIR"
+
+ORIG_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  echo "error: tracked working tree is dirty; commit or stash before benchmarking." >&2
+  exit 1
+fi
+
+restore() {
+  echo ">> restoring $ORIG_REF"
+  git checkout --quiet "$ORIG_REF"
+}
+trap restore EXIT
+
+mkdir -p "$SAVE_DIR"
+rm -f "$SAVE_DIR"/encode_e2e_*.benchee
+
+run_one() {
+  local ref="$1" tag="$2"
+  echo "============================================================"
+  echo ">> $tag: $ref"
+  echo "============================================================"
+  git checkout --quiet "$ref"
+  TAG="$tag" mix run --no-start bench/clickhouse_encode_e2e.exs
+}
+
+run_one "$BASELINE" before
+run_one "$ORIG_REF" after
+
+echo "============================================================"
+echo ">> comparison (after vs before)"
+echo "============================================================"
+mix run --no-start bench/compare_encode_e2e.exs

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -130,6 +130,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   @spec encode_batch([LogEvent.t()], TypeDetection.event_type()) :: iodata()
   def encode_batch([%LogEvent{body: body} | _] = rows, event_type)
       when is_event_type(event_type) do
+    # mapping_config_id is uniform across the batch (set from the event-type's
+    # config_id), so encode it once. Do NOT hoist source_uuid/source_name the
+    # same way -- a batch can mix sources (see pipeline.ex), so those vary per row.
     mapping_config_id = RowBinaryEncoder.uuid(body["mapping_config_id"])
     Enum.map(rows, &encode_row(&1, event_type, mapping_config_id))
   end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -112,27 +112,42 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
 
   @doc false
   @spec encode_row(LogEvent.t(), TypeDetection.event_type()) :: iodata()
-  def encode_row(%LogEvent{} = event, :log), do: encode_log_row(event)
-  def encode_row(%LogEvent{} = event, :metric), do: encode_metric_row(event)
-  def encode_row(%LogEvent{} = event, :trace), do: encode_trace_row(event)
+  def encode_row(%LogEvent{body: body} = event, event_type) when is_event_type(event_type) do
+    encode_row(event, event_type, RowBinaryEncoder.uuid(body["mapping_config_id"]))
+  end
+
+  @spec encode_row(LogEvent.t(), TypeDetection.event_type(), iodata()) :: iodata()
+  defp encode_row(%LogEvent{} = event, :log, mapping_config_id),
+    do: encode_log_row(event, mapping_config_id)
+
+  defp encode_row(%LogEvent{} = event, :metric, mapping_config_id),
+    do: encode_metric_row(event, mapping_config_id)
+
+  defp encode_row(%LogEvent{} = event, :trace, mapping_config_id),
+    do: encode_trace_row(event, mapping_config_id)
 
   @doc false
   @spec encode_batch([LogEvent.t()], TypeDetection.event_type()) :: iodata()
-  def encode_batch([%LogEvent{} | _] = rows, event_type) when is_event_type(event_type) do
-    Enum.map(rows, &encode_row(&1, event_type))
+  def encode_batch([%LogEvent{body: body} | _] = rows, event_type)
+      when is_event_type(event_type) do
+    mapping_config_id = RowBinaryEncoder.uuid(body["mapping_config_id"])
+    Enum.map(rows, &encode_row(&1, event_type, mapping_config_id))
   end
 
   @doc false
   defdelegate columns_for_type(event_type), to: QueryTemplates
 
-  @spec encode_log_row(LogEvent.t()) :: iodata()
-  defp encode_log_row(%LogEvent{
-         id: id,
-         body: body,
-         source_uuid: source_uuid,
-         source_name: source_name,
-         ingested_at: ingested_at
-       }) do
+  @spec encode_log_row(LogEvent.t(), iodata()) :: iodata()
+  defp encode_log_row(
+         %LogEvent{
+           id: id,
+           body: body,
+           source_uuid: source_uuid,
+           source_name: source_name,
+           ingested_at: ingested_at
+         },
+         mapping_config_id
+       ) do
     source_uuid_str = Atom.to_string(source_uuid)
 
     [
@@ -154,20 +169,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
       RowBinaryEncoder.map_string_string(body["resource_attributes"] || %{}),
       RowBinaryEncoder.map_string_string(body["scope_attributes"] || %{}),
       RowBinaryEncoder.map_string_string(body["log_attributes"] || %{}),
-      RowBinaryEncoder.uuid(body["mapping_config_id"]),
+      mapping_config_id,
       RowBinaryEncoder.nullable(ingested_at, &RowBinaryEncoder.datetime64(&1, 6)),
       RowBinaryEncoder.int64(body["timestamp"])
     ]
   end
 
-  @spec encode_metric_row(LogEvent.t()) :: iodata()
-  defp encode_metric_row(%LogEvent{
-         id: id,
-         body: body,
-         source_uuid: source_uuid,
-         source_name: source_name,
-         ingested_at: ingested_at
-       }) do
+  @spec encode_metric_row(LogEvent.t(), iodata()) :: iodata()
+  defp encode_metric_row(
+         %LogEvent{
+           id: id,
+           body: body,
+           source_uuid: source_uuid,
+           source_name: source_name,
+           ingested_at: ingested_at
+         },
+         mapping_config_id
+       ) do
     source_uuid_str = Atom.to_string(source_uuid)
 
     [
@@ -216,20 +234,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
       RowBinaryEncoder.array_float64(body["exemplars.value"] || []),
       RowBinaryEncoder.array_string(body["exemplars.span_id"] || []),
       RowBinaryEncoder.array_string(body["exemplars.trace_id"] || []),
-      RowBinaryEncoder.uuid(body["mapping_config_id"]),
+      mapping_config_id,
       RowBinaryEncoder.nullable(ingested_at, &RowBinaryEncoder.datetime64(&1, 6)),
       RowBinaryEncoder.int64(body["timestamp"])
     ]
   end
 
-  @spec encode_trace_row(LogEvent.t()) :: iodata()
-  defp encode_trace_row(%LogEvent{
-         id: id,
-         body: body,
-         source_uuid: source_uuid,
-         source_name: source_name,
-         ingested_at: ingested_at
-       }) do
+  @spec encode_trace_row(LogEvent.t(), iodata()) :: iodata()
+  defp encode_trace_row(
+         %LogEvent{
+           id: id,
+           body: body,
+           source_uuid: source_uuid,
+           source_name: source_name,
+           ingested_at: ingested_at
+         },
+         mapping_config_id
+       ) do
     source_uuid_str = Atom.to_string(source_uuid)
 
     [
@@ -265,7 +286,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
         body["links.attributes"] || [],
         &RowBinaryEncoder.map_string_string/1
       ),
-      RowBinaryEncoder.uuid(body["mapping_config_id"]),
+      mapping_config_id,
       RowBinaryEncoder.nullable(ingested_at, &RowBinaryEncoder.datetime64(&1, 6)),
       RowBinaryEncoder.int64(body["timestamp"])
     ]

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
@@ -387,7 +387,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder do
   end
 
   @spec map_string_string(map() | [{String.t(), String.t()}]) :: iodata()
-  def map_string_string(items), do: map(items, &string/1, &string/1)
+  def map_string_string(items) when is_map(items) do
+    :maps.fold(&fold_string_string/3, [varint(map_size(items))], items)
+  end
+
+  def map_string_string(items) when is_list(items) do
+    map(items, &string/1, &string/1)
+  end
+
+  @spec fold_string_string(String.t() | iodata(), String.t() | iodata(), iodata()) :: iodata()
+  defp fold_string_string(key, value, acc) when is_binary(key) and is_binary(value) do
+    [acc, varint(byte_size(key)), key, varint(byte_size(value)), value]
+  end
+
+  defp fold_string_string(key, value, acc) do
+    [acc, string(key), string(value)]
+  end
 
   @spec map_string_uint64(map() | [{String.t(), non_neg_integer()}]) :: iodata()
   def map_string_uint64(items), do: map(items, &string/1, &uint64/1)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
@@ -56,6 +56,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder do
   # =============================================================================
 
   @spec uuid(Ecto.UUID.t() | String.t()) :: binary()
+  def uuid(
+        <<a::binary-size(8), ?-, b::binary-size(4), ?-, c::binary-size(4), ?-, d::binary-size(4),
+          ?-, e::binary-size(12)>> = uuid_string
+      ) do
+    case Base.decode16(<<a::binary, b::binary, c::binary, d::binary, e::binary>>, case: :mixed) do
+      {:ok, <<u1::64, u2::64>>} ->
+        <<u1::64-little, u2::64-little>>
+
+      _other ->
+        raise ArgumentError, "invalid UUID: #{inspect(uuid_string)}"
+    end
+  end
+
   def uuid(uuid_string) when is_non_empty_binary(uuid_string) do
     uuid_raw =
       uuid_string
@@ -358,19 +371,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder do
 
   def map(items, key_encoder, value_encoder)
       when is_map(items) and is_function(key_encoder, 1) and is_function(value_encoder, 1) do
-    pairs = Map.to_list(items)
-    encode_map_pairs(pairs, key_encoder, value_encoder)
+    :maps.fold(
+      fn k, v, acc -> [acc, key_encoder.(k), value_encoder.(v)] end,
+      [varint(map_size(items))],
+      items
+    )
   end
 
   def map(items, key_encoder, value_encoder)
       when is_list(items) and is_function(key_encoder, 1) and is_function(value_encoder, 1) do
-    encode_map_pairs(items, key_encoder, value_encoder)
-  end
-
-  defp encode_map_pairs(pairs, key_encoder, value_encoder) do
     [
-      varint(length(pairs))
-      | Enum.flat_map(pairs, fn {k, v} -> [key_encoder.(k), value_encoder.(v)] end)
+      varint(length(items))
+      | Enum.map(items, fn {k, v} -> [key_encoder.(k), value_encoder.(v)] end)
     ]
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder.ex
@@ -400,6 +400,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder do
     [acc, varint(byte_size(key)), key, varint(byte_size(value)), value]
   end
 
+  # Fallback for non-binary (iodata) keys/values -- preserves string/1 behavior.
   defp fold_string_string(key, value, acc) do
     [acc, string(key), string(value)]
   end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/row_binary_encoder_test.exs
@@ -1095,6 +1095,46 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoderTest do
       # string("a") = 2 bytes, string("1") = 2 bytes
       assert byte_size(rest) == 4
     end
+
+    test "encodes a single binary pair from map input exactly" do
+      encoded = RowBinaryEncoder.map_string_string(%{"name" => "alice"})
+
+      assert IO.iodata_to_binary(encoded) == <<1, 4, "name", 5, "alice">>
+    end
+
+    test "map input stays byte-identical to the generic map/3 string encoder" do
+      # The specialized is_map fast path must match delegating to map/3 with
+      # &string/1 for any map (both traverse via :maps.fold, so key order and
+      # therefore the bytes are identical).
+      for input <- [
+            %{"name" => "alice"},
+            %{"name" => "alice", "city" => "boston", "role" => "admin"},
+            %{"" => "", "k" => "v"}
+          ] do
+        specialized = IO.iodata_to_binary(RowBinaryEncoder.map_string_string(input))
+
+        generic =
+          IO.iodata_to_binary(
+            RowBinaryEncoder.map(input, &RowBinaryEncoder.string/1, &RowBinaryEncoder.string/1)
+          )
+
+        assert specialized == generic
+      end
+    end
+
+    test "falls back to string/1 for iodata-list values" do
+      # The guarded fallback preserves string/1's iodata handling: an
+      # iodata-list value encodes identically to its flattened binary.
+      encoded = RowBinaryEncoder.map_string_string(%{"name" => ["al", ?i, "ce"]})
+
+      assert IO.iodata_to_binary(encoded) == <<1, 4, "name", 5, "alice">>
+    end
+
+    test "falls back to string/1 for iodata-list keys" do
+      encoded = RowBinaryEncoder.map_string_string(%{["na", "me"] => "alice"})
+
+      assert IO.iodata_to_binary(encoded) == <<1, 4, "name", 5, "alice">>
+    end
   end
 
   describe "map_string_uint64/1" do


### PR DESCRIPTION
## What

Allocation-reduction optimizations to the ClickHouse RowBinary encoder hot path (`ingester.ex`, `row_binary_encoder.ex`). All output is byte-identical and map iteration order is unchanged — these are constant-factor wins on transient allocation, not a payload or behavior change.

- **Hoist batch-constant `mapping_config_id`** — it is the same UUID for every row in a batch, so `encode_batch/2` now encodes it once and reuses the bytes instead of re-parsing it per row. (Only this field is batch-constant; `source_uuid`/`source_name` vary per row because a single pipeline batches events from multiple sources, so they are deliberately not hoisted.)
- **`uuid/1` fast path** — a binary-pattern-match clause for canonical hyphenated UUIDs avoids the `String.replace("-", "")` intermediate; non-canonical input falls through to the original clause.
- **`:maps.fold` map encoder** — the generic `map/3` replaces `Map.to_list` + `length/1` + `Enum.flat_map`, dropping a list materialization, an O(n) length walk, and an unnecessary flatten.
- **Specialized `map_string_string`** — the hottest map encoder, used for every resource/scope/log/span attribute map plus the maps nested in metric exemplars and trace events/links. It now encodes directly with `:maps.fold`, inlining the length-prefix for binary keys/values so each pair emits one flat iolist fragment instead of two nested ones; a guarded fallback clause preserves behavior for non-binary (iodata) values.

## Results

Apple M5, measured with Benchee. End-to-end encode stage — the real `Ingester.encode_batch/2` over realistic 500-event log/metric/trace batches (`bench/clickhouse_encode_e2e.exs`), combined effect of all commits vs the PR base:

| batch | allocation | throughput |
| --- | --- | --- |
| log | −28% | 1.32× |
| metric | −21% | ~1.08× |
| trace | −25% | ~1.12× |

Allocation reduction is the reliable signal here (Benchee reports it deterministically across runs); throughput varies more run-to-run, with log the clearest gain.

Per-optimization micro-benchmarks (`bench/clickhouse_row_encoding.exs`, `bench/clickhouse_map_encoding.exs`, `bench/clickhouse_encoder_primitives.exs`):

| change | speedup | allocation |
| --- | --- | --- |
| batch UUID hoist (500-row log batch) | 1.14× | −13% |
| `uuid/1` fast path (per call) | 1.46× | −27% |
| generic `map/3`, 15 keys | 1.54× | −8% |
| `map_string_string`, 15 keys | 1.41× | −19% |
| `map_string_string`, 100 keys | 3.3× | −17% |

Output is byte-identical (verified by each benchmark's sanity check). This measures the encode stage only — downstream gzip and the HTTP insert are unchanged — so the win is reduced GC pressure on the ingest path rather than a 1:1 ingest-throughput change.

## Benchmarks

`bench/run_encode_e2e.sh [baseline_sha]` runs the e2e encode bench against a baseline SHA and the current HEAD, then prints a before/after comparison. Snapshots are written to a temp dir, never the repo tree (consistent with the other benches here, which print to stdout and persist nothing).
