### PR TITLE
feat: add Management API endpoint for alerts (Api.AlertController)

### DIFF
--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -140,10 +140,13 @@ defmodule Logflare.Alerting do
 
   """
   def create_alert_query(%User{} = user, attrs \\ %{}) do
+    backends = Map.get(attrs, :backends) || Map.get(attrs, "backends")
+
     user
     |> Ecto.build_assoc(:alert_queries)
     |> Repo.preload(:user)
     |> AlertQuery.changeset(attrs)
+    |> put_backends(backends)
     |> Repo.insert()
   end
 
@@ -165,15 +168,15 @@ defmodule Logflare.Alerting do
     alert_query
     |> preload_alert_query()
     |> AlertQuery.changeset(attrs)
-    |> then(fn
-      changeset when not is_nil(backends) ->
-        Ecto.Changeset.put_assoc(changeset, :backends, backends)
-
-      changeset ->
-        changeset
-    end)
+    |> put_backends(backends)
     |> Repo.update()
     |> handle_schedule_change(alert_query)
+  end
+
+  defp put_backends(changeset, nil), do: changeset
+
+  defp put_backends(changeset, backends) do
+    Ecto.Changeset.put_assoc(changeset, :backends, backends)
   end
 
   defp handle_schedule_change({:ok, %AlertQuery{} = updated} = result, previous) do

--- a/lib/logflare/alerting.ex
+++ b/lib/logflare/alerting.ex
@@ -102,6 +102,23 @@ defmodule Logflare.Alerting do
     |> Repo.one()
   end
 
+  @doc """
+  Fetches a single alert query by arbitrary conditions, scoped to the
+  alert queries the user has team access to.
+  """
+  @spec fetch_alert_query_by_user_access(User.t() | TeamUser.t(), keyword()) ::
+          {:ok, AlertQuery.t()} | {:error, :not_found}
+  def fetch_alert_query_by_user_access(user_or_team_user, kw) when is_list(kw) do
+    AlertQuery
+    |> Teams.filter_by_user_access(user_or_team_user)
+    |> where([alert_query], ^kw)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      alert_query -> {:ok, alert_query}
+    end
+  end
+
   def preload_alert_query(alert) do
     alert
     |> Repo.preload([:user, :backends])
@@ -143,13 +160,13 @@ defmodule Logflare.Alerting do
 
   """
   def update_alert_query(%AlertQuery{} = alert_query, attrs) do
-    backends_modified = if backends = Map.get(attrs, :backends), do: true, else: false
+    backends = Map.get(attrs, :backends) || Map.get(attrs, "backends")
 
     alert_query
     |> preload_alert_query()
     |> AlertQuery.changeset(attrs)
     |> then(fn
-      changeset when backends_modified == true ->
+      changeset when not is_nil(backends) ->
         Ecto.Changeset.put_assoc(changeset, :backends, backends)
 
       changeset ->

--- a/lib/logflare/alerting/alert_query.ex
+++ b/lib/logflare/alerting/alert_query.ex
@@ -19,7 +19,8 @@ defmodule Logflare.Alerting.AlertQuery do
              :query,
              :webhook_notification_url,
              :slack_hook_url,
-             :enabled
+             :enabled,
+             :backends
            ]}
   typed_schema "alert_queries" do
     field :name, :string

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -20,7 +20,11 @@ defmodule LogflareWeb.Api.AlertController do
   )
 
   def index(%{assigns: %{user: user}} = conn, _params) do
-    alerts = Alerting.list_alert_queries_user_access(user)
+    alerts =
+      user
+      |> Alerting.list_alert_queries_user_access()
+      |> Enum.map(&Alerting.preload_alert_query/1)
+
     json(conn, alerts)
   end
 
@@ -35,7 +39,7 @@ defmodule LogflareWeb.Api.AlertController do
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
     with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token) do
-      json(conn, alert)
+      json(conn, Alerting.preload_alert_query(alert))
     end
   end
 
@@ -52,7 +56,7 @@ defmodule LogflareWeb.Api.AlertController do
     with {:ok, alert} <- Alerting.create_alert_query(user, params) do
       conn
       |> put_status(201)
-      |> json(alert)
+      |> json(Alerting.preload_alert_query(alert))
     end
   end
 
@@ -78,7 +82,7 @@ defmodule LogflareWeb.Api.AlertController do
 
         %{method: "PUT"} ->
           put_status(conn, 200)
-          |> json(updated)
+          |> json(Alerting.preload_alert_query(updated))
       end
     end
   end

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -5,10 +5,14 @@ defmodule LogflareWeb.Api.AlertController do
   alias Logflare.Alerting
   alias Logflare.Backends
   alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.BadRequest
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
+  alias LogflareWeb.OpenApiSchemas.AlertApiCreateParams
   alias LogflareWeb.OpenApiSchemas.AlertApiSchema
