### PR TITLE
chore: upgrade sql parser to support additional ClickHouse features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arrow"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +772,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "regex"
@@ -889,11 +937,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
+checksum = "c66e3b7374ad4a6af849b08b3e7a6eda0edbd82f0fd59b57e22671bf16979899"
 dependencies = [
  "log",
+ "recursive",
  "serde",
 ]
 
@@ -905,6 +954,19 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlparser",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1060,6 +1122,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
+checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
+checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
+checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749780d15ad1ee15fd74f5f84b0665560b6abb913de744c2b69155770f9601da"
+checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sqlparser"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
 dependencies = [
  "log",
  "serde",

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -132,6 +132,12 @@ defmodule Logflare.Sql do
     "zookeepersessionuptime"
   ]
 
+  @allowed_clickhouse_settings [
+    "distributed_index_analysis",
+    "enable_parallel_replicas",
+    "max_parallel_replicas"
+  ]
+
   @doc """
   Formats a SQL query string for display.
 
@@ -584,6 +590,7 @@ defmodule Logflare.Sql do
     with :ok <- check_single_query_only(ast),
          :ok <- check_select_statement_only(ast, dialect),
          :ok <- maybe_check_restricted_functions(ast, dialect, data),
+         :ok <- maybe_check_restricted_settings(ast, dialect),
          :ok <- has_wildcard_in_select(ast),
          :ok <- check_all_sources_allowed(ast, data) do
       :ok
@@ -595,6 +602,10 @@ defmodule Logflare.Sql do
        do: has_restricted_functions(ast, data)
 
   defp maybe_check_restricted_functions(_ast, _dialect, _data), do: :ok
+
+  defp maybe_check_restricted_settings(ast, "clickhouse"), do: has_restricted_settings(ast)
+
+  defp maybe_check_restricted_settings(_ast, _dialect), do: :ok
 
   # applies only to the sandboed query
   defp maybe_validate_sandboxed_query_ast({cte_ast, ast}, data) when is_list(ast) do
@@ -782,6 +793,38 @@ defmodule Logflare.Sql do
   defp function_restricted?(name, "bigquery"), do: name in @bq_restricted_functions
   defp function_restricted?(name, "clickhouse"), do: name in @ch_restricted_functions
   defp function_restricted?(_name, _dialect), do: false
+
+  defp has_restricted_settings(ast) when is_list(ast),
+    do: has_restricted_settings(ast, :ok)
+
+  defp has_restricted_settings({"settings", settings}, :ok) when is_list(settings) do
+    check_settings_allowed(settings)
+  end
+
+  defp has_restricted_settings(kv, :ok = acc) when is_list(kv) or is_map(kv) do
+    Enum.reduce(kv, acc, fn kv, nested_acc -> has_restricted_settings(kv, nested_acc) end)
+  end
+
+  defp has_restricted_settings({_k, v}, :ok = acc) when is_list(v) or is_map(v) do
+    has_restricted_settings(v, acc)
+  end
+
+  defp has_restricted_settings(_kv, acc), do: acc
+
+  defp check_settings_allowed(settings) do
+    found_restricted =
+      for %{"key" => %{"value" => key}} <- settings,
+          normalized = String.downcase(key),
+          normalized not in @allowed_clickhouse_settings do
+        normalized
+      end
+
+    if Enum.empty?(found_restricted) do
+      :ok
+    else
+      {:error, "Restricted setting #{Enum.join(found_restricted, ", ")}"}
+    end
+  end
 
   defp has_restricted_sources(cte_ast, ast) when is_list(ast) do
     aliases =

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -730,7 +730,7 @@ defmodule Logflare.Sql do
   end
 
   defp has_restricted_functions(
-         {"Table", %{"args" => args, "name" => [%{"value" => _} | _] = names}},
+         {"Table", %{"args" => %{"args" => args}, "name" => [%{"value" => _} | _] = names}},
          :ok,
          %{dialect: dialect} = data
        )

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -134,8 +134,26 @@ defmodule Logflare.Sql do
 
   @allowed_clickhouse_settings [
     "distributed_index_analysis",
+    "enable_multiple_prewhere_read_steps",
     "enable_parallel_replicas",
-    "max_parallel_replicas"
+    "force_data_skipping_indices",
+    "force_index_by_date",
+    "force_primary_key",
+    "join_algorithm",
+    "max_parallel_replicas",
+    "optimize_aggregation_in_order",
+    "optimize_move_to_prewhere",
+    "optimize_move_to_prewhere_if_final",
+    "optimize_read_in_order",
+    "optimize_read_in_window_order",
+    "optimize_use_implicit_projections",
+    "query_plan_direct_read_from_text_index",
+    "query_plan_text_index_add_hint",
+    "text_index_hint_max_selectivity",
+    "use_query_condition_cache",
+    "use_skip_indexes",
+    "use_skip_indexes_for_disjunctions",
+    "use_skip_indexes_if_final"
   ]
 
   @doc """

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -676,14 +676,13 @@ defmodule Logflare.Sql do
     end
   end
 
