### PR TITLE
fix(openapi): correct Management API response contracts

### DIFF
--- a/lib/logflare_web/controllers/api/query_controller.ex
+++ b/lib/logflare_web/controllers/api/query_controller.ex
@@ -10,7 +10,6 @@ defmodule LogflareWeb.Api.QueryController do
   alias Logflare.Sql
   alias Logflare.User
   alias LogflareWeb.OpenApi.BadRequest
-  alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.One
   alias LogflareWeb.OpenApi.Unauthorized
   alias LogflareWeb.OpenApiSchemas.QueryParseResult

--- a/lib/logflare_web/controllers/api/query_controller.ex
+++ b/lib/logflare_web/controllers/api/query_controller.ex
@@ -112,7 +112,10 @@ defmodule LogflareWeb.Api.QueryController do
         required: false
       ]
     ],
-    responses: %{200 => List.response(QueryResult)}
+    responses: %{
+      200 => List.response(QueryResult),
+      400 => BadRequest.response()
+    }
   )
 
   def query(%{assigns: %{user: user}} = conn, params) do

--- a/lib/logflare_web/controllers/api/query_controller.ex
+++ b/lib/logflare_web/controllers/api/query_controller.ex
@@ -12,6 +12,7 @@ defmodule LogflareWeb.Api.QueryController do
   alias LogflareWeb.OpenApi.BadRequest
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.One
+  alias LogflareWeb.OpenApi.Unauthorized
   alias LogflareWeb.OpenApiSchemas.QueryParseResult
   alias LogflareWeb.OpenApiSchemas.QueryResult
 
@@ -46,7 +47,8 @@ defmodule LogflareWeb.Api.QueryController do
     ],
     responses: %{
       200 => One.response(QueryParseResult),
-      400 => BadRequest.response()
+      400 => BadRequest.response(),
+      401 => Unauthorized.response()
     }
   )
 
@@ -113,8 +115,9 @@ defmodule LogflareWeb.Api.QueryController do
       ]
     ],
     responses: %{
-      200 => List.response(QueryResult),
-      400 => BadRequest.response()
+      200 => One.response(QueryResult),
+      400 => BadRequest.response(),
+      401 => Unauthorized.response()
     }
   )
 

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -102,10 +102,16 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule Unauthorized do
-    require OpenApiSpex
-    OpenApiSpex.schema(%{})
+    def schema do
+      %Schema{
+        title: "UnauthorizedResponse",
+        type: :object,
+        properties: %{error: %Schema{type: :string}},
+        required: [:error]
+      }
+    end
 
-    def response, do: {"Unauthorized", "text/plain", __MODULE__}
+    def response, do: {"Unauthorized", "application/json", schema()}
   end
 
   defmodule ServerError do

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -65,7 +65,7 @@ defmodule LogflareWeb.OpenApi do
       }
     end
 
-    def response, do: {"Not found", "text/plain", schema()}
+    def response, do: {"Not found", "application/json", schema()}
   end
 
   defmodule UnprocessableEntity do
@@ -82,10 +82,16 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule BadRequest do
-    require OpenApiSpex
-    OpenApiSpex.schema(%{})
+    def schema do
+      %Schema{
+        title: "BadRequestResponse",
+        type: :object,
+        properties: %{error: %Schema{type: :string}},
+        required: [:error]
+      }
+    end
 