+  alias LogflareWeb.OpenApiSchemas.AlertApiUpdateParams
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -45,15 +49,18 @@ defmodule LogflareWeb.Api.AlertController do
 
   operation(:create,
     summary: "Create alert",
-    request_body: AlertApiSchema.params(),
+    request_body: AlertApiCreateParams.params(),
     responses: %{
       201 => Created.response(AlertApiSchema),
-      404 => NotFound.response()
+      400 => BadRequest.response(),
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
   def create(%{assigns: %{user: user}} = conn, params) do
-    with {:ok, alert} <- Alerting.create_alert_query(user, params) do
+    with {:ok, attrs} <- verify_backends_owner(params, user),
+         {:ok, alert} <- Alerting.create_alert_query(user, attrs) do
       conn
       |> put_status(201)
       |> json(Alerting.preload_alert_query(alert))
@@ -63,11 +70,13 @@ defmodule LogflareWeb.Api.AlertController do
   operation(:update,
     summary: "Update alert",
     parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
-    request_body: AlertApiSchema.params(),
+    request_body: AlertApiUpdateParams.params(),
     responses: %{
       204 => Accepted.response(),
       200 => Accepted.response(AlertApiSchema),
-      404 => NotFound.response()
+      400 => BadRequest.response(),
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -78,7 +87,9 @@ defmodule LogflareWeb.Api.AlertController do
       conn
       |> case do
         %{method: "PATCH"} ->
-          send_resp(conn, 204, "")
+          conn
+          |> put_status(204)
+          |> text("")
 
         %{method: "PUT"} ->
           put_status(conn, 200)
@@ -87,29 +98,43 @@ defmodule LogflareWeb.Api.AlertController do
     end
   end
 
+  defp verify_backends_owner(%{"backends" => _}, _user) do
+    {:error, "backends is read-only; use backend_ids"}
+  end
+
+  defp verify_backends_owner(%{"backend_ids" => ids}, _user) when not is_list(ids) do
+    {:error, "backend_ids must be an array"}
+  end
+
   defp verify_backends_owner(%{"backend_ids" => ids} = params, user) do
-    ids
-    |> Enum.reduce_while({:ok, []}, fn id, {:ok, acc} ->
-      case Backends.fetch_backend_by(id: id, user_id: user.id) do
-        {:ok, backend} -> {:cont, {:ok, [backend | acc]}}
-        {:error, :not_found} -> {:halt, {:error, :not_found}}
-      end
-    end)
-    |> case do
-      {:ok, backends} ->
-        attrs =
-          params
-          |> Map.delete("backend_ids")
-          |> Map.put("backends", Enum.reverse(backends))
+    with :ok <- validate_backend_ids(ids),
+         {:ok, backends} <- fetch_backends(Enum.uniq(ids), user) do
+      attrs =
+        params
+        |> Map.delete("backend_ids")
+        |> Map.put("backends", backends)
 
-        {:ok, attrs}
-
-      error ->
-        error
+      {:ok, attrs}
     end
   end
 
   defp verify_backends_owner(params, _user), do: {:ok, params}
+
+  defp validate_backend_ids(ids) do
+    if Enum.all?(ids, &(is_integer(&1) and &1 > 0)),
+      do: :ok,
+      else: {:error, "backend_ids must contain positive integers"}
+  end
+
+  defp fetch_backends(ids, user), do: fetch_backends(ids, user, [])
+
+  defp fetch_backends([], _user, acc), do: {:ok, Enum.reverse(acc)}
+
+  defp fetch_backends([id | ids], user, acc) do
+    with {:ok, backend} <- Backends.fetch_backend_by(id: id, user_id: user.id) do
+      fetch_backends(ids, user, [backend | acc])
+    end
+  end
 
   operation(:delete,
     summary: "Delete alert",
@@ -124,7 +149,8 @@ defmodule LogflareWeb.Api.AlertController do
     with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token),
          {:ok, _} <- Alerting.delete_alert_query(alert) do
       conn
-      |> send_resp(204, [])
+      |> put_status(204)
+      |> text("")
       |> halt()
     end
   end

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -1,0 +1,127 @@
+defmodule LogflareWeb.Api.AlertController do
+  use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Logflare.Alerting
+  alias Logflare.Backends
+  alias LogflareWeb.OpenApi.Accepted
+  alias LogflareWeb.OpenApi.Created
+  alias LogflareWeb.OpenApi.List
+  alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApiSchemas.AlertApiSchema
+
+  action_fallback(LogflareWeb.Api.FallbackController)
+
+  tags(["management"])
+
+  operation(:index,
+    summary: "List alerts",
+    responses: %{200 => List.response(AlertApiSchema)}
+  )
+
+  def index(%{assigns: %{user: user}} = conn, _params) do
+    alerts = Alerting.list_alert_queries_user_access(user)
+    json(conn, alerts)
+  end
+
+  operation(:show,
+    summary: "Fetch alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    responses: %{
+      200 => AlertApiSchema.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token) do
+      json(conn, alert)
+    end
+  end
+
+  operation(:create,
+    summary: "Create alert",
+    request_body: AlertApiSchema.params(),
+    responses: %{
+      201 => Created.response(AlertApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def create(%{assigns: %{user: user}} = conn, params) do
+    with {:ok, alert} <- Alerting.create_alert_query(user, params) do
+      conn
+      |> put_status(201)
+      |> json(alert)
+    end
+  end
+
+  operation(:update,
+    summary: "Update alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    request_body: AlertApiSchema.params(),
+    responses: %{
+      204 => Accepted.response(),
+      200 => Accepted.response(AlertApiSchema),
+      404 => NotFound.response()
+    }
+  )
+
+  def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token),
+         {:ok, attrs} <- verify_backends_owner(params, user),
+         {:ok, updated} <- Alerting.update_alert_query(alert, attrs) do
+      conn
+      |> case do
+        %{method: "PATCH"} ->
+          send_resp(conn, 204, "")
+
+        %{method: "PUT"} ->
+          put_status(conn, 200)
+          |> json(updated)
+      end
+    end
+  end
+
+  defp verify_backends_owner(%{"backend_ids" => ids} = params, user) do
+    ids
+    |> Enum.reduce_while({:ok, []}, fn id, {:ok, acc} ->
+      case Backends.fetch_backend_by(id: id, user_id: user.id) do
+        {:ok, backend} -> {:cont, {:ok, [backend | acc]}}
+        {:error, :not_found} -> {:halt, {:error, :not_found}}
+      end
+    end)
+    |> case do
+      {:ok, backends} ->
+        attrs =
+          params
+          |> Map.delete("backend_ids")
+          |> Map.put("backends", Enum.reverse(backends))
+
+        {:ok, attrs}
+
+      error ->
+        error
+    end
+  end
+
+  defp verify_backends_owner(params, _user), do: {:ok, params}
+
+  operation(:delete,
+    summary: "Delete alert",
+    parameters: [token: [in: :path, description: "Alert UUID", type: :string]],
+    responses: %{
+      204 => Accepted.response(),
+      404 => NotFound.response()
+    }
+  )
+
+  def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
+    with {:ok, alert} <- Alerting.fetch_alert_query_by_user_access(user, token: token),
+         {:ok, _} <- Alerting.delete_alert_query(alert) do
+      conn
+      |> send_resp(204, [])
+      |> halt()
+    end
+  end
+end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -159,17 +159,57 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
   end
 
+  defmodule AlertApiCreateParams do
+    @properties %{
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      language: %Schema{type: :string},
+      query: %Schema{type: :string},
+      cron: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
+      enabled: %Schema{type: :boolean},
+      backend_ids: %Schema{
+        type: :array,
+        items: %Schema{type: :integer, minimum: 1},
+        description: "Complete replacement set of attached backend IDs"
+      }
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query, :cron]
+  end
+
+  defmodule AlertApiUpdateParams do
+    @properties %{
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      language: %Schema{type: :string},
+      query: %Schema{type: :string},
+      cron: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
+      enabled: %Schema{type: :boolean},
+      backend_ids: %Schema{
+        type: :array,
+        items: %Schema{type: :integer, minimum: 1},
+        description: "Complete replacement set of attached backend IDs"
+      }
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
   defmodule AlertApiSchema do
     @properties %{
       id: %Schema{type: :integer},
       token: %Schema{type: :string},
       name: %Schema{type: :string},
-      description: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
       language: %Schema{type: :string},
       query: %Schema{type: :string},
       cron: %Schema{type: :string},
-      slack_hook_url: %Schema{type: :string},
-      webhook_notification_url: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
       enabled: %Schema{type: :boolean},
       backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema}
     }
@@ -370,10 +410,10 @@ defmodule LogflareWeb.OpenApiSchemas do
           LogflareWeb.OpenApiSchemas.SyslogConfigSchema
         ]
       },
-      metadata: %Schema{type: :object},
+      metadata: %Schema{type: :object, nullable: true},
       default_ingest?: %Schema{type: :boolean},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string},
+      updated_at: %Schema{type: :string}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :type, :config]

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -170,7 +170,8 @@ defmodule LogflareWeb.OpenApiSchemas do
       cron: %Schema{type: :string},
       slack_hook_url: %Schema{type: :string},
       webhook_notification_url: %Schema{type: :string},
-      enabled: %Schema{type: :boolean}
+      enabled: %Schema{type: :boolean},
+      backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query, :cron, :language]

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -159,6 +159,23 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
   end
 
+  defmodule AlertApiSchema do
+    @properties %{
+      id: %Schema{type: :integer},
+      token: %Schema{type: :string},
+      name: %Schema{type: :string},
+      description: %Schema{type: :string},
+      language: %Schema{type: :string},
+      query: %Schema{type: :string},
+      cron: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string},
+      webhook_notification_url: %Schema{type: :string},
+      enabled: %Schema{type: :boolean}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query, :cron, :language]
+  end
+
   defmodule KeyValueApiSchema do
     @properties %{
       id: %Schema{type: :integer},

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -470,6 +470,11 @@ defmodule LogflareWeb.Router do
       only: [:index, :show, :create, :update, :delete]
     )
 
