### PR TITLE
fix(sql): guard nil get_in results used as for-generators (subquery/UNION FROM crashes)

### DIFF
--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -784,7 +784,7 @@ defmodule Logflare.Sql do
     unknown_table_names =
       for statement <- ast,
           from <- extract_all_from(statement),
-          %{"value" => table_name} <- get_in(from, ["relation", "Table", "name"]),
+          %{"value" => table_name} <- get_in(from, ["relation", "Table", "name"]) || [],
           table_name not in aliases,
           table_name not in sandboxed_cte_names do
         table_name

--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -630,7 +630,7 @@ defmodule Logflare.Sql.DialectTranslation do
   defp cte_from_table_aliases(nil), do: []
 
   defp cte_from_table_aliases(tree) do
-    for from_tree <- get_in(tree, ["query", "body", "Select", "from"]),
+    for from_tree <- get_in(tree, ["query", "body", "Select", "from"]) || [],
         table_name = get_in(from_tree, ["relation", "Table", "alias", "name", "value"]),
         table_name != nil do
       table_name

--- a/test/logflare/sql/dialect_translation_test.exs
+++ b/test/logflare/sql/dialect_translation_test.exs
@@ -190,6 +190,15 @@ defmodule Logflare.Sql.DialectTranslationTest do
              String.contains?(pg_query, "metadata ->> 'level'")
   end
 
+  test "translates a CTE whose body is a UNION (non-SELECT body)" do
+    bq_query =
+      "WITH x AS (SELECT a FROM t UNION SELECT b FROM t2) SELECT c FROM x"
+
+    assert {:ok, pg_query} = DialectTranslation.translate_bq_to_pg(bq_query)
+    assert is_binary(pg_query)
+    assert String.contains?(pg_query, "UNION")
+  end
+
   test "translates three-part CTE column access to JSON operators" do
     bq_query = """
     WITH logs AS (

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -180,6 +180,12 @@ defmodule Logflare.SqlTest do
                "select c from src order by c asc"},
               "with src as (select a from #{table}) select c from src order by c asc"
             },
+            # sandboxed query with a derived table (subquery) in the FROM clause
+            {
+              {"with src as (select a from my_table) select c from src",
+               "select c from (select c from src) as sub"},
+              "with src as (select a from #{table}) select c from (select c from src) as sub"
+            },
             # sandboxed CTEs with union all
             {
               {"with cte1 as (select a from my_table), cte2 as (select b from my_table) select a from cte1",

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -252,6 +252,12 @@ defmodule Logflare.SqlTest do
                "select a from my_table"},
               "Table not found in CTE: (my_table)"
             },
+            # sandbox: disallowed table inside a subquery FROM is still caught
+            {
+              {"with src as (select a from my_table) select c from src",
+               "select c from (select a from my_table) as sub"},
+              "Table not found in CTE: (my_table)"
+            },
             # sandbox: restricted functions
             {"SELECT SESSION_USER()", "Restricted function session_user"},
             {"SELECT EXTERNAL_QUERY('','')", "Restricted function external_query"},

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -186,6 +186,12 @@ defmodule Logflare.SqlTest do
                "select c from (select c from src) as sub"},
               "with src as (select a from #{table}) select c from (select c from src) as sub"
             },
+            # sandboxed query with UNNEST (a non-table relation) in the FROM clause
+            {
+              {"with src as (select a from my_table) select c from src",
+               "select c from src, unnest(src.col) as f"},
+              "with src as (select a from #{table}) select c from src, unnest(src.col) as f"
+            },
             # sandboxed CTEs with union all
             {
               {"with cte1 as (select a from my_table), cte2 as (select b from my_table) select a from cte1",


### PR DESCRIPTION
## Problem

Sandboxed endpoint queries that reference a derived table (subquery) in their `FROM` clause crash validation with `Protocol.Enumerable not implemented for Atom in Logflare.Sql.has_restricted_sources/2`. Surfaced in prod error logs.

The root cause is a recurring pattern: a `get_in(...)` result used directly as a `for` generator source. When `get_in` walks a path that doesn't exist for a given AST shape it returns `nil`, and `for x <- nil` raises `Protocol.Enumerable not implemented for Atom` (`nil` is an atom). This PR fixes two instances of that pattern.

## Fix 1 — `Logflare.Sql.has_restricted_sources/2` (the reported crash)

`extract_all_from/1` collects every `FROM` node in the AST, including those whose relation is a derived table (subquery) or `UNNEST`. For a plain table, `get_in(from, ["relation", "Table", "name"])` returns a list; for a non-table relation it returns `nil`, crashing the comprehension. Any sandboxed query with a subquery or comma-joined `UNNEST` in its `FROM` hits this, e.g. `select c from (select c from src) as sub`.

Guarded the generator source with `|| []`. The inner subquery's own `FROM` (the real table reference) is still collected separately by `extract_all_from/1`, so CTE-membership validation is unaffected.

## Fix 2 — `DialectTranslation.cte_from_table_aliases/1` (sibling bug found while auditing)

Same pattern: when a CTE's body is a `UNION` (or `VALUES`/nested query) rather than a plain `SELECT`, `get_in(tree, ["query", "body", "Select", "from"])` returns `nil` and the comprehension crashes. This is reachable via `Sql.translate(:bq_sql, :pg_sql, ...)` for Postgres/ClickHouse backends, e.g. `WITH x AS (SELECT a FROM t UNION SELECT b FROM t2) SELECT c FROM x`. The sibling function `cte_projection_aliases/1` was already guarded with `|| []`; this one was missed.
