### PR TITLE
ci: fix GHCR mirror token scope and allow manual version dispatch

### DIFF
--- a/.github/workflows/docker-retag-versioned.yml
+++ b/.github/workflows/docker-retag-versioned.yml
@@ -1,6 +1,11 @@
 name: Docker Retag Dev Image to Versioned Image
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Logflare version to retag and mirror (e.g. 1.45.4). Defaults to the VERSION file when empty.'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,16 +17,22 @@ jobs:
       docker_tag: ${{ steps.docker-image.outputs.tag }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="${INPUT_VERSION:-$(cat ./VERSION)}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Versioned - Merge multi-arch manifests and push (release only)
         run: |
-          make tag-versioned
+          make tag-versioned VERSION="${{ steps.version.outputs.version }}"
       - id: docker-image
         run: |
-          tag="supabase/logflare:$(cat ./VERSION)"
+          tag="supabase/logflare:${{ steps.version.outputs.version }}"
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
   trigger_cloudbuild:
@@ -53,7 +64,9 @@ jobs:
           owner: 'supabase'
           repositories: |
             cli
+            logflare
           permission-packages: write
+          permission-contents: read
 
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3


### PR DESCRIPTION
## Problem

The `mirror_image` job in `docker-retag-versioned.yml` fails when pushing to `ghcr.io/supabase/logflare`:

```
denied: permission_denied: installation not allowed to Write organization package
```

The GitHub App token was scoped only to `supabase/cli`, so it had no write rights to the `logflare` package once the package access was set up across both repos.

## Changes

- **Token scope fix**: add `supabase/logflare` alongside `supabase/cli` in the `create-github-app-token` `repositories` list, and pin least-privilege permissions (`packages: write`, `contents: read`).
- **Manual dispatch with explicit version**: add an optional `version` `workflow_dispatch` input. When provided it overrides the version used for retag + mirror (passed through to `make tag-versioned VERSION=…`); when omitted it falls back to the `VERSION` file, preserving current behavior.

## Notes

- `VERSION` is overridable in the Makefile (`VERSION ?= $(shell cat ./VERSION)`), so passing it on the command line is safe.
- Requires the GitHub App behind `IMAGE_PUSH_GH_CLIENT_ID` to have Write access to the `logflare` GHCR package (already granted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)