### PR TITLE
fix(bigquery): handle nested/heterogeneous list payloads on ingest

### DIFF
--- a/lib/logflare/google/bigquery/event_utils.ex
+++ b/lib/logflare/google/bigquery/event_utils.ex
@@ -69,4 +69,10 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   end
 
   defp wrap_fields({k, v}), do: {k, v}
+
+  defp wrap_fields(value) when is_list(value) do
+    Enum.map(value, &wrap_fields/1)
+  end
+
+  defp wrap_fields(value), do: value
 end

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -111,6 +111,19 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
     iex> TestUtils.get_bq_field_schema(schema, "a.b")
     %TFS{fields: [], mode: "REPEATED", name: "b", type: "RECORD"}
 
+  ### Nested arrays
+
+  BigQuery has no array-of-arrays type, so a populated nested array cannot be
+  represented as a column. Such a field is dropped from the schema (only that
+  field — sibling fields are still built) rather than producing an invalid
+  field schema:
+
+    iex> schema = SchemaBuilder.build_table_schema(%{"a"=> %{"b"=> [["x"], ["y"]], "c"=> 1}}, @default_schema)
+    iex> TestUtils.get_bq_field_schema(schema, "a.b")
+    nil
+    iex> TestUtils.get_bq_field_schema(schema, "a.c")
+    %TFS{ name: "c", mode: "NULLABLE", type: "INTEGER" }
+
   ### Exceptions
   There are certain cases where the inner field types are ambiguous and an error is raised.
   - Single nested arrays `[]`
@@ -135,11 +148,13 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
           param_key not in protected_keys do
         prev_field_schema = Enum.find(old_fields, &(&1.name == param_key)) || %{}
         param_value = Map.get(params, param_key)
-        new_field_schema = build_fields_schemas({param_key, param_value}, is_otel)
 
-        prev_field_schema
-        |> DeepMerge.deep_merge(new_field_schema)
+        case build_fields_schemas({param_key, param_value}, is_otel) do
+          nil -> nil
+          new_field_schema -> DeepMerge.deep_merge(prev_field_schema, new_field_schema)
+        end
       end
+      |> Enum.reject(&is_nil/1)
 
     # reject old fields that are now included in the params
     unrejected_fields = old_fields |> Enum.reject(&(&1.name in Map.keys(params)))
@@ -187,7 +202,10 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
       mode: "REPEATED",
       name: params_key,
       type: "RECORD",
-      fields: Enum.map(params_val, &build_fields_schemas(&1, false))
+      fields:
+        params_val
+        |> Enum.map(&build_fields_schemas(&1, false))
+        |> Enum.reject(&is_nil/1)
     }
   end
 
@@ -199,6 +217,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
       _ -> false
     end)
     |> Enum.map(&build_fields_schemas(&1, false))
+    |> Enum.reject(&is_nil/1)
   end
 
   defp build_fields_schemas({params_key, params_value}, is_otel) do
@@ -212,6 +231,12 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
           mode: "REPEATED",
           fields: build_fields_schemas(params_value, false)
         }
