### PR TITLE
chore: reduce backpressure threshold

### DIFF
--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -11,7 +11,7 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
   alias Logflare.SystemCache
   alias LogflareWeb.Api.FallbackController
 
-  @memory_limit 0.85
+  @memory_limit 0.80
 
   @type opts :: any()
 

--- a/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
@@ -29,9 +29,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     assert get_resp_header(conn, "retry-after") == ["3"]
   end
 
-  test "allows request when memory utilization is below 85%", %{conn: conn, source: source} do
+  test "allows request when memory utilization is below 80%", %{conn: conn, source: source} do
     SystemCache
-    |> stub(:memory_utilization, fn -> 0.84 end)
+    |> stub(:memory_utilization, fn -> 0.79 end)
 
     conn =
       conn


### PR DESCRIPTION
Drops backpressure threshold to 80 instead of 85% memory utilization