### PR TITLE
fix: eliminate ClickHouse pipeline CPU regression

### DIFF
--- a/bench/clickhouse_pipeline_cpu_runner.exs
+++ b/bench/clickhouse_pipeline_cpu_runner.exs
@@ -1,0 +1,129 @@
+# Fixed-work CPU runner for PR #3667's ClickHouse pipeline changes.
+#
+# Benchee is useful for local comparisons, but this script is intended to answer
+# the CPU claim directly: for the same number of rows, how many CPU seconds does
+# each path consume? Run one scenario per OS process and compare user+sys time.
+#
+# Linux:
+#   /usr/bin/time -v env SCENARIO=old BATCHES=100 BATCH_SIZE=10000 \
+#     mix run --no-start bench/clickhouse_pipeline_cpu_runner.exs
+#   /usr/bin/time -v env SCENARIO=stream_ets BATCHES=100 BATCH_SIZE=10000 \
+#     mix run --no-start bench/clickhouse_pipeline_cpu_runner.exs
+#
+# macOS:
+#   /usr/bin/time -lp env SCENARIO=old BATCHES=100 BATCH_SIZE=10000 \
+#     mix run --no-start bench/clickhouse_pipeline_cpu_runner.exs
+#
+# Scenarios:
+#   old              map all -> encode_batch -> gzip
+#   old_materialized map all -> encode_batch -> iodata_to_binary -> gzip
+#   stream           per-row encode_row -> incremental deflate
+#   stream_hoisted   stream with mapping_config_id UUID encoded once per batch
+#   stream_chunked   stream_hoisted plus deflate every CHUNK_ROWS rows
+#   stream_ets       stream plus per-row ETS lookup
+#   stream_ets_*     ETS variants of hoisted/chunked stream scenarios
+#   old_queue        add_to_table -> pop_pending -> old path
+#   id_queue         add_to_table -> take_pending_ids -> lookup -> stream -> delete_id
+#   id_queue_*       queue variants of hoisted/chunked stream scenarios
+#   id_queue_metadata optimized queue path with routing metadata + hoisted stream
+#
+# Compare CPU normalized by rows. Higher CPU% alone is not evidence of higher
+# cost if wall time changes; user+sys CPU seconds per row is the primary signal.
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+
+scenario =
+  case System.get_env("SCENARIO", "old") do
+    "old" -> :old
+    "old_materialized" -> :old_materialized
+    "stream" -> :stream
+    "stream_hoisted" -> :stream_hoisted
+    "stream_chunked" -> :stream_chunked
+    "stream_ets" -> :stream_ets
+    "stream_ets_hoisted" -> :stream_ets_hoisted
+    "stream_ets_chunked" -> :stream_ets_chunked
+    "old_queue" -> :old_queue
+    "id_queue" -> :id_queue
+    "id_queue_hoisted" -> :id_queue_hoisted
+    "id_queue_chunked" -> :id_queue_chunked
+    "id_queue_metadata" -> :id_queue_metadata
+    other -> raise ArgumentError, "unknown SCENARIO=#{inspect(other)}"
+  end
+
+type = System.get_env("EVENT_TYPE", "log") |> String.to_existing_atom()
+shape = System.get_env("SHAPE", "realistic") |> String.to_existing_atom()
+batch_size = System.get_env("BATCH_SIZE", "10000") |> String.to_integer()
+batches = System.get_env("BATCHES", "100") |> String.to_integer()
+warmup_batches = System.get_env("WARMUP_BATCHES", "3") |> String.to_integer()
+
+{compiled, config_id} = Data.compiled(type)
+events = Data.batch(type, batch_size, shape)
+encoded_bytes = Data.encoded_bytes(events, type, compiled, config_id)
+
+input = %{
+  events: events,
+  type: type,
+  compiled: compiled,
+  config_id: config_id
+}
+
+input =
+  if scenario in [:stream_ets, :stream_ets_hoisted, :stream_ets_chunked] do
+    Map.put(input, :processing_tid, Data.setup_processing_ets(events))
+  else
+    input
+  end
+
+input =
+  if scenario in [:old_queue, :id_queue, :id_queue_hoisted, :id_queue_chunked, :id_queue_metadata] do
+    {queue_key, queue_tid} = Data.setup_queue(8_888_888)
+
+    input
+    |> Map.put(:queue_key, queue_key)
+    |> Map.put(:queue_tid, queue_tid)
+  else
+    input
+  end
+
+IO.puts("scenario=#{scenario}")
+IO.puts("event_type=#{type}")
+IO.puts("shape=#{shape}")
+IO.puts("batch_size=#{batch_size}")
+IO.puts("batches=#{batches}")
+IO.puts("rows=#{batch_size * batches}")
+IO.puts("uncompressed_rowbinary_bytes_per_batch=#{encoded_bytes}")
+IO.puts("uncompressed_rowbinary_bytes_per_row=#{Float.round(encoded_bytes / batch_size, 2)}")
+
+for _ <- 1..warmup_batches do
+  Data.run_scenario(scenario, input) |> byte_size()
+end
+
+:erlang.garbage_collect()
+:erlang.statistics(:runtime)
+:erlang.statistics(:wall_clock)
+:erlang.statistics(:reductions)
+
+{elapsed_us, compressed_bytes} =
+  :timer.tc(fn ->
+    Enum.reduce(1..batches, 0, fn _, acc ->
+      acc + (Data.run_scenario(scenario, input) |> byte_size())
+    end)
+  end)
+
+{_, runtime_ms} = :erlang.statistics(:runtime)
+{_, wall_ms} = :erlang.statistics(:wall_clock)
+{_, reductions} = :erlang.statistics(:reductions)
+
+rows = batch_size * batches
+
+IO.puts("compressed_bytes_total=#{compressed_bytes}")
+IO.puts("elapsed_us=#{elapsed_us}")
+IO.puts("runtime_ms=#{runtime_ms}")
+IO.puts("wall_ms=#{wall_ms}")
+IO.puts("reductions=#{reductions}")
+IO.puts("rows_per_wall_second=#{Float.round(rows / (elapsed_us / 1_000_000), 2)}")
+IO.puts("wall_us_per_row=#{Float.round(elapsed_us / rows, 4)}")
+IO.puts("runtime_us_per_row=#{Float.round(runtime_ms * 1000 / rows, 4)}")
+IO.puts("reductions_per_row=#{Float.round(reductions / rows, 2)}")

