### PR TITLE
Fix/loadbalance ets queus

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -85,7 +85,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         concurrency: @producer_concurrency
       ],
       processors: [
-        default: [concurrency: @processor_concurrency, min_demand: 1, max_demand: 100]
+        default: [concurrency: @processor_concurrency, min_demand: 100, max_demand: 1000]
       ],
       batchers: [
         ch_fresh: [
@@ -187,6 +187,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         %{backend_id: backend_id}
       )
       when batcher in [:ch_fresh, :ch_stale] and is_event_type(event_type) do
+
     emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket)
 
     backend = Backends.Cache.get_backend(backend_id)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -187,7 +187,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         %{backend_id: backend_id}
       )
       when batcher in [:ch_fresh, :ch_stale] and is_event_type(event_type) do
-
     emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket)
 
     backend = Backends.Cache.get_backend(backend_id)

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -250,9 +250,8 @@ defmodule Logflare.Backends.IngestEventQueue do
       end
 
     if no_get_tid do
-      with all = [_ | _] <- list_counts_with_tids(key)
+      with all = [_ | _] <- list_counts_with_tids(key),
            available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
-
         Logflare.Utils.chunked_round_robin(
           batch,
           available_queues,

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -250,8 +250,9 @@ defmodule Logflare.Backends.IngestEventQueue do
       end
 
     if no_get_tid do
-      with all = [_ | _] <- list_counts_with_tids(key),
+      with all = [_ | _] <- list_counts_with_tids(key)
            available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
+
         Logflare.Utils.chunked_round_robin(
           batch,
           available_queues,
@@ -496,6 +497,7 @@ defmodule Logflare.Backends.IngestEventQueue do
         is_integer(size) do
       {table_key, size}
     end
+    |> Enum.sort_by(&elem(&1, 1), :desc)
   end
 
   @doc """


### PR DESCRIPTION
Queues where always round robined in the same order once they scaled up. This eventually results in uneven queue distribution and potentially some queues never getting load. 

The fix is to order by queue size before sending to the round robin function.

Also increase max demand for clickhouse processors so they dont need to make as many requests to ets. 