### PR TITLE
observability(clickhouse): make dynamic_pipeline.pipeline_count a per-backend-type gauge

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -237,7 +237,7 @@ defmodule Logflare.Telemetry do
           "Ingest requests rejected (429) — pending buffer full (per request, not per event)"
       ),
       last_value("logflare.system.finch.in_flight_requests", tags: [:pool, :url]),
-      distribution("logflare.backends.dynamic_pipeline.pipeline_count"),
+      last_value("logflare.backends.dynamic_pipeline.pipeline_count", tags: [:backend_type]),
       distribution("logflare.ingest.pipeline.stream_batch.stop.duration",
         unit: {:native, :millisecond}
       ),


### PR DESCRIPTION
## What

`logflare.backends.dynamic_pipeline.pipeline_count` was a `distribution` with **no tags**, so the OTLP export aggregated child-pipeline counts across *every* DynamicPipeline backend into one series.

Because BigQuery runs one DynamicPipeline **per source** (`min_pipelines: 0`, thousands of them, mostly idle at 0) and ClickHouse runs a handful (`min_pipelines: 1`), the series is overwhelmingly BigQuery and **cannot be sliced to a backend type** — which makes it unusable for judging, say, ClickHouse pipeline fan-out during an incident.

## Change

```diff
- distribution("logflare.backends.dynamic_pipeline.pipeline_count"),
+ last_value("logflare.backends.dynamic_pipeline.pipeline_count", tags: [:backend_type]),
```

- **`last_value`** — a gauge is the right shape for an instantaneous instance count (the histogram buckets of `distribution` weren't useful here).
- **`tags: [:backend_type]`** — `:backend_type` is already in the event metadata (`DynamicPipeline.build_telemetry_metadata/1`), so no emitter change is needed. ClickHouse and BigQuery now report as independent series.

## Tradeoff (deliberate)

Tagged by `:backend_type` only, not `:backend_token` — so multiple backends of the same type collapse into one gauge series (last write wins per scrape). That's intentional: adding `:backend_token` would explode cardinality on the BigQuery side (one series per source). If per-backend resolution is ever needed for ClickHouse specifically, that can be added narrowly.

## Test

`mix format` + `mix credo` clean; `test/logflare/telemetry_test.exs` — 12 tests, 0 failures (the metrics-well-formedness check still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)