+    resources("/alerts", Api.AlertController,
+      param: "token",
+      only: [:index, :show, :create, :update, :delete]
+    )
+
     resources("/endpoints", Api.EndpointController,
       param: "token",
       only: [:index, :show, :create, :update, :delete]

--- a/test/logflare/alerting_test.exs
+++ b/test/logflare/alerting_test.exs
@@ -138,6 +138,37 @@ defmodule Logflare.AlertingTest do
       assert alert_query.token
     end
 
+    test "create and update alert backends with atom and string keys", %{user: user} do
+      first_backend = insert(:backend, user: user)
+      second_backend = insert(:backend, user: user)
+      first_backend_id = first_backend.id
+      second_backend_id = second_backend.id
+
+      assert {:ok, created} =
+               Alerting.create_alert_query(
+                 user,
+                 Map.put(@valid_attrs, :backends, [first_backend])
+               )
+
+      assert [^first_backend_id] =
+               created
+               |> Alerting.preload_alert_query()
+               |> Map.fetch!(:backends)
+               |> Enum.map(& &1.id)
+
+      assert {:ok, updated} =
+               Alerting.update_alert_query(created, %{"backends" => [second_backend]})
+
+      assert [^second_backend_id] =
+               updated
+               |> Alerting.preload_alert_query()
+               |> Map.fetch!(:backends)
+               |> Enum.map(& &1.id)
+
+      assert {:ok, cleared} = Alerting.update_alert_query(updated, %{backends: []})
+      assert Alerting.preload_alert_query(cleared).backends == []
+    end
+
     test "bug: create_alert_query/1 with very long query", %{user: user} do
       assert {:ok, %AlertQuery{}} =
                Alerting.create_alert_query(user, %{

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -2,6 +2,12 @@ defmodule LogflareWeb.Api.AlertControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  alias Logflare.Alerting
+  alias LogflareWeb.OpenApiSchemas.AlertApiCreateParams
+  alias LogflareWeb.OpenApiSchemas.AlertApiSchema
+  alias LogflareWeb.OpenApiSchemas.AlertApiUpdateParams
+  alias OpenApiSpex.Schema
+
   setup %{conn: conn} do
     insert(:plan, name: "Free")
     user = insert(:user)
@@ -10,66 +16,162 @@ defmodule LogflareWeb.Api.AlertControllerTest do
     {:ok, conn: conn, user: user, backend: backend}
   end
 
-  test "list alerts", %{conn: conn, user: user} do
+  test "list alerts", %{conn: conn, user: user, backend: backend} do
     insert(:alert, user: insert(:user))
     alert = insert(:alert, user: user)
+    {:ok, alert} = Logflare.Alerting.update_alert_query(alert, %{backends: [backend]})
 
-    assert [result] =
-             conn
-             |> get(~p"/api/alerts")
-             |> json_response(200)
+    response =
+      conn
+      |> get(~p"/api/alerts")
+      |> json_response(200)
 
+    assert_schema(response, "AlertApiSchemaListResponse")
+    assert [result] = response
     assert result["id"] == alert.id
     assert result["token"] == alert.token
+    assert %{"id" => backend_id} = hd(result["backends"])
+    assert backend_id == backend.id
   end
 
   test "show alert", %{conn: conn, user: user} do
     alert = insert(:alert, user: user)
     insert(:alert, user: user)
 
-    assert result =
-             conn
-             |> get(~p"/api/alerts/#{alert.token}")
-             |> json_response(200)
+    result =
+      conn
+      |> get(~p"/api/alerts/#{alert.token}")
+      |> json_response(200)
 
+    assert_schema(result, "AlertApiSchema")
     assert result["id"] == alert.id
     assert result["token"] == alert.token
     assert result["name"] == alert.name
   end
 
+  test "documents alert request and response schemas" do
+    assert AlertApiCreateParams.schema().required == [:name, :query, :cron]
+    assert AlertApiUpdateParams.schema().required == []
+
+    for schema <- [AlertApiCreateParams, AlertApiUpdateParams] do
+      assert %{
+               backend_ids: %Schema{
+                 type: :array,
+                 items: %Schema{type: :integer, minimum: 1}
+               }
+             } = schema.schema().properties
+
+      refute Map.has_key?(schema.schema().properties, :backends)
+    end
+
+    assert %{backends: %Schema{type: :array}} = AlertApiSchema.schema().properties
+  end
+
   describe "with alerts" do
     test "create alert", %{conn: conn} do
-      assert %{"token" => alert_token} =
+      response =
+        conn
+        |> post(~p"/api/alerts", %{
+          name: "my alert",
+          query: "select current_date() as date",
+          cron: "0 0 1 * *",
+          language: "bq_sql"
+        })
+        |> json_response(201)
+
+      assert_schema(response, "AlertApiSchema")
+      assert %{"token" => alert_token} = response
+
+      response =
+        conn
+        |> get(~p"/api/alerts/#{alert_token}")
+        |> json_response(200)
+
+      assert_schema(response, "AlertApiSchema")
+    end
+
+    test "create alert defaults language when omitted", %{conn: conn} do
+      assert %{"language" => "bq_sql"} =
+               conn
+               |> post(~p"/api/alerts", %{
+                 name: "my alert",
+                 query: "select current_date() as date",
+                 cron: "0 0 1 * *"
+               })
+               |> json_response(201)
+    end
+
+    test "create alert with an owned backend", %{conn: conn, backend: backend} do
+      response =
+        conn
+        |> post(~p"/api/alerts", %{
+          name: "my alert",
+          query: "select current_date() as date",
+          cron: "0 0 1 * *",
+          language: "bq_sql",
+          backend_ids: [backend.id]
+        })
+        |> json_response(201)
+
+      assert_schema(response, "AlertApiSchema")
+      assert %{"token" => alert_token, "backends" => [%{"id" => backend_id}]} = response
+      assert backend_id == backend.id
+
+      assert %{"backends" => [%{"id" => ^backend_id}]} =
+               conn
+               |> get(~p"/api/alerts/#{alert_token}")
+               |> json_response(200)
+    end
+
+    test "rejects backend objects when creating", %{conn: conn, backend: backend} do
+      assert %{"error" => "backends is read-only; use backend_ids"} =
                conn
                |> post(~p"/api/alerts", %{
                  name: "my alert",
                  query: "select current_date() as date",
                  cron: "0 0 1 * *",
-                 language: "bq_sql"
+                 language: "bq_sql",
+                 backends: [%{id: backend.id}]
                })
-               |> json_response(201)
+               |> json_response(400)
+    end
 
-      assert alert_token
+    test "attacker cannot create an alert with a victim's backend", %{conn: conn, user: user} do
+      victim_backend = insert(:backend, user: insert(:user))
 
-      assert conn
-             |> get(~p"/api/alerts/#{alert_token}")
-             |> json_response(200)
+      assert %{"error" => "Not Found"} =
+               conn
+               |> post(~p"/api/alerts", %{
+                 name: "my alert",
+                 query: "select current_date() as date",
+                 cron: "0 0 1 * *",
+                 backend_ids: [victim_backend.id]
+               })
+               |> json_response(404)
+
+      assert Alerting.list_alert_queries(user) == []
     end
 
     test "create alert with bad params", %{conn: conn} do
-      assert %{"errors" => _} =
-               conn
-               |> post(~p"/api/alerts", %{name: "missing required fields"})
-               |> json_response(422)
+      response =
+        conn
+        |> post(~p"/api/alerts", %{name: "missing required fields"})
+        |> json_response(422)
+
+      assert_schema(response, "UnprocessableEntityResponse")
+      assert %{"errors" => %{"query" => _, "cron" => _}} = response
     end
 
     test "update alert", %{conn: conn, user: user} do
       alert = insert(:alert, user: user, name: "initial")
 
-      assert %{"token" => alert_token} =
-               conn
-               |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
-               |> json_response(200)
+      response =
+        conn
+        |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+        |> json_response(200)
+
+      assert_schema(response, "AlertApiSchema")
+      assert %{"token" => alert_token} = response
 
       assert %{"name" => "adjusted"} =
                conn
@@ -77,24 +179,130 @@ defmodule LogflareWeb.Api.AlertControllerTest do
                |> json_response(200)
     end
 
-    test "update alert to attach an owned backend", %{
+    test "patch alert returns no content and persists the update", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user, name: "initial")
+
+      response =
+        conn
+        |> patch(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+        |> text_response(204)
+
+      assert assert_schema(response, "AcceptedResponse") == ""
+
+      assert %{"name" => "adjusted"} =
+               conn
+               |> get(~p"/api/alerts/#{alert.token}")
+               |> json_response(200)
+    end
+
+    test "update alert with invalid params", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user, cron: "0 0 1 * *")
+
+      response =
+        conn
+        |> patch(~p"/api/alerts/#{alert.token}", %{cron: "not a cron expression"})
+        |> json_response(422)
+
+      assert_schema(response, "UnprocessableEntityResponse")
+      assert %{"errors" => %{"cron" => _}} = response
+    end
+
+    test "backend IDs replace associations and preserve them when omitted", %{
+      conn: conn,
+      user: user,
+      backend: backend
+    } do
+      alert = insert(:alert, user: user)
+      other_backend = insert(:backend, user: user)
+
+      response =
+        conn
+        |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id, other_backend.id]})
+        |> json_response(200)
+
+      assert_schema(response, "AlertApiSchema")
+
+      assert MapSet.new(Enum.map(response["backends"], & &1["id"])) ==
+               MapSet.new([backend.id, other_backend.id])
+
+      response =
+        conn
+        |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [other_backend.id]})
+        |> json_response(200)
+
+      assert %{"backends" => [%{"id" => other_backend_id}]} = response
+      assert other_backend_id == other_backend.id
+
+      response =
+        conn
+        |> put(~p"/api/alerts/#{alert.token}", %{name: "renamed"})
+        |> json_response(200)
+
+      assert %{"backends" => [%{"id" => ^other_backend_id}]} = response
+
+      assert %{"backends" => [%{"id" => ^other_backend_id}]} =
+               conn
+               |> get(~p"/api/alerts/#{alert.token}")
+               |> json_response(200)
+
+      assert %{"backends" => []} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: []})
+               |> json_response(200)
+
+      assert %{"backends" => []} =
+               conn
+               |> get(~p"/api/alerts/#{alert.token}")
+               |> json_response(200)
+    end
+
+    test "deduplicates backend IDs", %{conn: conn, user: user, backend: backend} do
+      alert = insert(:alert, user: user)
+
+      assert %{"backends" => [%{"id" => backend_id}]} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{
+                 backend_ids: [backend.id, backend.id]
+               })
+               |> json_response(200)
+
+      assert backend_id == backend.id
+    end
+
+    test "rejects backend IDs that are not an array", %{conn: conn, backend: backend} do
+      assert %{"error" => "backend_ids must be an array"} =
+               conn
+               |> post(~p"/api/alerts", %{
+                 name: "my alert",
+                 query: "select current_date() as date",
+                 cron: "0 0 1 * *",
+                 backend_ids: backend.id
+               })
+               |> json_response(400)
+    end
+
+    test "rejects non-positive and non-integer backend IDs", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user)
+
+      for invalid_id <- [0, -1, 1.5, "1", %{}] do
+        assert %{"error" => "backend_ids must contain positive integers"} =
+                 conn
+                 |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [invalid_id]})
+                 |> json_response(400)
+      end
+    end
+
+    test "rejects backend objects when updating", %{
       conn: conn,
       user: user,
       backend: backend
     } do
       alert = insert(:alert, user: user)
 
