### PR TITLE
feat: restore endpoint version

### DIFF
--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -169,6 +169,35 @@ defmodule Logflare.Endpoints do
     end
   end
 
+  @spec restore_query_version(EndpointQuery.t(), integer(), origin()) ::
+          {:ok, EndpointQuery.t(), integer()}
+          | {:error, Ecto.Changeset.t()}
+  def restore_query_version(%EndpointQuery{id: endpoint_id} = query, version_number, origin)
+      when is_integer(version_number) do
+    with {:version, %Version{id: version_id, meta: meta}} <-
+           {:version, get_endpoint_query_version(endpoint_id, version_number)},
+         {:restorable, true} <-
+           {:restorable, version_id != current_endpoint_version_id(endpoint_id)},
+         {:snapshot, snapshot} when is_map(snapshot) and map_size(snapshot) > 0 <-
+           {:snapshot, Map.get(meta, "endpoint_snapshot")},
+         {:ok, endpoint} <-
+           update_query(query, EndpointQuery.version_snapshot_attrs(snapshot), origin) do
+      {:ok, endpoint, version_number}
+    else
+      {:error, %Ecto.Changeset{}} = error ->
+        error
+
+      {:restorable, false} ->
+        {:error, invalid_restore_changeset(query, "Version is already current")}
+
+      {:snapshot, _} ->
+        {:error, invalid_restore_changeset(query, "Version snapshot is missing")}
+
+      {:version, nil} ->
+        {:error, invalid_restore_changeset(query, "Version not found")}
+    end
+  end
+
   @doc """
   Derives the SQL language from a backend ID.
 
@@ -253,6 +282,13 @@ defmodule Logflare.Endpoints do
 
   defp version_origin(%OauthAccessToken{id: id}), do: "API: id #{id}"
 
+  @spec invalid_restore_changeset(EndpointQuery.t(), String.t()) :: Ecto.Changeset.t()
+  defp invalid_restore_changeset(%EndpointQuery{} = query, message) do
+    query
+    |> change_query(%{})
+    |> Ecto.Changeset.add_error(:base, message)
+  end
+
   @spec lock_endpoint_query(EndpointQuery.t()) :: EndpointQuery.t()
   defp lock_endpoint_query(%EndpointQuery{id: query_id}) do
     from(query in EndpointQuery,
@@ -271,6 +307,17 @@ defmodule Logflare.Endpoints do
     )
     |> Repo.one()
     |> Kernel.+(1)
+  end
+
+  @spec current_endpoint_version_id(integer()) :: integer() | nil
+  defp current_endpoint_version_id(endpoint_id) do
+    from(version in Version,
+      where: version.item_type == "EndpointQuery" and version.item_id == ^endpoint_id,
+      order_by: [desc: version.id],
+      limit: 1,
+      select: version.id
+    )
+    |> Repo.one()
   end
 
   @spec should_kill_caches?(map()) :: boolean()

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -147,32 +147,42 @@ defmodule Logflare.Endpoints do
     |> EndpointQuery.update_by_user_changeset(attrs)
   end
 
-  @spec update_query(EndpointQuery.t(), map(), origin()) ::
+  @spec update_query(User.t() | TeamUser.t(), EndpointQuery.t(), map(), origin()) ::
           {:ok, EndpointQuery.t()} | {:error, Ecto.Changeset.t()}
-  def update_query(%EndpointQuery{} = query, params, origin) when is_map(params) do
-    Repo.transact(fn ->
-      query = lock_endpoint_query(query)
-      version_number = next_endpoint_version_number(query.id)
-      changeset = EndpointQuery.update_by_user_changeset(query, params)
-      opts = paper_trail_opts(changeset, origin, version_number)
+  def update_query(user_or_team_user, %EndpointQuery{} = query, params, origin)
+      when is_map(params) do
+    with :ok <- authorize_backend_id(query, backend_id(params), user_or_team_user) do
+      Repo.transact(fn ->
+        query = lock_endpoint_query(query)
+        version_number = next_endpoint_version_number(query.id)
+        changeset = EndpointQuery.update_by_user_changeset(query, params)
+        opts = paper_trail_opts(changeset, origin, version_number)
 
-      PaperTrail.update(changeset, opts)
-    end)
-    |> case do
-      {:ok, %{model: updated_query}} ->
-        changeset = query |> Repo.preload(:user) |> EndpointQuery.update_by_user_changeset(params)
-        maybe_kill_endpoint_caches(updated_query, changeset.changes)
-        {:ok, updated_query}
+        PaperTrail.update(changeset, opts)
+      end)
+      |> case do
+        {:ok, %{model: updated_query}} ->
+          changeset =
+            query |> Repo.preload(:user) |> EndpointQuery.update_by_user_changeset(params)
 
-      {:error, changeset} ->
-        {:error, changeset}
+          maybe_kill_endpoint_caches(updated_query, changeset.changes)
+          {:ok, updated_query}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
     end
   end
 
-  @spec restore_query_version(EndpointQuery.t(), integer(), origin()) ::
+  @spec restore_query_version(User.t() | TeamUser.t(), EndpointQuery.t(), integer(), origin()) ::
           {:ok, EndpointQuery.t(), integer()}
           | {:error, Ecto.Changeset.t()}
-  def restore_query_version(%EndpointQuery{id: endpoint_id} = query, version_number, origin)
+  def restore_query_version(
+        user_or_team_user,
+        %EndpointQuery{id: endpoint_id} = query,
+        version_number,
+        origin
+      )
       when is_integer(version_number) do
     with {:version, %Version{id: version_id, meta: meta}} <-
            {:version, get_endpoint_query_version(endpoint_id, version_number)},
@@ -180,21 +190,21 @@ defmodule Logflare.Endpoints do
            {:restorable, version_id != current_endpoint_version_id(endpoint_id)},
          {:snapshot, snapshot} when is_map(snapshot) and map_size(snapshot) > 0 <-
            {:snapshot, endpoint_snapshot(meta)},
-         {:ok, endpoint} <-
-           update_query(query, EndpointQuery.version_snapshot_attrs(snapshot), origin) do
+         attrs = EndpointQuery.version_snapshot_attrs(snapshot),
+         {:ok, endpoint} <- update_query(user_or_team_user, query, attrs, origin) do
       {:ok, endpoint, version_number}
     else
       {:error, %Ecto.Changeset{}} = error ->
         error
 
       {:restorable, false} ->
-        {:error, invalid_restore_changeset(query, "Version is already current")}
+        {:error, invalid_query_changeset(query, "Version is already current")}
 
       {:snapshot, _} ->
-        {:error, invalid_restore_changeset(query, "Version snapshot is missing")}
+        {:error, invalid_query_changeset(query, "Version snapshot is missing")}
 
       {:version, nil} ->
-        {:error, invalid_restore_changeset(query, "Version not found")}
+        {:error, invalid_query_changeset(query, "Version not found")}
     end
   end
 
@@ -286,8 +296,30 @@ defmodule Logflare.Endpoints do
   defp endpoint_snapshot(%{"endpoint_snapshot" => snapshot}), do: snapshot
   defp endpoint_snapshot(_meta), do: nil
 
-  @spec invalid_restore_changeset(EndpointQuery.t(), String.t()) :: Ecto.Changeset.t()
-  defp invalid_restore_changeset(%EndpointQuery{} = query, message) do
+  @spec backend_id(map()) :: integer() | String.t() | nil
+  defp backend_id(%{backend_id: backend_id}), do: backend_id
+  defp backend_id(%{"backend_id" => backend_id}), do: backend_id
+  defp backend_id(_attrs), do: nil
+
+  @spec authorize_backend_id(
+          EndpointQuery.t(),
+          integer() | String.t() | nil,
+          User.t() | TeamUser.t()
+        ) ::
+          :ok | {:error, Ecto.Changeset.t()}
+  defp authorize_backend_id(_query, backend_id, _user_or_team_user) when backend_id in [nil, ""],
+    do: :ok
+
+  defp authorize_backend_id(query, backend_id, user_or_team_user) do
+    if Backends.get_backend_by_user_access(user_or_team_user, backend_id) do
+      :ok
+    else
+      {:error, invalid_query_changeset(query, "Backend not found")}
+    end
+  end
+
+  @spec invalid_query_changeset(EndpointQuery.t(), String.t()) :: Ecto.Changeset.t()
+  defp invalid_query_changeset(%EndpointQuery{} = query, message) do
     query
     |> change_query(%{})
     |> Ecto.Changeset.add_error(:base, message)

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -24,6 +24,7 @@ defmodule Logflare.Endpoints do
   alias Logflare.SingleTenant
   alias Logflare.Sql
   alias Logflare.Teams
+  alias Logflare.TeamUsers
   alias Logflare.TeamUsers.TeamUser
   alias Logflare.User
   alias Logflare.Users
@@ -151,26 +152,26 @@ defmodule Logflare.Endpoints do
           {:ok, EndpointQuery.t()} | {:error, Ecto.Changeset.t()}
   def update_query(user_or_team_user, %EndpointQuery{} = query, params, origin)
       when is_map(params) do
-    with :ok <- authorize_backend_id(query, backend_id(params), user_or_team_user) do
-      Repo.transact(fn ->
+    Repo.transact(fn ->
+      with {:ok, query} <- authorize_update(user_or_team_user, query, params) do
         query = lock_endpoint_query(query)
         version_number = next_endpoint_version_number(query.id)
         changeset = EndpointQuery.update_by_user_changeset(query, params)
         opts = paper_trail_opts(changeset, origin, version_number)
 
         PaperTrail.update(changeset, opts)
-      end)
-      |> case do
-        {:ok, %{model: updated_query}} ->
-          changeset =
-            query |> Repo.preload(:user) |> EndpointQuery.update_by_user_changeset(params)
-
-          maybe_kill_endpoint_caches(updated_query, changeset.changes)
-          {:ok, updated_query}
-
-        {:error, changeset} ->
-          {:error, changeset}
       end
+    end)
+    |> case do
+      {:ok, %{model: updated_query}} ->
+        changeset =
+          query |> Repo.preload(:user) |> EndpointQuery.update_by_user_changeset(params)
+
+        maybe_kill_endpoint_caches(updated_query, changeset.changes)
+        {:ok, updated_query}
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 
@@ -301,18 +302,38 @@ defmodule Logflare.Endpoints do
   defp backend_id(%{"backend_id" => backend_id}), do: backend_id
   defp backend_id(_attrs), do: nil
 
-  @spec authorize_backend_id(
+  @spec authorize_update(User.t() | TeamUser.t(), EndpointQuery.t(), map()) ::
+          {:ok, EndpointQuery.t()} | {:error, Ecto.Changeset.t()}
+  defp authorize_update(user_or_team_user, query, params) do
+    user_or_team_user =
+      case user_or_team_user do
+        # Reload in case access changed
+        %TeamUser{id: team_user_id} -> TeamUsers.get_team_user_by(id: team_user_id)
+        %User{} = user -> user
+      end
+
+    with %_{} = user_or_team_user <- user_or_team_user,
+         %EndpointQuery{} = authorized_query <-
+           get_endpoint_query_by_user_access(user_or_team_user, query.id) do
+      authorize_backend(user_or_team_user, query, backend_id(params), authorized_query)
+    else
+      nil -> {:error, invalid_query_changeset(query, "Endpoint not found")}
+    end
+  end
+
+  @spec authorize_backend(
+          User.t() | TeamUser.t(),
           EndpointQuery.t(),
           integer() | String.t() | nil,
-          User.t() | TeamUser.t()
-        ) ::
-          :ok | {:error, Ecto.Changeset.t()}
-  defp authorize_backend_id(_query, backend_id, _user_or_team_user) when backend_id in [nil, ""],
-    do: :ok
+          EndpointQuery.t()
+        ) :: {:ok, EndpointQuery.t()} | {:error, Ecto.Changeset.t()}
+  defp authorize_backend(_user_or_team_user, _query, backend_id, authorized_query)
+       when backend_id in [nil, ""],
+       do: {:ok, authorized_query}
 
-  defp authorize_backend_id(query, backend_id, user_or_team_user) do
+  defp authorize_backend(user_or_team_user, query, backend_id, authorized_query) do
     if Backends.get_backend_by_user_access(user_or_team_user, backend_id) do
-      :ok
+      {:ok, authorized_query}
     else
       {:error, invalid_query_changeset(query, "Backend not found")}
     end

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -179,7 +179,7 @@ defmodule Logflare.Endpoints do
          {:restorable, true} <-
            {:restorable, version_id != current_endpoint_version_id(endpoint_id)},
          {:snapshot, snapshot} when is_map(snapshot) and map_size(snapshot) > 0 <-
-           {:snapshot, Map.get(meta, "endpoint_snapshot")},
+           {:snapshot, endpoint_snapshot(meta)},
          {:ok, endpoint} <-
            update_query(query, EndpointQuery.version_snapshot_attrs(snapshot), origin) do
       {:ok, endpoint, version_number}
@@ -281,6 +281,10 @@ defmodule Logflare.Endpoints do
        when is_non_empty_binary(description), do: "API: #{description}"
 
   defp version_origin(%OauthAccessToken{id: id}), do: "API: id #{id}"
+
+  @spec endpoint_snapshot(term()) :: term()
+  defp endpoint_snapshot(%{"endpoint_snapshot" => snapshot}), do: snapshot
+  defp endpoint_snapshot(_meta), do: nil
 
   @spec invalid_restore_changeset(EndpointQuery.t(), String.t()) :: Ecto.Changeset.t()
   defp invalid_restore_changeset(%EndpointQuery{} = query, message) do

--- a/lib/logflare/endpoints/endpoint_query.ex
+++ b/lib/logflare/endpoints/endpoint_query.ex
@@ -18,7 +18,6 @@ defmodule Logflare.Endpoints.EndpointQuery do
   alias Logflare.User
 
   @version_snapshot_fields [
-    :token,
     :name,
     :query,
     :description,
@@ -95,6 +94,29 @@ defmodule Logflare.Endpoints.EndpointQuery do
     changeset
     |> Changeset.apply_changes()
     |> Map.take(@version_snapshot_fields)
+  end
+
+  def version_snapshot(%__MODULE__{} = query) do
+    Map.take(query, @version_snapshot_fields)
+  end
+
+  @spec version_snapshot_attrs(map()) :: map()
+  def version_snapshot_attrs(snapshot) when is_map(snapshot) do
+    fields =
+      Enum.filter(@version_snapshot_fields, fn field ->
+        Map.has_key?(snapshot, Atom.to_string(field))
+      end)
+
+    snapshot
+    |> from_version_snapshot()
+    |> Map.take(fields)
+  end
+
+  @spec from_version_snapshot(map()) :: t()
+  def from_version_snapshot(snapshot) when is_map(snapshot) do
+    %__MODULE__{}
+    |> Changeset.cast(snapshot, @version_snapshot_fields)
+    |> Changeset.apply_changes()
   end
 
   @doc false

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -85,7 +85,7 @@ defmodule LogflareWeb.Api.EndpointController do
          origin <- conn.assigns[:access_token] || user,
          query when not is_nil(query) <-
            Endpoints.get_endpoint_query_by_user_access(user, token: token),
-         {:ok, query} <- Endpoints.update_query(query, params, origin) do
+         {:ok, query} <- Endpoints.update_query(user, query, params, origin) do
       conn
       |> case do
         %{method: "PUT"} ->

--- a/lib/logflare_web/core_components.ex
+++ b/lib/logflare_web/core_components.ex
@@ -61,6 +61,10 @@ defmodule LogflareWeb.CoreComponents do
 
   attr :id, :string, required: false
   attr :disabled, :boolean, default: false
+  attr :button_class, :any, default: "btn btn-primary"
+  attr :placement, :string, default: "below", values: ["above", "below"]
+  attr :pin, :string, default: "left", values: ["left", "right"]
+
   slot :inner_block, required: true
 
   slot :menu_item, required: true do
@@ -68,14 +72,20 @@ defmodule LogflareWeb.CoreComponents do
   end
 
   def button_dropdown(assigns) do
-    assigns = assigns |> assign_new(:id, fn -> "button-dropdown-#{UUID.uuid4()}" end)
+    assigns =
+      assigns
+      |> assign_new(:id, fn -> "button-dropdown-#{UUID.uuid4()}" end)
+      |> assign_new(:menu_class, fn
+        %{placement: placement, pin: pin} ->
+          [button_dropdown_placement_class(placement), button_dropdown_pin_class(pin)]
+      end)
 
     ~H"""
     <div class="tw-relative" id={@id}>