--- a/bench/clickhouse_pipeline_encode_compress_cpu.exs
+++ b/bench/clickhouse_pipeline_encode_compress_cpu.exs
@@ -1,0 +1,100 @@
+# Benchmarks the CPU-sensitive ClickHouse pipeline change from PR #3667.
+#
+# It compares the old batch path against the new incremental gzip path using the
+# same generated events and the same RowBinary encoder:
+#
+#   old:    map all events -> Ingester.encode_batch/2 -> :zlib.gzip/1
+#   stream: map one event  -> Ingester.encode_row/2   -> :zlib.deflate/3
+#   ets:    stream path plus the extra ETS lookup performed by id-passing batches
+#
+# Usage examples:
+#
+#   mix run --no-start bench/clickhouse_pipeline_encode_compress_cpu.exs
+#   EVENT_TYPES=log BATCH_SIZES=1000,10000 SHAPES=small,realistic \
+#     mix run --no-start bench/clickhouse_pipeline_encode_compress_cpu.exs
+#
+# Use Benchee's reduction/memory metrics to understand BEAM-side overhead, but
+# use bench/clickhouse_pipeline_cpu_runner.exs under /usr/bin/time for the final
+# "does this consume more CPU seconds per row?" answer, because zlib work happens
+# in native code and is not fully represented by reductions.
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+
+parse_csv = fn env, default, mapper ->
+  env
+  |> System.get_env(default)
+  |> String.split(",", trim: true)
+  |> Enum.map(mapper)
+end
+
+batch_sizes = parse_csv.("BATCH_SIZES", "1000,10000", &String.to_integer/1)
+event_types = parse_csv.("EVENT_TYPES", "log,metric,trace", &String.to_existing_atom/1)
+shapes = parse_csv.("SHAPES", "realistic", &String.to_existing_atom/1)
+benchee_time = System.get_env("BENCH_TIME", "5") |> String.to_integer()
+benchee_warmup = System.get_env("BENCH_WARMUP", "2") |> String.to_integer()
+
+inputs =
+  for shape <- shapes,
+      type <- event_types,
+      batch_size <- batch_sizes,
+      into: %{} do
+    {compiled, config_id} = Data.compiled(type)
+    events = Data.batch(type, batch_size, shape)
+    processing_tid = Data.setup_processing_ets(events)
+    encoded_bytes = Data.encoded_bytes(events, type, compiled, config_id)
+
+    label = "#{type}/#{shape}/batch=#{batch_size}"
+
+    IO.puts(
+      "#{label}: #{encoded_bytes} uncompressed RowBinary bytes " <>
+        "(#{Float.round(encoded_bytes / batch_size, 1)} bytes/event)"
+    )
+
+    {label,
+     %{
+       events: events,
+       type: type,
+       compiled: compiled,
+       config_id: config_id,
+       processing_tid: processing_tid
+     }}
+  end
+
+IO.puts("")
+
+Benchee.run(
+  %{
+    "old encode_batch + gzip" => fn input ->
+      Data.run_scenario(:old, input)
+    end,
+    "old materialize + gzip" => fn input ->
+      Data.run_scenario(:old_materialized, input)
+    end,
+    "new stream deflate" => fn input ->
+      Data.run_scenario(:stream, input)
+    end,
+    "new stream deflate (hoisted uuid)" => fn input ->
+      Data.run_scenario(:stream_hoisted, input)
+    end,
+    "new stream deflate (chunked)" => fn input ->
+      Data.run_scenario(:stream_chunked, input)
+    end,
+    "new stream deflate + ETS lookup" => fn input ->
+      Data.run_scenario(:stream_ets, input)
+    end,
+    "new stream deflate + ETS lookup (hoisted uuid)" => fn input ->
+      Data.run_scenario(:stream_ets_hoisted, input)
+    end,
+    "new stream deflate + ETS lookup (chunked)" => fn input ->
+      Data.run_scenario(:stream_ets_chunked, input)
+    end
+  },
+  inputs: inputs,
+  time: benchee_time,
+  warmup: benchee_warmup,
+  memory_time: System.get_env("BENCH_MEMORY_TIME", "2") |> String.to_integer(),
+  reduction_time: System.get_env("BENCH_REDUCTION_TIME", "2") |> String.to_integer(),
+  print: [configuration: false]
+)

--- a/bench/clickhouse_pipeline_eprof.exs
+++ b/bench/clickhouse_pipeline_eprof.exs
@@ -1,0 +1,75 @@
+# eprof profiler for ClickHouse encode/compress pipeline scenarios.
+#
+# This is intentionally separate from the Benchee scripts: it answers "where is
+# the CPU going?" rather than "which scenario is faster?". It profiles fixed
+# work in a single BEAM process and prints eprof's total-time table.
+#
+# Usage:
+#
+#   SCENARIO=old BATCH_SIZE=1000 ITERATIONS=1 \
+#     mix run --no-start bench/clickhouse_pipeline_eprof.exs
+#   SCENARIO=stream_ets BATCH_SIZE=10 ITERATIONS=100 \
+#     mix run --no-start bench/clickhouse_pipeline_eprof.exs
+#
+# Scenarios are the same as clickhouse_pipeline_cpu_runner.exs:
+#   old, old_materialized, stream, stream_hoisted, stream_chunked,
+#   stream_ets, stream_ets_hoisted, stream_ets_chunked,
+#   old_queue, id_queue, id_queue_hoisted, id_queue_chunked, id_queue_metadata
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+
+scenario = System.get_env("SCENARIO", "old") |> String.to_existing_atom()
+type = System.get_env("EVENT_TYPE", "log") |> String.to_existing_atom()
+shape = System.get_env("SHAPE", "small") |> String.to_existing_atom()
+batch_size = System.get_env("BATCH_SIZE", "1000") |> String.to_integer()
+iterations = System.get_env("ITERATIONS", "1") |> String.to_integer()
+
+{compiled, config_id} = Data.compiled(type)
+events = Data.batch(type, batch_size, shape)
+
+input = %{
+  events: events,
+  type: type,
+  compiled: compiled,
+  config_id: config_id
+}
+
+input =
+  if scenario in [:stream_ets, :stream_ets_hoisted, :stream_ets_chunked] do
+    Map.put(input, :processing_tid, Data.setup_processing_ets(events))
+  else
+    input
+  end
+
+input =
+  if scenario in [:old_queue, :id_queue, :id_queue_hoisted, :id_queue_chunked, :id_queue_metadata] do
+    {queue_key, queue_tid} = Data.setup_queue(7_777_777)
+
+    input
+    |> Map.put(:queue_key, queue_key)
+    |> Map.put(:queue_tid, queue_tid)
+  else
+    input
+  end
+
+Data.run_scenario(scenario, input) |> byte_size()
+:erlang.garbage_collect()
+
+IO.puts(
+  "scenario=#{scenario} event_type=#{type} shape=#{shape} " <>
+    "batch_size=#{batch_size} iterations=#{iterations}"
+)
+
+:eprof.start()
+
+:eprof.profile(fn ->
+  for _ <- 1..iterations do
+    Data.run_scenario(scenario, input) |> byte_size()
+  end
+end)
+
+:eprof.stop_profiling()
+:eprof.analyze(:total)
+:eprof.stop()

--- a/bench/clickhouse_pipeline_queue_cpu.exs
+++ b/bench/clickhouse_pipeline_queue_cpu.exs
@@ -1,0 +1,94 @@
+# Queue-level CPU benchmark for PR #3667's ClickHouse id-passing pipeline.
+#
+# This includes the ETS queue operations that the isolated encode/compress bench
+# intentionally omits:
+#
+#   old queue path: add_to_table -> pop_pending -> encode_batch -> gzip
+#   id queue path:  add_to_table -> take_pending_ids -> routing lookup ->
+#                   per-row ETS lookup -> stream deflate -> delete_id ack
+#
+# It still avoids ClickHouse/network I/O so the result is focused on local CPU,
+# ETS, mapping, encoding, compression, and ack/delete overhead.
+#
+# Usage:
+#
+#   mix run --no-start bench/clickhouse_pipeline_queue_cpu.exs
+#   EVENT_TYPES=log BATCH_SIZES=1000,10000 SHAPES=realistic \
+#     mix run --no-start bench/clickhouse_pipeline_queue_cpu.exs
+#
+# For fixed-work CPU seconds per row, use bench/clickhouse_pipeline_cpu_runner.exs
+# with SCENARIO=old_queue and SCENARIO=id_queue under /usr/bin/time.
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+
+parse_csv = fn env, default, mapper ->
+  env
+  |> System.get_env(default)
+  |> String.split(",", trim: true)
+  |> Enum.map(mapper)
+end
+
+batch_sizes = parse_csv.("BATCH_SIZES", "1000,10000", &String.to_integer/1)
+event_types = parse_csv.("EVENT_TYPES", "log", &String.to_existing_atom/1)
+shapes = parse_csv.("SHAPES", "realistic", &String.to_existing_atom/1)
+benchee_time = System.get_env("BENCH_TIME", "5") |> String.to_integer()
+benchee_warmup = System.get_env("BENCH_WARMUP", "2") |> String.to_integer()
+
+inputs =
+  for {shape, shape_idx} <- Enum.with_index(shapes),
+      {type, type_idx} <- Enum.with_index(event_types),
+      {batch_size, size_idx} <- Enum.with_index(batch_sizes),
+      into: %{} do
+    {compiled, config_id} = Data.compiled(type)
+    events = Data.batch(type, batch_size, shape)
+    backend_id = 9_000_000 + shape_idx * 10_000 + type_idx * 100 + size_idx
+    {queue_key, queue_tid} = Data.setup_queue(backend_id)
+    encoded_bytes = Data.encoded_bytes(events, type, compiled, config_id)
+
+    label = "#{type}/#{shape}/batch=#{batch_size}"
+
+    IO.puts(
+      "#{label}: #{encoded_bytes} uncompressed RowBinary bytes " <>
+        "(#{Float.round(encoded_bytes / batch_size, 1)} bytes/event)"
+    )
+
+    {label,
+     %{
+       events: events,
+       type: type,
+       compiled: compiled,
+       config_id: config_id,
+       queue_key: queue_key,
+       queue_tid: queue_tid
+     }}
+  end
+
+IO.puts("")
+
+Benchee.run(
+  %{
+    "old queue pop + encode_batch + gzip" => fn input ->
+      Data.run_scenario(:old_queue, input)
+    end,
+    "id-passing queue + stream deflate" => fn input ->
+      Data.run_scenario(:id_queue, input)
+    end,
+    "id-passing queue + stream deflate (hoisted uuid)" => fn input ->
+      Data.run_scenario(:id_queue_hoisted, input)
+    end,
+    "id-passing queue + stream deflate (chunked)" => fn input ->
+      Data.run_scenario(:id_queue_chunked, input)
+    end,
+    "id-passing queue + metadata routing + hoisted stream" => fn input ->
+      Data.run_scenario(:id_queue_metadata, input)
+    end
+  },
+  inputs: inputs,
+  time: benchee_time,
+  warmup: benchee_warmup,
+  memory_time: System.get_env("BENCH_MEMORY_TIME", "2") |> String.to_integer(),
+  reduction_time: System.get_env("BENCH_REDUCTION_TIME", "2") |> String.to_integer(),
+  print: [configuration: false]
+)

