### PR TITLE
fix(api): make backend and endpoint access team-aware

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -65,8 +65,14 @@ defmodule Logflare.Backends do
   """
   @spec list_backends(keyword()) :: [Backend.t()]
   def list_backends(filters) when is_list(filters) do
-    filters
-    |> Enum.reduce(from(b in Backend), fn
+    Backend
+    |> filter_backends(filters)
+    |> Repo.all()
+    |> Enum.map(fn sb -> typecast_config_string_map_to_atom_map(sb) end)
+  end
+
+  defp filter_backends(query, filters) do
+    Enum.reduce(filters, query, fn
       {:types, types}, q when is_list(types) ->
         where(q, [b], b.type in ^types)
 
@@ -109,15 +115,16 @@ defmodule Logflare.Backends do
         q
         |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
         |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
-        |> where([b, sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
-        |> distinct([b], b.id)
+        |> where([b, ..., sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
+        |> distinct_backends()
 
       _, q ->
         q
     end)
-    |> Repo.all()
-    |> Enum.map(fn sb -> typecast_config_string_map_to_atom_map(sb) end)
   end
+
+  defp distinct_backends(%Ecto.Query{distinct: nil} = query), do: distinct(query, [b], b.id)
+  defp distinct_backends(query), do: query
 
   @doc """
   Lists `Backend`s by user
@@ -132,24 +139,29 @@ defmodule Logflare.Backends do
   @doc """
   Lists all backends a user has access to, including where the user is a team member.
   """
-  @spec list_backends_by_user_access(User.t()) :: [Backend.t()]
-  def list_backends_by_user_access(%User{} = user) do
+  @spec list_backends_by_user_access(User.t(), keyword()) :: [Backend.t()]
+  def list_backends_by_user_access(%User{} = user, filters \\ []) when is_list(filters) do
     Backend
     |> Teams.filter_by_user_access(user)
+    |> filter_backends(filters)
     |> Repo.all()
     |> Enum.map(fn sb -> typecast_config_string_map_to_atom_map(sb) end)
   end
 
   @doc """
-  Gets a backend by id that the user has access to.
+  Gets a backend that the user has access to.
   Returns the backend if the user owns it or is a team member, otherwise returns nil.
   """
-  @spec get_backend_by_user_access(User.t() | TeamUser.t(), integer() | String.t()) ::
+  @spec get_backend_by_user_access(User.t() | TeamUser.t(), integer() | String.t() | keyword()) ::
           Backend.t() | nil
   def get_backend_by_user_access(user_or_team_user, id) when is_integer(id) or is_binary(id) do
+    get_backend_by_user_access(user_or_team_user, id: id)
+  end
+
+  def get_backend_by_user_access(user_or_team_user, filters) when is_list(filters) do
     Backend
     |> Teams.filter_by_user_access(user_or_team_user)
-    |> where([backend], backend.id == ^id)
+    |> where([backend], ^filters)
     |> Repo.one()
     |> typecast_config_string_map_to_atom_map()
   end

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -74,16 +74,22 @@ defmodule Logflare.Endpoints do
   end
 
   @doc """
-  Gets an endpoint query by id that the user has access to.
+  Gets an endpoint query that the user has access to.
   Returns the endpoint query if the user owns it or is a team member, otherwise returns nil.
   """
-  @spec get_endpoint_query_by_user_access(User.t() | TeamUser.t(), integer() | String.t()) ::
-          EndpointQuery.t() | nil
+  @spec get_endpoint_query_by_user_access(
+          User.t() | TeamUser.t(),
+          integer() | String.t() | keyword()
+        ) :: EndpointQuery.t() | nil
   def get_endpoint_query_by_user_access(user_or_team_user, id)
       when is_integer(id) or is_binary(id) do
+    get_endpoint_query_by_user_access(user_or_team_user, id: id)
+  end
+
+  def get_endpoint_query_by_user_access(user_or_team_user, filters) when is_list(filters) do
     EndpointQuery
     |> Teams.filter_by_user_access(user_or_team_user)
-    |> where([query], query.id == ^id)
+    |> where([query], ^filters)
     |> Repo.one()
   end
 

--- a/lib/logflare_web/controllers/api/alert_controller.ex
+++ b/lib/logflare_web/controllers/api/alert_controller.ex
@@ -131,8 +131,9 @@ defmodule LogflareWeb.Api.AlertController do
   defp fetch_backends([], _user, acc), do: {:ok, Enum.reverse(acc)}
 
   defp fetch_backends([id | ids], user, acc) do