-      <button type="button" class="btn btn-primary" phx-click={JS.toggle(to: "##{@id} ul")} disabled={@disabled}>
+      <button type="button" class={@button_class} phx-click={JS.toggle(to: "##{@id} ul")} disabled={@disabled}>
         {render_slot(@inner_block)}
       </button>
-      <ul phx-click-away={JS.hide()} style="display: none;" class="tw-absolute tw-left-0 tw-m-0 tw-px-0 tw-bottom-full tw-bg-white tw-rounded-md tw-border tw-border-gray-300 tw-shadow tw-py-2 tw-min-w-[11rem] tw-list-none tw-z-10">
+      <ul phx-click-away={JS.hide()} style="display: none;" class={[@menu_class, "tw-absolute tw-m-0 tw-px-0 tw-bg-white tw-rounded-md tw-border tw-border-gray-300 tw-shadow tw-py-2 tw-min-w-[11rem] tw-list-none tw-z-10"]}>
         <%= for menu_item <- @menu_item do %>
           <li :if={menu_item[:heading]} class="tw-mt-2 first:tw-mt-0 tw-border-0 tw-border-t first:tw-border-t-0 tw-border-solid tw-border-gray-200 tw-px-3 tw-pt-2 tw-pb-1 tw-text-xs tw-font-semibold tw-text-gray-500 tw-uppercase">
             {menu_item.heading}