-      assert %{"token" => alert_token, "backends" => [%{"id" => backend_id}]} =
+      assert %{"error" => "backends is read-only; use backend_ids"} =
                conn
-               |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
-               |> json_response(200)
-
-      assert backend_id == backend.id
-
-      assert %{"backends" => [%{"id" => ^backend_id}]} =
-               conn
-               |> get(~p"/api/alerts/#{alert_token}")
-               |> json_response(200)
+               |> put(~p"/api/alerts/#{alert.token}", %{backends: [%{id: backend.id}]})
+               |> json_response(400)
     end
 
     test "attacker cannot attach a victim's backend to their alert", %{
@@ -106,9 +314,12 @@ defmodule LogflareWeb.Api.AlertControllerTest do
       victim = insert(:user)
       victim_backend = insert(:backend, user: victim)
 
-      conn
-      |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
-      |> json_response(404)
+      response =
+        conn
+        |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
+        |> json_response(404)
+
+      assert_schema(response, "NotFoundResponse")
 
       reloaded =
         Logflare.Alerting.get_alert_query!(alert.id)
@@ -133,16 +344,90 @@ defmodule LogflareWeb.Api.AlertControllerTest do
                |> json_response(200)
     end
 
+    test "team member can manage team-owned alerts", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      owner = team_user.team.user
+      managed_alert = insert(:alert, user: owner, name: "initial")
+      deleted_alert = insert(:alert, user: owner)
+      conn = add_access_token(conn, member, "private")
+
+      response =
+        conn
+        |> get(~p"/api/alerts")
+        |> json_response(200)
+
+      assert_schema(response, "AlertApiSchemaListResponse")
+
+      assert MapSet.new(Enum.map(response, & &1["token"])) ==
+               MapSet.new([managed_alert.token, deleted_alert.token])
+
+      response =
+        conn
+        |> get(~p"/api/alerts/#{managed_alert.token}")
+        |> json_response(200)
+
+      assert_schema(response, "AlertApiSchema")
+      assert response["token"] == managed_alert.token
+
+      assert conn
+             |> patch(~p"/api/alerts/#{managed_alert.token}", %{name: "updated"})
+             |> text_response(204) == ""
+
+      assert %{"name" => "updated"} =
+               conn
+               |> get(~p"/api/alerts/#{managed_alert.token}")
+               |> json_response(200)
+
+      assert conn
+             |> delete(~p"/api/alerts/#{deleted_alert.token}")
+             |> text_response(204) == ""
+    end
+
+    test "team member cannot yet attach a team-owned backend", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      owner = team_user.team.user
+      alert = insert(:alert, user: owner)
+      backend = insert(:backend, user: owner)
+
+      response =
+        conn
+        |> add_access_token(member, "private")
+        |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
+        |> json_response(404)
+
+      assert_schema(response, "NotFoundResponse")
+    end
+
+    test "show alert with bad user", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user)
+
+      response =
+        conn
+        |> add_access_token(insert(:user), "private")
+        |> get(~p"/api/alerts/#{alert.token}")
+        |> json_response(404)
+
+      assert_schema(response, "NotFoundResponse")
+    end
+
     test "delete alert", %{conn: conn, user: user} do
       alert = insert(:alert, user: user)
 
