### PR TITLE
fix: correct OpenAPI schema property/required mismatches, fix Postgres password redaction gap

### DIFF
--- a/lib/logflare/backends/adaptor/postgres_adaptor.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor.ex
@@ -229,10 +229,20 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor do
 
   @impl Logflare.Backends.Adaptor
   def redact_config(config) do
-    url = Map.get(config, :url) || Map.get(config, "url")
-    updated = String.replace(url, ~r/(.+):.+\@/, "\\g{1}:REDACTED@")
-    Map.put(config, :url, updated)
+    config
+    |> redact_url()
+    |> Map.replace(:password, "REDACTED")
+    |> Map.replace("password", "REDACTED")
   end
+
+  defp redact_url(config) do
+    config
+    |> Map.replace_lazy(:url, &redact_url_string/1)
+    |> Map.replace_lazy("url", &redact_url_string/1)
+  end
+
+  defp redact_url_string(nil), do: nil
+  defp redact_url_string(url), do: String.replace(url, ~r/(.+):.+\@/, "\\g{1}:REDACTED@")
 
   @spec to_query_error(
           :cannot_connect

--- a/lib/logflare/endpoints/endpoint_query.ex
+++ b/lib/logflare/endpoints/endpoint_query.ex
@@ -42,6 +42,7 @@ defmodule Logflare.Endpoints.EndpointQuery do
              :description,
              :name,
              :query,
+             :language,
              :source_mapping,
              :sandboxable,
              :cache_duration_seconds,
@@ -50,7 +51,8 @@ defmodule Logflare.Endpoints.EndpointQuery do
              :enable_auth,
              :labels,
              :redact_pii,
-             :enable_dynamic_reservation
+             :enable_dynamic_reservation,
+             :backend_id
            ]}
   typed_schema "endpoint_queries" do
     field(:token, Ecto.UUID, autogenerate: true)

--- a/lib/logflare/rules/rule.ex
+++ b/lib/logflare/rules/rule.ex
@@ -16,7 +16,8 @@ defmodule Logflare.Rules.Rule do
              :id,
              :source_id,
              :lql_string,
-             :backend_id
+             :backend_id,
+             :sink
            ]}
 
   typed_schema "rules" do

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -35,7 +35,16 @@ defmodule Logflare.Sources.Source do
              :transform_key_values,
              :transform_drop_fields,
              :bigquery_clustering_fields,
-             :default_ingest_backend_enabled?
+             :default_ingest_backend_enabled?,
+             :notifications_every,
+             :lock_schema,
+             :validate_schema,
+             :drop_lql_string,
+             :default_search_lql,
+             :suggested_keys,
+             :disable_tailing,
+             :bq_storage_write_api,
+             :labels
            ]}
 
   defmodule Metrics do

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -62,12 +62,17 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string},
       name: %Schema{type: :string},
       query: %Schema{type: :string},
+      language: %Schema{type: :string},
       source_mapping: %Schema{type: :object, nullable: true},
       sandboxable: %Schema{type: :boolean, nullable: true},
       cache_duration_seconds: %Schema{type: :integer},
       proactive_requerying_seconds: %Schema{type: :integer},
       max_limit: %Schema{type: :integer},
-      enable_auth: %Schema{type: :boolean}
+      enable_auth: %Schema{type: :boolean},
+      redact_pii: %Schema{type: :boolean},
+      enable_dynamic_reservation: %Schema{type: :boolean},
+      labels: %Schema{type: :string, nullable: true},
+      backend_id: %Schema{type: :integer, nullable: true}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query]
   end
@@ -100,6 +105,7 @@ defmodule LogflareWeb.OpenApiSchemas do
     @properties %{
       name: %Schema{type: :string},
       description: %Schema{type: :string, nullable: true},
+      service_name: %Schema{type: :string, nullable: true},
       token: %Schema{type: :string},
       id: %Schema{type: :integer},
       favorite: %Schema{type: :boolean},
@@ -113,9 +119,22 @@ defmodule LogflareWeb.OpenApiSchemas do
       metrics: %Schema{type: :object},
       notifications: %Schema{type: :object, items: Notification},
       custom_event_message_keys: %Schema{type: :string},
+      backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema},
+      retention_days: %Schema{type: :integer, nullable: true},
+      transform_copy_fields: %Schema{type: :string, nullable: true},
+      transform_key_values: %Schema{type: :string, nullable: true},
+      transform_drop_fields: %Schema{type: :string, nullable: true},
+      bigquery_clustering_fields: %Schema{type: :string, nullable: true},
       default_ingest_backend_enabled?: %Schema{type: :boolean},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      notifications_every: %Schema{type: :integer},