-  defp check_all_sources_allowed(kv, acc, data) when is_list(kv) or is_map(kv) do
-    kv
-    |> Enum.reduce(acc, fn kv, nested_acc ->
+  defp check_all_sources_allowed(kv, acc, data) when is_list_or_map(kv) do
+    Enum.reduce(kv, acc, fn kv, nested_acc ->
       check_all_sources_allowed(kv, nested_acc, data)
     end)
   end
 
-  defp check_all_sources_allowed({_k, v}, acc, data) when is_list(v) or is_map(v) do
+  defp check_all_sources_allowed({_k, v}, acc, data) when is_list_or_map(v) do
     check_all_sources_allowed(v, acc, data)
   end
 
@@ -751,12 +750,11 @@ defmodule Logflare.Sql do
     end
   end
 
-  defp has_restricted_functions(kv, :ok = acc, data) when is_list(kv) or is_map(kv) do
-    kv
-    |> Enum.reduce(acc, fn kv, nested_acc -> has_restricted_functions(kv, nested_acc, data) end)
+  defp has_restricted_functions(kv, :ok = acc, data) when is_list_or_map(kv) do
+    Enum.reduce(kv, acc, fn kv, nested_acc -> has_restricted_functions(kv, nested_acc, data) end)
   end
 
-  defp has_restricted_functions({_k, v}, :ok = acc, data) when is_list(v) or is_map(v) do
+  defp has_restricted_functions({_k, v}, :ok = acc, data) when is_list_or_map(v) do
     has_restricted_functions(v, acc, data)
   end
 
@@ -801,11 +799,11 @@ defmodule Logflare.Sql do
     check_settings_allowed(settings)
   end
 
-  defp has_restricted_settings(kv, :ok = acc) when is_list(kv) or is_map(kv) do
+  defp has_restricted_settings(kv, :ok = acc) when is_list_or_map(kv) do
     Enum.reduce(kv, acc, fn kv, nested_acc -> has_restricted_settings(kv, nested_acc) end)
   end
 
-  defp has_restricted_settings({_k, v}, :ok = acc) when is_list(v) or is_map(v) do
+  defp has_restricted_settings({_k, v}, :ok = acc) when is_list_or_map(v) do
     has_restricted_settings(v, acc)
   end
 
@@ -889,12 +887,11 @@ defmodule Logflare.Sql do
     {:error, "restricted wildcard (*) in a result column"}
   end
 
-  defp has_wildcard_in_select(kv, acc) when is_list(kv) or is_map(kv) do
-    kv
-    |> Enum.reduce(acc, fn kv, nested_acc -> has_wildcard_in_select(kv, nested_acc) end)
+  defp has_wildcard_in_select(kv, acc) when is_list_or_map(kv) do
+    Enum.reduce(kv, acc, fn kv, nested_acc -> has_wildcard_in_select(kv, nested_acc) end)
   end
 
-  defp has_wildcard_in_select({_k, v}, acc) when is_list(v) or is_map(v) do
+  defp has_wildcard_in_select({_k, v}, acc) when is_list_or_map(v) do
     has_wildcard_in_select(v, acc)
   end
 
@@ -1026,14 +1023,13 @@ defmodule Logflare.Sql do
     new_names ++ prev
   end
 
-  defp find_all_source_names(kv, acc, data) when is_list(kv) or is_map(kv) do
-    kv
-    |> Enum.reduce(acc, fn kv, nested_acc ->
+  defp find_all_source_names(kv, acc, data) when is_list_or_map(kv) do
+    Enum.reduce(kv, acc, fn kv, nested_acc ->
       find_all_source_names(kv, nested_acc, data)
     end)
   end
 
-  defp find_all_source_names({_k, v}, acc, data) when is_list(v) or is_map(v) do
+  defp find_all_source_names({_k, v}, acc, data) when is_list_or_map(v) do
     find_all_source_names(v, acc, data)
   end
 
@@ -1081,7 +1077,7 @@ defmodule Logflare.Sql do
     {k, [new_first | other]}
   end
 
-  defp replace_old_source_names({k, v}, data) when is_list(v) or is_map(v) do
+  defp replace_old_source_names({k, v}, data) when is_list_or_map(v) do
     {k, replace_old_source_names(v, data)}
   end
 

--- a/lib/logflare/sql.ex
+++ b/lib/logflare/sql.ex
@@ -881,12 +881,7 @@ defmodule Logflare.Sql do
       if qualified_name in data.source_names do
         transformed_name = transformer.transform_source_name(qualified_name, data)
 
-        [
-          %{
-            "quote_style" => dialect_quote_style,
-            "value" => transformed_name
-          }
-        ]
+        [AstUtils.build_identifier(transformed_name, dialect_quote_style)]
       else
         names
       end

--- a/lib/logflare/sql/ast_utils.ex
+++ b/lib/logflare/sql/ast_utils.ex
@@ -5,6 +5,20 @@ defmodule Logflare.Sql.AstUtils do
 
   import Logflare.Utils.Guards
 
+  @empty_span %{
+    "start" => %{"line" => 0, "column" => 0},
+    "end" => %{"line" => 0, "column" => 0}
+  }
+
+  @doc """
+  Builds an identifier AST node map, including the `span` field the parser
+  requires when a hand-built AST is serialized back into SQL.
+  """
+  @spec build_identifier(value :: String.t() | nil, quote_style :: String.t() | nil) :: map()
+  def build_identifier(value, quote_style \\ nil) do
+    %{"value" => value, "quote_style" => quote_style, "span" => @empty_span}
+  end
+
   @doc """
   Recursively transforms an AST using a provided transform function.
 

--- a/lib/logflare/sql/dialect_translation.ex
+++ b/lib/logflare/sql/dialect_translation.ex
@@ -117,7 +117,7 @@ defmodule Logflare.Sql.DialectTranslation do
     {k,
      %{
        v
-       | "name" => [%{"quote_style" => quote_style, "value" => table_name}]
+       | "name" => [AstUtils.build_identifier(table_name, quote_style)]
      }}
   end
 
@@ -173,13 +173,13 @@ defmodule Logflare.Sql.DialectTranslation do
            v
            | "args" => %{
                "List" => %{
-                 "args" => [%{"Unnamed" => %{"Expr" => %{"Wildcard" => nil}}}],
+                 "args" => [%{"Unnamed" => "Wildcard"}],
                  "clauses" => [],
                  "duplicate_treatment" => nil
                }
              },
              "filter" => bq_to_pg_convert_functions(filter),
-             "name" => [%{"quote_style" => nil, "value" => "count"}]
+             "name" => [AstUtils.build_identifier("count")]
          }}
 
       "timestamp_sub" ->
@@ -237,7 +237,7 @@ defmodule Logflare.Sql.DialectTranslation do
                  "duplicate_treatment" => nil
                }
              },
-             "name" => [%{"quote_style" => nil, "value" => "date_trunc"}]
+             "name" => [AstUtils.build_identifier("date_trunc")]
          }}
 
       _ ->
@@ -528,7 +528,7 @@ defmodule Logflare.Sql.DialectTranslation do
 
       # If no valid identifiers remain, this is an error case - use empty Identifier
       [] ->
-        {"Identifier", %{"quote_style" => nil, "value" => ""}}
+        {"Identifier", AstUtils.build_identifier("")}
     end
   end
 
@@ -667,8 +667,8 @@ defmodule Logflare.Sql.DialectTranslation do
           "BinaryOp" => %{
             "left" => %{
               "CompoundIdentifier" => [
-                %{"quote_style" => nil, "value" => table},
-                %{"quote_style" => nil, "value" => "body"}
+                AstUtils.build_identifier(table),
+                AstUtils.build_identifier("body")
               ]
             },
             "op" => "LongArrow",
@@ -688,7 +688,7 @@ defmodule Logflare.Sql.DialectTranslation do
         "Nested" => %{
           "BinaryOp" => %{
             "left" => %{
-              "Identifier" => %{"quote_style" => nil, "value" => "body"}
+              "Identifier" => AstUtils.build_identifier("body")
             },
             "op" => "LongArrow",
             "right" => %{
@@ -711,8 +711,8 @@ defmodule Logflare.Sql.DialectTranslation do
         "BinaryOp" => %{
           "left" => %{
             "CompoundIdentifier" => [
-              %{"quote_style" => nil, "value" => table},
-              %{"quote_style" => nil, "value" => field}
+              AstUtils.build_identifier(table),
+              AstUtils.build_identifier(field)
             ]
           },
           "op" => select_json_operator(data, false),
@@ -732,7 +732,7 @@ defmodule Logflare.Sql.DialectTranslation do
     %{
       "Nested" => %{
         "BinaryOp" => %{
-          "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
+          "left" => %{"Identifier" => AstUtils.build_identifier(base)},
           "op" => select_json_operator(data, false),
           "right" => %{
             "Value" => %{"SingleQuotedString" => key}
@@ -754,7 +754,7 @@ defmodule Logflare.Sql.DialectTranslation do
     %{
       "Nested" => %{
         "BinaryOp" => %{
-          "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
+          "left" => %{"Identifier" => AstUtils.build_identifier(base)},
           "op" => select_json_operator(data, true),
           "right" => %{
             "Value" => %{"SingleQuotedString" => path}
@@ -775,7 +775,7 @@ defmodule Logflare.Sql.DialectTranslation do
         %{
           "Nested" => %{
             "BinaryOp" => %{
-              "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
+              "left" => %{"Identifier" => AstUtils.build_identifier(base)},
               "op" => select_json_operator(data, false),
               "right" => %{
                 "Value" => %{"SingleQuotedString" => key}
@@ -791,7 +791,7 @@ defmodule Logflare.Sql.DialectTranslation do
         %{
           "Nested" => %{
             "BinaryOp" => %{
-              "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
+              "left" => %{"Identifier" => AstUtils.build_identifier(base)},
               "op" => select_json_operator(data, true),
               "right" => %{
                 "Value" => %{"SingleQuotedString" => path}
@@ -810,7 +810,7 @@ defmodule Logflare.Sql.DialectTranslation do
     %{
       "Nested" => %{
         "BinaryOp" => %{
-          "left" => %{"Identifier" => %{"quote_style" => nil, "value" => base}},
+          "left" => %{"Identifier" => AstUtils.build_identifier(base)},
           "op" => select_json_operator(data, false),
           "right" => %{
             "Value" => %{"SingleQuotedString" => name}
@@ -1059,7 +1059,7 @@ defmodule Logflare.Sql.DialectTranslation do
     if normalized_identifier do
       {"ExprWithAlias",
        %{
-         "alias" => %{"quote_style" => nil, "value" => normalized_identifier},
+         "alias" => AstUtils.build_identifier(normalized_identifier),
          "expr" => traverse_convert_identifiers(identifier, data)
        }}
     else
@@ -1158,8 +1158,8 @@ defmodule Logflare.Sql.DialectTranslation do
                "BinaryOp" => %{
                  "left" => %{
                    "CompoundIdentifier" => [
-                     %{"quote_style" => nil, "value" => table_alias},
-                     %{"quote_style" => nil, "value" => cte_field}
+                     AstUtils.build_identifier(table_alias),
+                     AstUtils.build_identifier(cte_field)
                    ]
                  },
                  "op" => op,
@@ -1248,8 +1248,8 @@ defmodule Logflare.Sql.DialectTranslation do
            "BinaryOp" => %{
              "left" => %{
                "CompoundIdentifier" => [
-                 %{"quote_style" => nil, "value" => cte_name},
-                 %{"quote_style" => nil, "value" => field}
+                 AstUtils.build_identifier(cte_name),
+                 AstUtils.build_identifier(field)
                ]
              },
              "op" => select_json_operator(data, false),
@@ -1268,8 +1268,8 @@ defmodule Logflare.Sql.DialectTranslation do
            "BinaryOp" => %{
              "left" => %{
                "CompoundIdentifier" => [
-                 %{"quote_style" => nil, "value" => cte_name},
-                 %{"quote_style" => nil, "value" => field}
+                 AstUtils.build_identifier(cte_name),
+                 AstUtils.build_identifier(field)
                ]
              },
              "op" => select_json_operator(data, true),
@@ -1380,7 +1380,8 @@ defmodule Logflare.Sql.DialectTranslation do
               },
               "parameters" => "None",
               "filter" => nil,
-              "name" => [%{"quote_style" => nil, "value" => "to_timestamp"}],
+              "uses_odbc_syntax" => false,
+              "name" => [AstUtils.build_identifier("to_timestamp")],
               "null_treatment" => nil,
               "over" => nil,
               "within_group" => []
@@ -1426,7 +1427,8 @@ defmodule Logflare.Sql.DialectTranslation do
               },
               "parameters" => "None",
               "filter" => nil,
-              "name" => [%{"quote_style" => nil, "value" => "to_timestamp"}],
+              "uses_odbc_syntax" => false,
+              "name" => [AstUtils.build_identifier("to_timestamp")],
               "null_treatment" => nil,
               "over" => nil,
               "within_group" => []
@@ -1455,7 +1457,7 @@ defmodule Logflare.Sql.DialectTranslation do
         "expr" => expr,
         "data_type" => %{
           "Custom" => [
-            [%{"quote_style" => nil, "value" => "jsonb"}],
+            [AstUtils.build_identifier("jsonb")],
             []
           ]
         },
@@ -1471,7 +1473,7 @@ defmodule Logflare.Sql.DialectTranslation do
         "expr" => expr,
         "data_type" => %{
           "Custom" => [
-            [%{"quote_style" => nil, "value" => "jsonb"}],
+            [AstUtils.build_identifier("jsonb")],
             []
           ]
         },

--- a/lib/logflare/sql/parser.ex
+++ b/lib/logflare/sql/parser.ex
@@ -3,7 +3,6 @@ defmodule Logflare.Sql.Parser do
   Provides functionality for converting SQL queries into an AST and back to SQL strings.
 
   This leverages the [sqlparser](https://crates.io/crates/sqlparser) Rust crate to handle SQL parsing and AST generation.
-
   """
 
   import Logflare.Utils.Guards

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.49.0", features = ["serde"]}
+sqlparser = { version = "0.50.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.51.0", features = ["serde"]}
+sqlparser = { version = "0.52.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.50.0", features = ["serde"]}
+sqlparser = { version = "0.51.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.53.0", features = ["serde"]}
+sqlparser = { version = "0.54.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.52.0", features = ["serde"]}
+sqlparser = { version = "0.53.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/native/sqlparser_ex/Cargo.toml
+++ b/native/sqlparser_ex/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.37.2"
-sqlparser = { version = "0.48.0", features = ["serde"]}
+sqlparser = { version = "0.49.0", features = ["serde"]}
 # sqlparser = {git = "https://github.com/Logflare/sqlparser-rs", branch = "main", features = ["serde"]}
 # sqlparser = {version = "0.27.0", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -633,6 +633,69 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  describe "SAMPLE and query-level SETTINGS execution" do
+    setup do
+      insert(:plan, name: "Free")
+
+      {source, backend} = setup_clickhouse_test()
+
+      start_supervised!({ClickHouseAdaptor, backend})
+      assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+
+      [source: source, backend: backend]
+    end
+
+    test "executes a query with query-level SETTINGS", %{source: source, backend: backend} do
+      log_event = build_mapped_log_event(source: source, message: "settings exec test")
+      assert :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log)
+
+      Process.sleep(100)
+
+      table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
+
+      query =
+        "SELECT source_name, count(*) AS event_count FROM #{table_name} " <>
+          "GROUP BY source_name SETTINGS max_threads = 4, max_execution_time = 10"
+
+      assert {:ok, {[row], bytes}} = ClickHouseAdaptor.execute_ch_query(backend, query)
+      assert row["source_name"] == source.name
+      assert row["event_count"] >= 1
+      assert is_integer(bytes)
+    end
+
+    test "executes a SAMPLE query against a sampling-keyed table", %{backend: backend} do
+      table_name = "sample_test_#{System.unique_integer([:positive])}"
+
+      ddl =
+        "CREATE TABLE #{table_name} (id UInt64, val String) " <>
+          "ENGINE = MergeTree ORDER BY cityHash64(id) SAMPLE BY cityHash64(id)"
+
+      assert {:ok, _} = ClickHouseAdaptor.execute_ch_query(backend, ddl)
+
+      on_exit(fn ->
+        ClickHouseAdaptor.execute_ch_query(backend, "DROP TABLE IF EXISTS #{table_name}")
+      end)
+
+      values = Enum.map_join(1..100, ", ", fn i -> "(#{i}, 'v#{i}')" end)
+
+      assert {:ok, _} =
+               ClickHouseAdaptor.execute_ch_query(
+                 backend,
+                 "INSERT INTO #{table_name} (id, val) VALUES #{values}"
+               )
+
+      assert {:ok, {[%{"sampled" => sampled}], bytes}} =
+               ClickHouseAdaptor.execute_ch_query(
+                 backend,
+                 "SELECT count(*) AS sampled FROM #{table_name} SAMPLE 0.1"
+               )
+
+      assert is_integer(sampled)
+      assert sampled <= 100
+      assert is_integer(bytes)
+    end
+  end
+
   describe "LQL query integration" do
     setup do
       insert(:plan, name: "Free")

--- a/test/logflare/sql/parser_test.exs
+++ b/test/logflare/sql/parser_test.exs
@@ -42,6 +42,46 @@ defmodule Logflare.Sql.ParserTest do
     end
   end
 
+  describe "parse/2 with clickhouse SAMPLE clause" do
+    test "Parses and round-trips a SAMPLE ratio" do
+      query = "SELECT a FROM default.otel_logs SAMPLE 0.1"
+
+      assert {:ok, ast} = Parser.parse("clickhouse", query)
+      assert {:ok, ^query} = Parser.to_string(ast)
+    end
+
+    test "Parses and round-trips a SAMPLE fractional expression" do
+      assert {:ok, ast} =
+               Parser.parse("clickhouse", "SELECT a FROM default.otel_logs SAMPLE 1/10")
+
+      assert {:ok, "SELECT a FROM default.otel_logs SAMPLE 1 / 10"} = Parser.to_string(ast)
+    end
+
+    test "Parses and round-trips a SAMPLE with OFFSET" do
+      query = "SELECT a FROM default.otel_logs SAMPLE 0.1 OFFSET 0.5"
+
+      assert {:ok, ast} = Parser.parse("clickhouse", query)
+      assert {:ok, ^query} = Parser.to_string(ast)
+    end
+  end
+
+  describe "parse/2 with clickhouse query-level SETTINGS" do
+    test "Parses and round-trips a single setting" do
+      query = "SELECT a FROM t SETTINGS max_threads = 4"
+
+      assert {:ok, ast} = Parser.parse("clickhouse", query)
+      assert {:ok, ^query} = Parser.to_string(ast)
+    end
+
+    test "Parses and round-trips multiple settings alongside GROUP BY" do
+      query =
+        "SELECT user_id, count() FROM events GROUP BY user_id SETTINGS max_threads = 4, max_execution_time = 10"
+
+      assert {:ok, ast} = Parser.parse("clickhouse", query)
+      assert {:ok, ^query} = Parser.to_string(ast)
+    end
+  end
+
   describe "to_string/1" do
     test "Converts a parsed query AST back to a string" do
       bq_query = "SELECT * FROM `foo`.`bar`.`baz`"

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -810,6 +810,40 @@ defmodule Logflare.SqlTest do
         assert String.downcase(err) =~ "restricted function #{function_name}"
       end
     end
+
+    test "allows allowlisted query-level settings" do
+      user = insert(:user)
+      _source = insert(:source, user: user, name: "my_ch_table")
+
+      allowed_settings =
+        ~w(distributed_index_analysis enable_parallel_replicas max_parallel_replicas)
+
+      for setting <- allowed_settings do
+        query = "select a from my_ch_table SETTINGS #{setting} = 1"
+        assert {:ok, _transformed} = Sql.transform(:ch_sql, query, user)
+      end
+    end
+
+    test "rejects disallowed query-level settings" do
+      user = insert(:user)
+      _source = insert(:source, user: user, name: "my_ch_table")
+
+      query = "select a from my_ch_table SETTINGS allow_introspection_functions = 1"
+
+      assert {:error, err} = Sql.transform(:ch_sql, query, user)
+      assert String.downcase(err) =~ "restricted setting allow_introspection_functions"
+    end
+
+    test "rejects disallowed query-level settings in sandboxed queries" do
+      user = insert(:user)
+      _source = insert(:source, user: user, name: "my_ch_table")
+
+      cte_query = "with src as (select a from my_ch_table) select a from src"
+      consumer_query = "select a from src SETTINGS allow_introspection_functions = 1"
+
+      assert {:error, err} = Sql.transform(:ch_sql, {cte_query, consumer_query}, user)
+      assert String.downcase(err) =~ "restricted setting allow_introspection_functions"
+    end
   end
 
   test "sources/2 creates a source mapping present for sources present in the query" do

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -816,7 +816,17 @@ defmodule Logflare.SqlTest do
       _source = insert(:source, user: user, name: "my_ch_table")
 
       allowed_settings =
-        ~w(distributed_index_analysis enable_parallel_replicas max_parallel_replicas)
+        ~w(
+          distributed_index_analysis
+          enable_multiple_prewhere_read_steps
+          enable_parallel_replicas
+          force_primary_key
+          max_parallel_replicas
+          optimize_read_in_order
+          query_plan_direct_read_from_text_index
+          use_skip_indexes
+          use_skip_indexes_for_disjunctions
+        )
 
       for setting <- allowed_settings do
         query = "select a from my_ch_table SETTINGS #{setting} = 1"

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -1485,7 +1485,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1499,7 +1499,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select 'string' ~ 'str' as has_substring|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1513,7 +1513,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select (t.body ->> 'test') ~ 'str' as has_substring from "c.d.e" t|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1531,7 +1531,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select (body #>> '{metadata,nested}') ~ 'val' as has_substring from "c.d.e" t|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1550,7 +1550,7 @@ defmodule Logflare.SqlTest do
         ~s|select (body #> '{metadata,nested}') as nested from "c.d.e" t where (body #>> '{metadata,nested}') ~ 'val'|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1580,7 +1580,7 @@ defmodule Logflare.SqlTest do
         ~s|with data as (select (body -> 'metadata') as metadata from "c.d.e") select (t.metadata #>> '{deep,even}') as nested from data t where (t.metadata #>> '{deep,even}') ~ 'deep'|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       assert {:ok, transformed} = Sql.transform(:pg_sql, translated, user)
 
@@ -1601,21 +1601,21 @@ defmodule Logflare.SqlTest do
       bq_query = "select countif(test = '1') from my_table"
       pg_query = ~s|select count(*) filter (where (body ->> 'test') = '1') from my_table|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "current_timestamp handling " do
       bq_query = "select current_timestamp() as t"
       pg_query = ~s|select current_timestamp as t|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
       refute translated =~ "current_timestamp()"
 
       # in cte
       bq_query = "with a as (select current_timestamp() as t) select a.t"
       pg_query = ~s|with a as (select current_timestamp as t) select a.t as t|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
       refute translated =~ "current_timestamp()"
     end
 
@@ -1623,14 +1623,14 @@ defmodule Logflare.SqlTest do
       bq_query = "select timestamp_sub(current_timestamp(), interval 1 day) as t"
       pg_query = ~s|select current_timestamp - interval '1 day' as t|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "timestamp_trunc without a field reference" do
       bq_query = "select timestamp_trunc(current_timestamp(), day) as t"
       pg_query = ~s|select date_trunc('day', current_timestamp) as t|
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE aliases are not converted to json query" do
@@ -1641,7 +1641,7 @@ defmodule Logflare.SqlTest do
         ~s|with test as (select (body -> 'id') as id, (body -> 'metadata') as metadata from mytable) select id as id, (metadata -> 'request') as request from test|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE alias fields do not get converted to json query if referenced" do
@@ -1668,7 +1668,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE table quotations are converted" do
@@ -1684,7 +1684,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE cross join UNNESTs are removed" do
@@ -1704,7 +1704,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE order by is " do
@@ -1725,7 +1725,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE order by without from " do
@@ -1746,7 +1746,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE cross join UNNESTs with filter reference" do
@@ -1768,7 +1768,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE cross join UNNESTs with multiple from" do
@@ -1790,7 +1790,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "field references within a cast() are converted to ->> syntax for string casting" do
@@ -1798,7 +1798,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select cast( (body ->> 'col') as timestamp) as date from my_table|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "field references within a DATE_TRUNC() are converted to ->> syntax for string casting" do
@@ -1806,7 +1806,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select DATE_TRUNC('day',  (body ->> 'col')) as date from my_table|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "field references in left-right operators are converted to ->> syntax" do
@@ -1814,7 +1814,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select (t.body ->> 'id') = 'test' as value from my_table t|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "order by json query" do
@@ -1823,7 +1823,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select (body -> 'id') as id from my_source t order by (t.body -> 'my_col')|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     # test "cte WHERE identifiers are translated correctly"
@@ -1837,7 +1837,7 @@ defmodule Logflare.SqlTest do
         ~s|select $1::text as arg1, $2::text as arg2, coalesce($3::text, '') > $4::text as arg_copy|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
       # determines sequence of parameters
       assert {:ok, %{1 => "test", 2 => "test_another", 4 => "test"}} =
                Sql.parameter_positions(bq_query)
@@ -1868,7 +1868,7 @@ defmodule Logflare.SqlTest do
       pg_query = ~s|select (t.body -> 'timestamp') as ts from my_table t|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
 
       # only convert if not in projection
       bq_query = ~s|select t.id as id from my_table t where t.timestamp is not null|
@@ -1877,7 +1877,7 @@ defmodule Logflare.SqlTest do
         ~s|select (t.body -> 'id') as id from my_table t where (to_timestamp( (t.body ->> 'timestamp')::bigint / 1000000.0) AT TIME ZONE 'UTC') is not null|
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "special handling of timestamp field and date_trunc : " do
@@ -1892,7 +1892,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "special handling of timestamp field for binary ops" do
@@ -1909,7 +1909,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "CTE fields in binary op are cast to text only when equal" do
@@ -1926,7 +1926,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "translate in operator arguments to text" do
@@ -1941,7 +1941,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "translate between operator sides to numeric" do
@@ -1956,7 +1956,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     test "translate >, >=, =, <, <=  operator to numeric if comparison side is a number" do
@@ -1991,7 +1991,7 @@ defmodule Logflare.SqlTest do
       """
 
       {:ok, translated} = Sql.translate(:bq_sql, :pg_sql, bq_query)
-      assert Sql.Parser.parse("postgres", translated) == Sql.Parser.parse("postgres", pg_query)
+      assert_semantically_equal(translated, pg_query)
     end
 
     # functions metrics
@@ -2029,4 +2029,28 @@ defmodule Logflare.SqlTest do
 
     PostgresAdaptor.insert_log_event(source, backend, log_event)
   end
+
+  # sqlparser 0.53+ records source-location metadata on the AST (`span` byte offsets and `*_token` keys such as `select_token`).
+  # The crate treats these as non-semantic. Its `AttachedToken`/span comparisons ignore them
+  # but the NIF serializes them to JSON, so a plain `==` on the decoded ASTs would fail
+  # on cosmetic differences (e.g. a lowercase `select` vs the rendered `SELECT`).
+  #
+  # These helpers compare two SQL strings for semantic equality by stripping that
+  # metadata first, mirroring the crate's own equality semantics.
+  defp assert_semantically_equal(actual_sql, expected_sql) do
+    assert {:ok, actual_ast} = Sql.Parser.parse("postgres", actual_sql)
+    assert {:ok, expected_ast} = Sql.Parser.parse("postgres", expected_sql)
+    assert strip_source_metadata(actual_ast) == strip_source_metadata(expected_ast)
+  end
+
+  defp strip_source_metadata(%{} = node) do
+    node
+    |> Enum.reject(fn {key, _value} -> key == "span" or String.ends_with?(key, "_token") end)
+    |> Map.new(fn {key, value} -> {key, strip_source_metadata(value)} end)
+  end
+
+  defp strip_source_metadata(list) when is_list(list),
+    do: Enum.map(list, &strip_source_metadata/1)
+
+  defp strip_source_metadata(other), do: other
 end

--- a/test/logflare/sql_test.exs
+++ b/test/logflare/sql_test.exs
@@ -2030,7 +2030,8 @@ defmodule Logflare.SqlTest do
     PostgresAdaptor.insert_log_event(source, backend, log_event)
   end
 
-  # sqlparser 0.53+ records source-location metadata on the AST (`span` byte offsets and `*_token` keys such as `select_token`).
+  # sqlparser 0.53+ records source-location metadata on the AST
+  # (`span` byte offsets and `*_token` keys such as `select_token`).
   # The crate treats these as non-semantic. Its `AttachedToken`/span comparisons ignore them
   # but the NIF serializes them to JSON, so a plain `==` on the decoded ASTs would fail
   # on cosmetic differences (e.g. a lowercase `select` vs the rendered `SELECT`).


### PR DESCRIPTION
This bumps the Rust-based `sqlparser` crate to v0.54.0 (_from v0.48.0_) to allow for the ClickHouse "SAMPLE" keyword to be used in queries / endpoints / etc. Aside from this, we also handle ClickHouse's query-level session settings similar to functions by defining an allowlist of select settings.

The biggest challenge was the jump to 0.53 due to [this](https://github.com/apache/datafusion-sqlparser-rs/pull/1435) change, which now prevents us from doing quick equality assertions as we serialize the AST to JSON. For that I had to put together a helper function for a number of comparison tests - particularly around BQ -> PG transformations.

I also added a couple integration tests to also validate that ClickHouse actually is able to use the output of the parser for things like SAMPLE. Either way - this gap seems to be covered enough for now.