@@ -86,6 +96,42 @@ defmodule LogflareWeb.CoreComponents do
         <% end %>
       </ul>
     </div>
+    """
+  end
+
+  defp button_dropdown_placement_class("above"), do: "tw-mb-2 tw-bottom-full"
+  defp button_dropdown_placement_class("below"), do: "tw-mt-2 tw-top-full"
+
+  defp button_dropdown_pin_class("left"), do: "tw-left-0"
+  defp button_dropdown_pin_class("right"), do: "tw-right-0"
+
+  attr :href, :string, default: "#"
+  attr :class, :any, default: "tw-block tw-text-gray-500"
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def button_dropdown_menu_link(assigns) do
+    ~H"""
+    <a href={@href} class={["tw-no-underline", @class]} {@rest}>
+      {render_slot(@inner_block)}
+    </a>
+    """
+  end
+
+  attr :class, :any,
+    default:
+      "tw-block tw-text-gray-500 tw-w-full tw-border-0 tw-bg-transparent tw-p-0 tw-text-left"
+
+  attr :rest, :global, include: ~w(type)
+
+  slot :inner_block, required: true
+
+  def button_dropdown_menu_button(assigns) do
+    ~H"""
+    <button type="button" class={@class} {@rest}>
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 

--- a/lib/logflare_web/live/endpoints/endpoints_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_live.ex
@@ -505,7 +505,7 @@ defmodule LogflareWeb.EndpointsLive do
   defp upsert_query(show_endpoint, user, origin, params) do
     case show_endpoint do
       nil -> Endpoints.create_query(user, params, origin)
-      %_{} -> Endpoints.update_query(show_endpoint, params, origin)
+      %_{} -> Endpoints.update_query(origin, show_endpoint, params, origin)
     end
   end
 

--- a/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
@@ -27,14 +27,29 @@ defmodule LogflareWeb.EndpointsVersionsLive do
         </.subheader_path_link>/versions
       </:path>
     </.subheader>
-
+    <script>
+      window.addEventListener("phx:hide-restoring-indicator", () => {
+        document.getElementById("restoring-indicator")?.classList.add("tw-hidden")
+      })
+    </script>
     <.versions versions={@streams.versions} current_version_id={@current_version_id} load_more?={not is_nil(@next_cursor_id)} loading?={@load_more_versions.loading}>
+      <:subhead>
+        <div id="restoring-indicator" class="tw-hidden">
+          <div class="tw-h-16 tw-rounded tw-border tw-border-zinc-900 tw-bg-dashboard-grey tw-animate-pulse tw-flex tw-items-center tw-justify-center tw-text-zinc-200">
+            Restoring
+          </div>
+        </div>
+      </:subhead>
       <:col :let={version} class="lg:tw-col-span-1" label="Version">
-        <span :if={version.id == @current_version_id} class="tw-inline-flex tw-items-center tw-rounded-sm tw-bg-[#2155a3] tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-white">
-          current
-        </span>
-        <div class="tw-w-full lg:tw-text-right tw-pt-1 tw-text-sm tw-font-medium tw-text-white ">
-          {version_number(version)}
+        <div class="tw-flex tw-w-full tw-flex-col tw-items-start tw-gap-2 lg:tw-items-end">
+          <div class="tw-px-2 tw-py-1 tw-text-sm tw-font-medium tw-text-white">
+            {version_number(version)}
+          </div>
+          <div :if={version.id == @current_version_id}>
+            <span class="tw-inline-flex tw-items-center tw-rounded-sm tw-bg-[#2155a3] tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-white">
+              current
+            </span>
+          </div>
         </div>
       </:col>
       <:col :let={version} class="lg:tw-col-span-7" label="Changes">
