### PR TITLE
fix: close endpoint version modal

### DIFF
--- a/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
@@ -173,7 +173,9 @@ defmodule LogflareWeb.EndpointsVersionsLive do
     {:noreply, socket}
   end
 
-  def handle_params(_params, _uri, socket), do: {:noreply, socket}
+  def handle_params(_params, _uri, socket) do
+    {:noreply, assign(socket, :selected_version, nil)}
+  end
 
   @impl true
   def handle_event("load-more", _params, %{assigns: %{next_cursor_id: nil}} = socket) do

--- a/test/logflare_web/live_views/endpoints_versions_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_versions_live_test.exs
@@ -143,6 +143,16 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       assert modal_html =~ "2 as version_number"
       assert modal_html =~ "snapshot description"
       assert_query_displayed(view, "select 2 as version_number")
+
+      view
+      |> element("#endpoint-version-snapshot-modal .phx-modal-close")
+      |> render_click()
+
+      patched_uri = assert_patch(view) |> URI.parse()
+
+      assert "/endpoints/#{endpoint.id}/versions" == patched_uri.path
+      assert "t=#{team.id}" == patched_uri.query
+      refute has_element?(view, "#endpoint-version-snapshot-modal")
     end
 
     test "loads additional versions", %{


### PR DESCRIPTION
Fixes an issue where closing the endpoint version modal would not clear the modal UI.

### Before
https://github.com/user-attachments/assets/25c3c429-fa68-4b41-afad-6ffc3dc3e757


### After


https://github.com/user-attachments/assets/cbacb8f2-5971-4428-980f-8d3ac5fcabc1