-      assert conn
-             |> delete(~p"/api/alerts/#{alert.token}")
-             |> response(204)
+      response =
+        conn
+        |> delete(~p"/api/alerts/#{alert.token}")
+        |> text_response(204)
 
-      assert conn
-             |> get(~p"/api/alerts/#{alert.token}")
-             |> json_response(404)
+      assert assert_schema(response, "AcceptedResponse") == ""
+
+      response =
+        conn
+        |> get(~p"/api/alerts/#{alert.token}")
+        |> json_response(404)
+
+      assert_schema(response, "NotFoundResponse")
     end
 
     test "delete alert with bad user", %{conn: conn, user: user} do

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -84,18 +84,17 @@ defmodule LogflareWeb.Api.AlertControllerTest do
     } do
       alert = insert(:alert, user: user)
 
-      assert %{"token" => alert_token} =
+      assert %{"token" => alert_token, "backends" => [%{"id" => backend_id}]} =
                conn
                |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
                |> json_response(200)
 
-      updated =
-        Logflare.Alerting.get_alert_query!(alert.id)
-        |> Logflare.Alerting.preload_alert_query()
-
-      assert alert_token == updated.token
-      assert [%{id: backend_id}] = updated.backends
       assert backend_id == backend.id
+
+      assert %{"backends" => [%{"id" => ^backend_id}]} =
+               conn
+               |> get(~p"/api/alerts/#{alert_token}")
+               |> json_response(200)
     end
 
     test "attacker cannot attach a victim's backend to their alert", %{

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -1,0 +1,163 @@
+defmodule LogflareWeb.Api.AlertControllerTest do
+  @moduledoc false
+  use LogflareWeb.ConnCase
+
+  setup %{conn: conn} do
+    insert(:plan, name: "Free")
+    user = insert(:user)
+    conn = add_access_token(conn, user, "private")
+    backend = insert(:backend, user: user)
+    {:ok, conn: conn, user: user, backend: backend}
+  end
+
+  test "list alerts", %{conn: conn, user: user} do
+    insert(:alert, user: insert(:user))
+    alert = insert(:alert, user: user)
+
+    assert [result] =
+             conn
+             |> get(~p"/api/alerts")
+             |> json_response(200)
+
+    assert result["id"] == alert.id
+    assert result["token"] == alert.token
+  end
+
+  test "show alert", %{conn: conn, user: user} do
+    alert = insert(:alert, user: user)
+    insert(:alert, user: user)
+
+    assert result =
+             conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(200)
+
+    assert result["id"] == alert.id
+    assert result["token"] == alert.token
+    assert result["name"] == alert.name
+  end
+
+  describe "with alerts" do
+    test "create alert", %{conn: conn} do
+      assert %{"token" => alert_token} =
+               conn
+               |> post(~p"/api/alerts", %{
+                 name: "my alert",
+                 query: "select current_date() as date",
+                 cron: "0 0 1 * *",
+                 language: "bq_sql"
+               })
+               |> json_response(201)
+
+      assert alert_token
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert_token}")
+             |> json_response(200)
+    end
+
+    test "create alert with bad params", %{conn: conn} do
+      assert %{"errors" => _} =
+               conn
+               |> post(~p"/api/alerts", %{name: "missing required fields"})
+               |> json_response(422)
+    end
+
+    test "update alert", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user, name: "initial")
+
+      assert %{"token" => alert_token} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+               |> json_response(200)
+
+      assert %{"name" => "adjusted"} =
+               conn
+               |> get(~p"/api/alerts/#{alert_token}")
+               |> json_response(200)
+    end
+
+    test "update alert to attach an owned backend", %{
+      conn: conn,
+      user: user,
+      backend: backend
+    } do
+      alert = insert(:alert, user: user)
+
+      assert %{"token" => alert_token} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
+               |> json_response(200)
+
+      updated =
+        Logflare.Alerting.get_alert_query!(alert.id)
+        |> Logflare.Alerting.preload_alert_query()
+
+      assert alert_token == updated.token
+      assert [%{id: backend_id}] = updated.backends
+      assert backend_id == backend.id
+    end
+
+    test "attacker cannot attach a victim's backend to their alert", %{
+      conn: conn,
+      user: user
+    } do
+      alert = insert(:alert, user: user)
+
+      victim = insert(:user)
+      victim_backend = insert(:backend, user: victim)
+
+      conn
+      |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
+      |> json_response(404)
+
+      reloaded =
+        Logflare.Alerting.get_alert_query!(alert.id)
+        |> Logflare.Alerting.preload_alert_query()
+
+      assert reloaded.backends == []
+    end
+
+    test "update alert with bad user", %{conn: conn, user: user} do
+      other_user = insert(:user)
+      alert = insert(:alert, user: user, name: "initial")
+
+      assert %{"error" => _} =
+               conn
+               |> add_access_token(other_user, "private")
+               |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
+               |> json_response(404)
+
+      assert %{"name" => "initial"} =
+               conn
+               |> get(~p"/api/alerts/#{alert.token}")
+               |> json_response(200)
+    end
+
+    test "delete alert", %{conn: conn, user: user} do
+      alert = insert(:alert, user: user)
+
+      assert conn
+             |> delete(~p"/api/alerts/#{alert.token}")
+             |> response(204)
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(404)
+    end
+
+    test "delete alert with bad user", %{conn: conn, user: user} do
+      other_user = insert(:user)
+      alert = insert(:alert, user: user)
+
+      assert conn
+             |> add_access_token(other_user, "private")
+             |> delete(~p"/api/alerts/#{alert.token}")
+             |> response(404)
+
+      assert conn
+             |> get(~p"/api/alerts/#{alert.token}")
+             |> json_response(200)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds Management API CRUD for `Logflare.Alerting.AlertQuery` at `/api/alerts`, enabling Terraform-provider coverage for alerts under O11Y-2143.