@@ -46,16 +61,7 @@ defmodule LogflareWeb.EndpointsVersionsLive do
         <span class="tw-text-sm tw-font-medium tw-text-zinc-300 lg:tw-whitespace-nowrap">{version.origin || "unknown"}</span>
       </:col>
       <:col :let={version} class="lg:tw-col-span-2" label="Updated">
-        <div class="tw-flex tw-flex-col tw-gap-0.5">
-          <span class="tw-text-sm tw-font-medium tw-text-zinc-200 tw-tabular-nums">
-            {Calendar.strftime(version.inserted_at, "%Y-%m-%d %H:%M:%S UTC")}
-          </span>
-          <div class="tw-flex tw-items-center tw-gap-2">
-            <span class="tw-text-xs tw-text-zinc-500 ">
-              {time_ago(version.inserted_at)}
-            </span>
-          </div>
-        </div>
+        <.version_updated version={version} current_version_id={@current_version_id} />
       </:col>
     </.versions>
 
@@ -88,28 +94,31 @@ defmodule LogflareWeb.EndpointsVersionsLive do
     attr :class, :string
   end
 
+  slot :subhead
+
   def versions(assigns) do
     ~H"""
-    <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-5">
+    <section class="mx-auto container pt-3 tw-flex tw-flex-col tw-gap-5 ">
       <div class="tw-hidden lg:tw-grid tw-grid-cols-12 tw-px-4 tw-text-left tw-text-sm tw-font-semibold tw-text-zinc-400">
         <div :for={col <- @col} class={["first:tw-text-center tw-px-4 tw-py-2", col[:class]]}>{col.label}</div>
       </div>
 
+      {render_slot(@subhead)}
       <div class="tw-flex tw-flex-col tw-gap-3" id="endpoint-versions" phx-update="stream">
         <div id="versions-empty" class="tw-hidden only:tw-flex tw-min-h-[12rem] tw-w-full tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-zinc-800 tw-bg-dashboard-grey tw-p-4 tw-text-center">
           <p class="tw-mb-0 tw-text-zinc-400">
             No versions recorded for this endpoint.
           </p>
         </div>
-        <a
+        <div
           :for={{dom_id, version} <- @versions}
           id={dom_id}
-          phx-click="show-version"
-          phx-value-version-number={version_number(version)}
-          href="#"
-          class="tw-block tw-rounded tw-border tw-border-zinc-900 tw-bg-dashboard-grey tw-no-underline hover:tw-border-zinc-700 hover:tw-bg-[#232323] focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-[#2155a3] lg:tw-grid tw-grid-cols-12"
+          class="tw-relative tw-z-0 tw-block tw-rounded tw-border tw-border-zinc-900 tw-bg-dashboard-grey tw-no-underline hover:tw-border-zinc-700 hover:tw-bg-[#232323] focus-within:tw-z-30 focus-within:tw-outline-none focus-within:tw-ring-2 focus-within:tw-ring-[#2155a3] lg:tw-grid tw-grid-cols-12"
         >
-          <div :for={col <- @col} class={["tw-px-4 tw-py-2", col[:class]]}>
+          <button type="button" class="tw-absolute tw-inset-0 tw-z-10 tw-w-full tw-border-0 tw-bg-transparent tw-p-0" phx-click="show-version" phx-value-version-number={version_number(version)}>
+            <span class="tw-sr-only">Show version {version_number(version)}</span>
+          </button>
+          <div :for={col <- @col} class={["tw-pointer-events-none tw-relative tw-z-20 tw-px-4 tw-py-2", col[:class]]}>
             <div class="tw-mb-2 lg:tw-hidden tw-text-sm tw-font-semibold tw-text-zinc-400">
               {col.label}
             </div>
@@ -117,7 +126,7 @@ defmodule LogflareWeb.EndpointsVersionsLive do
               {render_slot(col, version)}
             </div>
           </div>
-        </a>
+        </div>
       </div>
 
       <div :if={@load_more?} class="tw-flex tw-justify-center">
@@ -129,6 +138,49 @@ defmodule LogflareWeb.EndpointsVersionsLive do
     """
   end
 
