### PR TITLE
feat(http egress): record response status on http_egress span

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/egress_tracer.ex
+++ b/lib/logflare/backends/adaptor/http_based/egress_tracer.ex
@@ -53,7 +53,30 @@ defmodule Logflare.Backends.Adaptor.HttpBased.EgressTracer do
     )
 
     OpenTelemetry.Tracer.with_span :http_egress, %{attributes: attributes} do
-      Tesla.run(env, next)
+      case Tesla.run(env, next) do
+        {:ok, %Tesla.Env{status: status} = resp_env} = result ->
+          OpenTelemetry.Tracer.set_attribute(:response_status_code, status)
+
+          if response_length = response_length(resp_env) do
+            OpenTelemetry.Tracer.set_attribute(:response_length, response_length)
+          end
+
+          if status >= 400 do
+            OpenTelemetry.Tracer.set_status(:error, "HTTP #{status}")
+          end
+
+          result
+
+        {:error, reason} = result ->
+          OpenTelemetry.Tracer.set_attribute(:error, inspect(reason))
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
+          result
+      end
     end
   end
+
+  defp response_length(%Tesla.Env{body: body}) when is_binary(body),
+    do: IO.iodata_length(body)
+
+  defp response_length(_env), do: nil
 end

--- a/test/logflare/backends/adaptor/http_based/egress_tracer_test.exs
+++ b/test/logflare/backends/adaptor/http_based/egress_tracer_test.exs
@@ -1,0 +1,83 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.EgressTracerTest do
+  use Logflare.DataCase, async: false
+
+  require Record
+
+  alias Logflare.Backends.Adaptor.HttpBased.EgressTracer
+
+  @span_fields Record.extract(:span, from: "deps/opentelemetry/include/otel_span.hrl")
+  Record.defrecordp(:span, @span_fields)
+
+  setup do
+    :ok = :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
+    on_exit(fn -> :otel_simple_processor.set_exporter(:none) end)
+    :ok
+  end
+
+  defp run(response, opts \\ []) do
+    env = %Tesla.Env{
+      method: :post,
+      url: "https://example.com",
+      headers: [{"content-type", "application/json"}],
+      body: "payload",
+      opts: opts
+    }
+
+    next = [{:fn, fn _env -> response end}]
+    EgressTracer.call(env, next, [])
+  end
+
+  defp collect_span do
+    receive do
+      {:span, s} -> s
+    after
+      0 -> flunk("expected an :http_egress span to be exported")
+    end
+  end
+
+  defp attrs(s), do: :otel_attributes.map(span(s, :attributes))
+
+  test "records request attributes on the span" do
+    run({:ok, %Tesla.Env{status: 202, body: "ok"}})
+
+    s = collect_span()
+    assert span(s, :name) == :http_egress
+
+    attributes = attrs(s)
+    assert attributes[:body_length] == byte_size("payload")
+    assert attributes[:request_length] == attributes[:body_length] + attributes[:headers_length]
+  end
+
+  test "records response status code and length for a successful response" do
+    run({:ok, %Tesla.Env{status: 202, body: "accepted"}})
+
+    s = collect_span()
+    attributes = attrs(s)
+    assert attributes[:response_status_code] == 202
+    assert attributes[:response_length] == byte_size("accepted")
+    assert span(s, :status) == :undefined
+  end
+
+  test "marks the span as errored on a non-2xx response" do
+    run({:ok, %Tesla.Env{status: 500, body: "boom"}})
+
+    s = collect_span()
+    attributes = attrs(s)
+    assert attributes[:response_status_code] == 500
+    assert {:status, :error, "HTTP 500"} = span(s, :status)
+  end
+
+  test "marks the span as errored on a transport error" do
+    run({:error, :econnrefused})
+
+    s = collect_span()
+    attributes = attrs(s)
+    assert attributes[:error] == ":econnrefused"
+    assert {:status, :error, ":econnrefused"} = span(s, :status)
+  end
+
+  test "passes the result through unchanged" do
+    assert {:ok, %Tesla.Env{status: 202}} = run({:ok, %Tesla.Env{status: 202, body: "ok"}})
+    assert {:error, :econnrefused} = run({:error, :econnrefused})
+  end
+end


### PR DESCRIPTION
The `:http_egress` span (the only OpenTelemetry span on the HTTP-based egress path, used by the Datadog and webhook backends) only carried request-side attributes: `body_length`, `headers_length`, and `request_length`. The result of the HTTP call was never inspected, so a failed push and a successful one produced spans that looked identical apart from timing — you could not tell from a trace whether an egress actually succeeded.

## What this does

In `EgressTracer`, capture the result of `Tesla.run/2` and annotate the span before passing the result through unchanged:

- `response_status_code` and `response_length` attributes on a completed response
- span status set to `:error` with message `HTTP <status>` on a non-2xx response
- `error` attribute plus `:error` span status on a transport-level error (`{:error, reason}`)

Middleware behaviour is otherwise unchanged — the original `{:ok, env}` / `{:error, reason}` result is returned verbatim.

## Notes

- Applies to every HTTP-based backend (Datadog, generic webhook, etc.), since they all share this Tesla middleware.
- Attribute names follow the existing snake_case atom style in this module rather than OTel HTTP semantic conventions (`http.response.status_code`); adopting semconv across the egress span could be a follow-up.

## Testing

- New `egress_tracer_test.exs` drives the middleware directly and asserts span name, request/response attributes, and `:error` span status for both non-2xx responses and transport errors (uses the `:otel_simple_processor` span-export harness already used by `opentelemetry_test.exs`).
- `mix lint.diff` clean; `mix test.typings` (dialyzer) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)