-    def response, do: {"Bad request", "text/plain", __MODULE__}
+    def response, do: {"Bad request", "application/json", schema()}
   end
 
   defmodule Unauthorized do

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -86,7 +86,14 @@ defmodule LogflareWeb.OpenApi do
       %Schema{
         title: "BadRequestResponse",
         type: :object,
-        properties: %{error: %Schema{type: :string}},
+        properties: %{
+          error: %Schema{
+            oneOf: [
+              %Schema{type: :string},
+              %Schema{type: :object}
+            ]
+          }
+        },
         required: [:error]
       }
     end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -44,13 +44,7 @@ defmodule LogflareWeb.OpenApiSchemas do
 
   defmodule QueryResult do
     @properties %{
-      result: %Schema{type: :object},
-      errors: %Schema{
-        oneOf: [
-          %Schema{type: :object},
-          %Schema{type: :string}
-        ]
-      }
+      result: %Schema{type: :array, items: %Schema{type: :object}}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: [:result]
   end

--- a/test/logflare_web/controllers/api/access_tokens_controller_test.exs
+++ b/test/logflare_web/controllers/api/access_tokens_controller_test.exs
@@ -105,10 +105,17 @@ defmodule LogflareWeb.Api.AccessTokensTest do
     end
 
     test "must use private token", %{conn: conn, user: user} do
-      conn
-      |> add_access_token(user, "public")
-      |> post(~p"/api/access-tokens")
-      |> json_response(401)
+      conn =
+        conn
+        |> add_access_token(user, "public")
+        |> post(~p"/api/access-tokens")
+
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
+      assert %{error: "Unauthorized"} =
+               conn
+               |> json_response(401)
+               |> assert_schema("UnauthorizedResponse")
     end
   end
 

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -73,11 +73,15 @@ defmodule LogflareWeb.Api.QueryControllerTest do
         {:ok, TestUtils.gen_bq_response([%{"my_time" => "123"}])}
       end)
 
-      response =
+      conn =
         conn
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/query?#{[bq_sql: ~s|select current_datetime() as 'my_time'|]}")
-        |> json_response(200)
+
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
+      response = json_response(conn, 200)
+      assert_schema(response, "QueryResult")
 
       assert %{"result" => [%{"my_time" => "123"}]} = response
 
@@ -88,6 +92,7 @@ defmodule LogflareWeb.Api.QueryControllerTest do
         |> get(~p"/api/query?#{[sql: ~s|select current_datetime() as 'my_time'|]}")
         |> json_response(200)
 
+      assert_schema(response, "QueryResult")
       assert %{"result" => [%{"my_time" => "123"}]} = response
     end
 

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -12,11 +12,20 @@ defmodule LogflareWeb.Api.QueryControllerTest do
     {:ok, user: user}
   end
 
-  test "no query param provided", %{conn: conn, user: user} do
-    conn
-    |> add_access_token(user, ~w(private))
-    |> get(~p"/api/query")
-    |> json_response(400)
+  test "no query param provided returns a JSON 400 error", %{conn: conn, user: user} do
+    conn =
+      conn
+      |> add_access_token(user, ~w(private))
+      |> get(~p"/api/query")
+
+    assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
+    assert %{error: message} =
+             conn
+             |> json_response(400)
+             |> assert_schema("BadRequestResponse")
+
+    assert message =~ "No query params provided"
   end
 
   describe "validate/2" do

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -38,13 +38,19 @@ defmodule LogflareWeb.Api.QueryControllerTest do
       assert %{"result" => %{"parameters" => []}} = json_response(conn, 200)
     end
 
-    test "invalid valid sql query returns 200 ok", %{conn: conn, user: user} do
+    test "invalid sql query returns a JSON 400 error", %{conn: conn, user: user} do
       conn =
         conn
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/query/parse?#{[bq_sql: ~s|update something SET test = 'something'|]}")
 
-      assert %{"error" => err} = json_response(conn, 400)
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
+      assert %{error: err} =
+               conn
+               |> json_response(400)
+               |> assert_schema("BadRequestResponse")
+
       assert err =~ "SELECT"
     end
   end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -79,13 +79,19 @@ defmodule LogflareWeb.Api.TeamControllerTest do
     } do
       invalid_user = insert(:user)
 
+      conn =
+        conn
+        |> add_access_token(invalid_user, "private")
+        |> get(~p"/api/teams/#{main_team.token}")
+
+      assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
+
       conn