+  attr :version, Version, required: true
+  attr :current_version_id, :integer, default: nil
+
+  def version_updated(assigns) do
+    ~H"""
+    <div class="tw-flex tw-flex-col tw-gap-0.5">
+      <span class="tw-text-sm tw-font-medium tw-text-zinc-200 tw-tabular-nums">
+        {Calendar.strftime(@version.inserted_at, "%Y-%m-%d %H:%M:%S UTC")}
+      </span>
+      <div class="tw-flex tw-w-full tw-items-center tw-gap-2 -tw-mr-6">
+        <span :if={relative_time_ago(@version.inserted_at)} class="tw-text-xs tw-text-zinc-500 ">
+          {relative_time_ago(@version.inserted_at)}
+        </span>
+        <div :if={@version.id != @current_version_id} class="tw-pointer-events-auto tw-ml-auto tw-shrink-0 -tw-mr-6">
+          <.version_actions version={@version} />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :version, Version, required: true
+
+  def version_actions(assigns) do
+    ~H"""
+    <.button_dropdown id={"endpoint-version-actions-#{@version.id}"} button_class="btn btn-link" placement="below" pin="right">
+      <span class="tw-sr-only">Version actions</span>
+      <i class="fas fa-ellipsis-h" aria-hidden="true"></i>
+      <:menu_item>
+        <.button_dropdown_menu_button phx-click={restore_version()} phx-value-version-number={version_number(@version)}>
+          Restore
+        </.button_dropdown_menu_button>
+      </:menu_item>
+    </.button_dropdown>
+    """
+  end
+
+  defp restore_version,
+    do:
+      JS.remove_class("tw-hidden", to: "#restoring-indicator")
+      |> JS.push("restore-version")
+      |> JS.dispatch("click", to: "body")
+
   @impl true
   def mount(%{"id" => endpoint_id} = params, _session, socket) do
     user = socket.assigns.team_user || socket.assigns.user
@@ -139,16 +191,11 @@ defmodule LogflareWeb.EndpointsVersionsLive do
           redirect(socket, to: ~p"/endpoints")
 
         endpoint ->
-          {versions, next_cursor_id} = fetch_page(endpoint.id)
-
           socket
           |> assign(:endpoint, endpoint)
-          |> assign(:current_version_id, current_version_id(versions))
-          |> assign(:next_cursor_id, next_cursor_id)
-          |> assign(:load_more_versions, AsyncResult.ok(nil))
           |> assign(:selected_version, nil)
           |> maybe_assign_team_context(params, endpoint)
-          |> stream(:versions, versions, reset: true)
+          |> assign_versions(endpoint)
       end
 
     {:ok, socket}
@@ -164,7 +211,7 @@ defmodule LogflareWeb.EndpointsVersionsLive do
              Endpoints.get_endpoint_query_version(endpoint.id, version_number) do
         socket
         |> assign(:selected_version, selected_version)
-        |> assign(:endpoint_snapshot, snapshot_to_endpoint(selected_version))
+        |> assign(:endpoint_snapshot, version_endpoint_snapshot(selected_version))
       else
         _ ->
           socket
@@ -215,7 +262,51 @@ defmodule LogflareWeb.EndpointsVersionsLive do
      )}
   end
 
+  def handle_event("restore-version", %{"version-number" => version_number}, socket) do
+    endpoint = socket.assigns.endpoint
+    user = socket.assigns.team_user || socket.assigns.user
+
+    case Integer.parse(version_number) do
+      {version_number, ""} ->
+        socket =
+          socket
+          |> start_async(:version_restored, fn ->
+            Endpoints.restore_query_version(endpoint, version_number, user)
+          end)
+
+        {:noreply, socket}
+
+      _ ->
+        {:noreply,
+         socket
+         |> push_event("hide-restoring-indicator", %{})
+         |> put_flash(:error, "Unable to restore endpoint version.")}
+    end
+  end
+
   @impl true
+  def handle_async(:version_restored, {:ok, {:ok, endpoint, original_version_number}}, socket) do
+    socket =
+      socket
+      |> assign(:endpoint, endpoint)
+      |> push_event("hide-restoring-indicator", %{})
+      |> assign_versions(endpoint)
+
+    {:noreply,
+     put_flash(
+       socket,
+       :info,
+       "Restored endpoint version #{original_version_number} as new version #{socket.assigns.current_version_number}."
+     )}
+  end
+
+  def handle_async(:version_restored, _, socket) do
+    {:noreply,
+     socket
+     |> push_event("hide-restoring-indicator", %{})
+     |> put_flash(:error, "Unable to restore endpoint version.")}
+  end
+
   def handle_async(:load_more_versions, {:ok, {versions, next_cursor_id}}, socket) do
     {:noreply,
      socket
@@ -251,6 +342,19 @@ defmodule LogflareWeb.EndpointsVersionsLive do
     |> Repo.all()
   end
 
+  @spec assign_versions(Phoenix.LiveView.Socket.t(), EndpointQuery.t()) ::
+          Phoenix.LiveView.Socket.t()
+  defp assign_versions(socket, %EndpointQuery{id: endpoint_id}) do
+    {versions, next_cursor_id} = fetch_page(endpoint_id)
+
+    socket
+    |> assign(:current_version_id, current_version_id(versions))
+    |> assign(:current_version_number, current_version_number(versions))
+    |> assign(:next_cursor_id, next_cursor_id)
+    |> assign(:load_more_versions, AsyncResult.ok(nil))
+    |> stream(:versions, versions, reset: true)
+  end
+
   @spec maybe_filter_after_version(Ecto.Queryable.t(), integer() | nil) :: Ecto.Query.t()
   defp maybe_filter_after_version(query, nil), do: query
 
@@ -261,6 +365,10 @@ defmodule LogflareWeb.EndpointsVersionsLive do
   @spec current_version_id([Version.t()]) :: integer() | nil
   defp current_version_id([%Version{id: version_id} | _]), do: version_id
   defp current_version_id(_versions), do: nil
+
+  @spec current_version_number([Version.t()]) :: integer() | nil
+  defp current_version_number([%Version{} = version | _]), do: version_number(version)
+  defp current_version_number(_versions), do: nil
 
   @spec next_cursor_id([Version.t()]) :: integer() | nil
   defp next_cursor_id(versions) do
@@ -302,6 +410,17 @@ defmodule LogflareWeb.EndpointsVersionsLive do
 
   defp version_query_diff(_version), do: []
 
+  @spec relative_time_ago(DateTime.t() | NaiveDateTime.t()) :: String.t() | nil
+  defp relative_time_ago(datetime) do
+    relative = time_ago(datetime)
+
+    if relative == Calendar.strftime(datetime, "%Y-%m-%d") do
+      nil
+    else
+      relative
+    end
+  end
+
   defp query_diff_class("eq"), do: "tw-text-zinc-500"
   defp query_diff_class("del"), do: "tw-bg-red-950/40 tw-text-red-300 tw-line-through"
   defp query_diff_class("ins"), do: "tw-bg-emerald-950/40 tw-font-bold tw-text-emerald-400 px-1"
@@ -313,13 +432,11 @@ defmodule LogflareWeb.EndpointsVersionsLive do
   defp version_number(%Version{meta: %{"version_number" => version_number}}), do: version_number
   defp version_number(_version), do: nil
 
-  @spec snapshot_to_endpoint(Version.t()) :: EndpointQuery.t()
-  defp snapshot_to_endpoint(version) do
-    snapshot = Map.get(version.meta, "endpoint_snapshot", %{})
-
-    %EndpointQuery{}
-    |> Ecto.Changeset.cast(snapshot, EndpointQuery.version_snapshot_fields())
-    |> Ecto.Changeset.apply_changes()
+  @spec version_endpoint_snapshot(Version.t()) :: EndpointQuery.t()
+  defp version_endpoint_snapshot(%Version{meta: meta}) when is_map(meta) do
+    meta
+    |> Map.get("endpoint_snapshot", %{})
+    |> EndpointQuery.from_version_snapshot()
   end
 
   defp maybe_assign_team_context(socket, %{"t" => _team_id}, _endpoint), do: socket

--- a/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
+++ b/lib/logflare_web/live/endpoints/endpoints_versions_live.ex
@@ -271,7 +271,7 @@ defmodule LogflareWeb.EndpointsVersionsLive do
         socket =
           socket
           |> start_async(:version_restored, fn ->
-            Endpoints.restore_query_version(endpoint, version_number, user)
+            Endpoints.restore_query_version(user, endpoint, version_number, user)
           end)
 
         {:noreply, socket}

--- a/lib/logflare_web/live/search_live/form_components.ex
+++ b/lib/logflare_web/live/search_live/form_components.ex
@@ -320,7 +320,7 @@ defmodule LogflareWeb.SearchLive.FormComponents do
 
   def create_menu(assigns) do
     ~H"""
-    <.button_dropdown id="create-menu" disabled={@disabled}>
+    <.button_dropdown id="create-menu" disabled={@disabled} placement="above">
       <i class="fas fa-plus"></i>
       Create new...
       <:menu_item :if={Utils.flag("endpointsOpenBeta", @user)} heading="Endpoint">
@@ -357,7 +357,9 @@ defmodule LogflareWeb.SearchLive.FormComponents do
       end)
 
     ~H"""
-    <a phx-click="create_new" phx-value-resource={@resource} phx-value-kind={@kind} class="tw-block tw-text-gray-500 tw-no-underline" href="#">{@label}</a>
+    <.button_dropdown_menu_link phx-click="create_new" phx-value-resource={@resource} phx-value-kind={@kind}>
+      {@label}
+    </.button_dropdown_menu_link>
     """
   end
 end

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -134,7 +134,7 @@ defmodule Logflare.EndpointsTest do
                Endpoints.update_query(endpoint, %{query: "select a from my_table"}, user)
 
       assert_endpoint_version(endpoint, 1, user.email)
-      assert_endpoint_version(updated, 2, user.email, endpoint.token)
+      assert_endpoint_version(updated, 2, user.email)
     end
 
     test "update_query/3 does not create a version row when the update fails", %{user: user} do
@@ -155,7 +155,7 @@ defmodule Logflare.EndpointsTest do
 
       assert {:ok, deleted_endpoint} = Endpoints.delete_query(endpoint, user)
       assert_endpoint_version(endpoint, 1, user.email)