-    with {:ok, backend} <- Backends.fetch_backend_by(id: id, user_id: user.id) do
-      fetch_backends(ids, user, [backend | acc])
+    case Backends.get_backend_by_user_access(user, id) do
+      nil -> {:error, :not_found}
+      backend -> fetch_backends(ids, user, [backend | acc])
     end
   end
 

--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -20,7 +20,7 @@ defmodule LogflareWeb.Api.BackendController do
   )
 
   def index(%{assigns: %{user: user}} = conn, params) do
-    backends = Backends.list_backends(user_id: user.id, metadata: params["metadata"])
+    backends = Backends.list_backends_by_user_access(user, metadata: params["metadata"])
     json(conn, backends)
   end
 
@@ -34,8 +34,11 @@ defmodule LogflareWeb.Api.BackendController do
   )
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
-    with {:ok, backend} <- Backends.fetch_backend_by(token: token, user_id: user.id) do
+    with backend when not is_nil(backend) <-
+           Backends.get_backend_by_user_access(user, token: token) do
       json(conn, backend)
+    else
+      nil -> {:error, :not_found}
     end
   end
 

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -3,7 +3,6 @@ defmodule LogflareWeb.Api.EndpointController do
   use OpenApiSpex.ControllerSpecs
 
   alias Logflare.Backends
-  alias Logflare.Users
   alias Logflare.Endpoints
 
   alias LogflareWeb.OpenApi.Accepted
@@ -24,8 +23,7 @@ defmodule LogflareWeb.Api.EndpointController do
   )
 
   def index(%{assigns: %{user: user}} = conn, _) do
-    user = Users.preload_endpoints(user)
-    json(conn, user.endpoint_queries)
+    json(conn, Endpoints.list_endpoints_by_user_access(user))
   end
 
   operation(:show,
@@ -38,7 +36,8 @@ defmodule LogflareWeb.Api.EndpointController do
   )
 
   def show(%{assigns: %{user: user}} = conn, %{"token" => token}) do
-    with query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id) do
+    with query when not is_nil(query) <-
+           Endpoints.get_endpoint_query_by_user_access(user, token: token) do
       json(conn, query)
     else
       nil -> {:error, :not_found}
@@ -83,7 +82,8 @@ defmodule LogflareWeb.Api.EndpointController do
   def update(%{assigns: %{user: user}} = conn, %{"token" => token} = params) do
     with :ok <- authorize_backend_id(user, params),
          origin <- conn.assigns[:access_token] || user,
-         query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id),
+         query when not is_nil(query) <-
+           Endpoints.get_endpoint_query_by_user_access(user, token: token),
          {:ok, query} <- Endpoints.update_query(query, params, origin) do
       conn
       |> case do
@@ -117,7 +117,8 @@ defmodule LogflareWeb.Api.EndpointController do
   def delete(%{assigns: %{user: user}} = conn, %{"token" => token}) do
     origin = conn.assigns[:access_token] || user
 
-    with query when not is_nil(query) <- Endpoints.get_by(token: token, user_id: user.id),
+    with query when not is_nil(query) <-
+           Endpoints.get_endpoint_query_by_user_access(user, token: token),
          {:ok, _} <- Endpoints.delete_query(query, origin) do
       conn
       |> put_status(204)

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -447,6 +447,31 @@ defmodule Logflare.BackendsTest do
       refute forbidden_backend_id in backend_ids
     end
 
+    test "list_backends_by_user_access/2 filters team backends with sources or rules", %{
+      user: user
+    } do
+      team_user = insert(:team_user, email: user.email)
+      owner = team_user.team.user
+      source = insert(:source, user: owner)
+
+      backend_with_source = insert(:backend, user: owner, sources: [source])
+      backend_with_rule = insert(:backend, user: owner)
+      backend_with_both = insert(:backend, user: owner, sources: [source])
+      backend_without_sources_or_rules = insert(:backend, user: owner)
+      insert(:rule, source: source, backend: backend_with_rule, lql_string: "testing")
+      insert(:rule, source: source, backend: backend_with_both, lql_string: "testing")
+
+      backend_ids =
+        Backends.list_backends_by_user_access(user, has_sources_or_rules: true)
+        |> Enum.map(& &1.id)
+
+      assert backend_with_source.id in backend_ids
+      assert backend_with_rule.id in backend_ids
+      assert backend_with_both.id in backend_ids
+      assert Enum.count(backend_ids, &(&1 == backend_with_both.id)) == 1
+      refute backend_without_sources_or_rules.id in backend_ids
+    end
+
     test "get_backend_by_user_access/2" do
       owner = insert(:user)
       team_user = insert(:team_user, email: owner.email)

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -384,20 +384,27 @@ defmodule LogflareWeb.Api.AlertControllerTest do
              |> text_response(204) == ""
     end
 
