### PR TITLE
feat: add copy schema to clipboard button

### DIFF
--- a/lib/logflare_web/core_components.ex
+++ b/lib/logflare_web/core_components.ex
@@ -39,6 +39,26 @@ defmodule LogflareWeb.CoreComponents do
     """
   end
 
+  @doc "Button that copies text to the clipboard"
+  attr :text, :string, required: true
+
+  attr :variant, :string,
+    default: "secondary",
+    values: ["primary", "secondary"]
+
+  attr :class, :string, default: ""
+  attr :label, :string, default: "Copy"
+  attr :title, :string, default: "Copy to clipboard"
+  attr :rest, :global
+
+  def clipboard_button(assigns) do
+    ~H"""
+    <.button variant={@variant} class={@class} phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: @text})} data-toggle="tooltip" data-placement="top" title={@title} {@rest}>
+      <i class="fa fa-clone" aria-hidden="true"></i> {@label}
+    </.button>
+    """
+  end
+
   attr :id, :string, required: false
   attr :disabled, :boolean, default: false
   slot :inner_block, required: true

--- a/lib/logflare_web/live/access_tokens_live.ex
+++ b/lib/logflare_web/live/access_tokens_live.ex
@@ -75,9 +75,7 @@ defmodule LogflareWeb.AccessTokensLive do
             <p>Access token created successfully, copy this token to a safe location. For security purposes, this token will not be shown again.</p>
 
             <pre class="p-2"><%= @created_token.token %></pre>
-            <button class="btn btn-secondary" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: @created_token.token})} data-toggle="tooltip" data-placement="top" title="Copy to clipboard">
-              <i class="fa fa-clone" aria-hidden="true"></i> Copy
-            </button>
+            <.clipboard_button text={@created_token.token} />
             <button class="btn btn-secondary" phx-click="dismiss-created-token">
               Dismiss
             </button>
@@ -89,9 +87,7 @@ defmodule LogflareWeb.AccessTokensLive do
         <.alert variant="dark" class="tw-max-w-md">
           <h5>Legacy Ingest API Key</h5>
           <p><strong>Deprecated</strong>, use access tokens instead.</p>
-          <button class="btn btn-secondary btn-sm" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: @user.api_key})} data-toggle="tooltip" data-placement="top" title="Copy to clipboard">
-            <i class="fa fa-clone" aria-hidden="true"></i> Copy
-          </button>
+          <.clipboard_button text={@user.api_key} class="btn-sm" />
         </.alert>
       <% end %>
 
@@ -130,9 +126,7 @@ defmodule LogflareWeb.AccessTokensLive do
               </td>
 
               <td class="p-2">
-                <button :if={!(token.scopes =~ "private")} class="btn btn-secondary btn-sm" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: token.token})} data-toggle="tooltip" data-placement="top" title="Copy to clipboard">
-                  <i class="fa fa-clone" aria-hidden="true"></i> Copy
-                </button>
+                <.clipboard_button :if={!(token.scopes =~ "private")} text={token.token} class="btn-sm" />
                 <button class="btn text-danger btn-sm" data-confirm="Are you sure? This cannot be undone." phx-click="revoke-token" phx-value-token-id={token.id} data-toggle="tooltip" data-placement="top" title="Revoke access token forever">
                   <i class="fa fa-trash" aria-hidden="true"></i> Revoke
                 </button>

--- a/lib/logflare_web/live/query_live.ex
+++ b/lib/logflare_web/live/query_live.ex
@@ -151,7 +151,7 @@ defmodule LogflareWeb.QueryLive do
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                        <button type="button" class="btn btn-primary" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: Jason.encode!(value)})} data-toggle="tooltip" data-placement="top" title="Copy to clipboard"><i class="fa fa-clone" aria-hidden="true"></i> Copy</button>
+                        <.clipboard_button text={Jason.encode!(value)} variant="primary" />
                       </div>
                     </div>
                   </div>

--- a/lib/logflare_web/live/sources/bq_schema_component.ex
+++ b/lib/logflare_web/live/sources/bq_schema_component.ex
@@ -6,7 +6,7 @@ defmodule LogflareWeb.SourceBqSchemaComponent do
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
 
   @impl true
-  def render(%{source: source}) do
+  def render(%{source: source} = assigns) do
     bq_schema =
       SourceSchemas.Cache.get_source_schema_by(source_id: source.id)
       |> case do
@@ -14,6 +14,12 @@ defmodule LogflareWeb.SourceBqSchemaComponent do
         %_{bigquery_schema: schema} -> schema
       end
 
-    BqSchema.format_bq_schema(bq_schema)
+    assigns = assign(assigns, :bq_schema, BqSchema.format_bq_schema(bq_schema))
+
+    ~H"""
+    <div>
+      {@bq_schema}
+    </div>
+    """
   end
 end

--- a/lib/logflare_web/templates/shared/bq_schema.html.heex
+++ b/lib/logflare_web/templates/shared/bq_schema.html.heex
@@ -1,4 +1,9 @@
 <div id="source-schema-modal-table" class="table-responsive" phx-hook="SourceSchemaModalTable">
+  <div class="tw-pb-3 tw-text-right">
+    <.button variant="secondary" class="btn-sm" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: @markdown_schema})} data-toggle="tooltip" data-placement="top" title="Copy markdown to clipboard">
+      <i class="fa fa-clone" aria-hidden="true"></i> Copy markdown
+    </.button>
+  </div>
   <table class="table table-dark show-source-schema">
     <thead>
       <td scope="col"><strong>Field path</strong></td>

--- a/lib/logflare_web/templates/shared/bq_schema.html.heex
+++ b/lib/logflare_web/templates/shared/bq_schema.html.heex
@@ -1,8 +1,6 @@
 <div id="source-schema-modal-table" class="table-responsive" phx-hook="SourceSchemaModalTable">
   <div class="tw-pb-3 tw-text-right">
-    <.button variant="secondary" class="btn-sm" phx-click={JS.dispatch("logflare:copy-to-clipboard", detail: %{text: @markdown_schema})} data-toggle="tooltip" data-placement="top" title="Copy markdown to clipboard">
-      <i class="fa fa-clone" aria-hidden="true"></i> Copy markdown
-    </.button>
+    <.clipboard_button text={@markdown_schema} class="btn-sm" label="Copy markdown" title="Copy markdown to clipboard" />
   </div>
   <table class="table table-dark show-source-schema">
     <thead>

--- a/lib/logflare_web/views/helpers/bq_schema_helpers.ex
+++ b/lib/logflare_web/views/helpers/bq_schema_helpers.ex
@@ -1,22 +1,29 @@
 defmodule LogflareWeb.Helpers.BqSchema do
   @moduledoc false
-  alias LogflareWeb.SharedView
+  alias GoogleApi.BigQuery.V2.Model.TableFieldSchema, as: TFS
+  alias GoogleApi.BigQuery.V2.Model.TableSchema, as: TS
   alias Logflare.BigQuery.SchemaTypes
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.JSON
   alias Logflare.Utils
+  alias LogflareWeb.SharedView
 
   @type field_and_type :: {String.t(), String.t()}
+  @type format_bq_schema_opts :: [type: :markdown | :text]
   @type timestamp_format_opts :: [format: String.t()]
 
+  @spec format_bq_schema(nil) :: String.t()
   def format_bq_schema(nil), do: ""
 
+  @spec format_bq_schema(TS.t()) :: Phoenix.HTML.safe()
   def format_bq_schema(bq_schema) do
     SharedView.render("bq_schema.html",
-      fields_and_types: format_bq_schema(bq_schema, type: :text)
+      fields_and_types: format_bq_schema(bq_schema, type: :text),
+      markdown_schema: format_bq_schema(bq_schema, type: :markdown)
     )
   end
 
+  @spec format_bq_schema(TS.t(), format_bq_schema_opts()) :: [field_and_type()] | String.t()
   def format_bq_schema(bq_schema, type: :text) do
     bq_schema
     |> SchemaUtils.bq_schema_to_flat_typemap()
@@ -30,6 +37,17 @@ defmodule LogflareWeb.Helpers.BqSchema do
       {k, v}
     end)
     |> Enum.sort_by(fn {k, _v} -> k end)
+  end
+
+  def format_bq_schema(%TS{fields: fields}, type: :markdown) do
+    [
+      "# Logflare source schema",
+      "",
+      "Use this schema when writing Logflare LQL (https://docs.logflare.app/concepts/lql/)",
+      ""
+      | markdown_field_lines(fields || [])
+    ]
+    |> Enum.join("\n")
   end
 
   @timestamp_format "%a %b %d %Y %H:%M:%S"
@@ -55,6 +73,38 @@ defmodule LogflareWeb.Helpers.BqSchema do
   end
 
   defp convert_timezone(%DateTime{} = datetime, _timezone), do: datetime
+
+  defp markdown_field_lines(fields, path \\ [], depth \\ 0)
+
+  defp markdown_field_lines(fields, path, depth) when is_list(fields) do
+    fields
+    |> Enum.sort_by(& &1.name)
+    |> Enum.flat_map(&markdown_field_lines(&1, path, depth))
+  end
+
+  defp markdown_field_lines(%TFS{name: name, fields: fields} = field, path, depth) do
+    current_path = path ++ [name]
+
+    [markdown_field_line(field, current_path, depth)] ++
+      markdown_field_lines(fields || [], current_path, depth + 1)
+  end
+
+  defp markdown_field_line(%TFS{name: name, type: type, mode: mode}, path, depth) do
+    "#{markdown_indent(depth)}- `#{name}` #{markdown_type(type, mode)}#{markdown_note(path)}"
+  end
+
+  defp markdown_type(type, "REPEATED"), do: "ARRAY<#{type}>"
+  defp markdown_type(type, _mode), do: type
+
+  defp markdown_note(["event_message"]), do: " Human-readable event message."
+
+  defp markdown_note(["id"]), do: " Event UUID."
+
+  defp markdown_note(["timestamp"]), do: " Ingest timestamp."
+
+  defp markdown_note(_path), do: ""
+
+  defp markdown_indent(depth), do: String.duplicate("  ", depth)
 
   def encode_metadata(metadata) do
     metadata

--- a/lib/logflare_web/views/shared_view.ex
+++ b/lib/logflare_web/views/shared_view.ex
@@ -1,5 +1,4 @@
 defmodule LogflareWeb.SharedView do
   @moduledoc false
   use LogflareWeb, :view
-  alias Phoenix.LiveView.JS
 end

--- a/lib/logflare_web/views/shared_view.ex
+++ b/lib/logflare_web/views/shared_view.ex
@@ -1,4 +1,5 @@
 defmodule LogflareWeb.SharedView do
   @moduledoc false
   use LogflareWeb, :view
+  alias Phoenix.LiveView.JS
 end

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -226,6 +226,9 @@ defmodule LogflareWeb.SourceControllerTest do
       |> assert_has("a[data-target='#sourceSchemaModal']", text: "schema")
       |> assert_has("div#sourceSchemaModal")
       |> assert_has("h5", text: "Source Schema")
+      |> assert_has("#source-schema-modal-table button[title='Copy markdown to clipboard']",
+        text: "Copy markdown"
+      )
       |> assert_has("kbd", text: "metadata.status")
     end
 

--- a/test/logflare_web/views/helpers/bq_schema_helpers_test.exs
+++ b/test/logflare_web/views/helpers/bq_schema_helpers_test.exs
@@ -1,7 +1,40 @@
 defmodule LogflareWeb.Helpers.BqSchemaTest do
   use LogflareWeb.ConnCase, async: true
 
+  alias GoogleApi.BigQuery.V2.Model.TableFieldSchema, as: TFS
+  alias GoogleApi.BigQuery.V2.Model.TableSchema, as: TS
   alias LogflareWeb.Helpers.BqSchema
+
+  describe "format_bq_schema/2" do
+    test "formats a BigQuery schema as a markdown list" do
+      schema = %TS{
+        fields: [
+          %TFS{name: "event_message", type: "STRING", mode: "REQUIRED"},
+          %TFS{
+            name: "metadata",
+            type: "RECORD",
+            mode: "NULLABLE",
+            fields: [
+              %TFS{name: "tags", type: "STRING", mode: "REPEATED"},
+              %TFS{name: "user_id", type: "INTEGER", mode: "NULLABLE"}
+            ]
+          }
+        ]
+      }
+
+      assert BqSchema.format_bq_schema(schema, type: :markdown) ==
+               """
+               # Logflare source schema
+
+               Use this schema when writing Logflare LQL (https://docs.logflare.app/concepts/lql/)
+
+               - `event_message` STRING Human-readable event message.
+               - `metadata` RECORD
+                 - `tags` ARRAY<STRING>
+                 - `user_id` INTEGER\
+               """
+    end
+  end
 
   describe "format_timestamp/3" do
     test "formats timestamps with the default log timestamp format" do


### PR DESCRIPTION
* Adds a button to copy the source schema as LLM-friendly markdown. 
* Adds `clipboard_button/1` component as a reusable copy-to-clipboard button.

Text copied to clipboard is in the following format. Cursory tests showed better agent responses when a link to the LQL docs is included.

```
# Logflare source schema

Use this schema when writing Logflare LQL (https://docs.logflare.app/concepts/lql/)

- `event_message` STRING Human-readable event message.
- `id` STRING Event UUID.
- `level` STRING
- `metadata` ARRAY<RECORD>
  - `client_capabilities_str` STRING
  - `client_name` STRING
  - `client_version` STRING
  - `duration_ms` INTEGER
  - `jsonrpc_method` STRING
  - `request_path` STRING
  - `server_version` STRING
  - `session_id` STRING
  - `user_agent` STRING
  - `user_id` STRING
- `namespace` STRING
- `org_id` INTEGER
- `request_id` STRING
- `service` STRING
- `timestamp` TIMESTAMP Ingest timestamp.
```



<img width="2428" height="1730" alt="CleanShot 2026-06-25 at 12 03 34@2x" src="https://github.com/user-attachments/assets/6fb030d2-91c6-4d65-8c1e-64c56fece264" />


## Demo


https://github.com/user-attachments/assets/c16b5578-bb7b-4d0b-9847-df5c39eaeeb0



Fixes O11Y-2083