-      assert_endpoint_version(deleted_endpoint, 2, user.email, endpoint.token)
+      assert_endpoint_version(deleted_endpoint, 2, user.email)
     end
 
     test "get_endpoint_query_version/2 returns the requested version", %{
@@ -180,6 +180,58 @@ defmodule Logflare.EndpointsTest do
                Endpoints.get_endpoint_query_version(endpoint.id, 1)
 
       assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 99)
+    end
+
+    test "restore_query_version/3 restores a historical version by requested version number", %{
+      user: user
+    } do
+      endpoint = insert(:endpoint, user: user, description: "second description")
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 1,
+        origin: user.email,
+        snapshot_overrides: %{"description" => "first description"}
+      )
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 2,
+        origin: user.email
+      )
+
+      assert {:ok, restored_endpoint, 1} =
+               Endpoints.restore_query_version(endpoint, 1, user)
+
+      assert restored_endpoint.description == "first description"
+      assert restored_endpoint.token == endpoint.token
+      assert_endpoint_version(restored_endpoint, 3, user.email)
+    end
+
+    test "restore_query_version/3 rejects current and missing version numbers", %{
+      user: user
+    } do
+      endpoint = insert(:endpoint, user: user)
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 1,
+        origin: user.email
+      )
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 2,
+        origin: user.email
+      )
+
+      assert {:error, changeset} = Endpoints.restore_query_version(endpoint, 2, user)
+      assert "Version is already current" in errors_on(changeset).base
+
+      assert {:error, changeset} = Endpoints.restore_query_version(endpoint, 99, user)
+      assert "Version not found" in errors_on(changeset).base
+
+      assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 3)
     end
   end
 
@@ -218,8 +270,7 @@ defmodule Logflare.EndpointsTest do
                }
              ] = versions_for_endpoint(endpoint)
 
-      assert version_meta["endpoint_snapshot"] ==
-               expected_endpoint_snapshot(endpoint, %{"token" => nil})
+      assert version_meta["endpoint_snapshot"] == expected_endpoint_snapshot(endpoint)
     end
 
     test "create_query/3 writes version 1 with TeamUser origin", %{
@@ -239,8 +290,7 @@ defmodule Logflare.EndpointsTest do
                }
              ] = versions_for_endpoint(endpoint)
 
-      assert version_meta["endpoint_snapshot"] ==
-               expected_endpoint_snapshot(endpoint, %{"token" => nil})
+      assert version_meta["endpoint_snapshot"] == expected_endpoint_snapshot(endpoint)
     end
 
     test "create_query/3 writes version 1 with the expected API token description origin", %{
@@ -259,8 +309,7 @@ defmodule Logflare.EndpointsTest do
                }
              ] = versions_for_endpoint(endpoint)
 
-      assert version_meta["endpoint_snapshot"] ==
-               expected_endpoint_snapshot(endpoint, %{"token" => nil})
+      assert version_meta["endpoint_snapshot"] == expected_endpoint_snapshot(endpoint)
     end
 
     test "update_query/3 increments the version number and preserves the snapshot contract", %{
@@ -1036,13 +1085,12 @@ defmodule Logflare.EndpointsTest do
       "query" => endpoint.query,
       "redact_pii" => endpoint.redact_pii,
       "sandboxable" => endpoint.sandboxable,
-      "source_mapping" => endpoint.source_mapping,
-      "token" => endpoint.token
+      "source_mapping" => endpoint.source_mapping
     }
     |> Map.merge(overrides)
   end
 
-  defp assert_endpoint_version(endpoint, version_number, expected_origin, expected_token \\ nil) do
+  defp assert_endpoint_version(endpoint, version_number, expected_origin) do
     assert version =
              Endpoints.get_endpoint_query_version(endpoint.id, version_number)
 
@@ -1050,7 +1098,7 @@ defmodule Logflare.EndpointsTest do
     assert version.meta["version_number"] == version_number
 
     assert version.meta["endpoint_snapshot"] ==
-             expected_endpoint_snapshot(endpoint, %{"token" => expected_token})
+             expected_endpoint_snapshot(endpoint)
 
     version
   end

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.EndpointsTest do
 
   import Logflare.ClickHouseMappedEvents, only: [build_mapped_log_event: 1]
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.Backends.Adaptor.QueryResult
@@ -122,7 +123,7 @@ defmodule Logflare.EndpointsTest do
       assert_endpoint_version(endpoint, 1, "API: Acme")
     end
 
-    test "update_query/3 increments the version number and stores the updated snapshot", %{
+    test "update_query/4 increments the version number and stores the updated snapshot", %{
       user: user
     } do
       insert(:source, user: user, name: "my_table")
@@ -131,22 +132,39 @@ defmodule Logflare.EndpointsTest do
                Endpoints.create_query(user, @endpoint_query_attrs, user)
 
       assert {:ok, updated} =
-               Endpoints.update_query(endpoint, %{query: "select a from my_table"}, user)
+               Endpoints.update_query(user, endpoint, %{query: "select a from my_table"}, user)
 
       assert_endpoint_version(endpoint, 1, user.email)
       assert_endpoint_version(updated, 2, user.email)
     end
 
-    test "update_query/3 does not create a version row when the update fails", %{user: user} do
+    test "update_query/4 does not create a version row when the update fails", %{user: user} do
       assert {:ok, endpoint} =
                Endpoints.create_query(user, @endpoint_query_attrs, user)
 
       assert_endpoint_version(endpoint, 1, user.email)
 
       assert {:error, %Ecto.Changeset{}} =
-               Endpoints.update_query(endpoint, %{query: "select b from unknown"}, user)
+               Endpoints.update_query(user, endpoint, %{query: "select b from unknown"}, user)
 
       assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 2)
+    end
+
+    test "update_query/4 verifies user access to backend", %{user: user} do
+      endpoint = insert(:endpoint, user: user)
+      inaccessible_backend = insert(:backend)
+
+      assert {:error, changeset} =
+               Endpoints.update_query(
+                 user,
+                 endpoint,
+                 %{backend_id: inaccessible_backend.id},
+                 user
+               )
+
+      assert "Backend not found" in errors_on(changeset).base
+      assert Endpoints.get_endpoint_query(endpoint.id).backend_id == endpoint.backend_id
+      assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 1)
     end
 
     test "delete_query/2 stores the next version after prior history", %{user: user} do
@@ -182,7 +200,7 @@ defmodule Logflare.EndpointsTest do
       assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 99)
     end
 
-    test "restore_query_version/3 restores a historical version by requested version number", %{
+    test "restore_query_version/4 restores a historical version by requested version number", %{
       user: user
     } do
       endpoint = insert(:endpoint, user: user, description: "second description")
@@ -201,14 +219,47 @@ defmodule Logflare.EndpointsTest do
       )
 
       assert {:ok, restored_endpoint, 1} =
-               Endpoints.restore_query_version(endpoint, 1, user)
+               Endpoints.restore_query_version(user, endpoint, 1, user)
 
       assert restored_endpoint.description == "first description"
       assert restored_endpoint.token == endpoint.token
       assert_endpoint_version(restored_endpoint, 3, user.email)
     end
 
