### PR TITLE
bug: Stop `sql_fmt` from uppercasing identifiers

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -133,6 +133,17 @@ defmodule Logflare.Sql do
   ]
 
   @doc """
+  Formats a SQL query string for display.
+
+  Keyword capitalization is disabled to avoid corrupting case-sensitive
+  identifiers (e.g. a `logs` CTE being rewritten to `LOGS`).
+  """
+  @spec format(query :: String.t()) :: {:ok, String.t()}
+  def format(query) when is_binary(query) do
+    SqlFmt.format_query(query, uppercase: false)
+  end
+
+  @doc """
   Converts a language atom to its corresponding dialect.
 
   ## Examples

--- a/lib/logflare/teams/team_context.ex
+++ b/lib/logflare/teams/team_context.ex
@@ -142,7 +142,7 @@ defmodule Logflare.Teams.TeamContext do
 
   def resource_team_id_query(LogflareWeb.QueryLive, %{"q" => query}, user_or_team_user)
       when is_binary(query) and query != "" do
-    with {:ok, formatted} <- SqlFmt.format_query(query),
+    with {:ok, formatted} <- Sql.format(query),
          {:ok, [source_name | _]} <- Sql.extract_table_names(formatted) do
       Sources.Source
       |> Teams.filter_by_user_access(user_or_team_user)

--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -10,6 +10,7 @@ defmodule LogflareWeb.QueryComponents do
   alias Logflare.Logs.SearchOperations.Helpers
   alias Logflare.Lql
   alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Sql
   alias LogflareWeb.Utils
   alias Phoenix.LiveView.JS
 
@@ -118,7 +119,7 @@ defmodule LogflareWeb.QueryComponents do
         {:ok, formatted} =
           Utils.sql_params_to_sql(assigns.sql_string, assigns.params)
           |> prepare_table_name()
-          |> SqlFmt.format_query()
+          |> Sql.format()
 
         formatted
       end)

--- a/lib/logflare_web/live/alerts/alerts_live.ex
+++ b/lib/logflare_web/live/alerts/alerts_live.ex
@@ -14,6 +14,7 @@ defmodule LogflareWeb.AlertsLive do
   alias Logflare.Backends.QueryError
   alias Logflare.Endpoints
   alias Logflare.Repo
+  alias Logflare.Sql
   alias LogflareWeb.QueryComponents
   alias LogflareWeb.QueryErrorHelpers
   alias LogflareWeb.Utils
@@ -74,7 +75,7 @@ defmodule LogflareWeb.AlertsLive do
     {:ok, formatted_query} =
       params
       |> Map.get("query", "")
-      |> SqlFmt.format_query()
+      |> Sql.format()
 
     params = Map.put(params, "query", formatted_query)
 

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -13,6 +13,7 @@ defmodule LogflareWeb.EndpointsLive do
   alias Logflare.Backends.Backend
   alias Logflare.Endpoints
   alias Logflare.Endpoints.PiiRedactor
+  alias Logflare.Sql
   alias LogflareWeb.QueryComponents
   alias LogflareWeb.QueryErrorHelpers
   alias Logflare.Utils
@@ -144,7 +145,7 @@ defmodule LogflareWeb.EndpointsLive do
         %{assigns: %{live_action: :new}} = socket ->
           params =
             Map.replace_lazy(params, "query", fn sql ->
-              {:ok, formatted} = SqlFmt.format_query(sql)
+              {:ok, formatted} = Sql.format(sql)
               formatted
             end)
 

--- a/lib/logflare_web/live/monaco_editor_component.ex
+++ b/lib/logflare_web/live/monaco_editor_component.ex
@@ -24,6 +24,8 @@ defmodule LogflareWeb.MonacoEditorComponent do
           />
   """
 
+  alias Logflare.Sql
+
   def mount(socket) do
     {:ok, assign(socket, parse_error_message: nil, on_query_change: nil, query: nil)}
   end
@@ -120,7 +122,7 @@ defmodule LogflareWeb.MonacoEditorComponent do
   end
 
   def handle_event("format-query", %{"value" => value}, socket) do
-    {:ok, formatted} = SqlFmt.format_query(value)
+    {:ok, formatted} = Sql.format(value)
     {:noreply, socket |> LiveMonacoEditor.set_value(formatted, to: "query_string")}
   end
 

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -9,6 +9,7 @@ defmodule LogflareWeb.QueryLive do
   alias Logflare.Endpoints
   alias Logflare.Endpoints.EndpointQuery
   alias Logflare.Repo
+  alias Logflare.Sql
   alias Logflare.Teams.TeamContext
   alias LogflareWeb.AuthLive
   alias LogflareWeb.QueryComponents
@@ -197,7 +198,7 @@ defmodule LogflareWeb.QueryLive do
           nil
 
         v ->
-          {:ok, formatted} = SqlFmt.format_query(v)
+          {:ok, formatted} = Sql.format(v)
           formatted
       end
 
@@ -330,7 +331,7 @@ defmodule LogflareWeb.QueryLive do
   end
 
   def handle_event("format-query", _params, socket) do
-    {:ok, formatted} = SqlFmt.format_query(socket.assigns.query_string)
+    {:ok, formatted} = Sql.format(socket.assigns.query_string)
     {:noreply, LiveMonacoEditor.set_value(socket, formatted, to: "query")}
   end
 

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -28,6 +28,21 @@ defmodule Logflare.SqlTest do
     end)
   end
 