The alert resource's list and lookup paths follow existing team-access semantics; backend attachment has the limitation below.

### Backend attachment contract

- Create requires `name`, `query`, and `cron`; `language` defaults to `bq_sql` when omitted.
- Create and update accept `backend_ids`, a complete replacement set of positive integer backend IDs.
- IDs are deduplicated and must belong directly to the authenticated user.
- `backends` is response-only and returns the attached backend objects. Supplying `backends` in a request returns `400`; use `backend_ids` instead.
- Invalid `backend_ids` return `400` rather than raising.

Alerts now preload and serialize attached backends in all response-producing actions, so Terraform can reconcile the association.

### OpenAPI

- Separate create and update request schemas: create requires alert fields; update permits partial updates.
- Documents `backend_ids` only on write schemas and `backends` only on the response schema.
- Documents `backend_ids` as positive integers, nullable backend metadata, and the actual naïve timestamp serialization.
- Correctly documents nullable optional fields and `400`, `404`, and `422` responses.

### Known limitation / follow-up

Alert list, fetch, update, and delete are team-access scoped, but `backend_ids` are resolved only among the token owner's directly owned backends. Consequently, a member can manage an existing team alert but cannot discover or attach that team's owner-owned backends through the Management API. `/api/backends` list and show have the same direct-owner scope.

This does not affect the owner-token Terraform use case. Team-aware backend discovery and attachment should be addressed together in a follow-up: make backend list/show and alert attachment use the existing backend access helpers, then cover team-owned attachment, unrelated-backend rejection, and team backend discovery.

Implements O11Y-2143.