-    test "restore_query_version/3 rejects current and missing version numbers", %{
+    test "restore_query_version/4 rejects a backend inaccessible to the actor", %{user: user} do
+      team = insert(:team, user: user)
+      team_user = insert(:team_user, team: team)
+      current_backend = insert(:backend, user: user)
+      inaccessible_backend = insert(:backend)
+      endpoint = insert(:endpoint, user: user, backend: current_backend)
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 1,
+        origin: user.email,
+        snapshot_overrides: %{"backend_id" => inaccessible_backend.id}
+      )
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 2,
+        origin: user.email
+      )
+
+      assert %EndpointQuery{} =
+               Endpoints.get_endpoint_query_by_user_access(team_user, endpoint.id)
+
+      assert nil == Backends.get_backend_by_user_access(team_user, inaccessible_backend.id)
+
+      assert {:error, changeset} =
+               Endpoints.restore_query_version(team_user, endpoint, 1, team_user)
+
+      assert "Backend not found" in errors_on(changeset).base
+      assert Endpoints.get_endpoint_query(endpoint.id).backend_id == current_backend.id
+      assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 3)
+    end
+
+    test "restore_query_version/4 rejects current and missing version numbers", %{
       user: user
     } do
       endpoint = insert(:endpoint, user: user)
@@ -225,17 +276,17 @@ defmodule Logflare.EndpointsTest do
         origin: user.email
       )
 
-      assert {:error, changeset} = Endpoints.restore_query_version(endpoint, 2, user)
+      assert {:error, changeset} = Endpoints.restore_query_version(user, endpoint, 2, user)
       assert "Version is already current" in errors_on(changeset).base
 
-      assert {:error, changeset} = Endpoints.restore_query_version(endpoint, 99, user)
+      assert {:error, changeset} = Endpoints.restore_query_version(user, endpoint, 99, user)
       assert "Version not found" in errors_on(changeset).base
 
       assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 3)
     end
   end
 
-  test "update_query/3 " do
+  test "update_query/4" do
     user = insert(:user)
     source = insert(:source, user: user, name: "my_table")
     endpoint = insert(:endpoint, user: user, query: "select current_datetime() as date")
@@ -243,11 +294,11 @@ defmodule Logflare.EndpointsTest do
     allow_context_cache_sandbox()
     warm_endpoint_query_validation_caches(source)
 
-    assert {:ok, %{query: ^sql}} = Endpoints.update_query(endpoint, %{query: sql}, user)
+    assert {:ok, %{query: ^sql}} = Endpoints.update_query(user, endpoint, %{query: sql}, user)
 
     # does not allow updating of query with unknown sources
     assert {:error, %Ecto.Changeset{}} =
-             Endpoints.update_query(endpoint, %{query: "select b from unknown"}, user)
+             Endpoints.update_query(user, endpoint, %{query: "select b from unknown"}, user)
   end
 
   describe "endpoint query history" do
@@ -312,7 +363,7 @@ defmodule Logflare.EndpointsTest do
       assert version_meta["endpoint_snapshot"] == expected_endpoint_snapshot(endpoint)
     end
 
-    test "update_query/3 increments the version number and preserves the snapshot contract", %{
+    test "update_query/4 increments the version number and preserves the snapshot contract", %{
       user: user,
       endpoint_params: endpoint_params
     } do
@@ -332,7 +383,7 @@ defmodule Logflare.EndpointsTest do
         labels: "environment"
       }
 
