### PR TITLE
feat(telemetry): expose batch flush trigger and per-backend missing IDs

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -228,13 +228,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   defp emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],
-      %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
+      %{batch_size: batch_info.size},
       %{
         backend_type: :clickhouse,
         backend_id: backend_id,
         event_type: event_type,
         batcher: batcher,
-        day_bucket: day_bucket
+        day_bucket: day_bucket,
+        batch_trigger: batch_info.trigger
       }
     )
   end

--- a/lib/logflare/backends/adaptor/http_based/pipeline.ex
+++ b/lib/logflare/backends/adaptor/http_based/pipeline.ex
@@ -62,9 +62,10 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
   def handle_batch(:http, messages, batch_info, context) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],
-      %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
+      %{batch_size: batch_info.size},
       %{
-        backend_type: :http_based
+        backend_type: :http_based,
+        batch_trigger: batch_info.trigger
       }
     )
 

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -305,9 +305,10 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     def handle_batch(:http, messages, batch_info, context) do
       :telemetry.execute(
         [:logflare, :backends, :pipeline, :handle_batch],
-        %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
+        %{batch_size: batch_info.size},
         %{
-          backend_type: :webhook
+          backend_type: :webhook,
+          batch_trigger: batch_info.trigger
         }
       )
 

--- a/lib/logflare/backends/spool/producer_pipeline.ex
+++ b/lib/logflare/backends/spool/producer_pipeline.ex
@@ -149,8 +149,8 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
       }) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],
-      %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
-      %{backend_type: :spool_producer}
+      %{batch_size: batch_info.size},
+      %{backend_type: :spool_producer, batch_trigger: batch_info.trigger}
     )
 
     partition = :rand.uniform(partitions) - 1

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -204,9 +204,10 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   def handle_batch(:bq, messages, batch_info, context) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],
-      %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
+      %{batch_size: batch_info.size},
       %{
-        backend_type: :bigquery
+        backend_type: :bigquery,
+        batch_trigger: batch_info.trigger
       }
     )
 

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -206,6 +206,12 @@ defmodule Logflare.Telemetry do
         tags: [:backend_type],
         description: "Sum of batch sizes for broadway pipeline by backend type"
       ),
