### PR TITLE
O11Y-1914: replace apply/3 with explicit branches

### DIFF
--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -124,8 +124,17 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
       :"~" ->
         stringify(le_value) =~ expected
 
-      op when op in [:<=, :<, :>=, :>] ->
-        apply(Kernel, operator, [le_value, expected])
+      :< ->
+        le_value < expected
+
+      :<= ->
+        le_value <= expected
+
+      :> ->
+        le_value > expected
+
+      :>= ->
+        le_value >= expected
     end
   end
 

--- a/test/profiling/rules_tree_matching_bench.exs
+++ b/test/profiling/rules_tree_matching_bench.exs
@@ -306,6 +306,29 @@ regex_100_rules =
 regex_100_tree = RulesTree.build(regex_100_rules)
 
 # ---------------------------------------------------------------------------
+# Scenario 8: 100 comparison rules on an existing numeric field, all match
+# ---------------------------------------------------------------------------
+build_comparison_rules = fn path, base ->
+  for i <- 0..99 do
+    {op, value} =
+      case rem(i, 4) do
+        0 -> {:>, base - i - 1}
+        1 -> {:>=, base - i}
+        2 -> {:<, base + i + 1}
+        3 -> {:<=, base + i}
+      end
+
+    %Rule{id: i, lql_filters: [make_filter.(path, op, value)]}
+  end
+end
+
+comparison_100_otel_rules = build_comparison_rules.("attributes._http_status_code", 404)
+comparison_100_edge_rules = build_comparison_rules.("metadata.response.status_code", 200)
+
+comparison_100_otel_tree = RulesTree.build(comparison_100_otel_rules)
+comparison_100_edge_tree = RulesTree.build(comparison_100_edge_rules)
+
+# ---------------------------------------------------------------------------
 # Profile setup
 # ---------------------------------------------------------------------------
 profile_after =
@@ -366,6 +389,13 @@ suite =
       end,
       "rt regex only 100 | edge" => fn ->
         RulesTree.matching_rule_ids(edge_le, regex_100_tree)
+      end,
+      # Scenario 8: comparison-only 100, all match
+      "rt comparison 100 | otel" => fn ->
+        RulesTree.matching_rule_ids(otel_le, comparison_100_otel_tree)
+      end,
+      "rt comparison 100 | edge" => fn ->
+        RulesTree.matching_rule_ids(edge_le, comparison_100_edge_tree)
       end
     },
     time: 5,