-      |> add_access_token(invalid_user, "private")
-      |> get(~p"/api/teams/#{main_team.token}")
       |> json_response(404)
       |> assert_schema("NotFoundResponse")
 
       conn
+      |> recycle()
       |> add_access_token(invalid_user, "private")
       |> get(~p"/api/teams/#{non_owner_team.token}")
       |> json_response(404)

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -199,7 +199,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
 
       assert conn
              |> json_response(401)
-             |> assert_schema("Unauthorized") == %{"error" => "Unauthorized"}
+             |> assert_schema("UnauthorizedResponse") == %{error: "Unauthorized"}
 
       assert conn.halted == true
     end

--- a/test/logflare_web/open_api_test.exs
+++ b/test/logflare_web/open_api_test.exs
@@ -1,0 +1,38 @@
+defmodule LogflareWeb.OpenApiTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.Api.QueryController
+  alias LogflareWeb.Api.TeamController
+  alias OpenApiSpex.MediaType
+  alias OpenApiSpex.Response
+  alias OpenApiSpex.Schema
+
+  test "Management API 400 errors are documented as JSON" do
+    QueryController.open_api_operation(:parse)
+    |> Map.fetch!(:responses)
+    |> Map.fetch!(400)
+    |> assert_json_error_response("BadRequestResponse")
+  end
+
+  test "Management API 404 errors are documented as JSON" do
+    TeamController.open_api_operation(:show)
+    |> Map.fetch!(:responses)
+    |> Map.fetch!(404)
+    |> assert_json_error_response("NotFoundResponse")
+  end
+
+  defp assert_json_error_response(response, schema_title) do
+    assert %Response{
+             content: %{
+               "application/json" => %MediaType{
+                 schema: %Schema{
+                   title: ^schema_title,
+                   type: :object,
+                   properties: %{error: %Schema{type: :string}},
+                   required: [:error]
+                 }
+               }
+             }
+           } = response
+  end
+end

--- a/test/logflare_web/open_api_test.exs
+++ b/test/logflare_web/open_api_test.exs
@@ -7,28 +7,38 @@ defmodule LogflareWeb.OpenApiTest do
   alias OpenApiSpex.Response
   alias OpenApiSpex.Schema
 
+  @bad_request_error_schema %Schema{
+    oneOf: [
+      %Schema{type: :string},
+      %Schema{type: :object}
+    ]
+  }
+  @not_found_error_schema %Schema{type: :string}
+
   test "Management API 400 errors are documented as JSON" do
-    QueryController.open_api_operation(:parse)
-    |> Map.fetch!(:responses)
-    |> Map.fetch!(400)
-    |> assert_json_error_response("BadRequestResponse")
+    for action <- [:parse, :query] do
+      QueryController.open_api_operation(action)
+      |> Map.fetch!(:responses)
+      |> Map.fetch!(400)
+      |> assert_json_error_response("BadRequestResponse", @bad_request_error_schema)
+    end
   end
 
   test "Management API 404 errors are documented as JSON" do
     TeamController.open_api_operation(:show)
     |> Map.fetch!(:responses)
     |> Map.fetch!(404)
-    |> assert_json_error_response("NotFoundResponse")
+    |> assert_json_error_response("NotFoundResponse", @not_found_error_schema)
   end
 
-  defp assert_json_error_response(response, schema_title) do
+  defp assert_json_error_response(response, schema_title, error_schema) do
     assert %Response{
              content: %{
                "application/json" => %MediaType{
                  schema: %Schema{
                    title: ^schema_title,
                    type: :object,
-                   properties: %{error: %Schema{type: :string}},
+                   properties: %{error: ^error_schema},
                    required: [:error]
                  }
                }

--- a/test/logflare_web/open_api_test.exs
+++ b/test/logflare_web/open_api_test.exs
@@ -1,8 +1,10 @@
 defmodule LogflareWeb.OpenApiTest do
   use ExUnit.Case, async: true
 
+  alias LogflareWeb.Api.AccessTokenController
   alias LogflareWeb.Api.QueryController
   alias LogflareWeb.Api.TeamController
+  alias LogflareWeb.OpenApiSchemas.QueryResult
   alias OpenApiSpex.MediaType
   alias OpenApiSpex.Response
   alias OpenApiSpex.Schema
@@ -13,7 +15,24 @@ defmodule LogflareWeb.OpenApiTest do
       %Schema{type: :object}
     ]
   }