+  describe "format/1" do
+    test "formats a query" do
+      assert {:ok, formatted} = Sql.format("select 1 as id")
+      assert formatted =~ "select\n  1 as id"
+    end
+
+    test "does not uppercase identifiers that collide with reserved words" do
+      assert {:ok, formatted} =
+               Sql.format("with logs as (select id from otel_logs) select id from logs")
+
+      assert formatted =~ "logs"
+      refute formatted =~ "LOGS"
+    end
+  end
+
   describe "extract_table_names/2" do
     test "extracts simple table names" do
       assert {:ok, ["my_table"]} = Sql.extract_table_names("SELECT * FROM my_table")

--- a/test/logflare_web/components/query_components_test.exs
+++ b/test/logflare_web/components/query_components_test.exs
@@ -19,7 +19,7 @@ defmodule LogflareWeb.QueryComponentsTest do
           params: []
         })
 
-      assert html =~ ~r/SELECT\n  id,\n  name\nFROM\n  users\nWHERE\n  active = TRUE/
+      assert html =~ ~r/select\n  id,\n  name\nfrom\n  users\nwhere\n  active = true/
     end
 
     test "replaces multiple parameters in order" do
@@ -41,7 +41,7 @@ defmodule LogflareWeb.QueryComponentsTest do
         })
 
       # Check for HTML-encoded quotes: &#39; is ' and &quot; is "
-      assert html =~ "STATUS = &#39;active&#39;"
+      assert html =~ "status = &#39;active&#39;"
       assert html =~ "count &gt; &quot;100&quot;"
     end
 

--- a/test/logflare_web/live/monaco_editor_component_test.exs
+++ b/test/logflare_web/live/monaco_editor_component_test.exs
@@ -144,4 +144,43 @@ defmodule LogflareWeb.MonacoEditorComponentTest do
       assert_received {:query_changed, "select 2"}
     end
   end
+
+  describe "formatting the query" do
+    test "format-query preserves identifier case and does not uppercase a CTE named logs", %{
+      conn: conn
+    } do
+      defmodule FormatEditorLive do
+        use Phoenix.LiveView
+
+        def mount(_params, _session, socket) do
+          {:ok, assign(socket, form: %{"query" => ""} |> to_form())}
+        end
+
+        def render(assigns) do
+          ~H"""
+          <.live_component
+            module={LogflareWeb.MonacoEditorComponent}
+            id="test-editor"
+            field={@form[:query]}
+            endpoints={[]}
+            sources={[]}
+            alerts={[]}
+          />
+          """
+        end
+      end
+
+      {:ok, view, _html} = live_isolated(conn, FormatEditorLive)
+
+      query = "with logs as (select id from otel_logs) select id from logs"
+
+      view
+      |> with_target("#test-editor")
+      |> render_hook("format-query", %{"value" => query})
+
+      assert_push_event(view, "lme:set_value:query_string", %{"value" => formatted})
+      assert formatted =~ "logs"
+      refute formatted =~ "LOGS"
+    end
+  end
 end

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -433,7 +433,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       formatted_sql =
         """
-        SELECT
+        select
           t0.timestamp
         """
         |> String.trim()
@@ -467,9 +467,9 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       formatted_sql =
         """
-        SELECT
+        select
           (
-            CASE
+            case
         """
         |> String.trim()
 

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -1421,7 +1421,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
   end
 
   defp assert_query_displayed(view, query) do
-    {:ok, formatted_query} = SqlFmt.format_query(query)
+    {:ok, formatted_query} = Logflare.Sql.format(query)
 
     assert has_element?(view, "code", formatted_query)
   end

--- a/test/logflare_web/live_views/endpoints_versions_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_versions_live_test.exs
@@ -139,8 +139,8 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       assert modal_html =~ "Version 2"
       assert modal_html =~ "BigQuery SQL"
       assert modal_html =~ "copy"
-      assert modal_html =~ "SELECT"
-      assert modal_html =~ "2 AS version_number"
+      assert modal_html =~ "select"
+      assert modal_html =~ "2 as version_number"
       assert modal_html =~ "snapshot description"
       assert_query_displayed(view, "select 2 as version_number")
     end
@@ -283,7 +283,7 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
   defp endpoint_version_row(%Version{id: version_id}), do: "#versions-#{version_id}"
 
   defp assert_query_displayed(view, query) do
-    {:ok, formatted_query} = SqlFmt.format_query(query)
+    {:ok, formatted_query} = Logflare.Sql.format(query)
 
     assert has_element?(view, "code", formatted_query)
   end


### PR DESCRIPTION
Introduces a small wrapper function around `SqlFmt.format_query/2` to provide consistency around how the formatter handles casing as [the default behavior](https://sql-fmt.hexdocs.pm/SqlFmt.FormatOptions.html) is to capitalize reserved SQL keywords (_based on the default dialect of `:postgres`_). This fixes the issue with certain keywords/variables in CTEs from being uppercased ("logs" -> "LOGS") and then blowing up for case-sensitive backends like ClickHouse.

Backstory here is that the [`sql_fmt`](https://hex.pm/packages/sql_fmt) dep was introduced into the project back in October 2025. This hex package uses the same Rust-based [sqlformatter](https://github.com/apache/datafusion-sqlparser-rs) crate under the hood that we use for sql parsing (_but different versions_).

Longer-term, I think the move here will be to add formatting hooks to our existing `sqlparser_ex` NIF (`native/sqlparser_ex`) within the project. By wrapping the `SqlFmt.format_query/2` function in this PR - it makes that transition much simpler when the time comes. We should also be sure to leverage dialect-specific formatting at that stage, which may allow us to go back to upcasing reserved keywords when a dialect is known at runtime.