### PR TITLE
fix(openapi): describe Management API errors as JSON

### DIFF
--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -65,7 +65,7 @@ defmodule LogflareWeb.OpenApi do
       }
     end
 
-    def response, do: {"Not found", "text/plain", schema()}
+    def response, do: {"Not found", "application/json", schema()}
   end
 
   defmodule UnprocessableEntity do
@@ -82,10 +82,16 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule BadRequest do
-    require OpenApiSpex
-    OpenApiSpex.schema(%{})
+    def schema do
+      %Schema{
+        title: "BadRequestResponse",
+        type: :object,
+        properties: %{error: %Schema{type: :string}},
+        required: [:error]
+      }
+    end
 
-    def response, do: {"Bad request", "text/plain", __MODULE__}
+    def response, do: {"Bad request", "application/json", schema()}
   end
 
   defmodule Unauthorized do

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -38,13 +38,19 @@ defmodule LogflareWeb.Api.QueryControllerTest do
       assert %{"result" => %{"parameters" => []}} = json_response(conn, 200)
     end
 
-    test "invalid valid sql query returns 200 ok", %{conn: conn, user: user} do
+    test "invalid sql query returns a JSON 400 error", %{conn: conn, user: user} do
       conn =
         conn
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/query/parse?#{[bq_sql: ~s|update something SET test = 'something'|]}")
 
-      assert %{"error" => err} = json_response(conn, 400)
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
+      assert %{error: err} =
+               conn
+               |> json_response(400)
+               |> assert_schema("BadRequestResponse")
+
       assert err =~ "SELECT"
     end
   end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -79,13 +79,19 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     } do
       invalid_user = insert(:user)
 
+      conn =
+        conn
+        |> add_access_token(invalid_user, "private")
+        |> get(~p"/api/teams/#{main_team.token}")
+
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
       conn
-      |> add_access_token(invalid_user, "private")
-      |> get(~p"/api/teams/#{main_team.token}")
       |> json_response(404)
       |> assert_schema("NotFoundResponse")
 
       conn
+      |> recycle()
       |> add_access_token(invalid_user, "private")
       |> get(~p"/api/teams/#{non_owner_team.token}")
       |> json_response(404)

--- a/test/logflare_web/open_api_test.exs
+++ b/test/logflare_web/open_api_test.exs
@@ -1,0 +1,38 @@
+defmodule LogflareWeb.OpenApiTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.Api.QueryController
+  alias LogflareWeb.Api.TeamController
+  alias OpenApiSpex.MediaType
+  alias OpenApiSpex.Response
+  alias OpenApiSpex.Schema
+
+  test "Management API 400 errors are documented as JSON" do
+    QueryController.open_api_operation(:parse)
+    |> Map.fetch!(:responses)
+    |> Map.fetch!(400)
+    |> assert_json_error_response("BadRequestResponse")
+  end
+
+  test "Management API 404 errors are documented as JSON" do
+    TeamController.open_api_operation(:show)
+    |> Map.fetch!(:responses)
+    |> Map.fetch!(404)
+    |> assert_json_error_response("NotFoundResponse")
+  end
+
+  defp assert_json_error_response(response, schema_title) do
+    assert %Response{
+             content: %{
+               "application/json" => %MediaType{
+                 schema: %Schema{
+                   title: ^schema_title,
+                   type: :object,
+                   properties: %{error: %Schema{type: :string}},
+                   required: [:error]
+                 }
+               }
+             }
+           } = response
+  end
+end


### PR DESCRIPTION
## Summary
- declare shared Management API 400 and 404 error responses as `application/json`
- add the `BadRequestResponse` error schema
- cover representative 400 and 404 response content types and OpenAPI schemas

## Testing
- `../bin/test test/logflare_web/open_api_test.exs test/logflare_web/controllers/api/query_controller_test.exs test/logflare_web/controllers/api/team_controller_test.exs`

Closes https://linear.app/supabase/issue/O11Y-2155/fix-json-error-response-media-types-in-logflare-management-api-openapi
Tracks https://github.com/Logflare/logflare/issues/3684