-      assert {:ok, updated_endpoint} = Endpoints.update_query(endpoint, params, user)
+      assert {:ok, updated_endpoint} = Endpoints.update_query(user, endpoint, params, user)
       origin = user.email
 
       assert [
@@ -348,7 +399,7 @@ defmodule Logflare.EndpointsTest do
                expected_endpoint_snapshot(updated_endpoint)
     end
 
-    test "update_query/3 rollback path leaves history unchanged when the update fails", %{
+    test "update_query/4 rollback path leaves history unchanged when the update fails", %{
       user: user,
       endpoint_params: endpoint_params
     } do
@@ -357,7 +408,7 @@ defmodule Logflare.EndpointsTest do
       assert [%Version{id: create_version_id}] = versions_for_endpoint(endpoint)
 
       assert {:error, %Ecto.Changeset{}} =
-               Endpoints.update_query(endpoint, %{query: "select b from unknown"}, user)
+               Endpoints.update_query(user, endpoint, %{query: "select b from unknown"}, user)
 
       assert [
                %Version{
@@ -374,7 +425,7 @@ defmodule Logflare.EndpointsTest do
       assert {:ok, endpoint} = Endpoints.create_query(user, endpoint_params, user)
 
       assert {:ok, updated_endpoint} =
-               Endpoints.update_query(endpoint, %{labels: "environment"}, user)
+               Endpoints.update_query(user, endpoint, %{labels: "environment"}, user)
 
       assert {:ok, deleted_endpoint} = Endpoints.delete_query(updated_endpoint, user)
       origin = user.email
@@ -400,7 +451,7 @@ defmodule Logflare.EndpointsTest do
       assert {:ok, endpoint} = Endpoints.create_query(user, endpoint_params, user)
 
       assert {:ok, _updated_endpoint} =
-               Endpoints.update_query(endpoint, %{labels: "environment"}, user)
+               Endpoints.update_query(user, endpoint, %{labels: "environment"}, user)
 
       assert %Version{id: version_1_id} =
                Endpoints.get_endpoint_query_version(endpoint.id, 1)
@@ -849,7 +900,7 @@ defmodule Logflare.EndpointsTest do
           :enable_auth,
           :labels
         ] do
-      test "update_query/3 will kill all existing caches on field change (#{field_changed})" do
+      test "update_query/4 will kill all existing caches on field change (#{field_changed})" do
         expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 2, fn _, _, _ ->
           {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
         end)
@@ -869,7 +920,7 @@ defmodule Logflare.EndpointsTest do
             key -> Map.new([{key, 123}])
           end
 
-        assert {:ok, updated} = Endpoints.update_query(endpoint, params, user)
+        assert {:ok, updated} = Endpoints.update_query(user, endpoint, params, user)
         # should kill the cache process
         :timer.sleep(500)
         refute Process.alive?(cache_pid)

--- a/test/logflare_web/live_views/endpoints_versions_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_versions_live_test.exs
@@ -3,6 +3,7 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
 
   use LogflareWeb.ConnCase
 
+  alias Logflare.Endpoints
   alias PaperTrail.Version
 
   setup %{conn: conn} do
@@ -25,7 +26,47 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       {:ok, view, html} = live(conn, ~p"/endpoints/#{endpoint.id}/versions?t=#{team}")
 
       assert html =~ "No versions recorded for this endpoint."
-      refute has_element?(view, "#endpoint-versions a[id^='versions-']")
+
+      refute has_element?(
+               view,
+               "#endpoint-versions div[id^='versions-'] button[phx-click='show-version']"
+             )
+    end
+
+    test "omits relative timestamp when the version is older than a week", %{endpoint: endpoint} do
+      inserted_at =
+        DateTime.utc_now()
+        |> DateTime.add(-8, :day)
+        |> DateTime.truncate(:second)
+
+      current_version =
+        insert(:endpoint_version,
+          endpoint: endpoint,
+          version_number: 2,
+          item_changes: %{"description" => "current version"},
+          snapshot_overrides: %{"description" => "current version"}
+        )
+
+      version =
+        insert(:endpoint_version,
+          endpoint: endpoint,
+          version_number: 1,
+          inserted_at: inserted_at,
+          item_changes: %{"description" => "old version"},
+          snapshot_overrides: %{"description" => "old version"}
+        )
+
+      version_html =
+        render_component(&LogflareWeb.EndpointsVersionsLive.version_updated/1,
+          version: version,
+          current_version_id: current_version.id
+        )
+
+      date = Calendar.strftime(inserted_at, "%Y-%m-%d")
+
+      assert version_html =~ Calendar.strftime(inserted_at, "%Y-%m-%d %H:%M:%S UTC")
+      assert length(String.split(version_html, date)) - 1 == 1
+      assert version_html =~ "Restore"
     end
 
     test "lists versions, newest first", %{
@@ -80,6 +121,7 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       version_3_html = view |> element(endpoint_version_row(version_3)) |> render()
 
       assert version_3_html =~ "current"
+      assert version_3_html =~ "Just now"
       assert version_3_html =~ "latest description"
       assert version_3_html =~ "from endpoint_versions "
       assert html =~ user.email
@@ -123,7 +165,7 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/endpoints/#{endpoint.id}/versions?t=#{team}")
 
       view
-      |> element(endpoint_version_row(version))
+      |> element(endpoint_version_row_button(version))
       |> render_click()
 
       patched_uri = assert_patch(view) |> URI.parse()
@@ -191,6 +233,83 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
       assert html =~ "version-1-description"
       assert html =~ ~s|id="versions-#{List.first(versions).id}"|
       refute has_element?(view, "button", "Load more")
+    end
+
+    test "restores a historical version by appending a new current version", %{
+      conn: conn,
+      endpoint: endpoint,
+      team: team,
+      user: user
+    } do
+      version_1 =
+        insert(:endpoint_version,
+          endpoint: endpoint,
+          version_number: 1,
+          origin: user.email,
+          item_changes: %{"description" => "first description"},
+          snapshot_overrides: %{
+            "description" => "first description",
+            "query" => "select 1 as restored_version"
+          }
+        )
+
+      version_2 =
+        insert(:endpoint_version,
+          endpoint: endpoint,
+          version_number: 2,
+          origin: user.email,
+          item_changes: %{"description" => "second description"},
+          snapshot_overrides: %{
+            "description" => "second description",
+            "query" => "select 2 as current_version"
+          }
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/endpoints/#{endpoint.id}/versions?t=#{team}")
+
+      assert has_element?(view, version_restore_button(version_1), "Restore")
+      refute has_element?(view, version_restore_button(version_2), "Restore")
+
+      view
+      |> element(version_restore_button(version_1), "Restore")
+      |> render_click()
+
+      assert render_async(view) =~ "Restored endpoint version 1 as new version 3."
+
+      restored_endpoint = Endpoints.get_endpoint_query(endpoint.id)
+
+      assert restored_endpoint.description == "first description"
+      assert restored_endpoint.query == "select 1 as restored_version"
+
+      [
+        %Version{
+          meta: %{
+            "version_number" => 3,
+            "endpoint_snapshot" => %{"description" => "first description"}
+          },
+          origin: latest_version_origin
+        } = latest_version
+        | _versions
+      ] =
+        PaperTrail.get_versions(Endpoints.EndpointQuery, endpoint.id)
+        |> Enum.sort_by(& &1.id, :desc)
+
+      assert latest_version_origin == user.email
+
+      latest_version_html = view |> element(endpoint_version_row(latest_version)) |> render()
+
+      assert latest_version_html =~ "current"
+      assert latest_version_html =~ "first description"
+      refute has_element?(view, version_restore_button(latest_version), "Restore")
+    end
+
+    test "restore errors are displayed", %{conn: conn, endpoint: endpoint, team: team} do
+      {:ok, view, _html} = live(conn, ~p"/endpoints/#{endpoint.id}/versions?t=#{team}")
+
+      assert render_click(view, "restore-version", %{"version-number" => "abc"}) =~
+               "Unable to restore endpoint version."
+
+      assert Endpoints.get_endpoint_query(endpoint.id).query == endpoint.query
     end
 
     test "redirects when user cannot access endpoint versions", %{conn: conn} do
@@ -291,6 +410,12 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
   end
 
   defp endpoint_version_row(%Version{id: version_id}), do: "#versions-#{version_id}"
+
+  defp endpoint_version_row_button(%Version{} = version),
+    do: "#{endpoint_version_row(version)} button[phx-click='show-version']"
+
+  defp version_restore_button(%Version{} = version),
+    do: "#{endpoint_version_row(version)} button[phx-click][phx-value-version-number]"
 
   defp assert_query_displayed(view, query) do
     {:ok, formatted_query} = Logflare.Sql.format(query)

--- a/test/logflare_web/live_views/endpoints_versions_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_versions_live_test.exs
@@ -4,6 +4,7 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
   use LogflareWeb.ConnCase
 
   alias Logflare.Endpoints
+  alias Logflare.TeamUsers
   alias PaperTrail.Version
 
   setup %{conn: conn} do
@@ -310,6 +311,45 @@ defmodule LogflareWeb.EndpointsVersionsLiveTest do
                "Unable to restore endpoint version."
 
       assert Endpoints.get_endpoint_query(endpoint.id).query == endpoint.query
+    end
+
+    test "restore rejects a team member removed after mount", %{
+      conn: conn,
+      endpoint: endpoint,
+      team: team,
+      user: user
+    } do
+      team_user = insert(:team_user, team: team)
+
+      version_1 =
+        insert(:endpoint_version,
+          endpoint: endpoint,
+          version_number: 1,
+          origin: user.email,
+          snapshot_overrides: %{"query" => "select 1 as restored_version"}
+        )
+
+      insert(:endpoint_version,
+        endpoint: endpoint,
+        version_number: 2,
+        origin: user.email,
+        snapshot_overrides: %{"query" => "select 2 as current_version"}
+      )
+
+      {:ok, view, _html} =
+        conn
+        |> login_user(user, team_user)
+        |> live(~p"/endpoints/#{endpoint.id}/versions?t=#{team}")
+
+      assert {:ok, _team_user} = TeamUsers.delete_team_user(team_user)
+
+      view
+      |> element(version_restore_button(version_1), "Restore")
+      |> render_click()
+
+      assert render_async(view) =~ "Unable to restore endpoint version."
+      assert Endpoints.get_endpoint_query(endpoint.id).query == endpoint.query
+      assert nil == Endpoints.get_endpoint_query_version(endpoint.id, 3)
     end
 
     test "redirects when user cannot access endpoint versions", %{conn: conn} do


### PR DESCRIPTION
Adds the ability for users to restore an endpoint to a previous snapshot. 

* Endpoint versions include an action dropdown with a Restore button
  * To provide user feedback the 'Restoring' banner is optimistically displayed and hidden after the version is restored.
* Removes token as an endpoint snapshot field: this is autogenerated on database write so can't be capture in first snapshot, and then doesn't change anyway.


<img width="2732" height="1154" alt="CleanShot 2026-07-01 at 22 01 29@2x" src="https://github.com/user-attachments/assets/aa0d17b0-a2bc-43f9-9a81-5ac61a5591df" />


## Demo
https://github.com/user-attachments/assets/1092242a-f09c-4bce-9665-654c3aa11893