+
+      # BigQuery has no array-of-arrays type. A nested array yields a tuple
+      # inner type here (e.g. {"ARRAY", {"ARRAY", "STRING"}}); drop the field
+      # rather than emit an unrepresentable field schema.
+      {"ARRAY", inner_type} when is_tuple(inner_type) ->
+        nil
 
       {"ARRAY", inner_type} ->
         %TFS{

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -22,5 +22,40 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
 
       assert result == [event]
     end
+
+    test "handles nested list-of-lists (e.g. a serialized stacktrace)" do
+      event = %{
+        "stacktrace" => [
+          ["Elixir.ProjectThree.TmAmTicket", "ingest", 2],
+          ["Elixir.ProjectThree.TmHost", "dispatch", 1]
+        ]
+      }
+
+      assert EventUtils.prepare_for_ingest(event) == [event]
+    end
+
+    test "handles a list whose head is a map but tail contains lists and scalars" do
+      event = %{
+        "mixed" => [
+          %{"a" => %{"b" => 1}},
+          ["nested", "list"],
+          "scalar"
+        ]
+      }
+
+      result = EventUtils.prepare_for_ingest(event)
+
+      expected = [
+        %{
+          "mixed" => [
+            %{"a" => [%{"b" => 1}]},
+            ["nested", "list"],
+            "scalar"
+          ]
+        }
+      ]
+
+      assert result == expected
+    end
   end
 end

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -61,6 +61,80 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
     end
   end
 
+  describe "nested arrays (no BigQuery array-of-arrays type)" do
+    test "drops a top-level nested-array field but keeps sibling fields" do
+      schema =
+        SchemaBuilder.build_table_schema(
+          %{"bad" => [["x"], ["y"]], "good" => "keep"},
+          @default_schema
+        )
+
+      assert TestUtils.get_bq_field_schema(schema, "bad") == nil
+
+      assert %TFS{name: "good", type: "STRING", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(schema, "good")
+    end
+
+    test "drops a nested-array field inside a record but keeps sibling fields" do
+      schema =
+        SchemaBuilder.build_table_schema(
+          %{"a" => %{"bad" => [["x"], ["y"]], "good" => 1}},
+          @default_schema
+        )
+
+      assert TestUtils.get_bq_field_schema(schema, "a.bad") == nil
+
+      assert %TFS{name: "good", type: "INTEGER", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(schema, "a.good")
+
+      assert %TFS{name: "a", type: "RECORD", mode: "REPEATED"} =
+               TestUtils.get_bq_field_schema(schema, "a")
+    end
+
+    test "drops a nested-array field found inside an array of maps" do
+      schema =
+        SchemaBuilder.build_table_schema(
+          %{"a" => [%{"bad" => [[1], [2]], "good" => "ok"}]},
+          @default_schema
+        )
+
+      assert TestUtils.get_bq_field_schema(schema, "a.bad") == nil
+
+      assert %TFS{name: "good", type: "STRING", mode: "NULLABLE"} =
+               TestUtils.get_bq_field_schema(schema, "a.good")
+    end
+
+    test "produced schema is JSON-encodable (no tuple field types reach the BigQuery patch)" do
+      schema =
+        SchemaBuilder.build_table_schema(
+          %{"a" => %{"bad" => [["x"]], "good" => 1}},
+          @default_schema
+        )
+
+      assert {:ok, _json} = Poison.encode(schema)
+    end
+
+    test "drops a previously-typed field that now arrives as a nested array" do
+      prev_schema = SchemaBuilder.build_table_schema(%{"a" => "ok"}, @default_schema)
+
+      assert %TFS{name: "a", type: "STRING"} = TestUtils.get_bq_field_schema(prev_schema, "a")
+
+      curr_schema = SchemaBuilder.build_table_schema(%{"a" => [["x"], ["y"]]}, prev_schema)
+
+      assert TestUtils.get_bq_field_schema(curr_schema, "a") == nil
+      assert {:ok, _json} = Poison.encode(curr_schema)
+    end
+
+    test "a record whose only field is a nested array becomes a valid empty RECORD" do
+      schema = SchemaBuilder.build_table_schema(%{"a" => %{"bad" => [["x"]]}}, @default_schema)
+
+      assert %TFS{name: "a", type: "RECORD", mode: "REPEATED", fields: []} =
+               TestUtils.get_bq_field_schema(schema, "a")
+
+      assert {:ok, _json} = Poison.encode(schema)
+    end
+  end
+
   test "schema update: params do not match schema" do
     schema = SchemaBuilder.build_table_schema(%{"a" => %{"b" => 1.0}}, @default_schema)
 


### PR DESCRIPTION
## Problem

Two BigQuery code paths crash on the same blind spot: they inspect only the head of a list and assume the rest of the list matches. A payload containing a nested list-of-lists (for example a serialized stacktrace shipped as JSON arrays) or a heterogeneous list trips both.

**Insert path.** `Logflare.Google.BigQuery.EventUtils.wrap_fields/1` recurses over list elements but only has clauses for maps and `{k, v}` tuples. A bare list or scalar element — produced when a list's head is a map but later elements are lists/scalars, or when the value is a list-of-lists — matches no clause and raises `FunctionClauseError`, crashing the Broadway batch-processor stage.

**Schema-patch path.** `SchemaTypes.to_schema_type([["x"]])` returns `{"ARRAY", {"ARRAY", "STRING"}}`, and `SchemaBuilder` turns that into a `%TableFieldSchema{type: {"ARRAY", "STRING"}}` — a tuple where BigQuery requires a string type enum. BigQuery has no array-of-arrays type, so this field schema is invalid, and `Poison.encode!` crashes on it when the per-source `Schema` GenServer patches the table (there is no rescue around the patch).

## Fix

**Insert path:** add fallback clauses to `wrap_fields/1` — bare lists recurse over their elements, and any other value passes through unchanged. This stops the crash while preserving the existing nested-map wrapping behavior.

**Schema layer:** a nested array now drops only that field rather than emitting an unrepresentable field schema. Every field-collection site filters dropped fields, so sibling fields at any depth still build, and no tuple-typed field schema is ever produced (so the encode crash can't occur). `to_schema_type/1` is left unchanged — its nested-tuple output is the legacy read path consumed by `bq_type_to_ex`.

Nested-array values can't be stored as a typed BigQuery column, so the field is dropped (the existing `try_schema_update` rescue logs it). Preserving such values as a JSON string was considered but deferred — it would require coordinated changes in the ingest value transform and is a separate feature.