-  @not_found_error_schema %Schema{type: :string}
+  @string_error_schema %Schema{type: :string}
+
+  test "Management API query success is documented as an object containing result rows" do
+    response =
+      QueryController.open_api_operation(:query)
+      |> Map.fetch!(:responses)
+      |> Map.fetch!(200)
+
+    assert %Response{
+             content: %{"application/json" => %MediaType{schema: QueryResult}}
+           } = response
+
+    assert %Schema{
+             type: :object,
+             properties: %{result: %Schema{type: :array, items: %Schema{type: :object}}},
+             required: [:result]
+           } = QueryResult.schema()
+  end
 
   test "Management API 400 errors are documented as JSON" do
     for action <- [:parse, :query] do
@@ -24,11 +43,25 @@ defmodule LogflareWeb.OpenApiTest do
     end
   end
 
+  test "Management API 401 errors are documented as JSON" do
+    AccessTokenController.open_api_operation(:create)
+    |> Map.fetch!(:responses)
+    |> Map.fetch!(401)
+    |> assert_json_error_response("UnauthorizedResponse", @string_error_schema)
+
+    for action <- [:parse, :query] do
+      QueryController.open_api_operation(action)
+      |> Map.fetch!(:responses)
+      |> Map.fetch!(401)
+      |> assert_json_error_response("UnauthorizedResponse", @string_error_schema)
+    end
+  end
+
   test "Management API 404 errors are documented as JSON" do
     TeamController.open_api_operation(:show)
     |> Map.fetch!(:responses)
     |> Map.fetch!(404)
-    |> assert_json_error_response("NotFoundResponse", @not_found_error_schema)
+    |> assert_json_error_response("NotFoundResponse", @string_error_schema)
   end
 
   defp assert_json_error_response(response, schema_title, error_schema) do


### PR DESCRIPTION
## Problem

Several shared OpenAPI helpers documented Management API error responses as `text/plain`, even though `LogflareWeb.Api.FallbackController` already serializes all errors as JSON. As a result, the generated OpenAPI document—and any clients generated from it—advertised the wrong media types and error shapes.

Separately, `GET /api/query` returns an object containing result rows, but its OpenAPI response documented a top-level list with an object-valued `result` field, and also documented an `errors` field that the endpoint does not return.

This PR corrects the documented contracts only. **It does not change any Management API runtime responses.**

## Changes

### Error responses (shared helpers)
- Document shared 400, 401, and 404 responses as `application/json` instead of `text/plain`.
- Define `BadRequestResponse` as `{error: string | object}`. The `oneOf` covers both shapes the fallback controller emits: plain string messages and structured error objects.
- Define `UnauthorizedResponse` as JSON `{error: string}`. **Note:** this renames the generated component schema from `Unauthorized` to `UnauthorizedResponse`; clients referencing the old name will need to update.
- Change the `NotFoundResponse` content-type to `application/json` (schema unchanged, still `{error: string}`).

### `GET /api/query`
- Document the existing JSON 400 response, covering missing query parameters and query/backend errors.
- Correct the 200 response to an object with an array `result`, matching the actual `%{result: rows}` payload.
- Remove the previously documented top-level list wrapper and the `errors` field, neither of which the endpoint returns.

## Testing
- New `test/logflare_web/open_api_test.exs` asserts the documented OpenAPI contracts for representative 200, 400, 401, and 404 operations.
- Extended controller tests (query, access-token, team, endpoints) to assert runtime `content-type: application/json` and validate response bodies against the corresponding response schemas.
