### PR TITLE
fix: correct OpenAPI schema property/required mismatches

### DIFF
--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -62,12 +62,17 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string},
       name: %Schema{type: :string},
       query: %Schema{type: :string},
+      language: %Schema{type: :string},
       source_mapping: %Schema{type: :object, nullable: true},
       sandboxable: %Schema{type: :boolean, nullable: true},
       cache_duration_seconds: %Schema{type: :integer},
       proactive_requerying_seconds: %Schema{type: :integer},
       max_limit: %Schema{type: :integer},
-      enable_auth: %Schema{type: :boolean}
+      enable_auth: %Schema{type: :boolean},
+      redact_pii: %Schema{type: :boolean},
+      enable_dynamic_reservation: %Schema{type: :boolean},
+      labels: %Schema{type: :string, nullable: true},
+      backend_id: %Schema{type: :integer, nullable: true}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query]
   end
@@ -100,6 +105,7 @@ defmodule LogflareWeb.OpenApiSchemas do
     @properties %{
       name: %Schema{type: :string},
       description: %Schema{type: :string, nullable: true},
+      service_name: %Schema{type: :string, nullable: true},
       token: %Schema{type: :string},
       id: %Schema{type: :integer},
       favorite: %Schema{type: :boolean},
@@ -113,9 +119,13 @@ defmodule LogflareWeb.OpenApiSchemas do
       metrics: %Schema{type: :object},
       notifications: %Schema{type: :object, items: Notification},
       custom_event_message_keys: %Schema{type: :string},
-      default_ingest_backend_enabled?: %Schema{type: :boolean},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema},
+      retention_days: %Schema{type: :integer, nullable: true},
+      transform_copy_fields: %Schema{type: :string, nullable: true},
+      transform_key_values: %Schema{type: :string, nullable: true},
+      transform_drop_fields: %Schema{type: :string, nullable: true},
+      bigquery_clustering_fields: %Schema{type: :string, nullable: true},
+      default_ingest_backend_enabled?: %Schema{type: :boolean}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]
@@ -133,9 +143,7 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string},
       lql_string: %Schema{type: :string},
       backend_id: %Schema{type: :integer},
-      source_id: %Schema{type: :integer},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      source_id: %Schema{type: :integer}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
@@ -156,6 +164,8 @@ defmodule LogflareWeb.OpenApiSchemas do
       name: %Schema{type: :string},
       id: %Schema{type: :integer},
       token: %Schema{type: :string},
+      type: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
       config: %Schema{type: :object},
       metadata: %Schema{type: :object},
       default_ingest?: %Schema{type: :boolean},
@@ -163,7 +173,7 @@ defmodule LogflareWeb.OpenApiSchemas do
       updated_at: %Schema{type: :string, format: :"date-time"}
     }
 
-    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :type, :config]
   end
 
   defmodule BackendConnectionTest do
@@ -188,9 +198,16 @@ defmodule LogflareWeb.OpenApiSchemas do
       bigquery_project_id: %Schema{type: :string, nullable: true},
       bigquery_dataset_location: %Schema{type: :string, nullable: true},
       bigquery_dataset_id: %Schema{type: :string, nullable: true},
+      provider_uid: %Schema{type: :string},
+      bigquery_reservation_search: %Schema{type: :string, nullable: true},
+      bigquery_reservation_alerts: %Schema{type: :string, nullable: true},
+      bigquery_additional_projects: %Schema{type: :string, nullable: true},
       api_quota: %Schema{type: :integer},
       company: %Schema{type: :string, nullable: true},
-      token: %Schema{type: :string}
+      token: %Schema{type: :string},
+      metadata: %Schema{type: :object, nullable: true},
+      partner_upgraded: %Schema{type: :boolean},
+      system_monitoring: %Schema{type: :boolean}
     }
     use LogflareWeb.OpenApi,
       properties: @properties,

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -138,7 +138,7 @@ defmodule LogflareWeb.OpenApiSchemas do
       updated_at: %Schema{type: :string, format: :"date-time"}
     }
 
-    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+    use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
   end
 
   defmodule KeyValueApiSchema do


### PR DESCRIPTION
## Summary
Follow-up audit after finding the `RuleApiSchema` `required: [:name]` bug (#3663) — checked every schema in `lib/logflare_web/open_api_schemas.ex` against its underlying Ecto schema/changeset/`Jason.Encoder` implementation. Found the same class of issue (and its inverse) in several other schemas:

- **RuleApiSchema**: drop `inserted_at`/`updated_at` properties — `Rule`'s encoder never serializes them.
- **EndpointApiSchema**: add `redact_pii`, `enable_dynamic_reservation`, `labels`, `language`, `backend_id` properties (all castable via `changeset/2`; the first three are also response-serialized).
- **BackendApiSchema**: add `type` and `description` properties; `required` now `[:name, :type, :config]` matching `Backend.changeset/2`'s `validate_required/2` (both `type` and `config` are response-serialized).
- **User**: add `bigquery_reservation_search`, `bigquery_reservation_alerts`, `bigquery_additional_projects`, `metadata`, `partner_upgraded`, `system_monitoring`, `provider_uid` properties.
- **Source**: add `service_name`, `backends`, `retention_days`, `transform_copy_fields`, `transform_key_values`, `transform_drop_fields`, `bigquery_clustering_fields` properties; drop `inserted_at`/`updated_at` — never serialized.

One subtlety worth flagging for review: `language` (Endpoint) and `provider_uid` (User) are `validate_required`'d by their changesets but never appear in their `Jason.Encoder` `only:` list. I initially marked them `required` to match the changeset, but since the same schema module validates both request bodies and responses, that broke response validation in `endpoint_controller_test.exs`/`team_controller_test.exs`. They're included as properties only, not in `required`.

Depends on #3663 (this branch is stacked on it).

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix test test/logflare_web/controllers/api/ test/logflare/alerting_test.exs` (168 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` clean