### PR TITLE
feat: increase bigquery timeout to 60 seconds

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -43,7 +43,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @managed_service_account_partition_count 5
   @service_account_prefix "logflare-managed"
   @reservation_error_regex ~r/reservation/i
-  @search_reservation_query_timeout_ms 60_000
+  @search_query_timeout_ms 60_000
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = source_backend) do
@@ -581,7 +581,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       dryRun: Keyword.get(opts, :dry_run, false),
       query_type: query_type,
       reservation: reservation
-    ] ++ query_timeout_opts(query_type, reservation)
+    ] ++ query_timeout_opts(query_type)
   end
 
   @spec resolve_reservation(
@@ -598,16 +598,15 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   defp resolve_reservation(%User{}, _query_type, nil), do: nil
   defp resolve_reservation(%User{}, _query_type, override), do: override
 
-  @spec query_timeout_opts(query_type :: atom() | nil, reservation :: String.t() | nil) ::
-          Keyword.t()
-  defp query_timeout_opts(:search, reservation) when is_non_empty_binary(reservation) do
+  @spec query_timeout_opts(query_type :: atom() | nil) :: Keyword.t()
+  defp query_timeout_opts(:search) do
     [
-      jobTimeoutMs: @search_reservation_query_timeout_ms,
-      timeoutMs: @search_reservation_query_timeout_ms
+      jobTimeoutMs: @search_query_timeout_ms,
+      timeoutMs: @search_query_timeout_ms
     ]
   end
 
-  defp query_timeout_opts(_query_type, _reservation), do: []
+  defp query_timeout_opts(_query_type), do: []
 
   @spec execute_query_with_context(
           user_id :: integer(),

--- a/lib/logflare_web/query_error_helpers.ex
+++ b/lib/logflare_web/query_error_helpers.ex
@@ -5,6 +5,7 @@ defmodule LogflareWeb.QueryErrorHelpers do
   alias LogflareWeb.Utils
 
   @generic_query_error_message "Backend error! Retry your query. Please contact support if this continues."
+  @timeout_query_error_message "Query timed out. Retry your query or reduce the time range."
 
   @doc """
   Returns a user-facing query error message from a backend %QueryError{}.
@@ -51,6 +52,13 @@ defmodule LogflareWeb.QueryErrorHelpers do
 
       "total bytes processed for this query is expected to be greater than #{round(size)} #{units}"
     end
+  end
+
+  defp classified_query_error_message(%QueryError{
+         kind: :connection_error,
+         raw_error: :timeout
+       }) do
+    @timeout_query_error_message
   end
 
   defp classified_query_error_message(%QueryError{

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -400,7 +400,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
       assert_received {:timeouts, 60_000, 60_000}
     end
 
-    test "keeps the default timeout for searches without a reservation and for non-search queries" do
+    test "uses a 60s timeout for :search queries" do
       user = insert(:user, bigquery_dataset_id: "test_dataset")
 
       BigQueryAdaptor.execute_query(
@@ -409,8 +409,10 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
         query_type: :search
       )
 
-      assert_received {:timeouts, 25_000, 25_000}
+      assert_received {:timeouts, 60_000, 60_000}
+    end
 
+    test "keeps the default timeout for non-seareh queries" do
       user_with_reservation =
         insert(:user,
           bigquery_dataset_id: "test_dataset",

--- a/test/logflare_web/query_error_helpers_test.exs
+++ b/test/logflare_web/query_error_helpers_test.exs
@@ -46,6 +46,18 @@ defmodule LogflareWeb.QueryErrorHelpersTest do
                QueryErrorHelpers.generic_query_error_message()
     end
 
+    test "returns timeout message for connection timeouts" do
+      error =
+        query_error(
+          kind: :connection_error,
+          backend: BigQueryAdaptor,
+          raw_error: :timeout
+        )
+
+      assert QueryErrorHelpers.query_error_message(error) ==
+               "Query timed out. Retry your query or reduce the time range."
+    end
+
     test "returns missing field message for classified query errors" do
       error =
         query_error(


### PR DESCRIPTION
Removes distinction between BigQuery reservation and non-reservation searches: all now use a 60 second timeout.

Fixes O11Y-2041
