### PR TITLE
fix(clickhouse): trip circuit breaker immediately on TOO_MANY_PARTS

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker.ex
@@ -81,6 +81,33 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker do
   end
 
   @doc """
+  Immediately opens the breaker, bypassing the failure-count threshold.
+
+  Intended for failures that are self-amplifying under retry — notably a
+  ClickHouse `TOO_MANY_PARTS` (error 252) response, where retrying inserts
+  creates more parts and worsens the condition. Opening at once sheds requeued
+  retries and lets background merges catch up.
+
+  Synchronously updates the breaker so callers can rely on `check/1` seeing it
+  open when this function returns. A missing or concurrently stopped breaker is
+  a no-op.
+  """
+  @spec trip(Backend.t()) :: :ok
+  def trip(%Backend{id: backend_id}) do
+    case Registry.lookup(BackendRegistry, {__MODULE__, backend_id}) do
+      [{pid, _table}] ->
+        try do
+          GenServer.call(pid, :trip)
+        catch
+          :exit, _ -> :ok
+        end
+
+      [] ->
+        :ok
+    end
+  end
+
+  @doc """
   Returns the breaker's current state, or `nil` if no breaker is running.
 
   Useful for introspection (_and tests_).
@@ -107,37 +134,43 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker do
     {:reply, state, state}
   end
 
+  def handle_call(:trip, _from, %__MODULE__{} = state) do
+    now = System.system_time(:millisecond)
+    {:reply, :ok, open_breaker(state, now, length(state.failures), :forced)}
+  end
+
   @impl true
   def handle_cast(:record_failure, %__MODULE__{} = state) do
     now = System.system_time(:millisecond)
     cutoff = now - window_ms()
     failures = Enum.filter([now | state.failures], &(&1 >= cutoff))
 
-    {:noreply, maybe_trip(state, failures, now)}
+    if length(failures) >= max_failures() do
+      {:noreply, open_breaker(state, now, length(failures), :threshold)}
+    else
+      {:noreply, %{state | failures: failures}}
+    end
   end
 
-  @spec maybe_trip(t(), [integer()], integer()) :: t()
-  defp maybe_trip(%__MODULE__{} = state, failures, now) do
-    if length(failures) >= max_failures() do
-      blocked_until = now + block_ms()
-      :ets.insert(state.table, {@blocked_key, blocked_until})
+  @spec open_breaker(t(), integer(), non_neg_integer(), :threshold | :forced) :: t()
+  defp open_breaker(%__MODULE__{} = state, now, failure_count, reason) do
+    blocked_until = now + block_ms()
+    :ets.insert(state.table, {@blocked_key, blocked_until})
 
-      Logger.warning("ClickHouse circuit breaker opened",
-        backend_id: state.backend_id,
-        blocked_until: blocked_until,
-        failures: length(failures)
-      )
+    Logger.warning("ClickHouse circuit breaker opened",
+      backend_id: state.backend_id,
+      blocked_until: blocked_until,
+      failures: failure_count,
+      reason: reason
+    )
 
-      :telemetry.execute(
-        [:logflare, :clickhouse, :circuit_breaker, :open],
-        %{failures: length(failures)},
-        %{backend_id: state.backend_id}
-      )
+    :telemetry.execute(
+      [:logflare, :clickhouse, :circuit_breaker, :open],
+      %{failures: failure_count},
+      %{backend_id: state.backend_id, reason: reason}
+    )
 
-      %{state | failures: []}
-    else
-      %{state | failures: failures}
-    end
+    %{state | failures: []}
   end
 
   @spec safe_lookup(:ets.table(), term()) :: [tuple()]

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -48,6 +48,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @stale_batcher_concurrency 2
   @max_retries 1
 
+  # ClickHouse error 252 (TOO_MANY_PARTS): a partition holds more active parts than
+  # `parts_to_throw_insert`. Retrying inserts in this state creates yet more parts and
+  # worsens it, so it trips the circuit breaker immediately rather than accumulating
+  # toward the failure-count threshold. The marker matches the code embedded in the
+  # HTTP error body built by Ingester.do_insert/5.
+  @too_many_parts_marker "Code: 252"
+
   @doc false
   @spec max_retries() :: non_neg_integer()
   def max_retries, do: @max_retries
@@ -391,10 +398,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         Enum.map(bad, &Message.failed(&1, :not_found)) ++ good
 
       {:error, reason} ->
-        CircuitBreaker.record_failure(backend)
+        record_insert_failure(backend, reason)
         Enum.map(bad, &Message.failed(&1, reason)) ++ Enum.map(good, &Message.failed(&1, reason))
     end
   end
+
+  @spec record_insert_failure(Backend.t(), term()) :: :ok
+  defp record_insert_failure(backend, reason) do
+    if too_many_parts?(reason) do
+      CircuitBreaker.trip(backend)
+    else
+      CircuitBreaker.record_failure(backend)
+    end
+  end
+
+  @spec too_many_parts?(term()) :: boolean()
+  defp too_many_parts?(reason) when is_binary(reason),
+    do: String.contains?(reason, @too_many_parts_marker)
+
+  defp too_many_parts?(_reason), do: false
 
   @spec maybe_requeue_failed(backend_id :: pos_integer(), messages :: [Message.t()]) :: :ok
   defp maybe_requeue_failed(backend_id, messages) do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
@@ -72,6 +72,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreakerTest do
     end
   end
 
+  describe "trip/1" do
+    test "opens immediately regardless of failure count", %{backend: backend} do
+      start_supervised!({CircuitBreaker, backend})
+
+      assert :ok = CircuitBreaker.check(backend)
+
+      assert :ok = CircuitBreaker.trip(backend)
+
+      assert {:error, :circuit_open, blocked_until} = CircuitBreaker.check(backend)
+      assert is_integer(blocked_until)
+    end
+
+    test "is a no-op when no breaker is running (fail-safe)", %{backend: backend} do
+      assert :ok = CircuitBreaker.trip(backend)
+      assert :ok = CircuitBreaker.check(backend)
+    end
+  end
+
   describe "fail-safe on process death" do
     test "reads as closed after the breaker process crashes", %{backend: backend} do
       pid = start_supervised!({CircuitBreaker, backend})

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1042,9 +1042,88 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_received {:recorded_failure, ^expected_backend_id}
     end
+
+    test "trips the circuit breaker immediately on a TOO_MANY_PARTS (252) failure", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      test_pid = self()
+      expected_backend_id = backend.id
+
+      too_many_parts_error =
+        "HTTP 500: Code: 252. DB::Exception: Too many parts (600 with average size of 1.00 MiB) in table."
+
+      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
+                                                                        _event_type,
+                                                                        _compressed,
+                                                                        _opts ->
+        {:error, too_many_parts_error}
+      end)
+
+      # A 252 must trip immediately, not accumulate toward the failure-count threshold.
+      Mimic.reject(CircuitBreaker, :record_failure, 1)
+
+      Mimic.expect(CircuitBreaker, :trip, fn %{id: id} ->
+        send(test_pid, {:tripped, id})
+        :ok
+      end)
+
+      log_event = build(:log_event, source: source, message: "Test message")
+      tid = setup_processing_events([log_event])
+      messages = [batch_message(log_event, tid, backend.id)]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch_fresh,
+        batch_key: {:log, @day_bucket},
+        size: 1,
+        trigger: :flush
+      }
+
+      assert [%Message{status: {:failed, ^too_many_parts_error}}] =
+               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+
+      assert_received {:tripped, ^expected_backend_id}
+    end
   end
 
   describe "ack/3 circuit breaker" do
+    test "sheds a TOO_MANY_PARTS failure on its first acknowledgement", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      too_many_parts_error = "HTTP 500: Code: 252. DB::Exception: Too many parts in table."
+
+      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
+                                                                        _event_type,
+                                                                        _compressed,
+                                                                        _opts ->
+        {:error, too_many_parts_error}
+      end)
+
+      Mimic.reject(CircuitBreaker, :record_failure, 1)
+
+      event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+      tid = setup_processing_events([event])
+      messages = [batch_message(event, tid, backend.id)]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch_fresh,
+        batch_key: {:log, @day_bucket},
+        size: 1,
+        trigger: :flush
+      }
+
+      assert [failed_message = %Message{status: {:failed, ^too_many_parts_error}}] =
+               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+
+      log = capture_log(fn -> Pipeline.ack(:ack_ref, [], [failed_message]) end)
+
+      assert log =~ "circuit breaker open"
+      assert :ets.lookup(tid, event.id) == []
+    end
+
     test "sheds retriable messages instead of requeuing when the breaker is open", %{
       source: source,
       backend: backend


### PR DESCRIPTION
## Context

Incident analysis of a ClickHouse parts explosion (parts climbing through `parts_to_throw_insert` → error 252 `TOO_MANY_PARTS` → a large insert-retry storm). This PR addresses the part of that failure mode that is **correct to fix regardless of the still-unconfirmed root cause**.

## Changes

**Trip the circuit breaker immediately on `TOO_MANY_PARTS` (252)**

Once a partition is over `parts_to_throw_insert`, retrying inserts creates *more* parts and makes it worse. Previously a 252 was treated like any other failure and had to accumulate toward the breaker's 20-failures/30s threshold, while requeued retries kept hammering an already-throttled cluster.

- New synchronous `CircuitBreaker.trip/1` opens the breaker at once, bypassing the failure-count threshold, and does not return until `check/1` can see it open. `maybe_trip` is refactored into a shared `open_breaker/4` that tags the open reason (`:threshold` | `:forced`) in the log line and telemetry metadata.
- Insert failures now route through `record_insert_failure/2`: a `Code: 252` marker in the HTTP error body → `trip/1`; every other error keeps the existing `record_failure/1` counting behavior.