+      lock_schema: %Schema{type: :boolean},
+      validate_schema: %Schema{type: :boolean},
+      drop_lql_string: %Schema{type: :string, nullable: true},
+      default_search_lql: %Schema{type: :string, nullable: true},
+      suggested_keys: %Schema{type: :string, nullable: true},
+      disable_tailing: %Schema{type: :boolean, nullable: true},
+      bq_storage_write_api: %Schema{type: :boolean, nullable: true},
+      labels: %Schema{type: :string, nullable: true}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]
@@ -134,11 +153,10 @@ defmodule LogflareWeb.OpenApiSchemas do
       lql_string: %Schema{type: :string},
       backend_id: %Schema{type: :integer},
       source_id: %Schema{type: :integer},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      sink: %Schema{type: :string, nullable: true}
     }
 
-    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+    use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
   end
 
   defmodule KeyValueApiSchema do
@@ -151,19 +169,196 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:key, :value]
   end
 
+  defmodule WebhookConfigSchema do
+    @properties %{
+      url: %Schema{type: :string},
+      headers: %Schema{type: :object},
+      http: %Schema{type: :string, nullable: true},
+      gzip: %Schema{type: :boolean}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:url]
+  end
+
+  defmodule DatadogConfigSchema do
+    @properties %{
+      api_key: %Schema{type: :string},
+      region: %Schema{type: :string}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:api_key, :region]
+  end
+
+  defmodule SentryConfigSchema do
+    @properties %{
+      dsn: %Schema{type: :string}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:dsn]
+  end
+
+  defmodule PostgresConfigSchema do
+    @properties %{
+      url: %Schema{type: :string, nullable: true},
+      username: %Schema{type: :string, nullable: true},
+      password: %Schema{type: :string, nullable: true},
+      hostname: %Schema{type: :string, nullable: true},
+      database: %Schema{type: :string, nullable: true},
+      schema: %Schema{type: :string, nullable: true},
+      port: %Schema{type: :integer, nullable: true},
+      pool_size: %Schema{type: :integer, nullable: true}
+    }
+
+    # Either url, or hostname plus the other connection fields, must be
+    # provided -- Postgres.Adaptor.validate_config/1 enforces this at the
+    # changeset level; it isn't expressible as a plain `required` list.
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
+  defmodule BigQueryConfigSchema do
+    @properties %{
+      project_id: %Schema{type: :string, nullable: true},
+      dataset_id: %Schema{type: :string, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
+  defmodule LokiConfigSchema do
+    @properties %{
+      url: %Schema{type: :string},
+      headers: %Schema{type: :object},
+      username: %Schema{type: :string, nullable: true},
+      password: %Schema{type: :string, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:url]
+  end
+
+  defmodule ClickhouseConfigSchema do
+    @properties %{
+      url: %Schema{type: :string},
+      database: %Schema{type: :string},
+      port: %Schema{type: :integer},
+      username: %Schema{type: :string, nullable: true},
+      password: %Schema{type: :string, nullable: true},
+      pool_size: %Schema{type: :integer, nullable: true},
+      read_only_url: %Schema{type: :string, nullable: true},
+      insert_protocol: %Schema{type: :string, nullable: true},
+      native_port: %Schema{type: :integer, nullable: true},
+      native_pool_size: %Schema{type: :integer, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:url, :database, :port]
+  end
+
+  defmodule IncidentioConfigSchema do
+    @properties %{
+      api_token: %Schema{type: :string},
+      alert_source_config_id: %Schema{type: :string},
+      metadata: %Schema{type: :object}
+    }
+
+    use LogflareWeb.OpenApi,
+      properties: @properties,
+      required: [:api_token, :alert_source_config_id]
+  end
+
+  defmodule S3ConfigSchema do
+    @properties %{
+      endpoint: %Schema{type: :string, nullable: true},
+      s3_bucket: %Schema{type: :string},
+      storage_region: %Schema{type: :string},
+      access_key_id: %Schema{type: :string},
+      secret_access_key: %Schema{type: :string},
+      batch_timeout: %Schema{type: :integer, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi,
+      properties: @properties,
+      required: [:s3_bucket, :storage_region, :access_key_id, :secret_access_key]
+  end
+
+  defmodule AxiomConfigSchema do
+    @properties %{
+      domain: %Schema{type: :string},
+      api_token: %Schema{type: :string},
+      dataset_name: %Schema{type: :string}
+    }
+
+    use LogflareWeb.OpenApi,
+      properties: @properties,
+      required: [:domain, :api_token, :dataset_name]
+  end
+
+  defmodule OtlpConfigSchema do
+    @properties %{
+      endpoint: %Schema{type: :string},
+      protocol: %Schema{type: :string, nullable: true},
+      gzip: %Schema{type: :boolean},
+      headers: %Schema{type: :object}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:endpoint]
+  end
+
+  defmodule Last9ConfigSchema do
+    @properties %{
+      region: %Schema{type: :string},
+      username: %Schema{type: :string},
+      password: %Schema{type: :string}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:region, :username, :password]
+  end
+
+  defmodule SyslogConfigSchema do
+    @properties %{
+      host: %Schema{type: :string},
+      port: %Schema{type: :integer},
+      tls: %Schema{type: :boolean},
+      cipher_key: %Schema{type: :string, nullable: true},
+      ca_cert: %Schema{type: :string, nullable: true},
+      client_cert: %Schema{type: :string, nullable: true},
+      client_key: %Schema{type: :string, nullable: true},
+      structured_data: %Schema{type: :string, nullable: true},
+      max_message_bytes: %Schema{type: :integer, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:host, :port]
+  end
+
   defmodule BackendApiSchema do
     @properties %{
       name: %Schema{type: :string},
       id: %Schema{type: :integer},
       token: %Schema{type: :string},
-      config: %Schema{type: :object},
+      type: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      config: %Schema{
+        anyOf: [
+          LogflareWeb.OpenApiSchemas.WebhookConfigSchema,
+          LogflareWeb.OpenApiSchemas.DatadogConfigSchema,
+          LogflareWeb.OpenApiSchemas.SentryConfigSchema,
+          LogflareWeb.OpenApiSchemas.PostgresConfigSchema,
+          LogflareWeb.OpenApiSchemas.BigQueryConfigSchema,
+          LogflareWeb.OpenApiSchemas.LokiConfigSchema,
+          LogflareWeb.OpenApiSchemas.ClickhouseConfigSchema,
+          LogflareWeb.OpenApiSchemas.IncidentioConfigSchema,
+          LogflareWeb.OpenApiSchemas.S3ConfigSchema,
+          LogflareWeb.OpenApiSchemas.AxiomConfigSchema,
+          LogflareWeb.OpenApiSchemas.OtlpConfigSchema,
+          LogflareWeb.OpenApiSchemas.Last9ConfigSchema,
+          LogflareWeb.OpenApiSchemas.SyslogConfigSchema
+        ]
+      },
       metadata: %Schema{type: :object},
       default_ingest?: %Schema{type: :boolean},
       inserted_at: %Schema{type: :string, format: :"date-time"},
       updated_at: %Schema{type: :string, format: :"date-time"}
     }
 
-    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :type, :config]
   end
 
   defmodule BackendConnectionTest do
@@ -188,9 +383,15 @@ defmodule LogflareWeb.OpenApiSchemas do
       bigquery_project_id: %Schema{type: :string, nullable: true},
       bigquery_dataset_location: %Schema{type: :string, nullable: true},
       bigquery_dataset_id: %Schema{type: :string, nullable: true},
+      bigquery_reservation_search: %Schema{type: :string, nullable: true},
+      bigquery_reservation_alerts: %Schema{type: :string, nullable: true},
+      bigquery_additional_projects: %Schema{type: :string, nullable: true},
       api_quota: %Schema{type: :integer},
       company: %Schema{type: :string, nullable: true},
-      token: %Schema{type: :string}
+      token: %Schema{type: :string},
+      metadata: %Schema{type: :object, nullable: true},
+      partner_upgraded: %Schema{type: :boolean, nullable: true},
+      system_monitoring: %Schema{type: :boolean}
     }
     use LogflareWeb.OpenApi,
       properties: @properties,

--- a/test/logflare/backends/adaptor/postgres_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/postgres_adaptor_test.exs
@@ -49,6 +49,52 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptorTest do
       config = %{url: "postgresql://localhost:5432/dbname"}
       assert ^config = PostgresAdaptor.redact_config(config)
     end
+
+    test "redacts standalone password field when configured via individual fields" do
+      config = %{hostname: "localhost", username: "user", password: "secret123", database: "db"}
+
+      assert %{password: "REDACTED"} = PostgresAdaptor.redact_config(config)
+    end
+
+    test "does not crash when config has no url" do
+      config = %{hostname: "localhost", username: "user", password: "secret123"}
+
+      assert %{hostname: "localhost"} = PostgresAdaptor.redact_config(config)
+    end
+
+    test "redacts both url-embedded and standalone passwords when both are present" do
+      config = %{
+        url: "postgresql://user:secret123@localhost:5432/dbname",
+        password: "secret123"
+      }
+
+      assert %{
+               url: "postgresql://user:REDACTED@localhost:5432/dbname",
+               password: "REDACTED"
+             } = PostgresAdaptor.redact_config(config)
+    end
+
+    test "redacts a string-keyed url in place, without leaving the atom key unredacted" do
+      config = %{"url" => "postgresql://user:secret123@localhost:5432/dbname"}
+
+      assert %{"url" => "postgresql://user:REDACTED@localhost:5432/dbname"} =
+               redacted =
+               PostgresAdaptor.redact_config(config)
+
+      refute Map.has_key?(redacted, :url)
+    end
+
+    test "redacts both key variants if a config has both :url and \"url\"" do
+      config = %{
+        "url" => "postgresql://user:othersecret@localhost:5432/otherdb",
+        url: "postgresql://user:secret123@localhost:5432/dbname"
+      }
+
+      assert %{
+               "url" => "postgresql://user:REDACTED@localhost:5432/otherdb",
+               url: "postgresql://user:REDACTED@localhost:5432/dbname"
+             } = PostgresAdaptor.redact_config(config)
+    end
   end
 
   describe "with postgres repo" do


### PR DESCRIPTION
## Why
This Management API is what the Logflare Terraform provider will be built against — inaccurate OpenAPI docs would propagate into a wrong or incomplete provider, and the RFC explicitly calls out backend credential redaction as critical. This PR makes the docs match reality and, in the process, found and fixed a real credential-redaction bug worth fixing regardless of the provider work.

## Summary
- Audited `lib/logflare_web/open_api_schemas.ex` against the underlying Ecto schemas/changesets/`Jason.Encoder` impls for `Rule`, `Endpoint`, `Backend`, `User`, and `Source`. Fixed `required`/`properties` mismatches and added fields that were castable/UI-editable but had no API read path (see commit for full per-resource detail).
- Added 13 per-backend-type config schemas (`anyOf` on `BackendApiSchema.config`), one per adaptor, derived from each adaptor's actual `cast_config/2`/`validate_config/1` — Elastic excluded per the IaC RFC.
- Fixed a real, pre-existing security bug in `Postgres.Adaptor.redact_config/1`: a standalone `:password` field (used when a backend is configured via individual fields instead of a `url`) was returned in **plaintext**, and the function **crashed** on any config without a `url` key.

**Review history** (all from automated review, all verified against the actual code before fixing):
- [`provider_uid`](https://github.com/Logflare/logflare/pull/3663#discussion_r3532239147) would have leaked the team owner's OAuth provider UID to any team member via `GET /api/teams`. Reverted.
- [`language` required-in-docs](https://github.com/Logflare/logflare/pull/3663#discussion_r3532543632) was stricter than actual API behavior. Fixed.
- [`config` should be `anyOf`, not `oneOf`](https://github.com/Logflare/logflare/pull/3663#discussion_r3532543649). Fixed.
- `disable_tailing`/`bq_storage_write_api`/`partner_upgraded` marked non-nullable when nullable in reality. Fixed.
- [Postgres password redaction gap](https://github.com/Logflare/logflare/pull/3663#discussion_r3533267189). Fixed.
- [`redact_url/1` key-fidelity bug](https://github.com/Logflare/logflare/pull/3663#discussion_r3538708375). Fixed, then further simplified to `Map.replace_lazy/3` per a follow-up idiomatic-Elixir review pass, which also closes the both-keys-present edge case.

Fixes [O11Y-2144](https://linear.app/supabase/issue/O11Y-2144/ruleapischema-declares-required-name-but-rule-has-no-name-field).