-    test "team member cannot yet attach a team-owned backend", %{conn: conn} do
+    test "team member can attach a team-owned backend", %{conn: conn} do
       member = insert(:user)
       team_user = insert(:team_user, email: member.email)
       owner = team_user.team.user
       alert = insert(:alert, user: owner)
       backend = insert(:backend, user: owner)
+      unrelated_backend = insert(:backend)
+      conn = add_access_token(conn, member, "private")
 
       response =
         conn
-        |> add_access_token(member, "private")
         |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id]})
-        |> json_response(404)
+        |> json_response(200)
 
-      assert_schema(response, "NotFoundResponse")
+      assert %{"backends" => [%{"id" => backend_id}]} = response
+      assert backend_id == backend.id
+
+      assert %{"error" => "Not Found"} =
+               conn
+               |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [unrelated_backend.id]})
+               |> json_response(404)
     end
 
     test "show alert with bad user", %{conn: conn, user: user} do

--- a/test/logflare_web/controllers/api/backend_controller_test.exs
+++ b/test/logflare_web/controllers/api/backend_controller_test.exs
@@ -21,6 +21,31 @@ defmodule LogflareWeb.Api.BackendControllerTest do
                |> json_response(200)
     end
 
+    test "includes team-owned backends", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      backend = insert(:backend, user: team_user.team.user)
+      unrelated_backend = insert(:backend)
+
+      response =
+        conn
+        |> add_access_token(member, "private")
+        |> get(~p"/api/backends")
+        |> json_response(200)
+
+      backend_ids = MapSet.new(Enum.map(response, & &1["id"]))
+      assert backend.id in backend_ids
+      refute unrelated_backend.id in backend_ids
+
+      assert %{"id" => backend_id} =
+               conn
+               |> add_access_token(member, "private")
+               |> get(~p"/api/backends/#{backend.token}")
+               |> json_response(200)
+
+      assert backend_id == backend.id
+    end
+
     test "can filter on metadata column", %{conn: conn, user: user} do
       insert(:backend, user: user)
       backend = insert(:backend, user: user, metadata: %{my: "field", data: true})
@@ -329,6 +354,17 @@ defmodule LogflareWeb.Api.BackendControllerTest do
       |> response(404)
     end
 
+    test "team member cannot update a team-owned backend", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      backend = insert(:backend, user: team_user.team.user)
+
+      assert conn
+             |> add_access_token(member, "private")
+             |> patch("/api/backends/#{backend.token}", %{name: "updated"})
+             |> response(404)
+    end
+
     test "cannot transfer backend ownership via user_id param", %{conn: conn, user: user} do
       backend = insert(:backend, user: user)
       victim = insert(:user)
@@ -449,6 +485,17 @@ defmodule LogflareWeb.Api.BackendControllerTest do
              |> delete("/api/backends/#{backend.token}")
              |> response(404)
     end
+
+    test "team member cannot delete a team-owned backend", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      backend = insert(:backend, user: team_user.team.user)
+
+      assert conn
+             |> add_access_token(member, "private")
+             |> delete("/api/backends/#{backend.token}")
+             |> response(404)
+    end
   end
 
   describe "test_connection/2" do
@@ -495,6 +542,17 @@ defmodule LogflareWeb.Api.BackendControllerTest do
       |> add_access_token(user, "private")
       |> post("/api/backends/#{backend.token}/test")
       |> response(404)
+    end
+
+    test "team member cannot test a team-owned backend connection", %{conn: conn} do
+      member = insert(:user)
+      team_user = insert(:team_user, email: member.email)
+      backend = insert(:backend, user: team_user.team.user)
+
+      assert conn
+             |> add_access_token(member, "private")
+             |> post("/api/backends/#{backend.token}/test")
+             |> response(404)
     end
   end
 end

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -31,6 +31,57 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
     end
   end
 
