### PR TITLE
chore: fix time-of-day flaky test

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -46,6 +46,21 @@ defmodule Logflare.Backends do
   def max_buffer_queue_len, do: @max_pending_buffer_len_per_queue
 
   @doc """
+  Returns the maximum age, in microseconds, of an event that will be accepted at
+  ingestion. Events older than this are dropped as stale.
+  """
+  @spec max_event_age_us() :: non_neg_integer()
+  def max_event_age_us, do: @max_event_age_us
+
+  @doc """
+  Returns the maximum time, in microseconds, that an event's timestamp may be in
+  the future and still be accepted at ingestion. Events further ahead than this
+  are dropped.
+  """
+  @spec max_future_event_us() :: non_neg_integer()
+  def max_future_event_us, do: @max_future_event_us
+
+  @doc """
   Lists `Backend`s for a given source.
   """
   @spec list_backends(keyword()) :: [Backend.t()]

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1851,10 +1851,26 @@ defmodule LogflareWeb.Source.SearchLVTest do
     } do
       now = DateTime.utc_now()
       today_start = DateTime.new!(DateTime.to_date(now), ~T[00:00:00], "Etc/UTC")
-      yesterday_start = DateTime.add(today_start, -1, :day)
       one_second_ago = DateTime.add(now, -1, :second)
       included_for_today = Enum.max([one_second_ago, today_start], DateTime)
       seconds_since_today_start = DateTime.diff(now, today_start, :second)
+
+      # "yesterday" can span up to ~48h ago, but ingestion drops events older
+      # than Backends.max_event_age_us/0. Pick a timestamp that is both within
+      # yesterday and inside the staleness window: the midpoint of their overlap.
+      # Clamp the lower bound to yesterday's start so the midpoint stays within
+      # yesterday even when the staleness window exceeds 24h.
+      yesterday_start = DateTime.add(today_start, -1, :day)
+      yesterday_end = DateTime.add(today_start, -1, :second)
+      stale_boundary = DateTime.add(now, -Backends.max_event_age_us(), :microsecond)
+      overlap_start = Enum.max([stale_boundary, yesterday_start], DateTime)
+
+      included_for_yesterday =
+        DateTime.add(
+          overlap_start,
+          div(DateTime.diff(yesterday_end, overlap_start, :second), 2),
+          :second
+        )
 
       today_chart_period =
         cond do
@@ -1867,7 +1883,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
         {"t:last@5m", :second, {DateTime.add(now, -1, :minute), DateTime.add(now, 30, :second)}},
         {"t:this@day", today_chart_period,
          {included_for_today, DateTime.add(today_start, -1, :minute)}},
-        {"t:yesterday", :hour, {DateTime.add(yesterday_start, 12, :hour), now}}
+        {"t:yesterday", :hour, {included_for_yesterday, now}}
       ]
 
       Enum.each(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->


### PR DESCRIPTION
## Background

[example flaky run](<https://github.com/Logflare/logflare/actions/runs/29106216571/job/86407270550?pr=3675>)

`SearchLVTest` failed intermittently in CI.

* The `t:yesterday` case ingested an event fixed at yesterday noon.
* Ingestion [now drops events older than 24h](<https://github.com/Logflare/logflare/commit/f3395503dbcb69b45082018686d09a10df56786b>), so whenever the test ran after \~12:00 UTC, yesterday-noon was >24h old and silently dropped with only 1 of 2 expected events landed.
* It passed in the morning, failed in the afternoon (UTC)

## Change

* Compute the `t:yesterday` fixture timestamp as the midpoint between the staleness boundary (`now - max_event_age_us`) and yesterday's end, so it's always both within "yesterday" and inside the 24h ingest ingestion window
* if we roll back to a 72h cutoff, we clamp the lower bound for the midpoint comp to yesterday's start, so we always land in yesterday IFF the cutoff is >= 24H.
* Expose `Backends.max_event_age_us/0` and `Backends.max_future_event_us/0` to avoid a hard-coded 24h boundary

> \[!note\]
> This test could break again if we drop the ingestion cutoff below 24 hours, so I'm not crazy about this fix, but it will fix the flake for now.  If we ever do drop below 24 hours, the premise of this test needs revisited anyway.