### PR TITLE
feat: add Management API endpoint for alerts (Api.AlertController)

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -102,6 +102,23 @@ defmodule Logflare.Alerting do
     |> Repo.one()
   end
 
+  @doc """
+  Fetches a single alert query by arbitrary conditions, scoped to the
+  alert queries the user has team access to.
+  """
+  @spec fetch_alert_query_by_user_access(User.t() | TeamUser.t(), keyword()) ::
+          {:ok, AlertQuery.t()} | {:error, :not_found}
+  def fetch_alert_query_by_user_access(user_or_team_user, kw) when is_list(kw) do
+    AlertQuery
+    |> Teams.filter_by_user_access(user_or_team_user)
+    |> where([alert_query], ^kw)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      alert_query -> {:ok, alert_query}
+    end
+  end
+
   def preload_alert_query(alert) do
     alert
     |> Repo.preload([:user, :backends])
@@ -143,13 +160,13 @@ defmodule Logflare.Alerting do
 
   """
   def update_alert_query(%AlertQuery{} = alert_query, attrs) do
-    backends_modified = if backends = Map.get(attrs, :backends), do: true, else: false
+    backends = Map.get(attrs, :backends) || Map.get(attrs, "backends")
 
     alert_query
     |> preload_alert_query()
     |> AlertQuery.changeset(attrs)
     |> then(fn
-      changeset when backends_modified == true ->
+      changeset when not is_nil(backends) ->
         Ecto.Changeset.put_assoc(changeset, :backends, backends)
 
       changeset ->

--- a/lib/logflare/alerting/alert_query.ex
+++ b/lib/logflare/alerting/alert_query.ex
@@ -19,7 +19,8 @@ defmodule Logflare.Alerting.AlertQuery do
              :query,
              :webhook_notification_url,
              :slack_hook_url,
-             :enabled
+             :enabled,
+             :backends
            ]}
   typed_schema "alert_queries" do
     field :name, :string

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -20,7 +20,11 @@ defmodule LogflareWeb.Api.AlertController do
   )
 
   def index(%{assigns: %{user: user}} = conn, _params) do
-    alerts = Alerting.list_alert_queries_user_access(user)
+    alerts =
+      user
+      |> Alerting.list_alert_queries_user_access()
+      |> Enum.map(&Alerting.preload_alert_query/1)
+
     json(conn, alerts)
   end
 
@@ -35,7 +39,7 @@ defmodule LogflareWeb.Api.AlertController do
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
     with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token) do
-      json(conn, alert)
+      json(conn, Alerting.preload_alert_query(alert))
     end
   end
 
@@ -52,7 +56,7 @@ defmodule LogflareWeb.Api.AlertController do
     with {:ok, alert} <- Alerting.create_alert_query(user, params) do
       conn
       |> put_status(201)
-      |> json(alert)
+      |> json(Alerting.preload_alert_query(alert))
     end
   end
 
@@ -78,7 +82,7 @@ defmodule LogflareWeb.Api.AlertController do
 
         %{method: "PUT"} ->
           put_status(conn, 200)
-          |> json(updated)
+          |> json(Alerting.preload_alert_query(updated))
       end
     end
   end

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -1,0 +1,127 @@
+defmodule LogflareWeb.Api.AlertController do
+  use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Logflare.Alerting
+  alias Logflare.Backends
+  alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.Created
+  alias LogflareWeb.OpenApi.List
+  alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApiSchemas.AlertApiSchema
+
+  action_fallback(LogflareWeb.Api.FallbackController)
+
+  tags(["management"])
+
+  operation(:index,
+    summary: "List alerts",
+    responses: %{200 => List.response(AlertApiSchema)}
+  )
+
+  def index(%{assigns: %{user: user}} = conn, _params) do
+    alerts = Alerting.list_alert_queries_user_access(user)
+    json(conn, alerts)
+  end
+
+  operation(:show,
+    summary: "Fetch alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    responses: %{
+      200 => AlertApiSchema.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token) do
+      json(conn, alert)
+    end
+  end
+
+  operation(:create,
+    summary: "Create alert",
+    request_body: AlertApiSchema.params(),
+    responses: %{
+      201 => Created.response(AlertApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def create(%{assigns: %{user: user}} = conn, params) do
+    with {:ok, alert} <- Alerting.create_alert_query(user, params) do
+      conn
+      |> put_status(201)
+      |> json(alert)
+    end
+  end
+
+  operation(:update,
+    summary: "Update alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    request_body: AlertApiSchema.params(),
+    responses: %{
+      204 => Accepted.response(),
+      200 => Accepted.response(AlertApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token),
+         {:ok, attrs} <- verify_backends_owner(params, user),
+         {:ok, updated} <- Alerting.update_alert_query(alert, attrs) do
+      conn
+      |> case do
+        %{method: "PATCH"} ->
+          send_resp(conn, 204, "")
+
+        %{method: "PUT"} ->
+          put_status(conn, 200)
+          |> json(updated)
+      end
+    end
+  end
+
+  defp verify_backends_owner(%{"backend_ids" => ids} = params, user) do
+    ids
+    |> Enum.reduce_while({:ok, []}, fn id, {:ok, acc} ->
+      case Backends.fetch_backend_by(id: id, user_id: user.id) do
+        {:ok, backend} -> {:cont, {:ok, [backend | acc]}}
+        {:error, :not_found} -> {:halt, {:error, :not_found}}
+      end
+    end)
+    |> case do
+      {:ok, backends} ->
+        attrs =
+          params
+          |> Map.delete("backend_ids")
+          |> Map.put("backends", Enum.reverse(backends))
+
+        {:ok, attrs}
+
+      error ->
+        error
+    end
+  end
+
+  defp verify_backends_owner(params, _user), do: {:ok, params}
+
+  operation(:delete,
+    summary: "Delete alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    responses: %{
+      204 => Accepted.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token),
+         {:ok, _} <- Alerting.delete_alert_query(alert) do
+      conn
+      |> send_resp(204, [])
+      |> halt()
+    end
+  end
+end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -170,7 +170,8 @@ defmodule LogflareWeb.OpenApiSchemas do
       cron: %Schema{type: :string},
       slack_hook_url: %Schema{type: :string},
       webhook_notification_url: %Schema{type: :string},
-      enabled: %Schema{type: :boolean}
+      enabled: %Schema{type: :boolean},
+      backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query, :cron, :language]

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -159,6 +159,23 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
   end
 
+  defmodule AlertApiSchema do
+    @properties %{
+      id: %Schema{type: :integer},
+      token: %Schema{type: :string},
+      name: %Schema{type: :string},
+      description: %Schema{type: :string},
+      language: %Schema{type: :string},
+      query: %Schema{type: :string},
+      cron: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string},
+      webhook_notification_url: %Schema{type: :string},
+      enabled: %Schema{type: :boolean}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query, :cron, :language]
+  end
+
   defmodule KeyValueApiSchema do
     @properties %{
       id: %Schema{type: :integer},

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -470,6 +470,11 @@ defmodule LogflareWeb.Router do
       only: [:index, :show, :create, :update, :delete]
     )
 
+    resources("/alerts", Api.AlertController,
+      param: "token",
+      only: [:index, :show, :create, :update, :delete]
+    )
+
     resources("/endpoints", Api.EndpointController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -84,18 +84,17 @@ defmodule LogflareWeb.Api.AlertControllerTest do
     } do
       alert = insert(:alert, user: user)
 
-      assert %{"token" => alert_token} =
+      assert %{"token" => alert_token, "backends" => [%{"id" => backend_id}]} =
                conn
                |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
                |> json_response(200)
 
-      updated =
-        Logflare.Alerting.get_alert_query!(alert.id)
-        |> Logflare.Alerting.preload_alert_query()
-
-      assert alert_token == updated.token
-      assert [%{id: backend_id}] = updated.backends
       assert backend_id == backend.id
+
+      assert %{"backends" => [%{"id" => ^backend_id}]} =
+               conn
+               |> get(~p"/api/alerts/#{alert_token}")
+               |> json_response(200)
     end
 
     test "attacker cannot attach a victim's backend to their alert", %{

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -1,0 +1,163 @@
+defmodule LogflareWeb.Api.AlertControllerTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  setup %{conn: conn} do
+    insert(:plan, name: "Free")
+    user = insert(:user)
+    conn = add_access_token(conn, user, "private")
+    backend = insert(:backend, user: user)
+    {:ok, conn: conn, user: user, backend: backend}
+  end
+
+  test "list alerts", %{conn: conn, user: user} do
+    insert(:alert, user: insert(:user))
+    alert = insert(:alert, user: user)
+
+    assert [result] =
+             conn
+             |> get(~p"/api/alerts")
+             |> json_response(200)
+
+    assert result["id"] == alert.id
+    assert result["token"] == alert.token
+  end
+
+  test "show alert", %{conn: conn, user: user} do
+    alert = insert(:alert, user: user)
+    insert(:alert, user: user)
+
+    assert result =
+             conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(200)
+
+    assert result["id"] == alert.id
+    assert result["token"] == alert.token
+    assert result["name"] == alert.name
+  end
+
+  describe "with alerts" do
+    test "create alert", %{conn: conn} do
+      assert %{"token" => alert_token} =
+               conn
+               |> post(~p"/api/alerts", %{
+                 name: "my alert",
+                 query: "select current_date() as date",
+                 cron: "0 0 1 * *",
+                 language: "bq_sql"
+               })
+               |> json_response(201)
+
+      assert alert_token
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert_token}")
+             |> json_response(200)
+    end
+
+    test "create alert with bad params", %{conn: conn} do
+      assert %{"errors" => _} =
+               conn
+               |> post(~p"/api/alerts", %{name: "missing required fields"})
+               |> json_response(422)
+    end
+
+    test "update alert", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user, name: "initial")
+
+      assert %{"token" => alert_token} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+               |> json_response(200)
+
+      assert %{"name" => "adjusted"} =
+               conn
+               |> get(~p"/api/alerts/#{alert_token}")
+               |> json_response(200)
+    end
+
+    test "update alert to attach an owned backend", %{
+      conn: conn,
+      user: user,
+      backend: backend
+    } do
+      alert = insert(:alert, user: user)
+
+      assert %{"token" => alert_token} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
+               |> json_response(200)
+
+      updated =
+        Logflare.Alerting.get_alert_query!(alert.id)
+        |> Logflare.Alerting.preload_alert_query()
+
+      assert alert_token == updated.token
+      assert [%{id: backend_id}] = updated.backends
+      assert backend_id == backend.id
+    end
+
+    test "attacker cannot attach a victim's backend to their alert", %{
+      conn: conn,
+      user: user
+    } do
+      alert = insert(:alert, user: user)
+
+      victim = insert(:user)
+      victim_backend = insert(:backend, user: victim)
+
+      conn
+      |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
+      |> json_response(404)
+
+      reloaded =
+        Logflare.Alerting.get_alert_query!(alert.id)
+        |> Logflare.Alerting.preload_alert_query()
+
+      assert reloaded.backends == []
+    end
+
+    test "update alert with bad user", %{conn: conn, user: user} do
+      other_user = insert(:user)
+      alert = insert(:alert, user: user, name: "initial")
+
+      assert %{"error" => _} =
+               conn
+               |> add_access_token(other_user, "private")
+               |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+               |> json_response(404)
+
+      assert %{"name" => "initial"} =
+               conn
+               |> get(~p"/api/alerts/#{alert.token}")
+               |> json_response(200)
+    end
+
+    test "delete alert", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user)
+
+      assert conn
+             |> delete(~p"/api/alerts/#{alert.token}")
+             |> response(204)
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(404)
+    end
+
+    test "delete alert with bad user", %{conn: conn, user: user} do
+      other_user = insert(:user)
+      alert = insert(:alert, user: user)
+
+      assert conn
+             |> add_access_token(other_user, "private")
+             |> delete(~p"/api/alerts/#{alert.token}")
+             |> response(404)
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(200)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds Management API CRUD for `Logflare.Alerting.AlertQuery` at `/api/alerts`, enabling Terraform-provider coverage for alerts under O11Y-2143.

The alert resource's list and lookup paths follow existing team-access semantics; backend attachment has the limitation below.

### Backend attachment contract

- Create and update accept `backend_ids`, a complete replacement set of positive integer backend IDs.
- IDs are deduplicated and must belong directly to the authenticated user.
- `backends` is response-only and returns the attached backend objects. Supplying `backends` in a request returns `400`; use `backend_ids` instead.
- Invalid `backend_ids` return `400` rather than raising.

Alerts now preload and serialize attached backends in all response-producing actions, so Terraform can reconcile the association.

### OpenAPI

- Separate create and update request schemas: create requires alert fields; update permits partial updates.
- Documents `backend_ids` only on write schemas and `backends` only on the response schema.
- Correctly documents nullable optional fields and `400`, `404`, and `422` responses.

### Known limitation / follow-up

Alert list, fetch, update, and delete are team-access scoped, but `backend_ids` are resolved only among the token owner's directly owned backends. Consequently, a member can manage an existing team alert but cannot discover or attach that team's owner-owned backends through the Management API. `/api/backends` list and show have the same direct-owner scope.

This does not affect the owner-token Terraform use case. Team-aware backend discovery and attachment should be addressed together in a follow-up: make backend list/show and alert attachment use the existing backend access helpers, then cover team-owned attachment, unrelated-backend rejection, and team backend discovery.

### Stacking

#3663 has merged. This branch should be rebased onto `main` before final review so its already-merged changes are removed from this PR diff.

Implements O11Y-2143.

## Validation

- `../bin/test test/logflare_web/controllers/api/alert_controller_test.exs test/logflare/alerting_test.exs` — 47 tests and 1 doctest passing
- `../bin/x mix compile --warnings-as-errors`
- formatting check
- strict Credo on affected files