+  describe "team access" do
+    test "team member can manage team-owned endpoints and attach a team-owned backend", %{
+      conn: conn
+    } do
+      member = insert(:user, endpoints_beta: true)
+      team_user = insert(:team_user, email: member.email)
+      owner = team_user.team.user
+      managed_endpoint = insert(:endpoint, user: owner, name: "initial")
+      deleted_endpoint = insert(:endpoint, user: owner)
+      unrelated_endpoint = insert(:endpoint)
+      backend = insert(:backend, user: owner)
+      conn = add_access_token(conn, member, "private")
+
+      response =
+        conn
+        |> get(~p"/api/endpoints")
+        |> json_response(200)
+
+      assert MapSet.new(Enum.map(response, & &1["token"])) ==
+               MapSet.new([managed_endpoint.token, deleted_endpoint.token])
+
+      assert %{"token" => managed_token} =
+               conn
+               |> get(~p"/api/endpoints/#{managed_endpoint.token}")
+               |> json_response(200)
+
+      assert managed_token == managed_endpoint.token
+
+      assert conn
+             |> get(~p"/api/endpoints/#{unrelated_endpoint.token}")
+             |> response(404)
+
+      assert conn
+             |> patch(~p"/api/endpoints/#{managed_endpoint.token}", %{name: "updated"})
+             |> text_response(204) == ""
+
+      assert conn
+             |> patch(~p"/api/endpoints/#{managed_endpoint.token}", %{backend_id: backend.id})
+             |> text_response(204) == ""
+
+      assert %{backend_id: backend_id, name: "updated"} =
+               Endpoints.get_endpoint_query(managed_endpoint.id)
+
+      assert backend_id == backend.id
+
+      assert conn
+             |> delete(~p"/api/endpoints/#{deleted_endpoint.token}")
+             |> text_response(204) == ""
+    end
+  end
+
   describe "show/2" do
     test "returns single endpoint query for given user", %{
       conn: conn,


### PR DESCRIPTION
## Summary
Make Management API backend/endpoint access consistent with the team-access model introduced for browser/LiveView flows, so team members can discover and use resources owned elsewhere on their team via the API.

- **Backends:** `GET /api/backends` (list) and `GET /api/backends/:token` (show) now respect team access. Alert backend attachment (`PUT /api/alerts/:token`) can now reference any team-accessible backend.
- **Endpoints:** list, show, update, and delete now respect team access.
- **Intentional asymmetry:** backend *mutations* (update, delete, test_connection) and backend/endpoint *creation* remain owner-scoped. Team members get 404 for those, matching current behavior. Only discovery/attachment (backends) and full read+write (endpoints) become team-aware here; broadening backend mutation is a deliberate follow-up rather than part of this change.

## Behavior change
Existing API tokens calling `GET /api/backends` and `GET /api/endpoints` will now receive team-accessible resources in addition to owner-owned ones. Inaccessible resources return 404 (Not Found) consistently.

## Implementation notes
- Controllers now route through the existing `*_by_user_access` helpers instead of owner-only `fetch_backend_by`/`get_by(user_id:)`.
- `get_backend_by_user_access/2` and `get_endpoint_query_by_user_access/2` gain a keyword-filter form so callers can look up by `token:` as well as `id:`.
- `list_backends_by_user_access/2` gains a `filters` argument and now shares a private `filter_backends/2` with `list_backends/1`.
- Because `Teams.filter_by_user_access/2` injects team joins plus `distinct: true`, `has_sources_or_rules` was updated to bind trailing joins via `[b, ..., sb, r]` and a `distinct_backends/1` guard avoids re-adding a conflicting `distinct`. **← main logic to review.**

## Context
[#2851](https://github.com/Logflare/logflare/pull/2851) introduced query-param team switching and the `*_by_user_access` helpers for browser/LiveView flows; the Management API only authenticated the token owner. [#3682](https://github.com/Logflare/logflare/pull/3682) added the Alerts Management API and documented this follow-up: alerts were team-accessible while backend discovery/attachment stayed owner-scoped. This PR closes that gap.

## Stacking
Depends on #3682. Rebase onto `main` and retarget after #3682 merges.

## Non-goals
- Backend create/update/delete/test_connection stay owner-only.
- No changes to browser/LiveView flows or single-tenant behavior.

## Validation
Local: `../bin/test test/logflare_web/controllers/api/alert_controller_test.exs test/logflare_web/controllers/api/backend_controller_test.exs test/logflare_web/controllers/api/endpoint_controller_test.exs test/logflare/backends_test.exs`

New coverage: team read of backend list/show; team rejection of backend update/delete/test (404); team endpoint list/show/update/delete + backend attachment; alert attach allowed + unrelated backend rejected; `has_sources_or_rules` filter under team access. CI green (Elixir CI, typings, format, coverage, E2E).

Linear: O11Y-2154