+      counter("logflare.backends.pipeline.handle_batch.batch_trigger",
+        event_name: [:logflare, :backends, :pipeline, :handle_batch],
+        tags: [:backend_type, :batch_trigger],
+        description:
+          "Count of broadway pipeline batches by backend type and flush trigger (:size | :timeout). A high :timeout share means batches flush before reaching batch_size"
+      ),
       counter("logflare.cache_buster.to_bust.count", tags: []),
       sum("logflare.logs.ingest_logs.drop_lql",
         event_name: [:logflare, :logs, :ingest_logs, :drop_lql],
@@ -363,7 +369,16 @@ defmodule Logflare.Telemetry do
       ),
       sum("logflare.ingest_event_queue.missing_ids.count",
         event_name: [:logflare, :ingest_event_queue, :missing_ids],
+        tags: [:backend_id, :event_type],
+        tag_values: &missing_ids_tag_values/1,
         description: "Count of event IDs not found in ETS during handle_batch fetch"
+      ),
+      distribution("logflare.ingest_event_queue.missing_ids.count",
+        event_name: [:logflare, :ingest_event_queue, :missing_ids],
+        tags: [:backend_id, :event_type],
+        tag_values: &missing_ids_tag_values/1,
+        reporter_options: batch_size_reporter_opts(),
+        description: "Distribution of missing-ID counts per handle_batch fetch"
       ),
       sum("logflare.ingest_event_queue.stale_processing.reset",
         event_name: [:logflare, :ingest_event_queue, :stale_processing],
@@ -566,5 +581,16 @@ defmodule Logflare.Telemetry do
 
   defp batch_size_reporter_opts do
     [buckets: [0, 1, 50, 100, 250, 500, 1_000, 5_000, 10_000, 20_000, 50_000]]
+  end
+
+  # The :missing_ids event is emitted by both the ClickHouse pipeline (backend_id + event_type
+  # metadata) and the BigQuery pipeline (source_id metadata only), so normalize both tags to a
+  # value that is always present regardless of emitter.
+  @spec missing_ids_tag_values(map()) :: %{backend_id: term(), event_type: term()}
+  defp missing_ids_tag_values(metadata) do
+    %{
+      backend_id: Map.get(metadata, :backend_id, :unknown),
+      event_type: Map.get(metadata, :event_type, :unknown)
+    }
   end
 end

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -554,6 +554,39 @@ defmodule Logflare.BigQuery.PipelineTest do
       assert is_integer(size) and size > 0
     end
 
+    test "emits handle_batch telemetry with batch_trigger in metadata (not measurements)", %{
+      source: source,
+      context: context,
+      batch_info: batch_info
+    } do
+      stub(Logflare.Google.BigQuery, :stream_batch!, fn _ctx, _rows ->
+        {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      le = build(:log_event, source: source)
+      {[message], _tid} = setup_queue(source, [le])
+
+      ref = make_ref()
+
+      :telemetry.attach(
+        "test-handle-batch-#{inspect(ref)}",
+        [:logflare, :backends, :pipeline, :handle_batch],
+        fn _event, measurements, metadata, pid ->
+          send(pid, {:handle_batch, measurements, metadata})
+        end,
+        self()
+      )
+
+      Pipeline.handle_batch(:bq, [message], batch_info, context)
+
+      assert_receive {:handle_batch, measurements, metadata}
+      assert measurements == %{batch_size: batch_info.size}
+      assert metadata.batch_trigger == batch_info.trigger
+      assert metadata.backend_type == :bigquery
+
+      :telemetry.detach("test-handle-batch-#{inspect(ref)}")
+    end
+
     test "excludes missing IDs and emits telemetry", %{
       source: source,
       context: context,


### PR DESCRIPTION
## Why

While investigating ClickHouse `TOO_MANY_PARTS` (error 252), we want to confirm two suspected drivers of small / under-filled inserts before changing insert behavior:

1. **How often do batches flush on `:timeout` vs `:size`?** A high `:timeout` share means batches ship before reaching `batch_size` → smaller parts.
2. **How many event IDs go missing from ETS between claim and batch-insert?** With the ID-passing pipeline, events stay in ETS as `:processing` and are only fetched at insert time; any ID gone by then is dropped, so the rows actually written can be far fewer than the batch Broadway sized.

Both signals were emitted in telemetry events but **not registered as metrics**, so nothing aggregated them. This PR wires them up. No behavior changes to the pipelines — telemetry only.

## Changes

- **`batch_trigger` → metadata.** It was in the `handle_batch` *measurements* map, where `Telemetry.Metrics` tags can't read it. Moved to metadata across all five emitters (clickhouse, bigquery, webhook, http_based, spool). `batch_size` stays in measurements; the dev dashboard (only measurements consumer) reads `batch_size` only and is unaffected.
- **New counter** `logflare.backends.pipeline.handle_batch.batch_trigger`, tagged `backend_type` + `batch_trigger` (`:size` | `:timeout` | `:flush`).
- **`missing_ids` now sliceable.** Added `backend_id`/`event_type` tags to the existing `sum` and added a `distribution` (per-batch missing counts). A `tag_values` fallback normalizes heterogeneous emitter metadata (ClickHouse carries `backend_id`+`event_type`; BigQuery carries `source_id`).

## Testing

- New regression test locks in the contract that `batch_trigger` is emitted in metadata (not measurements) and `batch_size` stays in measurements.
- `test/logflare/bigquery/pipeline_test.exs` passes (22/22).
- ClickHouse pipeline tests require a live ClickHouse and were not run in this environment.

## Follow-ups (not in this PR)

Depending on what the metrics show: server-side `async_insert` tuning / extending async to the fresh lane, excluding `:processing` rows from the overflow purge, or raising the fresh batch timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)