--- a/bench/support/clickhouse_pipeline_bench_data.exs
+++ b/bench/support/clickhouse_pipeline_bench_data.exs
@@ -1,0 +1,691 @@
+defmodule Logflare.Bench.ClickHousePipelineData do
+  @moduledoc false
+
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults
+  alias Logflare.Backends.IngestEventQueue
+  alias Logflare.LogEvent
+  alias Logflare.Mapper
+
+  @mapping_config_id "00000000-0000-0000-0001-000000000003"
+  @source_uuid String.to_atom("550e8400-e29b-41d4-a716-446655440000")
+
+  @type event_type :: :log | :metric | :trace
+
+  @spec compiled(event_type()) :: {reference(), String.t()}
+  def compiled(type) do
+    {type |> MappingDefaults.for_type() |> Mapper.compile!(), MappingDefaults.config_id(type)}
+  end
+
+  @spec batch(event_type(), pos_integer(), atom()) :: [LogEvent.t()]
+  def batch(type, count, shape \\ :realistic) when type in [:log, :metric, :trace] do
+    Enum.map(1..count, &event(type, &1, shape))
+  end
+
+  @spec encoded_bytes([LogEvent.t()], event_type(), reference(), String.t()) :: non_neg_integer()
+  def encoded_bytes(events, type, compiled, config_id) do
+    events
+    |> Enum.map(&map_event(&1, type, compiled, config_id))
+    |> Ingester.encode_batch(type)
+    |> IO.iodata_to_binary()
+    |> byte_size()
+  end
+
+  @spec old_encode_gzip([LogEvent.t()], event_type(), reference(), String.t()) :: binary()
+  def old_encode_gzip(events, type, compiled, config_id) do
+    events
+    |> Enum.map(&map_event(&1, type, compiled, config_id))
+    |> Ingester.encode_batch(type)
+    |> :zlib.gzip()
+  end
+
+  @spec old_materialize_then_gzip([LogEvent.t()], event_type(), reference(), String.t()) ::
+          binary()
+  def old_materialize_then_gzip(events, type, compiled, config_id) do
+    events
+    |> Enum.map(&map_event(&1, type, compiled, config_id))
+    |> Ingester.encode_batch(type)
+    |> IO.iodata_to_binary()
+    |> :zlib.gzip()
+  end
+
+  @spec stream_deflate_events([LogEvent.t()], event_type(), reference(), String.t()) :: binary()
+  def stream_deflate_events(events, type, compiled, config_id) do
+    gzip_stream(fn z ->
+      Enum.reduce(events, [], fn event, chunks ->
+        mapped = map_event(event, type, compiled, config_id)
+        [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type))]
+      end)
+    end)
+  end
+
+  @spec stream_deflate_events_hoisted([LogEvent.t()], event_type(), reference(), String.t()) ::
+          binary()
+  def stream_deflate_events_hoisted(events, type, compiled, config_id) do
+    mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
+    gzip_stream(fn z ->
+      Enum.reduce(events, [], fn event, chunks ->
+        mapped = map_event(event, type, compiled, config_id)
+        [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id))]
+      end)
+    end)
+  end
+
+  @spec stream_deflate_events_chunked([LogEvent.t()], event_type(), reference(), String.t()) ::
+          binary()
+  def stream_deflate_events_chunked(events, type, compiled, config_id) do
+    mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
+    gzip_stream_chunked(events, fn event ->
+      event
+      |> map_event(type, compiled, config_id)
+      |> Ingester.encode_row(type, mapping_config_id)
+    end)
+  end
+
+  @spec setup_processing_ets([LogEvent.t()]) :: :ets.tid()
+  def setup_processing_ets(events) do
+    tid = :ets.new(:clickhouse_pipeline_bench_queue, [:set, :public, read_concurrency: true])
+    claimed_at = System.monotonic_time(:millisecond)
+
+    for event <- events do
+      :ets.insert(
+        tid,
+        {event.id, :processing, event, :erlang.external_size(event.body), 1, claimed_at}
+      )
+    end
+
+    tid
+  end
+
+  @spec stream_deflate_ets([{term(), :ets.tid()}], event_type(), reference(), String.t()) ::
+          binary()
+  def stream_deflate_ets(id_tid_pairs, type, compiled, config_id) do
+    gzip_stream(fn z ->
+      Enum.reduce(id_tid_pairs, [], fn {id, tid}, chunks ->
+        case IngestEventQueue.lookup_id(tid, id) do
+          {^id, :processing, %LogEvent{} = event, _size} ->
+            mapped = map_event(event, type, compiled, config_id)
+            [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type))]
+
+          _ ->
+            chunks
+        end
+      end)
+    end)
+  end
+
+  @spec stream_deflate_ets_hoisted([{term(), :ets.tid()}], event_type(), reference(), String.t()) ::
+          binary()
+  def stream_deflate_ets_hoisted(id_tid_pairs, type, compiled, config_id) do
+    mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
+    gzip_stream(fn z ->
+      Enum.reduce(id_tid_pairs, [], fn {id, tid}, chunks ->
+        case IngestEventQueue.lookup_id(tid, id) do
+          {^id, :processing, %LogEvent{} = event, _size} ->
+            mapped = map_event(event, type, compiled, config_id)
+            [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id))]
+
+          _ ->
+            chunks
+        end
+      end)
+    end)
+  end
+
+  @spec stream_deflate_ets_chunked([{term(), :ets.tid()}], event_type(), reference(), String.t()) ::
+          binary()
+  def stream_deflate_ets_chunked(id_tid_pairs, type, compiled, config_id) do
+    mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
+    gzip_stream_chunked(id_tid_pairs, fn {id, tid} ->
+      case IngestEventQueue.lookup_id(tid, id) do
+        {^id, :processing, %LogEvent{} = event, _size} ->
+          event
+          |> map_event(type, compiled, config_id)
+          |> Ingester.encode_row(type, mapping_config_id)
+
+        _ ->
+          []
+      end
+    end)
+  end
+
+  @spec ensure_ingest_queue_started() :: :ok
+  def ensure_ingest_queue_started do
+    case Process.whereis(IngestEventQueue) do
+      nil ->
+        {:ok, _pid} = IngestEventQueue.start_link([])
+        :ok
+
+      _pid ->
+        :ok
+    end
+  end
+
+  @spec setup_queue(pos_integer()) :: {IngestEventQueue.consolidated_table_key(), :ets.tid()}
+  def setup_queue(backend_id) do
+    ensure_ingest_queue_started()
+    key = {:consolidated, backend_id, self()}
+
+    tid =
+      case IngestEventQueue.upsert_tid(key) do
+        {:ok, tid} -> tid
+        {:error, :already_exists, tid} -> tid
+      end
+
+    :ets.delete_all_objects(tid)
+    {key, tid}
+  end
+
+  @spec old_queue_pop_encode_gzip(
+          IngestEventQueue.consolidated_table_key(),
+          :ets.tid(),
+          [LogEvent.t()],
+          event_type(),
+          reference(),
+          String.t()
+        ) :: binary()
+  def old_queue_pop_encode_gzip(key, tid, events, type, compiled, config_id) do
+    :ets.delete_all_objects(tid)
+    :ok = IngestEventQueue.add_to_table({key, tid}, events)
+    {:ok, popped} = IngestEventQueue.pop_pending(key, length(events))
+    old_encode_gzip(popped, type, compiled, config_id)
+  end
+
+  @spec id_passing_queue_stream(
+          IngestEventQueue.consolidated_table_key(),
+          :ets.tid(),
+          [LogEvent.t()],
+          event_type(),
+          reference(),
+          String.t()
+        ) :: binary()
+  def id_passing_queue_stream(key, tid, events, type, compiled, config_id) do
+    id_passing_queue_stream(key, tid, events, type, compiled, config_id, :per_row)
+  end
+
+  @spec id_passing_queue_stream_hoisted(
+          IngestEventQueue.consolidated_table_key(),
+          :ets.tid(),
+          [LogEvent.t()],
+          event_type(),
+          reference(),
+          String.t()
+        ) :: binary()
+  def id_passing_queue_stream_hoisted(key, tid, events, type, compiled, config_id) do
+    id_passing_queue_stream(key, tid, events, type, compiled, config_id, :hoisted)
+  end
+
+  @spec id_passing_queue_stream_chunked(
+          IngestEventQueue.consolidated_table_key(),
+          :ets.tid(),
+          [LogEvent.t()],
+          event_type(),
+          reference(),
+          String.t()
+        ) :: binary()
+  def id_passing_queue_stream_chunked(key, tid, events, type, compiled, config_id) do
+    id_passing_queue_stream(key, tid, events, type, compiled, config_id, :chunked)
+  end
+
+  defp id_passing_queue_stream(key, tid, events, type, compiled, config_id, mode) do
+    :ets.delete_all_objects(tid)
+    :ok = IngestEventQueue.add_to_table({key, tid}, events)
+    {:ok, id_size_pairs, ^tid} = IngestEventQueue.take_pending_ids(key, length(events))
+
+    routed_pairs =
+      Enum.reduce(id_size_pairs, [], fn {id, _size}, acc ->
+        case IngestEventQueue.lookup_id(tid, id) do
+          {^id, :processing, %LogEvent{event_type: ^type}, _size} -> [{id, tid} | acc]
+          _ -> acc
+        end
+      end)
+
+    compress_and_delete(routed_pairs, tid, type, compiled, config_id, mode)
+  end
+
+  @spec id_passing_queue_stream_metadata(
+          IngestEventQueue.consolidated_table_key(),
+          :ets.tid(),
+          [LogEvent.t()],
+          event_type(),
+          reference(),
+          String.t()
+        ) :: binary()
+  def id_passing_queue_stream_metadata(key, tid, events, type, compiled, config_id) do
+    :ets.delete_all_objects(tid)
+    :ok = IngestEventQueue.add_to_table({key, tid}, events)
+
+    {:ok, metadata, ^tid} =
+      IngestEventQueue.take_pending_ids_with_metadata(key, length(events))
+
+    routed_pairs =
+      Enum.reduce(metadata, [], fn
+        {id, _size, ^type, _day_bucket, _freshness}, acc -> [{id, tid} | acc]
+        _other, acc -> acc
+      end)
+
+    compress_and_delete(routed_pairs, tid, type, compiled, config_id, :hoisted)
+  end
+
+  defp compress_and_delete(routed_pairs, tid, type, compiled, config_id, mode) do
+    compressed =
+      case mode do
+        :per_row -> stream_deflate_ets(routed_pairs, type, compiled, config_id)
+        :hoisted -> stream_deflate_ets_hoisted(routed_pairs, type, compiled, config_id)
+        :chunked -> stream_deflate_ets_chunked(routed_pairs, type, compiled, config_id)
+      end
+
+    Enum.each(routed_pairs, fn {id, ^tid} -> IngestEventQueue.delete_id(tid, id) end)
+
+    compressed
+  end
+
+  @spec run_scenario(atom(), map()) :: binary()
+  def run_scenario(:old, %{events: events, type: type, compiled: compiled, config_id: config_id}) do
+    old_encode_gzip(events, type, compiled, config_id)
+  end
+
+  def run_scenario(:old_materialized, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id
+      }) do
+    old_materialize_then_gzip(events, type, compiled, config_id)
+  end
+
+  def run_scenario(:stream, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id
+      }) do
+    stream_deflate_events(events, type, compiled, config_id)
+  end
+
+  def run_scenario(:stream_hoisted, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id
+      }) do
+    stream_deflate_events_hoisted(events, type, compiled, config_id)
+  end
+
+  def run_scenario(:stream_chunked, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id
+      }) do
+    stream_deflate_events_chunked(events, type, compiled, config_id)
+  end
+
+  def run_scenario(:stream_ets, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        processing_tid: tid
+      }) do
+    stream_deflate_ets(Enum.map(events, &{&1.id, tid}), type, compiled, config_id)
+  end
+
+  def run_scenario(:stream_ets_hoisted, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        processing_tid: tid
+      }) do
+    stream_deflate_ets_hoisted(Enum.map(events, &{&1.id, tid}), type, compiled, config_id)
+  end
+
+  def run_scenario(:stream_ets_chunked, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        processing_tid: tid
+      }) do
+    stream_deflate_ets_chunked(Enum.map(events, &{&1.id, tid}), type, compiled, config_id)
+  end
+
+  def run_scenario(:old_queue, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        queue_key: key,
+        queue_tid: tid
+      }) do
+    old_queue_pop_encode_gzip(key, tid, events, type, compiled, config_id)
+  end
+
+  def run_scenario(:id_queue, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        queue_key: key,
+        queue_tid: tid
+      }) do
+    id_passing_queue_stream(key, tid, events, type, compiled, config_id)
+  end
+
+  def run_scenario(:id_queue_hoisted, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        queue_key: key,
+        queue_tid: tid
+      }) do
+    id_passing_queue_stream_hoisted(key, tid, events, type, compiled, config_id)
+  end
+
+  def run_scenario(:id_queue_chunked, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        queue_key: key,
+        queue_tid: tid
+      }) do
+    id_passing_queue_stream_chunked(key, tid, events, type, compiled, config_id)
+  end
+
+  def run_scenario(:id_queue_metadata, %{
+        events: events,
+        type: type,
+        compiled: compiled,
+        config_id: config_id,
+        queue_key: key,
+        queue_tid: tid
+      }) do
+    id_passing_queue_stream_metadata(key, tid, events, type, compiled, config_id)
+  end
+
+  defp gzip_stream(fun) do
+    z = :zlib.open()
+
+    try do
+      :zlib.deflateInit(z, :default, :deflated, 31, 8, :default)
+      chunks = fun.(z)
+      IO.iodata_to_binary([chunks, :zlib.deflate(z, "", :finish)])
+    after
+      :zlib.deflateEnd(z)
+      :zlib.close(z)
+    end
+  end
+
+  defp gzip_stream_chunked(items, row_fun) do
+    chunk_rows = System.get_env("CHUNK_ROWS", "100") |> String.to_integer()
+    z = :zlib.open()
+
+    try do
+      :zlib.deflateInit(z, :default, :deflated, 31, 8, :default)
+
+      {chunks, pending, count} =
+        Enum.reduce(items, {[], [], 0}, fn item, {chunks, pending, count} ->
+          pending = [row_fun.(item) | pending]
+          count = count + 1
+
+          if count >= chunk_rows do
+            {[chunks, :zlib.deflate(z, :lists.reverse(pending))], [], 0}
+          else
+            {chunks, pending, count}
+          end
+        end)
+
+      chunks = if count > 0, do: [chunks, :zlib.deflate(z, :lists.reverse(pending))], else: chunks
+      IO.iodata_to_binary([chunks, :zlib.deflate(z, "", :finish)])
+    after
+      :zlib.deflateEnd(z)
+      :zlib.close(z)
+    end
+  end
+
+  defp map_event(%LogEvent{} = event, type, compiled, config_id) do
+    mapped_body =
+      event.body
+      |> Mapper.map(compiled)
+      |> Map.put("mapping_config_id", config_id)
+      |> maybe_compute_duration(type)
+      |> resolve_severity_number(type)
+
+    %{event | body: mapped_body}
+  end
+
+  defp maybe_compute_duration(
+         %{"start_time" => start_time, "end_time" => end_time, "duration" => 0} = body,
+         :trace
+       )
+       when is_integer(start_time) and is_integer(end_time) and end_time > start_time do
+    %{body | "duration" => end_time - start_time}
+  end
+
+  defp maybe_compute_duration(body, _type), do: body
+
+  defp resolve_severity_number(%{"severity_number_alt" => alt} = body, :log)
+       when is_integer(alt) and alt > 0 do
+    %{body | "severity_number" => alt}
+  end
+
+  defp resolve_severity_number(body, _type), do: body
+
+  defp event(:log, i, shape) do
+    base_event(:log, i, %{
+      "project" => "bench-project",
+      "trace_id" => Base.encode16(<<i::128>>, case: :lower),
+      "span_id" => Base.encode16(<<i::64>>, case: :lower),
+      "trace_flags" => 1,
+      "severity_text" => Enum.at(~w(DEBUG INFO WARN ERROR), rem(i, 4)),
+      "severity_number" => Enum.at([5, 9, 13, 17], rem(i, 4)),
+      "severity_number_alt" => Enum.at([0, 0, 13, 17], rem(i, 4)),
+      "service_name" => "checkout-service",
+      "event_message" => event_message(i, shape),
+      "scope_name" => "logflare.instrumentation",
+      "scope_version" => "1.0.0",
+      "scope_schema_url" => "",
+      "resource_schema_url" => "https://opentelemetry.io/schemas/1.21.0",
+      "resource_attributes" => resource_attributes(i, shape),
+      "scope_attributes" => %{"library.language" => "elixir"},
+      "log_attributes" => log_attributes(i, shape),
+      "timestamp" => 1_700_000_000_000_000 + i
+    })
+  end
+
+  defp event(:metric, i, shape) do
+    base_event(:metric, i, %{
+      "project" => "bench-project",
+      "time_unix" => 1_700_000_000_000_000 + i,
+      "start_time_unix" => 1_700_000_000_000_000,
+      "metric_name" => "http.server.duration",
+      "metric_description" => "Duration of inbound HTTP requests",
+      "metric_unit" => "ms",
+      "metric_type" => rem(i, 3) + 1,
+      "service_name" => "checkout-service",
+      "event_message" => "",
+      "scope_name" => "logflare.instrumentation",
+      "scope_version" => "1.0.0",
+      "scope_schema_url" => "",
+      "resource_schema_url" => "https://opentelemetry.io/schemas/1.21.0",
+      "resource_attributes" => resource_attributes(i, shape),
+      "scope_attributes" => %{"library.language" => "elixir"},
+      "attributes" => log_attributes(i, shape),
+      "aggregation_temporality" => "cumulative",
+      "is_monotonic" => true,
+      "flags" => 0,
+      "value" => i * 1.5,
+      "count" => i,
+      "sum" => i * 12.3,
+      "min" => 0.5,
+      "max" => i * 1.0,
+      "scale" => 0,
+      "zero_count" => 0,
+      "positive_offset" => 0,
+      "negative_offset" => 0,
+      "bucket_counts" => Enum.map(0..9, &(&1 + rem(i, 3))),
+      "explicit_bounds" => [0.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0],
+      "positive_bucket_counts" => [],
+      "negative_bucket_counts" => [],
+      "quantile_values" => [],
+      "quantiles" => [],
+      "exemplars.filtered_attributes" => [%{"trace_id" => "abc"}],
+      "exemplars.time_unix" => [1_700_000_000_000_000 + i],
+      "exemplars.value" => [i * 1.0],
+      "exemplars.span_id" => [Base.encode16(<<i::64>>, case: :lower)],
+      "exemplars.trace_id" => [Base.encode16(<<i::128>>, case: :lower)],
+      "timestamp" => 1_700_000_000_000_000 + i
+    })
+  end
+
+  defp event(:trace, i, shape) do
+    event_count = rem(i, 4)
+    start_time = 1_700_000_000_000_000 + i
+    end_time = start_time + rem(i, 800) * 1_000_000
+
+    base_event(:trace, i, %{
+      "project" => "bench-project",
+      "timestamp" => start_time,
+      "start_time" => start_time,
+      "end_time" => end_time,
+      "trace_id" => Base.encode16(<<i::128>>, case: :lower),
+      "span_id" => Base.encode16(<<i::64>>, case: :lower),
+      "parent_span_id" => Base.encode16(<<i + 1::64>>, case: :lower),
+      "trace_state" => "",
+      "span_name" => "POST /api/v1/orders",
+      "span_kind" => "SPAN_KIND_SERVER",
+      "service_name" => "checkout-service",
+      "event_message" => "",
+      "duration" => 0,
+      "status_code" => Enum.at(~w(STATUS_CODE_OK STATUS_CODE_ERROR), rem(i, 2)),
+      "status_message" => "",
+      "scope_name" => "logflare.instrumentation",
+      "scope_version" => "1.0.0",
+      "resource_attributes" => resource_attributes(i, shape),
+      "span_attributes" => log_attributes(i, shape),
+      "events.timestamp" => Enum.map(1..event_count//1, &(start_time + &1)),
+      "events.name" => Enum.map(1..event_count//1, &"event.#{&1}"),
+      "events.attributes" =>
+        Enum.map(1..event_count//1, fn n ->
+          %{"exception.type" => "Error#{n}", "exception.message" => "boom #{n}"}
+        end),
+      "links.trace_id" => [Base.encode16(<<i + 2::128>>, case: :lower)],
+      "links.span_id" => [Base.encode16(<<i + 2::64>>, case: :lower)],
+      "links.trace_state" => [""],
+      "links.attributes" => [%{"link.kind" => "child"}]
+    })
+  end
+
+  defp base_event(type, i, body) do
+    %LogEvent{
+      id: Ecto.UUID.generate(),
+      source_uuid: @source_uuid,
+      source_name: "bench source",
+      event_type: type,
+      day_bucket: div(1_700_000_000 + i, 86_400),
+      ingest_freshness: :fresh,
+      ingested_at: DateTime.utc_now(),
+      body: Map.put(body, "mapping_config_id", @mapping_config_id)
+    }
+  end
+
+  defp resource_attributes(i, :small) do
+    %{"service.name" => "checkout-service", "host.name" => "host-#{rem(i, 32)}"}
+  end
+
+  defp resource_attributes(i, shape) do
+    base = %{
+      "service.name" => "checkout-service",
+      "service.version" => "2.#{rem(i, 20)}.1",
+      "service.namespace" => "ecommerce",
+      "service.instance.id" => "i-0#{rem(i, 64)}a1b2c3d4e5f6",
+      "host.name" => "ip-10-0-#{rem(i, 256)}-#{rem(i * 7, 256)}.ec2.internal",
+      "host.arch" => "amd64",
+      "cloud.provider" => "aws",
+      "cloud.region" => "us-east-1",
+      "telemetry.sdk.name" => "opentelemetry",
+      "telemetry.sdk.language" => "erlang",
+      "telemetry.sdk.version" => "1.4.0"
+    }
+
+    base =
+      case rem(i, 3) do
+        0 ->
+          Map.merge(base, %{
+            "k8s.pod.name" => "checkout-service-#{rem(i, 9999)}-abcde",
+            "k8s.namespace.name" => "production",
+            "k8s.node.name" => "gke-prod-pool-#{rem(i, 16)}"
+          })
+
+        1 ->
+          Map.put(base, "deployment.environment", "production")
+
+        _ ->
+          base
+      end
+
+    if shape == :large do
+      Map.merge(base, %{
+        "large.attr.1" => String.duplicate("a", 512),
+        "large.attr.2" => String.duplicate("b", 512),
+        "large.attr.3" => String.duplicate("c", 512)
+      })
+    else
+      base
+    end
+  end
+
+  defp log_attributes(i, :small) do
+    %{"http.method" => "GET", "http.status_code" => "200", "request.id" => "req_#{i}"}
+  end
+
+  defp log_attributes(i, shape) do
+    base = %{
+      "http.method" => Enum.at(~w(GET POST PUT DELETE), rem(i, 4)),
+      "http.status_code" => "#{Enum.at([200, 201, 400, 404, 500], rem(i, 5))}",
+      "http.route" => "/api/v1/orders/:id/line_items",
+      "user.id" => "user_#{rem(i, 100_000)}",
+      "request.id" => "req_#{i}"
+    }
+
+    cond do
+      shape == :large ->
+        Map.put(
+          base,
+          "error.stack",
+          "** (RuntimeError) boom\n" <> String.duplicate("    at foo/bar:42\n", 50)
+        )
+
+      rem(i, 4) == 0 ->
+        Map.put(
+          base,
+          "error.stack",
+          "** (RuntimeError) boom\n" <> String.duplicate("    at foo/bar:42\n", 6)
+        )
+
+      true ->
+        base
+    end
+  end
+
+  defp event_message(i, :small), do: "GET /api/v1/orders/#{i} 200"
+
+  defp event_message(i, :large) do
+    ~s({"event":"order.created","order_id":#{i},"items":#{rem(i, 12) + 1},"total_cents":#{i * 137},"currency":"USD","customer":"user_#{rem(i, 100_000)}","note":"#{String.duplicate("x", 2_000 + rem(i, 500))}"})
+  end
+
+  defp event_message(i, _shape) do
+    if rem(i, 5) == 0 do
+      ~s({"event":"order.created","order_id":#{i},"items":#{rem(i, 12) + 1},"total_cents":#{i * 137},"currency":"USD","customer":"user_#{rem(i, 100_000)}","note":"#{String.duplicate("x", rem(i, 200))}"})
+    else
+      "GET /api/v1/orders/#{i}/line_items 200 in #{rem(i, 800)}ms"
+    end
+  end
+end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -139,19 +139,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   end
 
   @doc false
+  @spec encode_mapping_config_id(String.t()) :: iodata()
+  def encode_mapping_config_id(config_id), do: RowBinaryEncoder.uuid(config_id)
+
+  @doc false
   @spec encode_row(LogEvent.t(), TypeDetection.event_type()) :: iodata()
   def encode_row(%LogEvent{body: body} = event, event_type) when is_event_type(event_type) do
-    encode_row(event, event_type, RowBinaryEncoder.uuid(body["mapping_config_id"]))
+    encode_row(event, event_type, encode_mapping_config_id(body["mapping_config_id"]))
   end
 
+  @doc false
   @spec encode_row(LogEvent.t(), TypeDetection.event_type(), iodata()) :: iodata()
-  defp encode_row(%LogEvent{} = event, :log, mapping_config_id),
+  def encode_row(%LogEvent{} = event, :log, mapping_config_id),
     do: encode_log_row(event, mapping_config_id)
 
-  defp encode_row(%LogEvent{} = event, :metric, mapping_config_id),
+  def encode_row(%LogEvent{} = event, :metric, mapping_config_id),
     do: encode_metric_row(event, mapping_config_id)
 
-  defp encode_row(%LogEvent{} = event, :trace, mapping_config_id),
+  def encode_row(%LogEvent{} = event, :trace, mapping_config_id),
     do: encode_trace_row(event, mapping_config_id)
 
   @doc false

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -125,8 +125,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     }
   end
 
-  def transform({id, tid, _size, _event_type, _day_bucket, _freshness}, opts) do
-    transform({id, tid, 0}, opts)
+  def transform({id, tid, size, _event_type, _day_bucket, _freshness}, opts) do
+    transform({id, tid, size}, opts)
   end
 
   def transform({id, tid, _size}, opts) do

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -11,8 +11,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   `{event_type, day_bucket}` so each insert targets a single ClickHouse
   partition. Multiple sources are processed together in a single pipeline.
 
-  Uses ID-passing: the producer emits `{id, tid, size}` tuples and events
-  remain in ETS as `:processing` throughout. Each batcher fetches events
+  Uses ID-passing: the producer emits IDs plus small routing metadata while
+  events remain in ETS as `:processing` throughout. Each batcher fetches events
   from ETS and streams them through zlib deflate to build a gzip-compressed
   RowBinary payload without holding the full batch in process memory.
   """
@@ -73,7 +73,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       hibernate_after: 5_000,
       spawn_opt: [fullsweep_after: 100],
       producer: [
-        module: {BufferProducer, [backend_id: backend.id, consolidated: true, id_passing: true]},
+        module:
+          {BufferProducer,
+           [
+             backend_id: backend.id,
+             consolidated: true,
+             id_passing: true,
+             id_passing_metadata: true
+           ]},
         transformer: {__MODULE__, :transform, [backend_id: backend.id]},
         concurrency: @producer_concurrency
       ],
@@ -103,8 +110,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     {:via, module, {registry, new_identifier}}
   end
 
-  @spec transform(event :: {term(), :ets.tid(), non_neg_integer()}, opts :: keyword()) ::
-          Message.t()
+  @spec transform(
+          event ::
+            {term(), :ets.tid(), non_neg_integer()}
+            | {term(), :ets.tid(), non_neg_integer(), TypeDetection.event_type(), integer(),
+               :fresh | :stale},
+          opts :: keyword()
+        ) :: Message.t()
+  def transform({id, tid, _size, event_type, day_bucket, freshness}, opts)
+      when is_event_type(event_type) and freshness in [:fresh, :stale] do
+    %Message{
+      data: {id, tid, event_type, day_bucket, freshness},
+      acknowledger: {__MODULE__, :ack_id, %{backend_id: opts[:backend_id]}}
+    }
+  end
+
+  def transform({id, tid, _size, _event_type, _day_bucket, _freshness}, opts) do
+    transform({id, tid, 0}, opts)
+  end
+
   def transform({id, tid, _size}, opts) do
     %Message{
       data: {id, tid},
@@ -114,6 +138,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec handle_message(processor_name :: atom(), message :: Message.t(), context :: map()) ::
           Message.t()
+  def handle_message(
+        _processor_name,
+        %Message{data: {id, tid, event_type, day_bucket, freshness}} = message,
+        _context
+      )
+      when is_event_type(event_type) and freshness in [:fresh, :stale] do
+    message
+    |> Message.put_data({id, tid, event_type, day_bucket})
+    |> Message.put_batcher(ingest_freshness_to_batcher(freshness))
+    |> Message.put_batch_key({event_type, day_bucket})
+  end
+
   def handle_message(_processor_name, %Message{data: {id, tid}} = message, _context) do
     case IngestEventQueue.lookup_id(tid, id) do
       {^id, :processing, %LogEvent{event_type: event_type, day_bucket: day_bucket} = event, _}
@@ -247,9 +283,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       # good/bad end up reversed relative to `messages`; that's fine — Broadway
       # partitions and re-reverses handle_batch/4's return by status internally,
       # and neither the acknowledger nor ClickHouse cares about row order.
+      mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
       {good, bad, chunks} =
         Enum.reduce(messages, {[], [], []}, fn message, acc ->
-          encode_message(z, event_type, compiled, config_id, message, acc)
+          encode_message(z, event_type, compiled, config_id, mapping_config_id, message, acc)
         end)
 
       final_chunk = :zlib.deflate(z, "", :finish)
@@ -265,6 +303,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           TypeDetection.event_type(),
           reference(),
           String.t(),
+          iodata(),
           Message.t(),
           {[Message.t()], [Message.t()], iodata()}
         ) :: {[Message.t()], [Message.t()], iodata()}
@@ -273,6 +312,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
          event_type,
          compiled,
          config_id,
+         mapping_config_id,
          %{data: {id, tid, msg_event_type, _day_bucket}} = message,
          {good, bad, chunks}
        )
@@ -287,7 +327,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           |> resolve_severity_number(event_type)
 
         row_chunk =
-          :zlib.deflate(z, Ingester.encode_row(%{event | body: mapped_body}, event_type))
+          :zlib.deflate(
+            z,
+            Ingester.encode_row(%{event | body: mapped_body}, event_type, mapping_config_id)
+          )
 
         {[message | good], bad, [chunks, row_chunk]}
 
@@ -296,7 +339,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     end
   end
 
-  defp encode_message(_z, _event_type, _compiled, _config_id, message, {good, bad, chunks}) do
+  defp encode_message(
+         _z,
+         _event_type,
+         _compiled,
+         _config_id,
+         _mapping_config_id,
+         message,
+         {good, bad, chunks}
+       ) do
     {good, [message | bad], chunks}
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -370,6 +370,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           [Message.t()],
           [Message.t()]
         ) :: [Message.t()]
+  defp finalize_insert(_backend, _event_type, _batcher, _compressed, [] = _good, bad) do
+    # No rows encoded (every event was missing from ETS by batch time), so the
+    # compressed payload carries zero RowBinary rows. Skip the empty ClickHouse
+    # insert and fail the missing messages, mirroring Ingester.insert/5's empty guard.
+    Enum.map(bad, &Message.failed(&1, :not_found))
+  end
+
   defp finalize_insert(backend, event_type, batcher, compressed, good, bad) do
     case ClickHouseAdaptor.insert_log_events_compressed(
            backend,

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -18,6 +18,7 @@ defmodule Logflare.Backends.BufferProducer do
   @type standard_state :: %{
           consolidated: boolean(),
           id_passing: boolean(),
+          id_passing_metadata: boolean(),
           demand: non_neg_integer(),
           source_id: pos_integer() | nil,
           source_token: atom() | nil,
@@ -98,6 +99,7 @@ defmodule Logflare.Backends.BufferProducer do
     state = %{
       consolidated: false,
       id_passing: Keyword.get(opts, :id_passing, false),
+      id_passing_metadata: Keyword.get(opts, :id_passing_metadata, false),
       demand: 0,
       source_id: opts[:source_id],
       source_token: source.token,
@@ -118,11 +120,13 @@ defmodule Logflare.Backends.BufferProducer do
   @spec init_consolidated_state(pos_integer(), pos_integer(), keyword()) :: state()
   defp init_consolidated_state(backend_id, interval, opts) do
     id_passing = Keyword.get(opts, :id_passing, false)
+    id_passing_metadata = Keyword.get(opts, :id_passing_metadata, false)
 
     state = %{
       consolidated: true,
       demand: 0,
       id_passing: id_passing,
+      id_passing_metadata: id_passing_metadata,
       source_id: nil,
       source_token: nil,
       backend_id: backend_id,
@@ -307,8 +311,31 @@ defmodule Logflare.Backends.BufferProducer do
   end
 
   @spec do_fetch(state :: state(), count :: non_neg_integer()) :: [
-          LogEvent.t() | {term(), :ets.tid()}
+          LogEvent.t()
+          | {term(), :ets.tid(), non_neg_integer()}
+          | {term(), :ets.tid(), non_neg_integer(), LogEvent.TypeDetection.event_type(),
+             integer(), :fresh | :stale}
         ]
+  defp do_fetch(
+         %{consolidated: true, id_passing: true, id_passing_metadata: true, backend_id: bid},
+         n
+       ) do
+    key = {:consolidated, bid, self()}
+
+    case IngestEventQueue.take_pending_ids_with_metadata(key, n) do
+      {:error, :not_initialized} ->
+        []
+
+      {:ok, [], _tid} ->
+        []
+
+      {:ok, metadata, tid} ->
+        Enum.map(metadata, fn {id, size, event_type, day_bucket, freshness} ->
+          {id, tid, size, event_type, day_bucket, freshness}
+        end)
+    end
+  end
+
   defp do_fetch(%{consolidated: true, id_passing: true, backend_id: bid} = _state, n) do
     key = {:consolidated, bid, self()}
 
@@ -356,7 +383,7 @@ defmodule Logflare.Backends.BufferProducer do
   end
 
   @spec do_take_key(key :: table_key(), count :: non_neg_integer(), id_passing :: boolean()) ::
-          [LogEvent.t()] | [{term(), :ets.tid()}]
+          [LogEvent.t()] | [{term(), :ets.tid(), non_neg_integer()}]
   defp do_take_key({sid, bid, _pid} = key, n, true) do
     case IngestEventQueue.take_pending_ids(key, n) do
       {:error, :not_initialized} ->

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -595,16 +595,55 @@ defmodule Logflare.Backends.IngestEventQueue do
         {event_id, :pending, _event, size, _claim, _claimed_at} -> {event_id, size}
       end
 
+    take_pending_selected(sid_bid_pid, n, ms, fn {id, _size} -> id end)
+  end
+
+  @doc """
+  Takes pending item IDs plus small routing metadata, marking rows as `:processing`.
+
+  This is the ClickHouse ID-passing variant: it keeps full events in ETS for memory
+  savings, but returns the fields required to route Broadway messages without a
+  separate ETS lookup in `handle_message/3`.
+  """
+  @spec take_pending_ids_with_metadata(source_backend_pid() | consolidated_table_key(), integer()) ::
+          {:ok,
+           [
+             {term(), non_neg_integer(), LogEvent.TypeDetection.event_type(), integer(),
+              :fresh | :stale}
+           ], :ets.tid() | nil}
+          | {:error, :not_initialized}
+  def take_pending_ids_with_metadata(_, 0), do: {:ok, [], nil}
+
+  def take_pending_ids_with_metadata(sid_bid_pid, n) when is_integer(n) do
+    ms = [
+      {
+        {:"$1", :pending,
+         %{
+           __struct__: LogEvent,
+           event_type: :"$3",
+           day_bucket: :"$4",
+           ingest_freshness: :"$5"
+         }, :"$2", :_, :_},
+        [],
+        [{{:"$1", :"$2", :"$3", :"$4", :"$5"}}]
+      }
+    ]
+
+    take_pending_selected(sid_bid_pid, n, ms, fn {id, _size, _event_type, _day_bucket, _freshness} ->
+      id
+    end)
+  end
+
+  defp take_pending_selected(sid_bid_pid, n, ms, id_fun) do
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         {taken_pairs, _cont} <- :ets.select(tid, ms, n) do
+         {selected, _cont} <- :ets.select(tid, ms, n) do
       # One monotonic read per batch (not per event); every row claimed in this batch shares
       # the same claimed_at stamp, which is all the stale-recovery janitor needs.
       claimed_at = System.monotonic_time(:millisecond)
 
       # The claim counter's 0 -> 1 winner takes the event; a 2+ result (another consumer,
       # or a write_concurrency duplicate row within this select) loses, so no dedup needed.
-      confirmed =
-        Enum.filter(taken_pairs, fn {id, _size} -> claim_pending(tid, id, claimed_at) end)
+      confirmed = Enum.filter(selected, &claim_pending(tid, id_fun.(&1), claimed_at))
 
       {:ok, confirmed, tid}
     else

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -318,6 +318,38 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert result == []
     end
 
+    test "does not insert to ClickHouse when every routed row is missing from ETS", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      event1 = build(:log_event, source: source, message: "gone 1")
+      event2 = build(:log_event, source: source, message: "gone 2")
+
+      # Empty ETS table: rows were routed via the metadata fast path but deleted
+      # (e.g. by the janitor) before batch time, so encode_message finds nothing.
+      tid = setup_processing_events([])
+
+      messages = [
+        batch_message(event1, tid, backend.id),
+        batch_message(event2, tid, backend.id)
+      ]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch_fresh,
+        batch_key: {:log, @day_bucket},
+        size: 2,
+        trigger: :flush
+      }
+
+      Mimic.reject(ClickHouseAdaptor, :insert_log_events_compressed, 4)
+
+      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+
+      assert length(result) == 2
+      assert Enum.all?(result, &match?(%Message{status: {:failed, :not_found}}, &1))
+    end
+
     test "handles log events with different field types", %{
       context: context,
       source: source,

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -132,8 +132,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert %Message{
                data: {event_id, ^tid, :log, day_bucket, :fresh},
-               batcher: nil,
-               batch_key: nil,
+               batcher: :default,
+               batch_key: :default,
                acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id}}
              } = result
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -184,6 +184,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert day_bucket == event.day_bucket
     end
 
+    test "routes stale metadata messages to :ch_stale without an ETS lookup", %{
+      context: context,
+      backend: backend
+    } do
+      event = build(:log_event) |> Map.put(:ingest_freshness, :stale)
+      tid = setup_processing_events([])
+
+      message = %Message{
+        data: {event.id, tid, event.event_type, event.day_bucket, :stale},
+        acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+      }
+
+      result = Pipeline.handle_message(:default, message, context)
+
+      assert %Message{batcher: :ch_stale, batch_key: {:log, day_bucket}} = result
+      assert result.data == {event.id, tid, :log, event.day_bucket}
+      assert day_bucket == event.day_bucket
+    end
+
     test "routes fresh log events to :ch_fresh batcher keyed by {event_type, day_bucket}", %{
       context: context,
       backend: backend

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -116,9 +116,74 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert event_id == event.id
       assert backend_id == backend.id
     end
+
+    test "transforms metadata id-tuple into unrouted Broadway message with routing metadata", %{
+      backend: backend
+    } do
+      event = build(:log_event, message: "Test message")
+      tid = setup_processing_events([event])
+      opts = [backend_id: backend.id]
+
+      result =
+        Pipeline.transform(
+          {event.id, tid, 1000, event.event_type, event.day_bucket, event.ingest_freshness},
+          opts
+        )
+
+      assert %Message{
+               data: {event_id, ^tid, :log, day_bucket, :fresh},
+               batcher: nil,
+               batch_key: nil,
+               acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id}}
+             } = result
+
+      assert event_id == event.id
+      assert day_bucket == event.day_bucket
+      assert backend_id == backend.id
+    end
+
+    test "falls back to lookup routing when metadata tuple has invalid routing fields", %{
+      backend: backend
+    } do
+      event = build(:log_event, message: "Test message")
+      tid = setup_processing_events([event])
+
+      result =
+        Pipeline.transform(
+          {event.id, tid, 1000, nil, event.day_bucket, :fresh},
+          backend_id: backend.id
+        )
+
+      assert %Message{
+               data: {event_id, ^tid},
+               acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id}}
+             } = result
+
+      assert event_id == event.id
+      assert backend_id == backend.id
+    end
   end
 
   describe "handle_message/3" do
+    test "routes metadata messages without an ETS lookup", %{
+      context: context,
+      backend: backend
+    } do
+      event = build(:log_event)
+      tid = setup_processing_events([])
+
+      message = %Message{
+        data: {event.id, tid, event.event_type, event.day_bucket, event.ingest_freshness},
+        acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+      }
+
+      result = Pipeline.handle_message(:default, message, context)
+
+      assert %Message{batcher: :ch_fresh, batch_key: {:log, day_bucket}} = result
+      assert result.data == {event.id, tid, :log, event.day_bucket}
+      assert day_bucket == event.day_bucket
+    end
+
     test "routes fresh log events to :ch_fresh batcher keyed by {event_type, day_bucket}", %{
       context: context,
       backend: backend

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -254,6 +254,46 @@ defmodule Logflare.Backends.BufferProducerTest do
       assert IngestEventQueue.total_pending(consolidated_key) == 0
     end
 
+    test "pulls only IDs and routing metadata in consolidated id-passing metadata mode", %{
+      source: source,
+      backend: backend
+    } do
+      startup_key = {:consolidated, backend.id, nil}
+      IngestEventQueue.upsert_tid(startup_key)
+
+      buffer_producer_pid =
+        start_supervised!(
+          {BufferProducer,
+           backend_id: backend.id,
+           consolidated: true,
+           id_passing: true,
+           id_passing_metadata: true,
+           interval: 100}
+        )
+
+      consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
+      :timer.sleep(150)
+
+      le =
+        build(:log_event, source: source)
+        |> Map.put(:event_type, :trace)
+        |> Map.put(:day_bucket, 123_456)
+        |> Map.put(:ingest_freshness, :stale)
+
+      :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
+
+      [item] =
+        GenStage.stream([{buffer_producer_pid, max_demand: 1}])
+        |> Enum.take(1)
+
+      assert {event_id, tid, size, :trace, 123_456, :stale} = item
+      assert event_id == le.id
+      assert size == :erlang.external_size(le.body)
+
+      assert {^event_id, :processing, ^le, ^size} = IngestEventQueue.lookup_id(tid, event_id)
+      assert IngestEventQueue.total_pending(consolidated_key) == 0
+    end
+
     test "format_discarded logs backend_id for consolidated mode", %{backend: backend} do
       startup_key = {:consolidated, backend.id, nil}
       IngestEventQueue.upsert_tid(startup_key)

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -459,6 +459,36 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
+    test "can claim IDs with routing metadata without returning full events", %{
+      source: source,
+      sbp: sbp
+    } do
+      fresh =
+        build(:log_event, source: source)
+        |> Map.put(:event_type, :log)
+        |> Map.put(:day_bucket, 12_345)
+        |> Map.put(:ingest_freshness, :fresh)
+
+      stale =
+        build(:log_event, source: source)
+        |> Map.put(:event_type, :trace)
+        |> Map.put(:day_bucket, 54_321)
+        |> Map.put(:ingest_freshness, :stale)
+
+      assert :ok = IngestEventQueue.add_to_table(sbp, [fresh, stale])
+
+      assert {:ok, metadata, tid} = IngestEventQueue.take_pending_ids_with_metadata(sbp, 2)
+      assert tid != nil
+
+      assert Enum.sort(metadata) ==
+               Enum.sort([
+                 {fresh.id, :erlang.external_size(fresh.body), :log, 12_345, :fresh},
+                 {stale.id, :erlang.external_size(stale.body), :trace, 54_321, :stale}
+               ])
+
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+
     test "respects the requested count and leaves the remainder pending", %{
       source: source,
       sbp: sbp

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -489,6 +489,37 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
+    test "take_pending_ids_with_metadata/2 returns empty without claiming when count is 0", %{
+      source: source,
+      sbp: sbp
+    } do
+      assert :ok = IngestEventQueue.add_to_table(sbp, [build(:log_event, source: source)])
+
+      assert {:ok, [], nil} = IngestEventQueue.take_pending_ids_with_metadata(sbp, 0)
+      assert IngestEventQueue.total_pending(sbp) == 1
+    end
+
+    test "take_pending_ids_with_metadata/2 returns :not_initialized for an unknown table" do
+      assert {:error, :not_initialized} =
+               IngestEventQueue.take_pending_ids_with_metadata({-1, -1, self()}, 5)
+    end
+
+    test "take_pending_ids_with_metadata/2 claims rows with nil routing fields and returns nils",
+         %{source: source, sbp: sbp} do
+      event =
+        build(:log_event, source: source)
+        |> Map.put(:event_type, nil)
+        |> Map.put(:day_bucket, nil)
+        |> Map.put(:ingest_freshness, nil)
+
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+
+      assert {:ok, [metadata], tid} = IngestEventQueue.take_pending_ids_with_metadata(sbp, 1)
+      assert tid != nil
+      assert metadata == {event.id, :erlang.external_size(event.body), nil, nil, nil}
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+
     test "respects the requested count and leaves the remainder pending", %{
       source: source,
       sbp: sbp


### PR DESCRIPTION
## Summary

Stacked on #3667. This keeps the ClickHouse ID-passing + streaming compression memory savings while recovering CPU:

- hoists `mapping_config_id` UUID encoding once per batch for streamed RowBinary rows
- has the consolidated producer emit ID + small routing metadata so ClickHouse avoids the extra `handle_message/3` ETS lookup
- keeps full `LogEvent` payloads in ETS until batch compression/ack
- adds targeted benchmark/profiling scripts for CPU and memory investigation

## CPU results

Fixed-work CPU runner, `BATCH_SIZE=1000 BATCHES=20`:

| scenario | old_queue runtime µs/row | optimized runtime µs/row |
| --- | ---: | ---: |
| log/small | 31.95 | 30.40 |
| log/realistic | 51.75 | 31.55 |
| metric/small | 72.85 | 66.25 |
| metric/realistic | 99.05 | 81.55 |
| trace/small | 57.85 | 49.30 |
| trace/realistic | 70.50 | 64.25 |

Larger 50k-row log realistic run:

- `old_queue`: 61.50 runtime µs/row
- optimized `id_queue_metadata`: 46.42 runtime µs/row

