### PR TITLE
fix(ingest queue): tolerate dead ETS table on add_to_table insert

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -300,8 +300,22 @@ defmodule Logflare.Backends.IngestEventQueue do
         {id, :pending, event, :erlang.external_size(event.body), 0, 0}
       end
 
-    :ets.insert(tid, objects)
-    :ok
+    try do
+      :ets.insert(tid, objects)
+      :ok
+    rescue
+      ArgumentError ->
+        # The owning producer died and ETS reclaimed its table between tid
+        # resolution and this insert. Re-route to the supervisor-owned startup
+        # queue (where a clean producer exit also drains to) so the batch is not
+        # lost; give up only if the startup queue itself is gone.
+        :telemetry.execute([:logflare, :ingest_event_queue, :stale_table], %{count: 1}, %{})
+
+        case sid_bid_pid do
+          {_, _, nil} -> {:error, :not_initialized}
+          _ -> add_to_table(put_elem(sid_bid_pid, 2, nil), batch)
+        end
+    end
   end
 
   def add_to_table({_, _, _} = sid_bid_pid, batch, _opts) do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -98,6 +98,40 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert [] == IngestEventQueue.list_counts({source.id, nil})
     end
 
+    test "add_to_table/2 falls back to the startup queue when a producer table died mid-dispatch",
+         %{source: %{id: source_id}, backend: %{id: backend_id}} do
+      pid = self()
+      producer_key = {source_id, backend_id, pid}
+      startup_key = {source_id, backend_id, nil}
+
+      assert {:ok, producer_tid} = IngestEventQueue.upsert_tid(producer_key)
+      assert {:ok, _} = IngestEventQueue.upsert_tid(startup_key)
+
+      # Simulate the owning producer dying after its tid was resolved but before
+      # the insert ran. Driving the {key, tid} clause directly reproduces that
+      # window: get_tid would otherwise filter the dead table out first.
+      :ets.delete(producer_tid)
+
+      le = build(:log_event)
+      assert :ok = IngestEventQueue.add_to_table({producer_key, producer_tid}, [le])
+
+      assert IngestEventQueue.total_pending(startup_key) == 1
+    end
+
+    test "add_to_table/3 does not recurse when the startup queue table is stale", %{
+      source: %{id: source_id},
+      backend: %{id: backend_id}
+    } do
+      startup_key = {source_id, backend_id, nil}
+      assert {:ok, startup_tid} = IngestEventQueue.upsert_tid(startup_key)
+      :ets.delete(startup_tid)
+
+      # Drive the insert clause directly with the stale startup-queue tid; the
+      # fallback must bottom out instead of looping on {_, _, nil}.
+      assert {:error, :not_initialized} =
+               IngestEventQueue.add_to_table({startup_key, startup_tid}, [build(:log_event)])
+    end
+
     test "queues_pending_size/1 returns counts across all queues", %{
       source: %{id: source_id},
       backend: %{id: backend_id}


### PR DESCRIPTION
A `BufferProducer` owns its per-queue `:ets` table (created in `init`, no `heir`), so ETS reclaims the table the instant that producer process exits — which is routine during `DynamicPipeline` scale-down, crashes, or restarts.

`IngestEventQueue.add_to_table/3` resolves a tid via `get_tid` (which liveness-checks the table) and then runs `:ets.insert`. That leaves a TOCTOU window: the owning producer can die between the check and the insert, and `:ets.insert` then raises `ArgumentError: the table identifier does not refer to an existing ETS table`. The exception unwinds all the way through `dispatch_to_backends`/`ingest_logs`, so the entire ingest batch is lost (including chunks bound for healthy queues and other backends), and the caller gets an error that at-least-once shippers will retry — amplifying load during the exact churn window that triggered it.

## Fix

Wrap the insert in a `try/rescue`. On `ArgumentError`:

- Re-route the batch to the supervisor-owned startup queue (`{sid, bid, nil}` / `{:consolidated, bid, nil}`) — the same queue a clean producer exit drains to (`BufferProducer` moves there on `:EXIT`), and which the scaler already treats as a scale-up signal, so a new producer drains it on init.
- Bottom out with `{:error, :not_initialized}` if the startup queue itself is gone, with a `{_, _, nil}` guard so the fallback cannot recurse.
- Emit the existing `[:logflare, :ingest_event_queue, :stale_table]` telemetry (already used by the ack-path guards in `delete_id`/`update_status`) so the fallback is observable.

This mirrors the dead-table handling already present on the hot ack path; the dispatch insert was the one unguarded write left.

## Notes

- The fallback path intentionally skips the per-queue `@max_queue_size` check, so the startup queue is effectively unbounded on this route. It should fire rarely (only on actual producer death) and is bounded in practice by the `QueueJanitor` purge plus scale-up draining it.
- `QueueJanitor` has the same resolve-then-operate pattern on several unguarded paths and can raise the same error; left out of this PR to keep it focused.

## Testing

- Added two tests driving the `{key, tid}` clause with a stale tid: one asserting the batch falls through to the startup queue, one asserting no recursion when the startup queue is also gone.