--- a/test/profiling/rules_tree_matching_bench.history.exs
+++ b/test/profiling/rules_tree_matching_bench.history.exs
@@ -1,6 +1,144 @@
 [
   %{
     meta: %{
+      captured_at: "2026-07-10T15:51:33.695745Z",
+      git_sha: "63210949d",
+      label: "apply/3 baseline + comparison scenario",
+      machine: "Darwin Pauls-MBP.localdomain arm64"
+    },
+    results: %{
+      "rt comparison 100 | edge" => %{
+        ips: 204_134,
+        memory_avg_bytes: 28_912,
+        reductions_avg: 2459,
+        wall_avg_us: 4.9,
+        wall_median_us: 4.58,
+        wall_p99_us: 13.67
+      },
+      "rt comparison 100 | otel" => %{
+        ips: 207_380,
+        memory_avg_bytes: 35_320,
+        reductions_avg: 2597,
+        wall_avg_us: 4.82,
+        wall_median_us: 4.58,
+        wall_p99_us: 11.96
+      },
+      "rt drain 100 project= match | edge" => %{
+        ips: 6_592_328,
+        memory_avg_bytes: 384,
+        reductions_avg: 41,
+        wall_avg_us: 0.15,
+        wall_median_us: 0.13,
+        wall_p99_us: 0.25
+      },
+      "rt drain 100 project= match | otel" => %{
+        ips: 2_522_866,
+        memory_avg_bytes: 472,
+        reductions_avg: 62,
+        wall_avg_us: 0.4,
+        wall_median_us: 0.38,
+        wall_p99_us: 0.5
+      },
+      "rt drain 100 project= miss | edge" => %{
+        ips: 7_695_154,
+        memory_avg_bytes: 232,
+        reductions_avg: 31,
+        wall_avg_us: 0.13,
+        wall_median_us: 0.13,
+        wall_p99_us: 0.21
+      },
+      "rt drain 100 project= miss | otel" => %{
+        ips: 6_956_036,
+        memory_avg_bytes: 232,
+        reductions_avg: 31,
+        wall_avg_us: 0.14,
+        wall_median_us: 0.13,
+        wall_p99_us: 0.21
+      },
+      "rt drain 1000 project= match | edge" => %{
+        ips: 6_530_453,
+        memory_avg_bytes: 384,
+        reductions_avg: 41,
+        wall_avg_us: 0.15,
+        wall_median_us: 0.13,
+        wall_p99_us: 0.25
+      },
+      "rt drain 1000 project= match | otel" => %{
+        ips: 2_498_863,
+        memory_avg_bytes: 472,
+        reductions_avg: 62,
+        wall_avg_us: 0.4,
+        wall_median_us: 0.38,
+        wall_p99_us: 0.5
+      },
+      "rt empty | edge" => %{
+        ips: 48_411_342,
+        memory_avg_bytes: 112,
+        reductions_avg: 15,
+        wall_avg_us: 0.02,
+        wall_median_us: 0.02,
+        wall_p99_us: 0.03
+      },
+      "rt empty | otel" => %{
+        ips: 18_332_445,
+        memory_avg_bytes: 112,
+        reductions_avg: 15,
+        wall_avg_us: 0.05,
+        wall_median_us: 0.04,
+        wall_p99_us: 0.04
+      },
+      "rt mixed 100 | edge" => %{
+        ips: 248_593,
+        memory_avg_bytes: 4728,
+        reductions_avg: 796,
+        wall_avg_us: 4.02,
+        wall_median_us: 3.92,
+        wall_p99_us: 5.17
+      },
+      "rt mixed 100 | otel" => %{
+        ips: 240_041,
+        memory_avg_bytes: 4688,
+        reductions_avg: 535,
+        wall_avg_us: 4.17,
+        wall_median_us: 3.88,
+        wall_p99_us: 15.71
+      },
+      "rt regex only 100 | edge" => %{
+        ips: 38_464,
+        memory_avg_bytes: 3448,
+        reductions_avg: 3244,
+        wall_avg_us: 26.0,
+        wall_median_us: 25.67,
+        wall_p99_us: 31.75
+      },
+      "rt regex only 100 | otel" => %{
+        ips: 39_014,
+        memory_avg_bytes: 3448,
+        reductions_avg: 2024,
+        wall_avg_us: 25.63,
+        wall_median_us: 25.42,
+        wall_p99_us: 31.04
+      },
+      "rt scattered 100 path= match | edge" => %{
+        ips: 275_014,
+        memory_avg_bytes: 6512,
+        reductions_avg: 415,
+        wall_avg_us: 3.64,
+        wall_median_us: 3.58,
+        wall_p99_us: 4.63
+      },
+      "rt scattered 100 path= match | otel" => %{
+        ips: 200_634,
+        memory_avg_bytes: 6512,
+        reductions_avg: 415,
+        wall_avg_us: 4.98,
+        wall_median_us: 4.83,
+        wall_p99_us: 6.29
+      }
+    }
+  },
+  %{
+    meta: %{
       captured_at: "2026-06-01T14:41:59.833094Z",
       git_sha: "655e83a02",
       label: "eq_index leaf + 1f fast-path",


### PR DESCRIPTION
## Description

Replaces an `apply/3` in a hot path with explicit branches.

## Benchmarks

### Isolation

I ran a throwaway benchmark and observed a modest reduction in ... um ... reductions.

| | reds/call | wall (1M calls) |
|---|---|---|
| `apply(Kernel, :<, [a, b])` | **4.5** | 3675 µs |
| `a < b` (direct) | **2.5** | 1844 µs |

### Aggregate

In back-to-back runs of `mix run test/profiling/rules_tree_matching_bench.exs` - with and without this change - wall time changed within +/-3% (noise, not surprising) but critically, zero change in reductions.  On further examination, it didn't appear the existing benchmark exercised the apply branch, so I added Scenario 8.

Running back-to-back runs with and without the `apply/3` change

| scenario | reds (apply/3 → direct) | wall (median) | ips |
|---|---|---|---|
| `rt comparison 100 \| otel` | 2597 → 2521 (**−2.9%**) | 4.58 → 4.29 µs (−6.3%) | +6.9% |
| `rt comparison 100 \| edge` | 2459 → 2359 (**−4.1%**) | 4.58 → 4.33 µs (−5.5%) | +7.1% |

Modest improvement for a benchmark that explicitly targets numeric comparison.

## Impact

- Performance
  - In isolation results in a minor reductions improvement
  - In aggregate synthetic benchmarks, small measurable impact for workloads that heavily exercise numeric comparisons
- Readability
  - The change is small, low risk, and arguable easier to comprehend at a glance than a dynamic apply/3

## Links

[O11Y-1914](https://linear.app/supabase/issue/O11Y-1914/logflare-rulestree-replace-apply3-with-explicit-branches-in-check-op)