### PR TITLE
fix(ci): cache priv/native NIF artifacts so all crates load

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           path: |
             ~/.cargo
+            target
           key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
@@ -126,10 +127,11 @@ jobs:
           path: |
             deps
             _build
-          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           path: |
             ~/.cargo
+            target
           key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
@@ -145,10 +146,11 @@ jobs:
           path: |
             deps
             _build
-          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Restore Dialyzer PLT cache
         if: matrix.commands.name == 'Typing check'

--- a/.github/workflows/elixir-migration-check.yml
+++ b/.github/workflows/elixir-migration-check.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           path: |
             ~/.cargo
+            target
           key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
@@ -110,10 +111,11 @@ jobs:
           path: |
             deps
             _build
-          key: mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
           restore-keys: |
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v2-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
       - name: Install dependencies
         run: mix deps.get


### PR DESCRIPTION
Main CI broke after #3645 with NIF load failures - but for the crates I _didn't_ touch in that PR 🫠...

```
Failed to load NIF library: '.../priv/native/mapper_ex.so: ... No such file or directory'
Failed to load NIF library: '.../priv/native/arrowipc_ex.so: ...'
Failed to load NIF library: '.../priv/native/ch_compression_ex.so: ...'
```

The compiled `.so` files are gitignored and live in root `priv/native/` (_the `_build/.../priv` entry is just a symlink_), so they were never actually in the cache. Each `use Rustler` module only regenerates its `.so` when that module recompiles. When a native/dep change busts the exact cache key, `restore-keys` hands back a stale `_build` whose `.beam` make Mix skip the untouched NIF modules — so their `.so` silently never get rebuilt.

## Fix

- Add `priv/native` to the Mix cache path so the `.so` travel as a consistent set with `_build`.
- Add `target` to the Cargo cache so Rust crates don't recompile from scratch.
- Bump `mix-v2` → `mix-v3` to discard the poisoned caches (_fresh `.beam`, no `priv/native`_) and force one clean rebuild that seeds a correct cache.

Applied to all three workflows sharing the cache namespace: `elixir-ci.yml`, `e2e-tests.yml`, `elixir-migration-check.yml`.