### PR TITLE
feat: pagination for search

### DIFF
--- a/assets/js/source_lv_hooks.js
+++ b/assets/js/source_lv_hooks.js
@@ -22,11 +22,52 @@ hooks.SourceSchemaModalTable = {
 }
 
 hooks.SourceLogsSearchList = {
+  captureScrollAnchor() {
+    this.scrollPosition = window.scrollY
+
+    const firstVisibleLogEvent = [...this.el.querySelectorAll("#logs-list > li[data-event-id]")]
+      .find((element) => {
+        const { top, bottom } = element.getBoundingClientRect()
+        return top < window.innerHeight && bottom > 0
+      })
+
+    this.scrollAnchor = firstVisibleLogEvent && {
+      id: firstVisibleLogEvent.id,
+      top: firstVisibleLogEvent.getBoundingClientRect().top,
+    }
+  },
+  restoreScrollAnchor() {
+    const scrollAnchor = this.scrollAnchor
+    const scrollPosition = this.scrollPosition
+
+    requestAnimationFrame(() => {
+      const anchorElement = scrollAnchor && document.getElementById(scrollAnchor.id)
+
+      if (anchorElement && this.el.contains(anchorElement)) {
+        const scrollDelta = anchorElement.getBoundingClientRect().top - scrollAnchor.top
+        window.scrollBy(0, scrollDelta)
+      } else if (scrollPosition !== undefined) {
+        window.scrollTo(0, scrollPosition)
+      }
+    })
+  },
+  scrollToLatest() {
+    if (this.el.dataset.tailing === "true") {
+      window.scrollTo(0, document.body.scrollHeight)
+    }
+  },
+  beforeUpdate() {
+    this.captureScrollAnchor()
+  },
   updated() {
     const hook = this
     activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
 
-    window.scrollTo(0, document.body.scrollHeight)
+    if (this.el.dataset.tailing === "true") {
+      this.scrollToLatest()
+    } else {
+      this.restoreScrollAnchor()
+    }
 
     const observer =
       new IntersectionObserver((entries, observer) => {
@@ -47,10 +88,7 @@ hooks.SourceLogsSearchList = {
   },
   mounted() {
     activateDelegatedTooltips(this.el, '[data-toggle="tooltip"]')
-
-    $("html, body").animate({
-      scrollTop: document.body.scrollHeight
-    })
+    this.scrollToLatest()
   },
   destroyed() {
     $(this.el).tooltip("dispose")

--- a/lib/logflare/logs/event_page.ex
+++ b/lib/logflare/logs/event_page.ex
@@ -1,0 +1,49 @@
+defmodule Logflare.Logs.EventPage do
+  @moduledoc false
+
+  use TypedStruct
+
+  alias Logflare.LogEvent
+
+  @type boundary :: integer() | DateTime.t() | NaiveDateTime.t()
+  @type cursor :: %{timestamp: integer(), id: String.t()}
+  @type direction :: :previous | :next
+  @type intent :: :initial | :previous | :next
+  @type request :: %{
+          intent: intent(),
+          boundary: boundary() | nil,
+          cursor: cursor() | nil
+        }
+
+  typedstruct do
+    field :rows, [LogEvent.t()], enforce: true
+    field :request, request(), enforce: true
+    field :cursor, cursor() | nil, enforce: true
+    field :next_cursor, cursor() | nil, default: nil
+    field :has_more?, boolean(), enforce: true
+    field :events, :any, default: nil
+  end
+
+  @spec direction(intent()) :: direction()
+  def direction(:next), do: :next
+  def direction(_intent), do: :previous
+
+  @spec boundary(intent(), %{min: boundary(), max: boundary()} | nil) :: boundary() | nil
+  def boundary(:next, %{max: max}), do: max
+  def boundary(_intent, _bounds), do: nil
+
+  @spec valid_request?(term(), term(), boundary() | nil) :: boolean()
+  def valid_request?(:previous, cursor, _boundary), do: valid_cursor?(cursor)
+
+  def valid_request?(:next, cursor, boundary) do
+    not is_nil(boundary) or valid_cursor?(cursor)
+  end
+
+  def valid_request?(_intent, _cursor, _boundary), do: false
+
+  @spec valid_cursor?(term()) :: boolean()
+  def valid_cursor?(%{timestamp: timestamp, id: id}) when is_integer(timestamp) and is_binary(id),
+    do: true
+
+  def valid_cursor?(_cursor), do: false
+end

--- a/lib/logflare/logs/event_page.ex
+++ b/lib/logflare/logs/event_page.ex
@@ -27,11 +27,25 @@ defmodule Logflare.Logs.EventPage do
   def direction(:previous), do: :previous
   def direction(:initial), do: :previous
 
+  @doc """
+  Returns whether an event-page request has a valid intent and cursor.
 
+  An intent can be one of:
+  * `:next` - fetching the next page of newer events after the curosr
+  * `:previous` - fetch a page of older events before the cursor
+  * `:initial` - no cursor, used for the first search by Search LiveView.
+  """
+  @spec valid_request?(term(), term()) :: boolean()
+  def valid_request?(intent, cursor) when intent in [:previous, :next], do: valid_cursor?(cursor)
 
   def valid_request?(_intent, _cursor), do: false
 
+  @doc """
+  Validate the cursor for the page query has a timestamp and id.
 
+  The cursor timestamp is used as the beginning of the page request. The id is
+  used to deduplicate events with the same timestamp.
+  """
   @spec valid_cursor?(term()) :: boolean()
   def valid_cursor?(%{timestamp: timestamp, id: id}) when is_integer(timestamp) and is_binary(id),
     do: true

--- a/lib/logflare/logs/event_page.ex
+++ b/lib/logflare/logs/event_page.ex
@@ -5,13 +5,11 @@ defmodule Logflare.Logs.EventPage do
 
   alias Logflare.LogEvent
 
-  @type boundary :: integer() | DateTime.t() | NaiveDateTime.t()
   @type cursor :: %{timestamp: integer(), id: String.t()}
   @type direction :: :previous | :next
   @type intent :: :initial | :previous | :next
   @type request :: %{
           intent: intent(),
-          boundary: boundary() | nil,
           cursor: cursor() | nil
         }
 
@@ -26,20 +24,13 @@ defmodule Logflare.Logs.EventPage do
 
   @spec direction(intent()) :: direction()
   def direction(:next), do: :next
-  def direction(_intent), do: :previous
+  def direction(:previous), do: :previous
+  def direction(:initial), do: :previous
 
-  @spec boundary(intent(), %{min: boundary(), max: boundary()} | nil) :: boundary() | nil
-  def boundary(:next, %{max: max}), do: max
-  def boundary(_intent, _bounds), do: nil
 
-  @spec valid_request?(term(), term(), boundary() | nil) :: boolean()
-  def valid_request?(:previous, cursor, _boundary), do: valid_cursor?(cursor)
 
-  def valid_request?(:next, cursor, boundary) do
-    not is_nil(boundary) or valid_cursor?(cursor)
-  end
+  def valid_request?(_intent, _cursor), do: false
 
-  def valid_request?(_intent, _cursor, _boundary), do: false
 
   @spec valid_cursor?(term()) :: boolean()
   def valid_cursor?(%{timestamp: timestamp, id: id}) when is_integer(timestamp) and is_binary(id),

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -23,7 +23,6 @@ defmodule Logflare.LogEvent do
     field :body, :map, default: %{}
     field :valid, :boolean
     field :drop, :boolean, default: false
-    field :is_from_stale_query, :boolean
     field :timestamp_inferred, :boolean, default: false
     field :ingested_at, :utc_datetime_usec
     field :source_uuid, Ecto.UUID.Atom

--- a/lib/logflare/logs/logs_search.ex
+++ b/lib/logflare/logs/logs_search.ex
@@ -44,6 +44,7 @@ defmodule Logflare.Logs.Search do
          %{error: nil} = so <- apply_local_timestamp_correction(so),
          %{error: nil} = so <- apply_timestamp_filter_rules(so),
          %{error: nil} = so <- apply_filters(so),
+         %{error: nil} = so <- apply_cursor(so),
          %{error: nil} = so <- apply_select_rules(so),
          %{error: nil} = so <- do_query(so),
          %{error: nil} = so <- apply_warning_conditions(so),

--- a/lib/logflare/logs/search_operation.ex
+++ b/lib/logflare/logs/search_operation.ex
@@ -9,6 +9,7 @@ defmodule Logflare.Logs.SearchOperation do
   alias Logflare.Lql.Rules.ChartRule
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Lql.Rules.SelectRule
+  alias Logflare.Logs.EventPage
   alias Logflare.Sources.Source
 
   typedstruct do
@@ -35,6 +36,7 @@ defmodule Logflare.Logs.SearchOperation do
     field :chart_data_shape_id, atom(), default: nil, enforce: true
     field :type, :events | :aggregates
     field :status, {atom(), String.t() | [String.t()]}
+    field :event_page_request, EventPage.request()
   end
 
   def new(params) do

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -114,7 +114,7 @@ defmodule Logflare.Logs.SearchOperations do
     |> LoggerMetadata.with_metadata(fn ->
       backend = postgres_backend(so)
 
-      PostgresAdaptor.execute_query(backend, so.query, query_type: :search)
+      PostgresAdaptor.execute_query(backend, query_for_execution(so), query_type: :search)
     end)
   end
 
@@ -126,11 +126,20 @@ defmodule Logflare.Logs.SearchOperations do
     |> LoggerMetadata.with_metadata(fn ->
       BigQueryAdaptor.execute_query(
         {bq_project_id, dataset_id, so.source.user.id},
-        so.query,
+        query_for_execution(so),
         query_type: :search
       )
     end)
   end
+
+  @spec query_for_execution(SO.t()) :: Ecto.Query.t()
+  defp query_for_execution(%SO{
+         type: :events,
+         query: %Ecto.Query{limit: %Ecto.Query.LimitExpr{}} = query
+       }),
+       do: limit(query, ^fetch_limit())
+
+  defp query_for_execution(%SO{query: query}), do: query
 
   @spec source_logger_metadata(SO.t()) :: Keyword.t()
   defp source_logger_metadata(%SO{} = so) do
@@ -140,6 +149,13 @@ defmodule Logflare.Logs.SearchOperations do
   @spec put_sql_string(SO.t(), QueryResult.t()) :: SO.t()
   defp put_sql_string(%{sql_string: sql_string} = so, _response) when is_binary(sql_string),
     do: so
+
+  defp put_sql_string(%SO{backend_type: :bigquery, type: :events} = so, _response) do
+    case BigQueryAdaptor.ecto_to_sql(so.query, []) do
+      {:ok, {query_string, params}} -> %{so | sql_string: query_string, sql_params: params}
+      {:error, _reason} -> so
+    end
+  end
 
   defp put_sql_string(%SO{backend_type: :bigquery} = so, %QueryResult{
          query_string: query_string,
@@ -171,7 +187,7 @@ defmodule Logflare.Logs.SearchOperations do
       from(table_name(so))
       |> select(%{})
       |> order_events(direction)
-      |> limit(^fetch_limit())
+      |> limit(^default_limit())
 
     %{so | query: query}
   end

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -12,6 +12,7 @@ defmodule Logflare.Logs.SearchOperations do
   alias Logflare.DateTimeUtils
   alias Logflare.Google.BigQuery.GCPConfig
   alias Logflare.Google.BigQuery.GenUtils
+  alias Logflare.Logs.EventPage
   alias Logflare.Logs.SearchOperation, as: SO
   alias Logflare.Logs.SearchOperations.Helpers, as: SearchOperationHelpers
   alias Logflare.Logs.SearchUtils
@@ -46,6 +47,44 @@ defmodule Logflare.Logs.SearchOperations do
 
   @spec max_chart_ticks :: integer()
   def max_chart_ticks, do: @default_max_n_chart_ticks
+
+  @spec default_limit :: pos_integer()
+  def default_limit, do: @default_limit
+
+  @spec fetch_limit :: pos_integer()
+  def fetch_limit, do: @default_limit + 1
+
+  @spec new_event_page(map() | SO.t(), EventPage.intent(), EventPage.cursor() | nil) ::
+          {:ok, SO.t()} | {:error, :invalid_request | :tailing}
+  def new_event_page(%SO{} = so, :initial, nil) do
+    {:ok, %{so | event_page_request: %{intent: :initial, boundary: nil, cursor: nil}}}
+  end
+
+  def new_event_page(%SO{tailing?: false} = so, intent, cursor) do
+    corrected_so = apply_local_timestamp_correction(so)
+
+    bounds =
+      SearchOperationHelpers.bounded_timestamp_range(
+        corrected_so.lql_ts_filters,
+        chart_period(corrected_so)
+      )
+
+    boundary = EventPage.boundary(intent, bounds)
+
+    if EventPage.valid_request?(intent, cursor, boundary) do
+      {:ok, %{so | event_page_request: %{intent: intent, boundary: boundary, cursor: cursor}}}
+    else
+      {:error, :invalid_request}
+    end
+  end
+
+  def new_event_page(%SO{}, _intent, _cursor), do: {:error, :tailing}
+
+  def new_event_page(params, intent, cursor) when is_map(params) do
+    params
+    |> SO.new()
+    |> new_event_page(intent, cursor)
+  end
 
   @spec do_query(SO.t()) :: SO.t()
   def do_query(%SO{} = so) do
@@ -122,13 +161,65 @@ defmodule Logflare.Logs.SearchOperations do
 
   @spec apply_query_defaults(SO.t()) :: SO.t()
   def apply_query_defaults(%SO{} = so) do
+    direction =
+      case so.event_page_request do
+        %{intent: intent} -> EventPage.direction(intent)
+        nil -> :previous
+      end
+
     query =
       from(table_name(so))
       |> select(%{})
-      |> order_by([t], desc: t.timestamp)
-      |> limit(@default_limit)
+      |> order_events(direction)
+      |> limit(^fetch_limit())
 
     %{so | query: query}
+  end
+
+  defp order_events(query, :previous),
+    do: order_by(query, [t], desc: t.timestamp, desc: t.id)
+
+  defp order_events(query, :next), do: order_by(query, [t], asc: t.timestamp, asc: t.id)
+
+  @spec apply_cursor(SO.t()) :: SO.t()
+  def apply_cursor(
+        %SO{event_page_request: %{intent: intent, cursor: %{timestamp: timestamp, id: id}}} = so
+      ) do
+    timestamp = normalize_event_timestamp(so.backend_type, timestamp)
+    direction = EventPage.direction(intent)
+
+    %{so | query: where(so.query, ^cursor_condition(direction, timestamp, id))}
+  end
+
+  def apply_cursor(%SO{} = so), do: so
+
+  defp normalize_event_timestamp(:postgres, timestamp) when is_integer(timestamp),
+    do: DateTime.from_unix!(timestamp, :microsecond)
+
+  defp normalize_event_timestamp(_backend_type, timestamp), do: timestamp
+
+  defp cursor_condition(:previous, timestamp, id) when is_integer(timestamp) do
+    dynamic(
+      [t],
+      t.timestamp < fragment("TIMESTAMP_MICROS(?)", ^timestamp) or
+        (t.timestamp == fragment("TIMESTAMP_MICROS(?)", ^timestamp) and t.id <= ^id)
+    )
+  end
+
+  defp cursor_condition(:next, timestamp, id) when is_integer(timestamp) do
+    dynamic(
+      [t],
+      t.timestamp > fragment("TIMESTAMP_MICROS(?)", ^timestamp) or
+        (t.timestamp == fragment("TIMESTAMP_MICROS(?)", ^timestamp) and t.id > ^id)
+    )
+  end
+
+  defp cursor_condition(:previous, timestamp, id) do
+    dynamic([t], t.timestamp < ^timestamp or (t.timestamp == ^timestamp and t.id <= ^id))
+  end
+
+  defp cursor_condition(:next, timestamp, id) do
+    dynamic([t], t.timestamp > ^timestamp or (t.timestamp == ^timestamp and t.id > ^id))
   end
 
   @spec apply_halt_conditions(SO.t()) :: SO.t()
@@ -239,6 +330,15 @@ defmodule Logflare.Logs.SearchOperations do
     %{so | rows: rows}
   end
 
+  def apply_timestamp_filter_rules(
+        %SO{
+          type: :events,
+          event_page_request: %{intent: intent}
+        } = so
+      )
+      when intent in [:previous, :next],
+      do: apply_event_page_boundary(so)
+
   def apply_timestamp_filter_rules(%SO{backend_type: :postgres, type: :events} = so) do
     %{so | query: apply_postgres_event_timestamp_filter_rules(so)}
   end
@@ -341,6 +441,82 @@ defmodule Logflare.Logs.SearchOperations do
 
     %{so | query: q}
   end
+
+  defp apply_event_page_boundary(
+         %SO{
+           event_page_request: %{intent: intent, boundary: nil, cursor: %{timestamp: timestamp}}
+         } = so
+       ) do
+    direction = EventPage.direction(intent)
+    timestamp = normalize_event_timestamp(so.backend_type, timestamp)
+
+    %{so | query: apply_event_page_partition_filter(so.query, so, direction, timestamp)}
+  end
+
+  defp apply_event_page_boundary(%SO{event_page_request: %{boundary: nil}} = so), do: so
+
+  defp apply_event_page_boundary(
+         %SO{
+           event_page_request: %{intent: intent, boundary: boundary, cursor: %{}},
+           query: query
+         } = so
+       ) do
+    boundary = normalize_event_timestamp(so.backend_type, boundary)
+    direction = EventPage.direction(intent)
+    %{so | query: apply_event_page_partition_filter(query, so, direction, boundary)}
+  end
+
+  defp apply_event_page_boundary(
+         %SO{event_page_request: %{intent: intent, boundary: boundary}} = so
+       ) do
+    boundary = normalize_event_timestamp(so.backend_type, boundary)
+    direction = EventPage.direction(intent)
+    query = where(so.query, ^boundary_condition(direction, boundary))
+
+    %{so | query: apply_event_page_partition_filter(query, so, direction, boundary)}
+  end
+
+  defp boundary_condition(:previous, boundary) when is_integer(boundary),
+    do: dynamic([t], t.timestamp < fragment("TIMESTAMP_MICROS(?)", ^boundary))
+
+  defp boundary_condition(:next, boundary) when is_integer(boundary),
+    do: dynamic([t], t.timestamp > fragment("TIMESTAMP_MICROS(?)", ^boundary))
+
+  defp boundary_condition(:previous, boundary), do: dynamic([t], t.timestamp < ^boundary)
+  defp boundary_condition(:next, boundary), do: dynamic([t], t.timestamp > ^boundary)
+
+  defp apply_event_page_partition_filter(query, %SO{backend_type: :postgres}, _, _), do: query
+
+  defp apply_event_page_partition_filter(
+         query,
+         %SO{partition_by: :timestamp},
+         direction,
+         boundary
+       ) do
+    date = boundary |> event_boundary_datetime() |> DateTime.to_date()
+
+    case direction do
+      :previous -> where(query, [t], fragment("EXTRACT(DATE FROM ?)", t.timestamp) <= ^date)
+      :next -> where(query, [t], fragment("EXTRACT(DATE FROM ?)", t.timestamp) >= ^date)
+    end
+  end
+
+  defp apply_event_page_partition_filter(query, %SO{partition_by: :pseudo}, direction, boundary) do
+    date = boundary |> event_boundary_datetime() |> DateTime.to_date()
+
+    case direction do
+      :previous -> where(query, partition_date() <= ^date or in_streaming_buffer())
+      :next -> where(query, partition_date() >= ^date or in_streaming_buffer())
+    end
+  end
+
+  defp event_boundary_datetime(timestamp) when is_integer(timestamp),
+    do: DateTime.from_unix!(timestamp, :microsecond)
+
+  defp event_boundary_datetime(%DateTime{} = timestamp), do: timestamp
+
+  defp event_boundary_datetime(%NaiveDateTime{} = timestamp),
+    do: DateTime.from_naive!(timestamp, "Etc/UTC")
 
   defp apply_bq_aggregate_timestamp_filters(query, so, filters, chart_period) do
     period = to_bq_interval_token(chart_period)

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -48,12 +48,24 @@ defmodule Logflare.Logs.SearchOperations do
   @spec max_chart_ticks :: integer()
   def max_chart_ticks, do: @default_max_n_chart_ticks
 
+  @doc """
+  Default number of rows per page displayed to the user.
+  """
   @spec default_limit :: pos_integer()
   def default_limit, do: @default_limit
 
+  @doc """
+  Fetch one extra row as a sentinel to indicate if further pages are available.
+  """
   @spec fetch_limit :: pos_integer()
   def fetch_limit, do: @default_limit + 1
 
+  @doc """
+  Adds a validated event-page request to a search operation.
+
+  The first page does not need a cursor. Other pages require tailing to be false
+  and a valid cursor to page from.
+  """
   @spec new_event_page(map() | SO.t(), EventPage.intent(), EventPage.cursor() | nil) ::
           {:ok, SO.t()} | {:error, :invalid_request | :tailing}
   def new_event_page(%SO{} = so, :initial, nil) do
@@ -122,6 +134,7 @@ defmodule Logflare.Logs.SearchOperations do
     end)
   end
 
+  # Override the default limit; fetch extra row to check if more events are available
   @spec query_for_execution(SO.t()) :: Ecto.Query.t()
   defp query_for_execution(%SO{
          type: :events,

--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -57,22 +57,12 @@ defmodule Logflare.Logs.SearchOperations do
   @spec new_event_page(map() | SO.t(), EventPage.intent(), EventPage.cursor() | nil) ::
           {:ok, SO.t()} | {:error, :invalid_request | :tailing}
   def new_event_page(%SO{} = so, :initial, nil) do
-    {:ok, %{so | event_page_request: %{intent: :initial, boundary: nil, cursor: nil}}}
+    {:ok, %{so | event_page_request: %{intent: :initial, cursor: nil}}}
   end
 
   def new_event_page(%SO{tailing?: false} = so, intent, cursor) do
-    corrected_so = apply_local_timestamp_correction(so)
-
-    bounds =
-      SearchOperationHelpers.bounded_timestamp_range(
-        corrected_so.lql_ts_filters,
-        chart_period(corrected_so)
-      )
-
-    boundary = EventPage.boundary(intent, bounds)
-
-    if EventPage.valid_request?(intent, cursor, boundary) do
-      {:ok, %{so | event_page_request: %{intent: intent, boundary: boundary, cursor: cursor}}}
+    if EventPage.valid_request?(intent, cursor) do
+      {:ok, %{so | event_page_request: %{intent: intent, cursor: cursor}}}
     else
       {:error, :invalid_request}
     end
@@ -353,7 +343,7 @@ defmodule Logflare.Logs.SearchOperations do
         } = so
       )
       when intent in [:previous, :next],
-      do: apply_event_page_boundary(so)
+      do: apply_event_page_partition_filter(so)
 
   def apply_timestamp_filter_rules(%SO{backend_type: :postgres, type: :events} = so) do
     %{so | query: apply_postgres_event_timestamp_filter_rules(so)}
@@ -458,9 +448,9 @@ defmodule Logflare.Logs.SearchOperations do
     %{so | query: q}
   end
 
-  defp apply_event_page_boundary(
+  defp apply_event_page_partition_filter(
          %SO{
-           event_page_request: %{intent: intent, boundary: nil, cursor: %{timestamp: timestamp}}
+           event_page_request: %{intent: intent, cursor: %{timestamp: timestamp}}
          } = so
        ) do
     direction = EventPage.direction(intent)
@@ -469,47 +459,15 @@ defmodule Logflare.Logs.SearchOperations do
     %{so | query: apply_event_page_partition_filter(so.query, so, direction, timestamp)}
   end
 
-  defp apply_event_page_boundary(%SO{event_page_request: %{boundary: nil}} = so), do: so
-
-  defp apply_event_page_boundary(
-         %SO{
-           event_page_request: %{intent: intent, boundary: boundary, cursor: %{}},
-           query: query
-         } = so
-       ) do
-    boundary = normalize_event_timestamp(so.backend_type, boundary)
-    direction = EventPage.direction(intent)
-    %{so | query: apply_event_page_partition_filter(query, so, direction, boundary)}
-  end
-
-  defp apply_event_page_boundary(
-         %SO{event_page_request: %{intent: intent, boundary: boundary}} = so
-       ) do
-    boundary = normalize_event_timestamp(so.backend_type, boundary)
-    direction = EventPage.direction(intent)
-    query = where(so.query, ^boundary_condition(direction, boundary))
-
-    %{so | query: apply_event_page_partition_filter(query, so, direction, boundary)}
-  end
-
-  defp boundary_condition(:previous, boundary) when is_integer(boundary),
-    do: dynamic([t], t.timestamp < fragment("TIMESTAMP_MICROS(?)", ^boundary))
-
-  defp boundary_condition(:next, boundary) when is_integer(boundary),
-    do: dynamic([t], t.timestamp > fragment("TIMESTAMP_MICROS(?)", ^boundary))
-
-  defp boundary_condition(:previous, boundary), do: dynamic([t], t.timestamp < ^boundary)
-  defp boundary_condition(:next, boundary), do: dynamic([t], t.timestamp > ^boundary)
-
   defp apply_event_page_partition_filter(query, %SO{backend_type: :postgres}, _, _), do: query
 
   defp apply_event_page_partition_filter(
          query,
          %SO{partition_by: :timestamp},
          direction,
-         boundary
+         timestamp
        ) do
-    date = boundary |> event_boundary_datetime() |> DateTime.to_date()
+    date = timestamp |> event_timestamp_datetime() |> DateTime.to_date()
 
     case direction do
       :previous -> where(query, [t], fragment("EXTRACT(DATE FROM ?)", t.timestamp) <= ^date)
@@ -517,8 +475,8 @@ defmodule Logflare.Logs.SearchOperations do
     end
   end
 
-  defp apply_event_page_partition_filter(query, %SO{partition_by: :pseudo}, direction, boundary) do
-    date = boundary |> event_boundary_datetime() |> DateTime.to_date()
+  defp apply_event_page_partition_filter(query, %SO{partition_by: :pseudo}, direction, timestamp) do
+    date = timestamp |> event_timestamp_datetime() |> DateTime.to_date()
 
     case direction do
       :previous -> where(query, partition_date() <= ^date or in_streaming_buffer())
@@ -526,12 +484,12 @@ defmodule Logflare.Logs.SearchOperations do
     end
   end
 
-  defp event_boundary_datetime(timestamp) when is_integer(timestamp),
+  defp event_timestamp_datetime(timestamp) when is_integer(timestamp),
     do: DateTime.from_unix!(timestamp, :microsecond)
 
-  defp event_boundary_datetime(%DateTime{} = timestamp), do: timestamp
+  defp event_timestamp_datetime(%DateTime{} = timestamp), do: timestamp
 
-  defp event_boundary_datetime(%NaiveDateTime{} = timestamp),
+  defp event_timestamp_datetime(%NaiveDateTime{} = timestamp),
     do: DateTime.from_naive!(timestamp, "Etc/UTC")
 
   defp apply_bq_aggregate_timestamp_filters(query, so, filters, chart_period) do

--- a/lib/logflare/logs/search_operations/helpers.ex
+++ b/lib/logflare/logs/search_operations/helpers.ex
@@ -4,7 +4,9 @@ defmodule Logflare.Logs.SearchOperations.Helpers do
   alias Logflare.Logs.SearchOperations
   alias Logflare.Lql.Rules.FilterRule, as: FR
 
-  @type minmax :: %{min: DateTime.t(), max: DateTime.t(), message: nil | String.t()}
+  @type timestamp :: DateTime.t() | NaiveDateTime.t()
+  @type minmax :: %{min: timestamp(), max: timestamp(), message: nil | String.t()}
+  @type bounds :: %{min: timestamp(), max: timestamp()}
   @default_open_interval_length 1_000
 
   @spec get_min_max_filter_timestamps([FR.t()], atom()) :: minmax()
@@ -39,6 +41,31 @@ defmodule Logflare.Logs.SearchOperations.Helpers do
       |> min_max_timestamps()
 
     %{min: min, max: max, message: nil}
+  end
+
+  @spec bounded_timestamp_filters?([FR.t()]) :: boolean()
+  def bounded_timestamp_filters?(filters) do
+    has_closed_range? =
+      Enum.any?(filters, fn
+        %{operator: :range, values: [_, _]} -> true
+        _ -> false
+      end)
+
+    has_lower_bound? = Enum.any?(filters, &(&1.operator in [:>, :>=]))
+    has_upper_bound? = Enum.any?(filters, &(&1.operator in [:<, :<=]))
+
+    has_closed_range? or (has_lower_bound? and has_upper_bound?)
+  end
+
+  @spec bounded_timestamp_range([FR.t()], SearchOperations.chart_period()) :: bounds() | nil
+  def bounded_timestamp_range(filters, chart_period) do
+    if bounded_timestamp_filters?(filters) do
+      filters
+      |> get_min_max_filter_timestamps(chart_period)
+      |> Map.take([:min, :max])
+    else
+      nil
+    end
   end
 
   def default_min_max_for_tailing_chart_period(period) when is_atom(period) do

--- a/lib/logflare/logs/search_query_executor.ex
+++ b/lib/logflare/logs/search_query_executor.ex
@@ -127,23 +127,11 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
     rows = Enum.map(events_so.rows, &LogEvent.make_from_db(&1, %{source: params.source}))
 
-    old_rows = if params.search_op_log_events, do: params.search_op_log_events.rows, else: []
-
-    # prevents removal of log events loaded
-    # during initial tailing query
-    log_events =
-      old_rows
-      |> Enum.reject(& &1.is_from_stale_query)
-      |> Enum.concat(rows)
-      |> Enum.uniq_by(&{&1.body, &1.id})
-      |> Enum.sort_by(& &1.body["timestamp"], &>=/2)
-      |> Enum.take(100)
-
     send(
       state.caller,
       {:search_result,
        %{
-         events: %{events_so | rows: log_events}
+         events: %{events_so | rows: rows}
        }}
     )
 

--- a/lib/logflare/logs/search_query_executor.ex
+++ b/lib/logflare/logs/search_query_executor.ex
@@ -9,8 +9,10 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   import LogflareWeb.SearchLV.Utils
 
   alias Logflare.LogEvent
+  alias Logflare.Logs.EventPage
   alias Logflare.Logs.Search
   alias Logflare.Logs.SearchOperation, as: SO
+  alias Logflare.Logs.SearchOperations
   alias Logflare.Utils.Tasks
 
   @query_timeout 30_000
@@ -36,12 +38,21 @@ defmodule Logflare.Logs.SearchQueryExecutor do
      }}
   end
 
-  def query(pid, params) do
-    GenServer.call(pid, {:query, params}, @query_timeout)
+  @spec query(GenServer.server(), map()) :: :ok | :error
+  def query(pid, params), do: query(pid, params, :initial, nil)
+
+  @spec query(GenServer.server(), map(), EventPage.intent(), EventPage.cursor() | nil) ::
+          :ok | :error
+  def query(pid, params, intent, cursor) do
+    GenServer.call(
+      pid,
+      {:query, query_params(params), intent, cursor},
+      @query_timeout
+    )
   end
 
   def query_agg(pid, params) do
-    GenServer.call(pid, {:query_agg, params}, @query_timeout)
+    GenServer.call(pid, {:query_agg, query_params(params)}, @query_timeout)
   end
 
   def cancel_agg(pid) do
@@ -55,24 +66,30 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   # Callbacks
 
   @impl true
-  def handle_call({:query, new_params}, {lv_pid, _ref}, state) do
+  def handle_call({:query, params, intent, cursor}, {lv_pid, _ref}, state) do
     Logger.debug(
       "Starting search query from #{pid_to_string(lv_pid)} for #{state.source_id} source..."
     )
 
-    {ref, _params} = state.event_task
+    case SearchOperations.new_event_page(params, intent, cursor) do
+      {:ok, search_op} ->
+        {ref, _params} = state.event_task
 
-    if ref do
-      Logger.debug(
-        "SearchQueryExecutor: cancelling query task for #{pid_to_string(lv_pid)} live_view of #{state.source_id} source..."
-      )
+        if ref do
+          Logger.debug(
+            "SearchQueryExecutor: cancelling query task for #{pid_to_string(lv_pid)} live_view of #{state.source_id} source..."
+          )
 
-      Task.shutdown(ref, :brutal_kill)
+          Task.shutdown(ref, :brutal_kill)
+        end
+
+        new_ref = start_search_task(lv_pid, search_op)
+
+        {:reply, :ok, %{state | event_task: {new_ref, search_op.event_page_request}}}
+
+      {:error, _reason} ->
+        {:reply, :error, state}
     end
-
-    new_ref = start_search_task(lv_pid, new_params)
-
-    {:reply, :ok, %{state | event_task: {new_ref, new_params}}}
   end
 
   def handle_call({:query_agg, new_params}, {lv_pid, _ref}, state) do
@@ -118,49 +135,40 @@ defmodule Logflare.Logs.SearchQueryExecutor do
   end
 
   @impl true
-  def handle_info({_ref, {:search_result, lv_pid, %{events: events_so}}}, state) do
-    Logger.debug(
-      "SearchQueryExecutor: Getting search events for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
-    )
-
-    {_ref, params} = state.event_task
-
-    rows = Enum.map(events_so.rows, &LogEvent.make_from_db(&1, %{source: params.source}))
-
-    send(
-      state.caller,
-      {:search_result,
-       %{
-         events: %{events_so | rows: rows}
-       }}
-    )
-
-    {:noreply, %{state | event_task: {nil, nil}}}
+  def handle_info({ref, {:search_result, lv_pid, %{events: events_so}}}, state) do
+    if active_task?(state.event_task, ref) do
+      handle_event_result(lv_pid, events_so, state)
+    else
+      {:noreply, state}
+    end
   end
 
   @impl true
-  def handle_info({_ref, {:search_result, lv_pid, %{aggregates: aggregates_so}}}, state) do
-    Logger.debug(
-      "SearchQueryExecutor: Getting search aggregates for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
-    )
-
-    {_ref, _params} = state.agg_task
-
-    send(
-      state.caller,
-      {:search_result,
-       %{
-         aggregates: aggregates_so
-       }}
-    )
-
-    {:noreply, %{state | agg_task: {nil, nil}}}
+  def handle_info({ref, {:search_result, lv_pid, %{aggregates: aggregates_so}}}, state) do
+    if active_task?(state.agg_task, ref) do
+      handle_aggregate_result(lv_pid, aggregates_so, state)
+    else
+      {:noreply, state}
+    end
   end
 
   @impl true
-  def handle_info({_ref, {:search_error, _lv_pid, %SO{} = search_op}}, state) do
-    send(state.caller, {:search_error, search_op})
-    {:noreply, state}
+  def handle_info({ref, {:search_error, _lv_pid, %SO{type: :aggregates} = search_op}}, state) do
+    if active_task?(state.agg_task, ref) do
+      send(state.caller, {:search_error, search_op})
+      {:noreply, %{state | agg_task: {nil, nil}}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info({ref, {:search_error, _lv_pid, %SO{} = search_op}}, state) do
+    if active_task?(state.event_task, ref) do
+      send(state.caller, {:search_error, search_op})
+      {:noreply, %{state | event_task: {nil, nil}}}
+    else
+      {:noreply, state}
+    end
   end
 
   # handles task shutdown messages
@@ -176,9 +184,50 @@ defmodule Logflare.Logs.SearchQueryExecutor do
     {:noreply, state}
   end
 
-  def start_search_task(lv_pid, params) do
-    so = SO.new(params)
+  defp handle_event_result(lv_pid, events_so, state) do
+    Logger.debug(
+      "SearchQueryExecutor: Getting search events for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
+    )
 
+    page_size = SearchOperations.default_limit()
+    raw_rows = events_so.rows
+    has_sentinel_row? = length(raw_rows) >= SearchOperations.fetch_limit()
+
+    {page_rows, sentinel_row} =
+      raw_rows
+      |> Enum.map(&LogEvent.make_from_db(&1, %{source: events_so.source}))
+      |> then(fn rows -> {Enum.take(rows, page_size), Enum.at(rows, page_size)} end)
+
+    page_rows = uniq_sort_log_events(page_rows)
+
+    request = events_so.event_page_request
+    cursors = page_cursors(request, page_rows, sentinel_row)
+
+    event_page = %EventPage{
+      rows: page_rows,
+      request: request,
+      cursor: cursors.cursor,
+      next_cursor: cursors.next_cursor,
+      has_more?: has_sentinel_row?,
+      events: if(request.intent == :initial, do: %{events_so | rows: page_rows})
+    }
+
+    send(state.caller, {:search_result, %{event_page: event_page}})
+
+    {:noreply, %{state | event_task: {nil, nil}}}
+  end
+
+  defp handle_aggregate_result(lv_pid, aggregates_so, state) do
+    Logger.debug(
+      "SearchQueryExecutor: Getting search aggregates for #{pid_to_string(lv_pid)} / #{state.source_id} source..."
+    )
+
+    send(state.caller, {:search_result, %{aggregates: aggregates_so}})
+
+    {:noreply, %{state | agg_task: {nil, nil}}}
+  end
+
+  defp start_search_task(lv_pid, %SO{} = so) do
     Tasks.async(fn ->
       so
       |> Search.search()
@@ -192,7 +241,7 @@ defmodule Logflare.Logs.SearchQueryExecutor do
     end)
   end
 
-  def start_aggs_task(lv_pid, params) do
+  defp start_aggs_task(lv_pid, params) do
     so = SO.new(params)
 
     Tasks.async(fn ->
@@ -206,5 +255,47 @@ defmodule Logflare.Logs.SearchQueryExecutor do
           {:search_error, lv_pid, result}
       end
     end)
+  end
+
+  defp uniq_sort_log_events(log_events) do
+    log_events
+    |> Enum.uniq_by(&{&1.body["timestamp"], event_id(&1)})
+    |> Enum.sort_by(&{&1.body["timestamp"], event_id(&1)}, :desc)
+  end
+
+  defp log_event_cursor(nil), do: nil
+
+  defp log_event_cursor(%LogEvent{} = event) do
+    %{timestamp: event.body["timestamp"], id: event_id(event)}
+  end
+
+  defp page_cursors(%{intent: :initial}, rows, sentinel_row) do
+    %{
+      cursor: log_event_cursor(sentinel_row),
+      next_cursor: rows |> List.first() |> log_event_cursor()
+    }
+  end
+
+  defp page_cursors(%{intent: :previous}, _rows, sentinel_row) do
+    %{cursor: log_event_cursor(sentinel_row), next_cursor: nil}
+  end
+
+  defp page_cursors(%{intent: :next}, rows, _sentinel_row) do
+    %{cursor: rows |> List.first() |> log_event_cursor(), next_cursor: nil}
+  end
+
+  defp active_task?({%Task{ref: ref}, _params}, ref), do: true
+  defp active_task?(_task, _ref), do: false
+
+  defp event_id(%LogEvent{id: id, body: body}), do: id || body["id"]
+
+  defp query_params(params) do
+    Map.drop(params, [
+      :range_extension,
+      :search_op,
+      :search_op_log_events,
+      :search_op_log_aggregates,
+      :streams
+    ])
   end
 end

--- a/lib/logflare/logs/search_query_executor.ex
+++ b/lib/logflare/logs/search_query_executor.ex
@@ -191,6 +191,8 @@ defmodule Logflare.Logs.SearchQueryExecutor do
 
     page_size = SearchOperations.default_limit()
     raw_rows = events_so.rows
+
+    # indicates another page of events is available to fetch
     has_sentinel_row? = length(raw_rows) >= SearchOperations.fetch_limit()
 
     {page_rows, sentinel_row} =

--- a/lib/logflare/lql/rules.ex
+++ b/lib/logflare/lql/rules.ex
@@ -16,6 +16,8 @@ defmodule Logflare.Lql.Rules do
 
   @type lql_rule :: ChartRule.t() | FilterRule.t() | FromRule.t() | SelectRule.t()
   @type lql_rules :: [lql_rule()]
+  @type timestamp_extension_direction :: :previous | :next
+  @type timestamp_range :: %{min: NaiveDateTime.t(), max: NaiveDateTime.t()}
 
   # =============================================================================
   # Rule Type Extraction
@@ -277,6 +279,65 @@ defmodule Logflare.Lql.Rules do
   end
 
   @doc """
+  Returns the interval that satisfies all timestamp filters.
+  """
+  @spec effective_timestamp_range(lql_rules()) :: timestamp_range() | nil
+  def effective_timestamp_range(lql_rules) when is_list(lql_rules) do
+    {lower_bounds, upper_bounds} =
+      lql_rules
+      |> get_timestamp_filters()
+      |> Enum.reduce({[], []}, fn filter_rule, {lower_bounds, upper_bounds} ->
+        {new_lower_bounds, new_upper_bounds} = timestamp_bounds(filter_rule)
+
+        {
+          Enum.reverse(new_lower_bounds, lower_bounds),
+          Enum.reverse(new_upper_bounds, upper_bounds)
+        }
+      end)
+
+    case {lower_bounds, upper_bounds} do
+      {[], _} ->
+        nil
+
+      {_, []} ->
+        nil
+
+      _ ->
+        %{min: Enum.max(lower_bounds, NaiveDateTime), max: Enum.min(upper_bounds, NaiveDateTime)}
+    end
+  end
+
+  @doc """
+  Replaces timestamp filters with an absolute range extended to an event timestamp.
+  """
+  @spec extend_timestamp_range(lql_rules(), timestamp_extension_direction(), NaiveDateTime.t()) ::
+          lql_rules()
+  def extend_timestamp_range(lql_rules, direction, event_timestamp)
+      when is_list(lql_rules) and direction in [:previous, :next] and
+             is_struct(event_timestamp, NaiveDateTime) do
+    case effective_timestamp_range(lql_rules) do
+      nil ->
+        lql_rules
+
+      %{min: min, max: max} ->
+        values =
+          case direction do
+            :previous -> [event_timestamp, max]
+            :next -> [min, event_timestamp]
+          end
+
+        timestamp_rule =
+          FilterRule.build(
+            path: "timestamp",
+            operator: :range,
+            values: values
+          )
+
+        update_timestamp_rules(lql_rules, [timestamp_rule])
+    end
+  end
+
+  @doc """
   Creates new timestamp filters by jumping forward or backward in time.
 
   Takes existing timestamp filters, calculates the time difference, and creates
@@ -298,6 +359,32 @@ defmodule Logflare.Lql.Rules do
   def timestamp_filter_rule_is_shorthand?(%FilterRule{} = filter_rule) do
     FilterRule.shorthand_timestamp?(filter_rule)
   end
+
+  defp timestamp_bounds(%FilterRule{operator: :range, values: [min, max]})
+       when not is_nil(min) and not is_nil(max),
+       do: {[normalize_timestamp(min)], [normalize_timestamp(max)]}
+
+  defp timestamp_bounds(%FilterRule{operator: op, value: value})
+       when op in [:>, :>=] and not is_nil(value),
+       do: {[normalize_timestamp(value)], []}
+
+  defp timestamp_bounds(%FilterRule{operator: op, value: value})
+       when op in [:<, :<=] and not is_nil(value),
+       do: {[], [normalize_timestamp(value)]}
+
+  defp timestamp_bounds(%FilterRule{operator: :=, value: value}) when not is_nil(value),
+    do: {[normalize_timestamp(value)], [normalize_timestamp(value)]}
+
+  defp timestamp_bounds(%FilterRule{}), do: {[], []}
+
+  defp normalize_timestamp(%DateTime{} = timestamp) do
+    timestamp
+    |> DateTime.shift_zone!("Etc/UTC")
+    |> DateTime.to_naive()
+  end
+
+  defp normalize_timestamp(%NaiveDateTime{} = timestamp), do: timestamp
+  defp normalize_timestamp(%Date{} = timestamp), do: NaiveDateTime.new!(timestamp, ~T[00:00:00])
 
   # =============================================================================
   # LQL Parser Warnings

--- a/lib/logflare_web/live/search_live/event_pagination.ex
+++ b/lib/logflare_web/live/search_live/event_pagination.ex
@@ -1,0 +1,82 @@
+defmodule LogflareWeb.SearchLive.EventPagination do
+  @moduledoc false
+
+  alias Logflare.Logs.EventPage
+
+  @type cursor :: EventPage.cursor()
+  @type range_extension :: String.t()
+  @type button_state :: :hidden | :ready | :disabled
+  @type button :: %{state: button_state(), cursor: cursor() | nil}
+  @type buttons :: %{previous: button(), next: button()}
+
+  @enforce_keys []
+  defstruct next_exhausted?: false, range_extension: nil
+
+  @type t :: %__MODULE__{
+          next_exhausted?: boolean(),
+          range_extension: range_extension() | nil
+        }
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec complete_initial(t(), EventPage.t()) :: t()
+  def complete_initial(pagination, event_page) do
+    %{pagination | next_exhausted?: not event_page.has_more?}
+  end
+
+  @spec complete_page(t(), EventPage.t(), EventPage.direction()) :: t()
+  def complete_page(pagination, _event_page, :previous), do: pagination
+
+  def complete_page(pagination, event_page, :next) do
+    %{pagination | next_exhausted?: not event_page.has_more?}
+  end
+
+  @spec complete_tail(t(), EventPage.t()) :: t()
+  def complete_tail(pagination, %EventPage{next_cursor: nil}), do: pagination
+
+  def complete_tail(pagination, %EventPage{}), do: %{pagination | next_exhausted?: false}
+
+  @spec mark_range_extension(t(), String.t()) :: t()
+  def mark_range_extension(pagination, querystring) do
+    %{pagination | range_extension: querystring}
+  end
+
+  @spec clear_range_extension(t()) :: t()
+  def clear_range_extension(pagination), do: %{pagination | range_extension: nil}
+
+  @spec buttons(t(), keyword()) :: buttons()
+  def buttons(pagination, options) do
+    tailing? = Keyword.fetch!(options, :tailing?)
+    loading? = Keyword.fetch!(options, :loading?)
+    next_available? = Keyword.fetch!(options, :next_available?)
+    cursors = Keyword.fetch!(options, :cursors)
+
+    %{
+      previous: %{
+        state: previous_button(cursors.previous, tailing?, loading?),
+        cursor: cursors.previous
+      },
+      next: %{
+        state: next_button(pagination, tailing?, loading?, next_available?),
+        cursor: cursors.next
+      }
+    }
+  end
+
+  defp previous_button(_cursor, true, _loading?), do: :hidden
+  defp previous_button(nil, _tailing?, _loading?), do: :hidden
+  defp previous_button(_cursor, _tailing?, true), do: :disabled
+
+  defp previous_button(_cursor, _tailing?, _loading?), do: :ready
+
+  defp next_button(_pagination, true, _loading?, _next_available?), do: :hidden
+  defp next_button(_pagination, _tailing?, _loading?, false), do: :hidden
+
+  defp next_button(%__MODULE__{next_exhausted?: true}, _tailing?, _loading?, _next_available?),
+    do: :hidden
+
+  defp next_button(_pagination, _tailing?, true, _next_available?), do: :disabled
+
+  defp next_button(_pagination, _tailing?, _loading?, _next_available?), do: :ready
+end

--- a/lib/logflare_web/live/search_live/form_components.ex
+++ b/lib/logflare_web/live/search_live/form_components.ex
@@ -135,7 +135,6 @@ defmodule LogflareWeb.SearchLive.FormComponents do
   attr :uri_params, :map, required: true
   attr :lql_rules, :list, required: true
   attr :user, Logflare.User, required: true
-  attr :search_op_log_events, :any, default: nil
   attr :search_op_log_aggregates, :any, default: nil
   attr :has_results?, :boolean
   attr :source, Logflare.Sources.Source, required: true

--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -21,6 +21,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   @default_empty_event_message "(empty event message)"
 
   attr :search_op_log_events, :map, default: nil
+  attr :search_op_log_aggregates, :map, default: nil
+  attr :log_events, :any, default: []
   attr :last_query_completed_at, :any, default: nil
   attr :loading, :boolean, required: true
   attr :search_timezone, :string, required: true
@@ -33,8 +35,9 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
     ~H"""
     <div :if={@search_op_log_events} id="source-logs-search-list" data-last-query-completed-at={@last_query_completed_at} phx-hook="SourceLogsSearchList" class="mt-4">
-      <ul id="logs-list" class={["list-unstyled console-text-list", if(@loading, do: "blurred", else: nil)]}>
-        <.log_event :for={log <- @search_op_log_events.rows} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)} source_schema_flat_map={@source_schema_flat_map}>
+      <ul id="logs-list" phx-update="stream" class={["list-unstyled console-text-list", if(@loading, do: "blurred", else: nil)]}>
+        <.empty_result_list :if={not @loading} search_op_log_events={@search_op_log_events} search_op_log_aggregates={@search_op_log_aggregates} />
+        <.log_event :for={{dom_id, log} <- @log_events} id={dom_id} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)} source_schema_flat_map={@source_schema_flat_map}>
           {log.body["event_message"]}
           <:actions phx-no-format>
           <div class="group-has-[.log-event-selected-field]:tw-ml-[13rem] group-has-[.log-event-selected-field]:tw-pb-1.5 tw-inline-block">
@@ -277,7 +280,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
       )
 
     ~H"""
-    <div :if={show_empty_results?(@search_op_log_events)} class="tw-mt-4 tw-px-4 tw-py-3 tw-text-center tw-font-sans">
+    <div class="tw-mt-4 tw-px-4 tw-py-3 tw-text-center tw-font-sans tw-only:block hidden" id="empty-results-list">
       <h2 class="tw-text-lg tw-font-semibold tw-text-gray-400">
         No events matching your query
       </h2>
@@ -295,11 +298,6 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
     </div>
     """
   end
-
-  defp show_empty_results?(%{rows: rows})
-       when is_list(rows), do: Enum.empty?(rows)
-
-  defp show_empty_results?(_), do: false
 
   def extended_search_lql(datetime) do
     new_rule =

--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -9,6 +9,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
   alias Logflare.DateTimeUtils
   alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Logs.SearchOperation
   alias Logflare.Lql
   alias Logflare.Lql.Rules
   alias Logflare.Lql.Rules.FilterRule
@@ -20,24 +21,36 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   @log_levels ~W(debug info warning error alert critical notice emergency)
   @default_empty_event_message "(empty event message)"
 
-  attr :search_op_log_events, :map, default: nil
+  attr :search_op_log_events, SearchOperation, default: nil
   attr :search_op_log_aggregates, :map, default: nil
   attr :log_events, :any, default: []
-  attr :last_query_completed_at, :any, default: nil
   attr :loading, :boolean, required: true
+  attr :tailing?, :boolean, default: false
+
+  attr :pagination_buttons, :map,
+    default: %{
+      previous: %{state: :hidden, cursor: nil},
+      next: %{state: :hidden, cursor: nil}
+    }
+
   attr :search_timezone, :string, required: true
-  attr :empty_event_message_placeholder, :string, default: @default_empty_event_message
   attr :source_schema_flat_map, :map, default: %{}
-  attr :search_op, Logflare.Logs.SearchOperation
 
   def results_list(assigns) do
-    assigns = assign(assigns, :select_fields, build_select_fields(assigns.search_op))
+    lql_rules =
+      if assigns.search_op_log_events, do: assigns.search_op_log_events.lql_rules, else: []
+
+    assigns =
+      assigns
+      |> assign(:select_fields, build_select_fields(lql_rules))
+      |> assign(:earlier_result_dt, first_date_with_results(assigns.search_op_log_aggregates))
 
     ~H"""
-    <div :if={@search_op_log_events} id="source-logs-search-list" data-last-query-completed-at={@last_query_completed_at} phx-hook="SourceLogsSearchList" class="mt-4">
+    <div :if={@search_op_log_events} id="source-logs-search-list" data-tailing={if(@tailing?, do: "true", else: "false")} phx-hook="SourceLogsSearchList" class="mt-4 tw-relative">
+      <.load_more_button id="load-more-events-top" intent="previous" state={@pagination_buttons.previous.state} cursor={@pagination_buttons.previous.cursor} />
       <ul id="logs-list" phx-update="stream" class={["list-unstyled console-text-list", if(@loading, do: "blurred", else: nil)]}>
-        <.empty_result_list :if={not @loading} search_op_log_events={@search_op_log_events} search_op_log_aggregates={@search_op_log_aggregates} />
-        <.log_event :for={{dom_id, log} <- @log_events} id={dom_id} timezone={@search_timezone} log_event={log} select_fields={build_select_fields(@search_op)} source_schema_flat_map={@source_schema_flat_map}>
+        <.empty_result_list search_op_log_events={@search_op_log_events} earlier_result_dt={@earlier_result_dt} loading={@loading} />
+        <.log_event :for={{dom_id, log} <- @log_events} id={dom_id} data-event-id={event_id(log)} data-event-timestamp={log.body["timestamp"]} timezone={@search_timezone} log_event={log} select_fields={@select_fields} source_schema_flat_map={@source_schema_flat_map}>
           {log.body["event_message"]}
           <:actions phx-no-format>
           <div class="group-has-[.log-event-selected-field]:tw-ml-[13rem] group-has-[.log-event-selected-field]:tw-pb-1.5 tw-inline-block">
@@ -71,7 +84,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
                    phx-click={
                      JS.dispatch("logflare:copy-to-clipboard",
                        detail: %{
-                         text: formatted_for_clipboard(log, @search_op)
+                         text: formatted_for_clipboard(log, @search_op_log_events)
                        }
                      )
                    }
@@ -79,11 +92,31 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
                    data-placement="top"
                    title="Copy to clipboard"
                  >copy</.link>
-                <.log_event_permalink log_event_id={log.id} timestamp={log.body["timestamp"]} source={@search_op.source} lql={lql_with_recommended_fields(@search_op.lql_rules, log, @search_op.source)} class="tw-text-[0.65rem] group-hover:tw-visible tw-invisible" />
+                <.log_event_permalink log_event_id={log.id} timestamp={log.body["timestamp"]} source={@search_op_log_events.source} lql={lql_with_recommended_fields(@search_op_log_events.lql_rules, log, @search_op_log_events.source)} class="tw-text-[0.65rem] group-hover:tw-visible tw-invisible" />
                 </div>
                </:actions>
         </.log_event>
       </ul>
+      <.load_more_button id="load-more-events-bottom" intent="next" state={@pagination_buttons.next.state} cursor={@pagination_buttons.next.cursor} />
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :intent, :string, values: ~w(previous next), required: true
+  attr :state, :atom, values: ~w(hidden ready disabled)a, required: true
+  attr :cursor, :map, default: nil
+
+  def load_more_button(assigns) do
+    ~H"""
+    <div class={["tw-justify-center", if(@state == :hidden, do: "tw-hidden", else: "tw-flex")]}>
+      <button id={@id} type="button" class="tw-group btn btn-outline-secondary btn-sm tw-text-xs" phx-click="load_events" phx-value-intent={@intent} phx-value-cursor-id={@cursor && @cursor.id} phx-value-cursor-timestamp={@cursor && @cursor.timestamp} disabled={@state != :ready}>
+        <span class="tw-relative tw-whitespace-nowrap tw-w-20 tw-flex tw-justify-center">
+          <i class="spinner-border spinner-border-sm text-info tw-mr-1 tw-hidden group-[.phx-click-loading]:tw-inline" aria-hidden="true"></i>
+          <span class="group-[.phx-click-loading]:tw-hidden">Load more</span>
+          <span class="tw-hidden group-[.phx-click-loading]:tw-inline">Loading</span>
+        </span>
+      </button>
     </div>
     """
   end
@@ -126,8 +159,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
 
   def formatted_for_clipboard(log, search_op) do
     select_fields =
-      search_op
-      |> build_select_fields()
+      build_select_fields(search_op.lql_rules)
       |> Enum.map(fn %{display: display, key: key} ->
         value = get_field_value(log.body, key)
         separator = if String.length(value) > 64, do: "\n", else: " "
@@ -243,7 +275,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
   defp format_field_value(value) when is_map(value), do: Jason.encode!(value)
   defp format_field_value(value), do: inspect(value)
 
-  defp build_select_fields(%{lql_rules: lql_rules}) do
+  defp build_select_fields(lql_rules) when is_list(lql_rules) do
     lql_rules
     |> Lql.Rules.get_select_rules()
     |> Enum.map(fn
@@ -268,19 +300,13 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
     end
   end
 
-  attr :search_op_log_aggregates, :map, default: nil
   attr :search_op_log_events, :map, default: nil
+  attr :earlier_result_dt, :any, default: nil
+  attr :loading, :boolean, default: false
 
   def empty_result_list(assigns) do
-    assigns =
-      assigns
-      |> assign(
-        :earlier_result_dt,
-        first_date_with_results(assigns.search_op_log_aggregates)
-      )
-
     ~H"""
-    <div class="tw-mt-4 tw-px-4 tw-py-3 tw-text-center tw-font-sans tw-only:block hidden" id="empty-results-list">
+    <li id="empty-search-results" class={["tw-mt-4 tw-px-4 tw-py-3 tw-text-center tw-font-sans only:tw-block hidden", if(@loading, do: "tw-hidden", else: nil)]}>
       <h2 class="tw-text-lg tw-font-semibold tw-text-gray-400">
         No events matching your query
       </h2>
@@ -295,9 +321,11 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
           <i class="fas fa-search"></i><span class="fas-in-button hide-on-mobile">Extend search</span>
         </.link>
       </div>
-    </div>
+    </li>
     """
   end
+
+  defp event_id(%Logflare.LogEvent{id: id, body: body}), do: id || body["id"]
 
   def extended_search_lql(datetime) do
     new_rule =

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -35,6 +35,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   require Logger
 
+  @log_event_stream_limit 5_000
   @tail_search_interval 1000
   @user_idle_interval :timer.minutes(2)
   @timeout_search_error_message "Query timed out: Try restricting the timestamp range or adding more filtering to your query."
@@ -108,6 +109,8 @@ defmodule LogflareWeb.Source.SearchLV do
       saved_searches: saved_searches(source),
       force_query: Map.get(params, "force", "false") == "true"
     )
+    |> stream_configure(:log_events, dom_id: &log_event_dom_id/1)
+    |> stream(:log_events, [])
     |> maybe_assign_user_timezone(team_user, user)
   end
 
@@ -182,15 +185,6 @@ defmodule LogflareWeb.Source.SearchLV do
            {:ok, socket} <- check_suggested_keys(lql_rules, source, socket) do
         qs = Lql.encode!(lql_rules)
 
-        search_op_log_events =
-          if socket.assigns.search_op_log_events do
-            rows = socket.assigns.search_op_log_events.rows
-            events = Enum.map(rows, &Map.put(&1, :is_from_stale_query, true))
-            Map.put(socket.assigns.search_op_log_events, :rows, events)
-          else
-            socket.assigns.search_op_log_events
-          end
-
         socket =
           socket
           |> assign(:loading, true)
@@ -198,7 +192,6 @@ defmodule LogflareWeb.Source.SearchLV do
           |> assign(:tailing_initial?, true)
           |> assign(:lql_rules, lql_rules)
           |> assign(:querystring, qs)
-          |> assign(:search_op_log_events, search_op_log_events)
 
         if connected?(socket) do
           kickoff_queries(source.token, socket.assigns)
@@ -262,8 +255,16 @@ defmodule LogflareWeb.Source.SearchLV do
     </.subheader>
     <div class="container source-logs-search-container console-text">
       <div id="logs-list-container">
-        <LogEventComponents.empty_result_list :if={not @loading} search_op_log_events={@search_op_log_events} search_op_log_aggregates={@search_op_log_aggregates} />
-        <LogEventComponents.results_list search_op={@search_op} search_op_log_events={@search_op_log_events} last_query_completed_at={@last_query_completed_at} search_timezone={@search_timezone} loading={@loading} source_schema_flat_map={@source_schema_flat_map} />
+        <LogEventComponents.results_list
+          search_op={@search_op}
+          search_op_log_events={@search_op_log_events}
+          search_op_log_aggregates={@search_op_log_aggregates}
+          log_events={@streams.log_events}
+          last_query_completed_at={@last_query_completed_at}
+          search_timezone={@search_timezone}
+          loading={@loading}
+          source_schema_flat_map={@source_schema_flat_map}
+        />
       </div>
       <div>
         {live_react_component(
@@ -342,6 +343,9 @@ defmodule LogflareWeb.Source.SearchLV do
     socket =
       socket
       |> assign(:search_timezone, tz)
+      |> assign(:search_op_log_events, nil)
+      |> assign(:search_op_log_aggregates, nil)
+      |> stream(:log_events, [], reset: true)
       |> assign_new_search_with_qs(
         %{querystring: socket.assigns.querystring, tailing?: socket.assigns.tailing?},
         SourceSchemas.source_schema_flatmap_or_default(socket.assigns.source)
@@ -626,6 +630,26 @@ defmodule LogflareWeb.Source.SearchLV do
     end
   end
 
+  defp put_search_events(socket, rows)
+       when socket.assigns.tailing? and not socket.assigns.tailing_initial? do
+    rows
+    |> Enum.with_index()
+    |> Enum.reduce(socket, fn {row, index}, socket ->
+      stream_insert(socket, :log_events, row, at: index, limit: @log_event_stream_limit)
+    end)
+  end
+
+  defp put_search_events(socket, rows), do: stream(socket, :log_events, rows, reset: true)
+
+  defp maybe_assign_within_range_availability(socket, :previous, has_more?),
+    do: assign(socket, :event_page_within_range_available?, has_more?)
+
+  defp maybe_assign_within_range_availability(socket, :next, _has_more?), do: socket
+
+  defp active_event_page_request?(socket, %{intent: intent, cursor: cursor}) do
+    socket.assigns.event_page_loading_request == %{intent: intent, cursor: cursor}
+  end
+
   def handle_info(:soft_pause = ev, socket) do
     soft_pause(ev, socket)
   end
@@ -675,6 +699,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
     socket =
       socket
+      |> put_search_events(events_op.rows)
       |> assign(:search_op, events_op)
       |> assign(:search_op_error, nil)
       |> assign(:search_op_log_events, search_result.events)
@@ -684,16 +709,11 @@ defmodule LogflareWeb.Source.SearchLV do
       |> assign(:last_query_completed_at, DateTime.utc_now())
 
     socket =
-      cond do
-        match?({:warning, _}, search_result.events.status) ->
-          {:warning, message} = search_result.events.status
-          put_flash(socket, :info, message)
-
-        msg = warning_message(socket.assigns, search_result) ->
-          put_flash(socket, :warning, msg)
-
-        true ->
-          socket
+      if match?({:warning, _}, search_result.events.status) do
+        {:warning, message} = search_result.events.status
+        put_flash(socket, :info, message)
+      else
+        socket
       end
 
     {:noreply, socket}
@@ -724,7 +744,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   def handle_info(:schedule_tail_search, %{assigns: assigns} = socket) do
     if socket.assigns.tailing? do
-      SearchQueryExecutor.query(assigns.executor_pid, assigns)
+      SearchQueryExecutor.query(assigns.executor_pid, search_params(assigns))
     end
 
     {:noreply, socket}
@@ -732,7 +752,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   def handle_info(:schedule_tail_agg, %{assigns: assigns} = socket) do
     if socket.assigns.tailing? do
-      SearchQueryExecutor.query_agg(assigns.executor_pid, assigns)
+      SearchQueryExecutor.query_agg(assigns.executor_pid, search_params(assigns))
     end
 
     {:noreply, socket}
@@ -849,26 +869,6 @@ defmodule LogflareWeb.Source.SearchLV do
     push_patch(socket, to: path, replace: false)
   end
 
-  defp warning_message(assigns, search_op) do
-    tailing? = assigns.tailing?
-    querystring = assigns.querystring
-    log_events_empty? = Enum.empty?(search_op.events.rows)
-
-    cond do
-      log_events_empty? and not tailing? ->
-        "No log events matching your search query."
-
-      log_events_empty? and tailing? ->
-        "No log events matching your search query."
-
-      querystring == "" and log_events_empty? and tailing? ->
-        "No log events ingested during last 24 hours. Try searching over a longer time period, and clicking the bar chart to drill down."
-
-      true ->
-        nil
-    end
-  end
-
   defp adjust_timestamp_rules(timestamp_rules, search_timezone) do
     case Timex.Timezone.get(search_timezone) do
       {:error, _} -> timestamp_rules
@@ -894,9 +894,22 @@ defmodule LogflareWeb.Source.SearchLV do
     Logger.debug("Kicking off queries for #{source_token}", source_id: source_token)
 
     if assigns do
-      SearchQueryExecutor.query(assigns.executor_pid, assigns)
-      SearchQueryExecutor.query_agg(assigns.executor_pid, assigns)
+      params = search_params(assigns)
+      SearchQueryExecutor.query(assigns.executor_pid, params)
+      SearchQueryExecutor.query_agg(assigns.executor_pid, params)
     end
+  end
+
+  @spec search_params(map()) :: map()
+  defp search_params(assigns) do
+    Map.take(assigns, [
+      :source,
+      :querystring,
+      :tailing?,
+      :tailing_initial?,
+      :lql_rules,
+      :search_timezone
+    ])
   end
 
   @doc """
@@ -1155,6 +1168,11 @@ defmodule LogflareWeb.Source.SearchLV do
       to: %{uri | query: URI.encode_query(params)},
       class: "tw-block tw-pt-3"
     )
+  end
+
+  @spec log_event_dom_id(Logflare.LogEvent.t()) :: String.t()
+  defp log_event_dom_id(%Logflare.LogEvent{id: id, body: %{"timestamp" => timestamp}}) do
+    "log-events-#{id}-#{timestamp}"
   end
 
   @spec querystring_or_default(String.t(), Logflare.Sources.Source.t()) :: String.t()

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -11,8 +11,11 @@ defmodule LogflareWeb.Source.SearchLV do
 
   alias Logflare.Backends.QueryError
   alias Logflare.Billing
+  alias Logflare.Logs.EventPage
+  alias Logflare.Logs.SearchOperation
   alias Logflare.Logs.SearchQueryExecutor
   alias Logflare.Logs.SearchOperations
+  alias Logflare.Logs.SearchOperations.Helpers, as: SearchOperationHelpers
   alias Logflare.Logs.SearchUtils
   alias Logflare.Lql
   alias Logflare.Lql.Rules
@@ -27,6 +30,7 @@ defmodule LogflareWeb.Source.SearchLV do
   alias LogflareWeb.Helpers.BqSchema, as: BqSchemaHelpers
   alias LogflareWeb.QueryErrorHelpers
   alias LogflareWeb.Router.Helpers, as: Routes
+  alias LogflareWeb.SearchLive.EventPagination
   alias LogflareWeb.SearchLive.FormComponents
   alias LogflareWeb.SearchLive.SubheadComponents
   alias LogflareWeb.SearchLive.LogEventComponents
@@ -96,7 +100,6 @@ defmodule LogflareWeb.Source.SearchLV do
       tailing?: tailing?,
       resume_tailing_after_modal?: false,
       # search states
-      search_op: nil,
       search_op_error: nil,
       search_op_log_events: nil,
       search_op_log_aggregates: nil,
@@ -109,6 +112,7 @@ defmodule LogflareWeb.Source.SearchLV do
       saved_searches: saved_searches(source),
       force_query: Map.get(params, "force", "false") == "true"
     )
+    |> reset_event_pagination()
     |> stream_configure(:log_events, dom_id: &log_event_dom_id/1)
     |> stream(:log_events, [])
     |> maybe_assign_user_timezone(team_user, user)
@@ -156,6 +160,32 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, push_patch(socket, to: path, replace: true)}
   end
 
+  def handle_params(
+        %{"querystring" => qs} = params,
+        uri,
+        %{
+          assigns: %{
+            event_pagination: %{
+              range_extension: expected_querystring
+            }
+          }
+        } = socket
+      )
+      when is_binary(expected_querystring) do
+    if qs == expected_querystring do
+      {:noreply,
+       socket
+       |> update_event_pagination(&EventPagination.clear_range_extension/1)
+       |> assign(uri: URI.parse(uri), uri_params: params, querystring: qs)}
+    else
+      socket =
+        socket
+        |> update_event_pagination(&EventPagination.clear_range_extension/1)
+
+      handle_params(params, uri, socket)
+    end
+  end
+
   def handle_params(%{"querystring" => qs} = params, uri, socket) do
     source = socket.assigns.source
 
@@ -189,6 +219,7 @@ defmodule LogflareWeb.Source.SearchLV do
           socket
           |> assign(:loading, true)
           |> assign(:chart_loading, true)
+          |> reset_event_pagination()
           |> assign(:tailing_initial?, true)
           |> assign(:lql_rules, lql_rules)
           |> assign(:querystring, qs)
@@ -256,13 +287,13 @@ defmodule LogflareWeb.Source.SearchLV do
     <div class="container source-logs-search-container console-text">
       <div id="logs-list-container">
         <LogEventComponents.results_list
-          search_op={@search_op}
           search_op_log_events={@search_op_log_events}
           search_op_log_aggregates={@search_op_log_aggregates}
           log_events={@streams.log_events}
-          last_query_completed_at={@last_query_completed_at}
           search_timezone={@search_timezone}
           loading={@loading}
+          tailing?={@tailing?}
+          pagination_buttons={event_pagination_buttons(@event_pagination, @pagination_cursors, @tailing?, @loading, @lql_rules, @search_timezone)}
           source_schema_flat_map={@source_schema_flat_map}
         />
       </div>
@@ -343,9 +374,6 @@ defmodule LogflareWeb.Source.SearchLV do
     socket =
       socket
       |> assign(:search_timezone, tz)
-      |> assign(:search_op_log_events, nil)
-      |> assign(:search_op_log_aggregates, nil)
-      |> stream(:log_events, [], reset: true)
       |> assign_new_search_with_qs(
         %{querystring: socket.assigns.querystring, tailing?: socket.assigns.tailing?},
         SourceSchemas.source_schema_flatmap_or_default(socket.assigns.source)
@@ -375,6 +403,31 @@ defmodule LogflareWeb.Source.SearchLV do
 
     {:noreply, socket}
   end
+
+  def handle_event(
+        "load_events",
+        %{
+          "intent" => intent,
+          "cursor-id" => cursor_id,
+          "cursor-timestamp" => cursor_timestamp
+        },
+        %{assigns: %{loading: false, tailing?: false}} = socket
+      ) do
+    with {:ok, {intent, cursor}} <- event_page_request(intent, cursor_id, cursor_timestamp),
+         :ok <-
+           SearchQueryExecutor.query(
+             socket.assigns.executor_pid,
+             socket.assigns,
+             intent,
+             cursor
+           ) do
+      {:noreply, socket}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("load_events", _params, socket), do: {:noreply, socket}
 
   def handle_event(direction, _, socket) when direction in ["backwards", "forwards"] do
     rules = socket.assigns.lql_rules
@@ -623,11 +676,121 @@ defmodule LogflareWeb.Source.SearchLV do
       |> assign(:lql_rules, lql_rules)
       |> assign(:loading, true)
       |> assign(:chart_loading, true)
+      |> reset_event_pagination()
       |> clear_flash()
       |> push_patch_with_params(%{querystring: qs, tailing?: socket.assigns.tailing?})
     else
       socket
     end
+  end
+
+  defp update_event_pagination(socket, update) do
+    assign(socket, :event_pagination, update.(socket.assigns.event_pagination))
+  end
+
+  defp reset_event_pagination(socket) do
+    socket
+    |> assign(:event_pagination, EventPagination.new())
+    |> assign(:pagination_cursors, %{previous: nil, next: nil})
+  end
+
+  defp put_pagination_cursors(socket, event_page, :initial) do
+    assign(socket, :pagination_cursors, %{
+      previous: event_page.cursor,
+      next: event_page.next_cursor
+    })
+  end
+
+  defp put_pagination_cursors(socket, %EventPage{next_cursor: nil}, :tail), do: socket
+
+  defp put_pagination_cursors(socket, event_page, :tail) do
+    update(socket, :pagination_cursors, &%{&1 | next: event_page.next_cursor})
+  end
+
+  defp put_pagination_cursors(socket, event_page, intent) when intent in [:previous, :next] do
+    update(socket, :pagination_cursors, &Map.put(&1, intent, event_page.cursor))
+  end
+
+  defp event_page_request("previous", cursor_id, cursor_timestamp) do
+    build_event_page_request(:previous, cursor_id, cursor_timestamp)
+  end
+
+  defp event_page_request("next", cursor_id, cursor_timestamp) do
+    build_event_page_request(:next, cursor_id, cursor_timestamp)
+  end
+
+  defp event_page_request(_intent, _cursor_id, _cursor_timestamp), do: :error
+
+  defp build_event_page_request(intent, cursor_id, cursor_timestamp)
+       when is_binary(cursor_id) and is_binary(cursor_timestamp) do
+    with {cursor_timestamp, ""} <- Integer.parse(cursor_timestamp),
+         cursor = %{id: cursor_id, timestamp: cursor_timestamp},
+         true <- EventPage.valid_cursor?(cursor) do
+      {:ok, {intent, cursor}}
+    else
+      _ -> :error
+    end
+  end
+
+  defp build_event_page_request(_intent, _cursor_id, _cursor_timestamp), do: :error
+
+  defp event_pagination_buttons(
+         pagination,
+         cursors,
+         tailing?,
+         loading?,
+         lql_rules,
+         search_timezone
+       ) do
+    EventPagination.buttons(pagination,
+      cursors: cursors,
+      tailing?: tailing?,
+      loading?: loading?,
+      next_available?: next_page_available?(pagination, cursors.next, lql_rules, search_timezone)
+    )
+  end
+
+  defp next_page_available?(
+         %EventPagination{next_exhausted?: false},
+         cursor,
+         lql_rules,
+         search_timezone
+       )
+       when not is_nil(cursor) do
+    timestamp_filters =
+      %SearchOperation{
+        chart_data_shape_id: nil,
+        lql_ts_filters: Rules.get_timestamp_filters(lql_rules),
+        partition_by: :timestamp,
+        querystring: "",
+        search_timezone: search_timezone,
+        tailing?: false
+      }
+      |> SearchOperations.apply_local_timestamp_correction()
+      |> Map.fetch!(:lql_ts_filters)
+
+    %{max: range_end} =
+      SearchOperationHelpers.get_min_max_filter_timestamps(timestamp_filters, :second)
+
+    range_end =
+      case range_end do
+        %DateTime{} = datetime -> datetime
+        %NaiveDateTime{} = datetime -> DateTime.from_naive!(datetime, "Etc/UTC")
+      end
+
+    DateTime.compare(range_end, DateTime.utc_now()) in [:lt, :eq]
+  end
+
+  defp next_page_available?(_pagination, _cursor, _lql_rules, _search_timezone), do: false
+
+  defp put_event_page(socket, rows, :previous) do
+    socket
+    |> stream(:log_events, rows, at: -1)
+  end
+
+  defp put_event_page(socket, rows, :next) do
+    socket
+    |> stream(:log_events, Enum.reverse(rows), at: 0)
   end
 
   defp put_search_events(socket, rows)
@@ -639,15 +802,161 @@ defmodule LogflareWeb.Source.SearchLV do
     end)
   end
 
-  defp put_search_events(socket, rows), do: stream(socket, :log_events, rows, reset: true)
+  defp put_search_events(socket, rows) do
+    stream(socket, :log_events, rows, reset: true)
+  end
 
-  defp maybe_assign_within_range_availability(socket, :previous, has_more?),
-    do: assign(socket, :event_page_within_range_available?, has_more?)
+  defp apply_event_page_result(socket, %EventPage{} = event_page) do
+    socket
+    |> assign(:search_op_error, nil)
+    |> assign(:last_query_completed_at, DateTime.utc_now())
+    |> apply_event_page_result(event_page, event_page.request.intent)
+  end
 
-  defp maybe_assign_within_range_availability(socket, :next, _has_more?), do: socket
+  defp apply_event_page_result(
+         socket,
+         %EventPage{events: events_op} = event_page,
+         :initial
+       ) do
+    if socket.assigns.tailing_initial? do
+      apply_initial_event_page_result(socket, event_page, events_op)
+    else
+      apply_tail_event_page_result(socket, event_page)
+    end
+  end
 
-  defp active_event_page_request?(socket, %{intent: intent, cursor: cursor}) do
-    socket.assigns.event_page_loading_request == %{intent: intent, cursor: cursor}
+  defp apply_event_page_result(socket, event_page, intent) when intent in [:previous, :next] do
+    if event_page.rows != [] do
+      extend_timestamp_range(socket, event_page)
+    else
+      put_event_page_result(socket, event_page, intent)
+    end
+  end
+
+  defp apply_initial_event_page_result(socket, event_page, events_op) do
+    tailing_timer =
+      if socket.assigns.tailing? do
+        Process.send_after(self(), :schedule_tail_search, @tail_search_interval)
+      end
+
+    socket =
+      socket
+      |> reset_event_pagination()
+      |> put_search_events(event_page.rows)
+      |> update_event_pagination(&EventPagination.complete_initial(&1, event_page))
+      |> put_pagination_cursors(event_page, :initial)
+      |> assign(:search_op_log_events, events_op)
+      |> assign(:tailing_timer, tailing_timer)
+      |> assign(:loading, false)
+      |> assign(:tailing_initial?, false)
+
+    if match?({:warning, _}, events_op.status) do
+      {:warning, message} = events_op.status
+      put_flash(socket, :info, message)
+    else
+      socket
+    end
+  end
+
+  defp apply_tail_event_page_result(socket, event_page) do
+    tailing_timer =
+      if socket.assigns.tailing? do
+        Process.send_after(self(), :schedule_tail_search, @tail_search_interval)
+      end
+
+    socket
+    |> put_search_events(event_page.rows)
+    |> update_event_pagination(&EventPagination.complete_tail(&1, event_page))
+    |> put_pagination_cursors(event_page, :tail)
+    |> assign(:tailing_timer, tailing_timer)
+    |> assign(:loading, false)
+  end
+
+  defp extend_timestamp_range(
+         socket,
+         %EventPage{request: %{intent: :previous}} = event_page
+       ) do
+    event = List.last(event_page.rows)
+    timezone = socket.assigns.search_timezone
+    event_timestamp = event_timestamp(event, timezone)
+
+    lql_rules =
+      socket.assigns.lql_rules
+      |> adjust_timestamp_rules(timezone)
+
+    case Rules.effective_timestamp_range(lql_rules) do
+      %{min: range_start} ->
+        if NaiveDateTime.compare(event_timestamp, range_start) == :lt do
+          lql_rules =
+            lql_rules
+            |> Rules.extend_timestamp_range(:previous, event_timestamp)
+            |> maybe_adjust_chart_period()
+
+          push_timestamp_range_extension(socket, event_page, lql_rules)
+        else
+          put_event_page_result(socket, event_page, :previous)
+        end
+
+      _ ->
+        put_event_page_result(socket, event_page, :previous)
+    end
+  end
+
+  defp extend_timestamp_range(socket, %EventPage{request: %{intent: :next}} = event_page) do
+    event = List.first(event_page.rows)
+    timezone = socket.assigns.search_timezone
+    event_timestamp = event_timestamp(event, timezone)
+
+    lql_rules =
+      socket.assigns.lql_rules
+      |> adjust_timestamp_rules(timezone)
+
+    case Rules.effective_timestamp_range(lql_rules) do
+      %{max: range_end} ->
+        if NaiveDateTime.compare(event_timestamp, range_end) == :gt do
+          lql_rules =
+            lql_rules
+            |> Rules.extend_timestamp_range(:next, event_timestamp)
+            |> maybe_adjust_chart_period()
+
+          push_timestamp_range_extension(socket, event_page, lql_rules)
+        else
+          put_event_page_result(socket, event_page, :next)
+        end
+
+      _ ->
+        put_event_page_result(socket, event_page, :next)
+    end
+  end
+
+  defp put_event_page_result(socket, event_page, intent) when intent in [:previous, :next] do
+    socket
+    |> put_event_page(event_page.rows, intent)
+    |> update_event_pagination(&EventPagination.complete_page(&1, event_page, intent))
+    |> put_pagination_cursors(event_page, intent)
+  end
+
+  defp push_timestamp_range_extension(socket, event_page, lql_rules) do
+    querystring = Lql.encode!(lql_rules)
+
+    socket =
+      socket
+      |> assign(:lql_rules, lql_rules)
+      |> assign(:querystring, querystring)
+      |> assign(:chart_loading, true)
+      |> put_event_page_result(event_page, event_page.request.intent)
+      |> update_event_pagination(&EventPagination.mark_range_extension(&1, querystring))
+
+    SearchQueryExecutor.query_agg(socket.assigns.executor_pid, socket.assigns)
+
+    push_patch_with_params(socket, %{querystring: querystring, tailing?: false})
+  end
+
+  defp event_timestamp(event, timezone) do
+    event.body["timestamp"]
+    |> DateTime.from_unix!(:microsecond)
+    |> DateTime.shift_zone!(timezone)
+    |> DateTime.to_naive()
   end
 
   def handle_info(:soft_pause = ev, socket) do
@@ -691,32 +1000,16 @@ defmodule LogflareWeb.Source.SearchLV do
     {:noreply, socket}
   end
 
-  def handle_info({:search_result, %{events: events_op} = search_result}, socket) do
-    tailing_timer =
-      if socket.assigns.tailing? do
-        Process.send_after(self(), :schedule_tail_search, @tail_search_interval)
-      end
+  def handle_info({:search_result, %{event_page: %EventPage{} = event_page}}, socket) do
+    {:noreply, apply_event_page_result(socket, event_page)}
+  end
 
-    socket =
-      socket
-      |> put_search_events(events_op.rows)
-      |> assign(:search_op, events_op)
-      |> assign(:search_op_error, nil)
-      |> assign(:search_op_log_events, search_result.events)
-      |> assign(:tailing_timer, tailing_timer)
-      |> assign(:loading, false)
-      |> assign(:tailing_initial?, false)
-      |> assign(:last_query_completed_at, DateTime.utc_now())
-
-    socket =
-      if match?({:warning, _}, search_result.events.status) do
-        {:warning, message} = search_result.events.status
-        put_flash(socket, :info, message)
-      else
+  def handle_info(
+        {:search_error, %{event_page_request: %{intent: intent}} = search_op},
         socket
-      end
-
-    {:noreply, socket}
+      )
+      when intent in [:previous, :next] do
+    {:noreply, put_flash_query_error(socket, search_op.error)}
   end
 
   def handle_info({:search_error, search_op}, socket) do
@@ -744,7 +1037,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   def handle_info(:schedule_tail_search, %{assigns: assigns} = socket) do
     if socket.assigns.tailing? do
-      SearchQueryExecutor.query(assigns.executor_pid, search_params(assigns))
+      SearchQueryExecutor.query(assigns.executor_pid, assigns)
     end
 
     {:noreply, socket}
@@ -752,7 +1045,7 @@ defmodule LogflareWeb.Source.SearchLV do
 
   def handle_info(:schedule_tail_agg, %{assigns: assigns} = socket) do
     if socket.assigns.tailing? do
-      SearchQueryExecutor.query_agg(assigns.executor_pid, search_params(assigns))
+      SearchQueryExecutor.query_agg(assigns.executor_pid, assigns)
     end
 
     {:noreply, socket}
@@ -781,6 +1074,8 @@ defmodule LogflareWeb.Source.SearchLV do
 
         socket
         |> assign(:loading, true)
+        |> reset_event_pagination()
+        |> stream(:log_events, [], reset: true)
         |> assign(:tailing_initial?, true)
         |> clear_flash()
         |> assign(:lql_rules, lql_rules)
@@ -870,46 +1165,65 @@ defmodule LogflareWeb.Source.SearchLV do
   end
 
   defp adjust_timestamp_rules(timestamp_rules, search_timezone) do
-    case Timex.Timezone.get(search_timezone) do
-      {:error, _} -> timestamp_rules
-      tz -> do_adjust_timestamp_rules(timestamp_rules, tz)
+    case DateTime.now(search_timezone) do
+      {:ok, _datetime} -> do_adjust_timestamp_rules(timestamp_rules, search_timezone)
+      {:error, _reason} -> timestamp_rules
     end
   end
 
-  defp do_adjust_timestamp_rules(timestamp_rules, tz) do
+  defp do_adjust_timestamp_rules(timestamp_rules, timezone) do
     Enum.map(timestamp_rules, fn lql_rule ->
-      if Rules.timestamp_filter_rule_is_shorthand?(lql_rule) do
-        Map.replace!(lql_rule, :values, shift_timestamps(lql_rule.values, tz))
-      else
-        lql_rule
+      case lql_rule do
+        %{path: "timestamp", modifiers: %{timestamp_origin: :absolute}} ->
+          %{
+            lql_rule
+            | value: shift_timestamp(lql_rule.value, timezone),
+              values: shift_timestamps(lql_rule.values, timezone)
+          }
+
+        _ ->
+          lql_rule
       end
     end)
   end
 
+  @spec shift_timestamps([term()] | nil, Calendar.time_zone()) :: [term()] | nil
+  defp shift_timestamps(nil, _timezone), do: nil
+
   defp shift_timestamps(timestamps, timezone) do
-    Enum.map(timestamps, &Timex.shift(&1, seconds: Timex.diff(&1, timezone)))
+    Enum.map(timestamps, &shift_timestamp(&1, timezone))
   end
+
+  @spec shift_timestamp(term(), Calendar.time_zone()) :: term()
+  defp shift_timestamp(nil, _timezone), do: nil
+
+  defp shift_timestamp(timestamp, timezone) when is_integer(timestamp) do
+    timestamp
+    |> DateTime.from_unix!(:microsecond)
+    |> shift_timestamp(timezone)
+  end
+
+  defp shift_timestamp(%NaiveDateTime{} = timestamp, timezone) do
+    timestamp
+    |> DateTime.from_naive!("Etc/UTC")
+    |> shift_timestamp(timezone)
+  end
+
+  defp shift_timestamp(%DateTime{} = timestamp, timezone) do
+    timestamp
+    |> DateTime.shift_zone!(timezone)
+    |> DateTime.to_naive()
+  end
+
+  defp shift_timestamp(timestamp, _timezone), do: timestamp
 
   defp kickoff_queries(source_token, assigns) when is_atom(source_token) do
     Logger.debug("Kicking off queries for #{source_token}", source_id: source_token)
 
     if assigns do
-      params = search_params(assigns)
-      SearchQueryExecutor.query(assigns.executor_pid, params)
-      SearchQueryExecutor.query_agg(assigns.executor_pid, params)
+      SearchQueryExecutor.query(assigns.executor_pid, assigns)
+      SearchQueryExecutor.query_agg(assigns.executor_pid, assigns)
     end
-  end
-
-  @spec search_params(map()) :: map()
-  defp search_params(assigns) do
-    Map.take(assigns, [
-      :source,
-      :querystring,
-      :tailing?,
-      :tailing_initial?,
-      :lql_rules,
-      :search_timezone
-    ])
   end
 
   @doc """
@@ -1045,12 +1359,16 @@ defmodule LogflareWeb.Source.SearchLV do
     maybe_cancel_tailing_timer(socket)
     SearchQueryExecutor.cancel_query(executor_pid)
 
-    assign(socket, :tailing?, false)
+    socket
+    |> assign(:tailing?, false)
   end
 
   defp resume_tailing(socket) do
     kickoff_queries(socket.assigns.source.token, socket.assigns)
-    assign(socket, :tailing?, true)
+
+    socket
+    |> assign(:tailing?, true)
+    |> reset_event_pagination()
   end
 
   defp hard_play(
@@ -1068,6 +1386,7 @@ defmodule LogflareWeb.Source.SearchLV do
     socket =
       socket
       |> assign(:tailing?, true)
+      |> reset_event_pagination()
       |> push_patch_with_params(%{
         querystring: prev_assigns.querystring,
         tailing?: true

--- a/test/e2e/features/logs_search_test.exs
+++ b/test/e2e/features/logs_search_test.exs
@@ -35,6 +35,7 @@ defmodule E2e.Features.LogsSearchTest do
 
       %{
         source: source,
+        user: user,
         matching_message: matching_message,
         non_matching_message: non_matching_message
       }
@@ -54,6 +55,33 @@ defmodule E2e.Features.LogsSearchTest do
       )
       |> assert_has("#logs-list-container", text: matching_message)
       |> refute_has("#logs-list-container", text: non_matching_message)
+    end
+
+    test "loads the remaining previous page of search results", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      pagination_message = "featuresearchpagination#{System.unique_integer([:positive])}"
+
+      log_events =
+        for index <- 1..105 do
+          build(:log_event, source: source, message: "#{pagination_message}-#{index}")
+        end
+
+      assert {:ok, 105} = Backends.ingest_logs(log_events, source)
+      assert :ok = TestUtils.wait_for_postgres_events(source, user, pagination_message, 105)
+
+      conn
+      |> visit(~p"/auth/login/single_tenant")
+      |> assert_path(~p"/dashboard")
+      |> visit(
+        ~p"/sources/#{source.id}/search?#{%{querystring: ~s|event_message:~\"^#{pagination_message}-\"|}}"
+      )
+      |> assert_has("#logs-list li[data-event-id]", count: 100)
+      |> click("#load-more-events-top")
+      |> assert_has("#logs-list li[data-event-id]", count: 105)
+      |> refute_has("#load-more-events-top")
     end
 
     test "shows a missing field error from the search page", %{conn: conn, source: source} do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -22,7 +22,6 @@ defmodule Logflare.LogEventTest do
              drop: false,
              id: id,
              ingested_at: _,
-             is_from_stale_query: nil,
              source_id: source_id,
              valid: true,
              pipeline_error: nil,
@@ -655,7 +654,6 @@ defmodule Logflare.LogEventTest do
              drop: false,
              id: id,
              ingested_at: _,
-             is_from_stale_query: nil,
              valid: true,
              pipeline_error: nil,
              via_rule_id: nil

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -317,7 +317,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
       assert sql =~ ~s|FROM "#{PostgresAdaptor.table_name(so.source)}"|
       assert sql =~ ~s|ORDER BY l0."timestamp" DESC|
       assert sql =~ ~s|LIMIT $1|
-      assert params == [SearchOperations.fetch_limit()]
+      assert params == [SearchOperations.default_limit()]
     end
 
     test "apply_select_rules/1 uses postgres dialect defaults", %{so: so} do
@@ -347,7 +347,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
       {:ok, {sql, params}} = PostgresAdaptor.ecto_to_sql(so.query, [])
 
       assert sql =~ ~s|l0."event_message"|
-      assert params == ["error", SearchOperations.fetch_limit()]
+      assert params == ["error", SearchOperations.default_limit()]
     end
   end
 
@@ -908,7 +908,9 @@ defmodule Logflare.Logs.SearchOperationsTest do
       [base_so: base_so]
     end
 
-    test "do_query/1 uses BigQuery backend adaptor", %{base_so: base_so} do
+    test "do_query/1 fetches the sentinel row but stores canonical page SQL", %{base_so: base_so} do
+      base_so = SearchOperations.apply_query_defaults(base_so)
+
       Mimic.stub(BigQueryAdaptor, :execute_query, fn identifier, query, opts ->
         Process.put(:captured_identifier, identifier)
         Process.put(:captured_query, query)
@@ -917,8 +919,8 @@ defmodule Logflare.Logs.SearchOperationsTest do
         {:ok,
          QueryResult.new([%{"test" => "data"}], %{
            total_rows: 1,
-           query_string: "",
-           bq_params: []
+           query_string: "SELECT * FROM test_table LIMIT ?",
+           bq_params: [SearchOperations.fetch_limit()]
          })}
       end)
 
@@ -935,6 +937,18 @@ defmodule Logflare.Logs.SearchOperationsTest do
       assert user_id == base_so.source.user.id
       assert %Ecto.Query{} = captured_query
       assert captured_opts == [query_type: :search]
+
+      assert {:ok, {executed_sql, executed_params}} =
+               BigQueryAdaptor.ecto_to_sql(captured_query, [])
+
+      assert executed_sql =~ "LIMIT ?"
+      assert List.last(executed_params).parameterValue.value == SearchOperations.fetch_limit()
+
+      assert result_so.sql_string =~ "LIMIT ?"
+
+      assert List.last(result_so.sql_params).parameterValue.value ==
+               SearchOperations.default_limit()
+
       assert result_so.rows == [%{"test" => "data"}]
       refute result_so.error
     end

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -86,6 +86,36 @@ defmodule Logflare.Logs.SearchOperationsTest do
     end
   end
 
+  describe "new_event_page/3" do
+    setup do
+      [
+        so: %SO{
+          chart_data_shape_id: nil,
+          querystring: "",
+          partition_by: :timestamp,
+          chart_rules: [%ChartRule{period: :minute}],
+          tailing?: true
+        }
+      ]
+    end
+
+    test "creates an initial page request for a tailing search", %{so: so} do
+      assert {:ok, %{event_page_request: request}} =
+               SearchOperations.new_event_page(so, :initial, nil)
+
+      assert request == %{intent: :initial, boundary: nil, cursor: nil}
+    end
+
+    test "returns an invalid request error for an invalid page request", %{so: so} do
+      assert {:error, :invalid_request} =
+               %{so | tailing?: false} |> SearchOperations.new_event_page(:previous, nil)
+    end
+
+    test "returns a tailing error for tailing searches", %{so: so} do
+      assert {:error, :tailing} = SearchOperations.new_event_page(so, :previous, nil)
+    end
+  end
+
   describe "chart aggregation query generation" do
     setup %{user: user} do
       source = insert(:source, user: user, bq_table_id: "test_table")
@@ -282,11 +312,12 @@ defmodule Logflare.Logs.SearchOperationsTest do
     test "apply_query_defaults/1 uses the postgres table name", %{so: so} do
       so = SearchOperations.apply_query_defaults(so)
 
-      {:ok, {sql, _params}} = PostgresAdaptor.ecto_to_sql(so.query, [])
+      {:ok, {sql, params}} = PostgresAdaptor.ecto_to_sql(so.query, [])
 
       assert sql =~ ~s|FROM "#{PostgresAdaptor.table_name(so.source)}"|
       assert sql =~ ~s|ORDER BY l0."timestamp" DESC|
-      assert sql =~ ~s|LIMIT 100|
+      assert sql =~ ~s|LIMIT $1|
+      assert params == [SearchOperations.fetch_limit()]
     end
 
     test "apply_select_rules/1 uses postgres dialect defaults", %{so: so} do
@@ -316,7 +347,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
       {:ok, {sql, params}} = PostgresAdaptor.ecto_to_sql(so.query, [])
 
       assert sql =~ ~s|l0."event_message"|
-      assert params == ["error"]
+      assert params == ["error", SearchOperations.fetch_limit()]
     end
   end
 

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -103,12 +103,23 @@ defmodule Logflare.Logs.SearchOperationsTest do
       assert {:ok, %{event_page_request: request}} =
                SearchOperations.new_event_page(so, :initial, nil)
 
-      assert request == %{intent: :initial, boundary: nil, cursor: nil}
+      assert request == %{intent: :initial, cursor: nil}
     end
 
-    test "returns an invalid request error for an invalid page request", %{so: so} do
-      assert {:error, :invalid_request} =
-               %{so | tailing?: false} |> SearchOperations.new_event_page(:previous, nil)
+    test "creates a page request from its cursor", %{so: so} do
+      cursor = %{id: "event-id", timestamp: 1_769_904_600_000_000}
+
+      assert {:ok, %{event_page_request: request}} =
+               %{so | tailing?: false} |> SearchOperations.new_event_page(:next, cursor)
+
+      assert request == %{intent: :next, cursor: cursor}
+    end
+
+    test "returns an invalid request error when a page cursor is missing", %{so: so} do
+      for intent <- [:previous, :next] do
+        assert {:error, :invalid_request} =
+                 %{so | tailing?: false} |> SearchOperations.new_event_page(intent, nil)
+      end
     end
 
     test "returns a tailing error for tailing searches", %{so: so} do

--- a/test/logflare/lql/rules_test.exs
+++ b/test/logflare/lql/rules_test.exs
@@ -565,6 +565,54 @@ defmodule Logflare.Lql.RulesTest do
     end
   end
 
+  describe "extend_timestamp_range/3" do
+    test "replaces a timestamp range and changes only the beginning edge" do
+      timestamp_filter = %FilterRule{
+        path: "timestamp",
+        operator: :range,
+        values: [~N[2026-01-31 00:00:00], ~N[2026-02-01 00:00:00]]
+      }
+
+      extra_timestamp_filter = %FilterRule{
+        path: "timestamp",
+        operator: :<,
+        value: ~N[2026-01-31 12:00:00]
+      }
+
+      message_filter = %FilterRule{path: "event_message", operator: :=, value: "error"}
+      chart_rule = %ChartRule{aggregate: :count, path: "timestamp", period: :minute}
+      select_rule = %SelectRule{path: "metadata.request_id", wildcard: false}
+
+      lql_rules = [
+        timestamp_filter,
+        message_filter,
+        chart_rule,
+        extra_timestamp_filter,
+        select_rule
+      ]
+
+      result =
+        Rules.extend_timestamp_range(
+          lql_rules,
+          :previous,
+          ~N[2026-01-30 12:00:00.000000]
+        )
+
+      assert Rules.get_timestamp_filters(result) == [
+               %FilterRule{
+                 path: "timestamp",
+                 operator: :range,
+                 values: [~N[2026-01-30 12:00:00.000000], ~N[2026-01-31 12:00:00]],
+                 modifiers: %{}
+               }
+             ]
+
+      assert Rules.get_metadata_and_message_filters(result) == [message_filter]
+      assert Rules.get_chart_rule(result) == chart_rule
+      assert Rules.get_select_rules(result) == [select_rule]
+    end
+  end
+
   describe "jump_timestamp/2" do
     test "creates new timestamp range by jumping forwards" do
       timestamp_filter = %FilterRule{

--- a/test/logflare_web/live/search_live/event_context_component_test.exs
+++ b/test/logflare_web/live/search_live/event_context_component_test.exs
@@ -258,8 +258,8 @@ defmodule LogflareWeb.SearchLive.EventContextComponentTest do
 
       html =
         view
-        |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
-        |> element("#logs-list li:first-of-type a", "context")
+        |> TestUtils.wait_for_render("#logs-list li[data-event-id] a")
+        |> element("#logs-list li[data-event-id] a", "context")
         |> render_click()
 
       # Verify the context modal opens
@@ -277,8 +277,8 @@ defmodule LogflareWeb.SearchLive.EventContextComponentTest do
         live_with_redirect(conn, ~p"/sources/#{source.id}/search?tailing=false")
 
       view
-      |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
-      |> element("#logs-list li:first-of-type a", "context")
+      |> TestUtils.wait_for_render("#logs-list li[data-event-id] a")
+      |> element("#logs-list li[data-event-id] a", "context")
       |> render_click()
 
       view

--- a/test/logflare_web/live/search_live/event_pagination_test.exs
+++ b/test/logflare_web/live/search_live/event_pagination_test.exs
@@ -1,0 +1,71 @@
+defmodule LogflareWeb.SearchLive.EventPaginationTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Logs.EventPage
+  alias LogflareWeb.SearchLive.EventPagination
+
+  describe "buttons/2" do
+    test "determines visibility from cursor and exhaustion state" do
+      previous_cursor = %{id: "previous", timestamp: 1}
+      next_cursor = %{id: "next", timestamp: 2}
+
+      pagination =
+        EventPagination.new()
+        |> EventPagination.complete_initial(%EventPage{
+          rows: [],
+          request: %{intent: :initial, boundary: nil, cursor: nil},
+          cursor: previous_cursor,
+          next_cursor: next_cursor,
+          has_more?: true
+        })
+
+      buttons =
+        EventPagination.buttons(pagination,
+          cursors: %{previous: previous_cursor, next: next_cursor},
+          tailing?: false,
+          loading?: false,
+          next_available?: true
+        )
+
+      assert %{
+               previous: %{state: :ready, cursor: ^previous_cursor},
+               next: %{state: :ready, cursor: ^next_cursor}
+             } = buttons
+
+      hidden_next_buttons =
+        EventPagination.buttons(pagination,
+          cursors: %{previous: previous_cursor, next: next_cursor},
+          tailing?: false,
+          loading?: false,
+          next_available?: false
+        )
+
+      assert %{next: %{state: :hidden, cursor: ^next_cursor}} = hidden_next_buttons
+
+      pagination =
+        EventPagination.complete_page(
+          pagination,
+          %EventPage{
+            rows: [],
+            request: %{intent: :next, boundary: nil, cursor: next_cursor},
+            cursor: next_cursor,
+            has_more?: false
+          },
+          :next
+        )
+
+      buttons =
+        EventPagination.buttons(pagination,
+          cursors: %{previous: previous_cursor, next: next_cursor},
+          tailing?: false,
+          loading?: false,
+          next_available?: true
+        )
+
+      assert %{
+               previous: %{state: :ready, cursor: ^previous_cursor},
+               next: %{state: :hidden, cursor: ^next_cursor}
+             } = buttons
+    end
+  end
+end

--- a/test/logflare_web/live/search_live/event_pagination_test.exs
+++ b/test/logflare_web/live/search_live/event_pagination_test.exs
@@ -13,7 +13,7 @@ defmodule LogflareWeb.SearchLive.EventPaginationTest do
         EventPagination.new()
         |> EventPagination.complete_initial(%EventPage{
           rows: [],
-          request: %{intent: :initial, boundary: nil, cursor: nil},
+          request: %{intent: :initial, cursor: nil},
           cursor: previous_cursor,
           next_cursor: next_cursor,
           has_more?: true
@@ -47,7 +47,7 @@ defmodule LogflareWeb.SearchLive.EventPaginationTest do
           pagination,
           %EventPage{
             rows: [],
-            request: %{intent: :next, boundary: nil, cursor: next_cursor},
+            request: %{intent: :next, cursor: next_cursor},
             cursor: next_cursor,
             has_more?: false
           },

--- a/test/logflare_web/live/search_live/log_event_components_test.exs
+++ b/test/logflare_web/live/search_live/log_event_components_test.exs
@@ -13,6 +13,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
 
   @default_attrs %{
     search_op_log_events: nil,
+    log_events: [],
     last_query_completed_at: nil,
     loading: false,
     search_timezone: "Etc/UTC",
@@ -62,7 +63,9 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
           | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events
+            search_op_log_events: search_op_log_events,
+            lql_rules: lql_rules,
+            log_events: stream_entries(search_op_log_events.rows)
         })
 
       assert html =~ "Log message 1"
@@ -77,7 +80,7 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
             search_op_log_events: %{rows: []}
         })
 
-      assert html =~ ~r|id="logs-list" class="(.*)blurred"|
+      assert html =~ ~r|id="logs-list".*class="(.*)blurred"|
     end
 
     test "renders empty state when no log events", %{source: source, lql_rules: lql_rules} do
@@ -114,7 +117,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
           | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events
+            search_op_log_events: search_op_log_events,
+            log_events: stream_entries(search_op_log_events.rows)
         })
 
       assert html =~ "(empty event message)"
@@ -150,7 +154,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
           | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events
+            search_op_log_events: search_op_log_events,
+            log_events: stream_entries(search_op_log_events.rows)
         })
 
       assert html =~ "Normal log message"
@@ -305,5 +310,26 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
 
              """
     end
+  end
+
+  defp stream_entries(log_events) do
+    log_events
+    |> Enum.with_index()
+    |> Enum.map(fn {log_event, index} -> {"log-events-#{index}", log_event} end)
+  end
+
+  defp pagination_search_op(source, lql_rules, timestamps) do
+    %SearchOperation{
+      chart_data_shape_id: nil,
+      partition_by: :timestamp,
+      querystring: "",
+      source: source,
+      lql_rules: lql_rules,
+      lql_ts_filters: [
+        %FilterRule{path: "timestamp", operator: :range, values: timestamps}
+      ],
+      search_timezone: "Etc/UTC",
+      tailing?: false
+    }
   end
 end

--- a/test/logflare_web/live/search_live/log_event_components_test.exs
+++ b/test/logflare_web/live/search_live/log_event_components_test.exs
@@ -5,8 +5,10 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
   import Phoenix.Component
 
   alias Logflare.Lql
+  alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Lql.Rules.SelectRule
   alias Logflare.LogEvent
+  alias Logflare.Logs.SearchOperation
   alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
   alias LogflareWeb.SearchLive.LogEventComponents
@@ -14,14 +16,13 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
   @default_attrs %{
     search_op_log_events: nil,
     log_events: [],
-    last_query_completed_at: nil,
     loading: false,
+    pagination_buttons: %{
+      previous: %{state: :hidden, cursor: nil},
+      next: %{state: :hidden, cursor: nil}
+    },
     search_timezone: "Etc/UTC",
-    tailing?: false,
-    querystring: "",
-    lql_rules: [],
-    source: nil,
-    search_op: nil
+    tailing?: false
   }
 
   describe "results_list/1" do
@@ -35,17 +36,16 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
           bigquery_clustering_fields: "session_id"
         )
 
-      search_op_log_events = %{
-        rows: [
-          build(:log_event, message: "Log message 1", metadata: %{user_id: 123}, source: source)
-        ]
-      }
-
       {:ok, lql_rules} =
         Lql.decode(
           "c:count(*) c:group_by(t::minute)",
           SchemaBuilder.initial_table_schema()
         )
+
+      search_op_log_events =
+        search_operation(source, lql_rules, [
+          build(:log_event, message: "Log message 1", metadata: %{user_id: 123}, source: source)
+        ])
 
       [
         source: source,
@@ -54,41 +54,137 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
       ]
     end
 
-    test "renders log events list", %{
-      source: source,
-      search_op_log_events: search_op_log_events,
-      lql_rules: lql_rules
-    } do
+    test "renders log events list", %{search_op_log_events: search_op_log_events} do
       html =
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
-          | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events,
-            lql_rules: lql_rules,
+          | search_op_log_events: search_op_log_events,
             log_events: stream_entries(search_op_log_events.rows)
         })
 
       assert html =~ "Log message 1"
+      assert html =~ ~s(data-tailing="false")
     end
 
-    test "renders loading state", %{source: source, lql_rules: lql_rules} do
+    test "renders loading state", %{search_op_log_events: search_op_log_events} do
       html =
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
           | loading: true,
-            search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: %{rows: []}
+            search_op_log_events: %{search_op_log_events | rows: []}
         })
 
       assert html =~ ~r|id="logs-list".*class="(.*)blurred"|
     end
 
-    test "renders empty state when no log events", %{source: source, lql_rules: lql_rules} do
+    test "renders the previous-page pagination button", %{
+      source: source,
+      search_op_log_events: search_op_log_events,
+      lql_rules: lql_rules
+    } do
+      search_op =
+        pagination_search_op(
+          source,
+          lql_rules,
+          [~N[2026-01-01 00:00:00], ~N[2026-01-01 01:00:00]]
+        )
+
       html =
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
-          | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            loading: false,
+          | search_op_log_events: search_op,
+            log_events: stream_entries(search_op_log_events.rows),
+            pagination_buttons: %{
+              previous: %{state: :ready, cursor: %{id: "previous", timestamp: 1}},
+              next: %{state: :hidden, cursor: nil}
+            }
+        })
+
+      assert html =~ ~s(id="load-more-events-top")
+      assert html =~ ~s(phx-value-intent="previous")
+      assert html =~ ~s(phx-value-cursor-id="previous")
+      assert html =~ ~s(phx-value-cursor-timestamp="1")
+
+      [button] =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("#load-more-events-top span")
+        |> Enum.filter(&(Floki.text(&1) == "Load more"))
+
+      refute button
+             |> Floki.attribute("class")
+             |> Enum.join(" ")
+             |> String.split()
+             |> Enum.member?("phx-click-loading")
+    end
+
+    test "keeps the previous-page button hidden without a cursor", %{
+      search_op_log_events: search_op_log_events
+    } do
+      html =
+        render_component(&LogEventComponents.results_list/1, %{
+          @default_attrs
+          | search_op_log_events: search_op_log_events,
+            log_events: stream_entries(search_op_log_events.rows),
+            pagination_buttons: %{
+              previous: %{state: :hidden, cursor: nil},
+              next: %{state: :hidden, cursor: nil}
+            }
+        })
+
+      document = Floki.parse_fragment!(html)
+
+      assert [_button] =
+               Floki.find(document, "div.tw-hidden > #load-more-events-top[disabled]")
+
+      assert [_button] =
+               Floki.find(document, "div.tw-hidden > #load-more-events-bottom[disabled]")
+    end
+
+    test "disables pagination buttons while the search is loading", %{
+      source: source,
+      search_op_log_events: search_op_log_events,
+      lql_rules: lql_rules
+    } do
+      search_op =
+        pagination_search_op(
+          source,
+          lql_rules,
+          [~N[2026-01-01 00:00:00], ~N[2026-01-01 01:00:00]]
+        )
+
+      html =
+        render_component(&LogEventComponents.results_list/1, %{
+          @default_attrs
+          | search_op_log_events: search_op,
+            log_events: stream_entries(search_op_log_events.rows),
+            loading: true,
+            pagination_buttons: %{
+              previous: %{state: :disabled, cursor: %{id: "previous", timestamp: 1}},
+              next: %{state: :disabled, cursor: %{id: "next", timestamp: 2}}
+            }
+        })
+
+      document = Floki.parse_fragment!(html)
+
+      assert [_top_button] =
+               Floki.find(
+                 document,
+                 "#load-more-events-top[disabled][phx-click='load_events']"
+               )
+
+      assert [_bottom_button] =
+               Floki.find(
+                 document,
+                 "#load-more-events-bottom[disabled][phx-click='load_events'][phx-value-intent='next']"
+               )
+    end
+
+    test "renders empty state when no log events" do
+      html =
+        render_component(&LogEventComponents.results_list/1, %{
+          @default_attrs
+          | loading: false,
             search_op_log_events: nil
         })
 
@@ -111,13 +207,12 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         valid: true
       }
 
-      search_op_log_events = %{rows: [log_event_without_message]}
+      search_op_log_events = search_operation(source, lql_rules, [log_event_without_message])
 
       html =
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
-          | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events,
+          | search_op_log_events: search_op_log_events,
             log_events: stream_entries(search_op_log_events.rows)
         })
 
@@ -148,13 +243,13 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
         valid: true
       }
 
-      search_op_log_events = %{rows: [normal_log_event, log_event_without_message]}
+      search_op_log_events =
+        search_operation(source, lql_rules, [normal_log_event, log_event_without_message])
 
       html =
         render_component(&LogEventComponents.results_list/1, %{
           @default_attrs
-          | search_op: %{source: source, lql_rules: lql_rules, search_timezone: "Etc/UTC"},
-            search_op_log_events: search_op_log_events,
+          | search_op_log_events: search_op_log_events,
             log_events: stream_entries(search_op_log_events.rows)
         })
 
@@ -316,6 +411,19 @@ defmodule LogflareWeb.SearchLive.LogEventComponentsTest do
     log_events
     |> Enum.with_index()
     |> Enum.map(fn {log_event, index} -> {"log-events-#{index}", log_event} end)
+  end
+
+  defp search_operation(source, lql_rules, rows) do
+    %SearchOperation{
+      chart_data_shape_id: nil,
+      partition_by: :timestamp,
+      querystring: "",
+      rows: rows,
+      source: source,
+      lql_rules: lql_rules,
+      search_timezone: "Etc/UTC",
+      tailing?: false
+    }
   end
 
   defp pagination_search_op(source, lql_rules, timestamps) do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -2069,16 +2069,31 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
     setup [:setup_user_session]
 
-    test "loading the next page appends newer rows and updates the URL range", %{
-      conn: conn,
-      events: events,
-      querystring: querystring,
-      source: source
-    } do
-      view = open_pagination_search(conn, source, querystring, Enum.at(events, 101))
+    test "load next page starts after newest fetched event and updates the URL range",
+         %{
+           conn: conn,
+           events: events,
+           message_prefix: message_prefix,
+           querystring: querystring,
+           source: source,
+           user: user
+         } do
+      newest_fetched_event = Enum.at(events, 101)
+      view = open_pagination_search(conn, source, querystring, newest_fetched_event)
 
       initial_ids = events |> Enum.slice(2, 100) |> log_event_dom_ids()
       assert visible_log_event_ids(view) == initial_ids
+
+      late_event =
+        build(:log_event,
+          source: source,
+          id: "#{message_prefix}-late",
+          timestamp: newest_fetched_event.body["timestamp"] + 500_000,
+          message: "#{message_prefix} late"
+        )
+
+      backend = Backends.get_default_backend(user)
+      assert {:ok, 1} = PostgresAdaptor.insert_log_events(source, backend, [late_event])
 
       view
       |> element("#load-more-events-bottom")
@@ -2089,7 +2104,13 @@ defmodule LogflareWeb.Source.SearchLVTest do
       view
       |> TestUtils.wait_for_render(log_event_selector(List.last(events)))
 
-      expected_ids = events |> Enum.slice(2, 101) |> log_event_dom_ids()
+      expected_ids =
+        events
+        |> Enum.slice(2, 101)
+        |> Kernel.++([late_event])
+        |> Enum.sort_by(& &1.body["timestamp"])
+        |> log_event_dom_ids()
+
       assert visible_log_event_ids(view) == expected_ids
     end
 

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1716,8 +1716,12 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       {redirect_path, _flash} = assert_redirect(view)
       assert redirect_path =~ "/query?q=SELECT"
-      assert redirect_path =~ "something123"
-      assert redirect_path =~ source.name
+
+      %{"q" => query} = URI.new!(redirect_path) |> Map.get(:query) |> URI.decode_query()
+
+      assert query =~ "something123"
+      assert query =~ source.name
+      assert query =~ "LIMIT 100"
     end
 
     test "create new alert, endpoint from search", %{
@@ -1749,6 +1753,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
         assert query =~ "SELECT t0.timestamp, t0.id, t0.event_message FROM `#{source.name}`"
         assert query =~ "something123"
         assert query =~ source.name
+        assert query =~ "LIMIT 100"
         assert name == source.name
       end)
     end

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -13,6 +13,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
   alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.Backends.QueryError
   alias Logflare.Google.BigQuery.SchemaUtils
+  alias Logflare.Lql.Rules
   alias Logflare.SingleTenant
   alias Logflare.Sources.Source.BigQuery.Schema
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
@@ -369,7 +370,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
         )
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       assert view |> element(".subhead") |> render() =~ "(+08:00)"
       assert render(view) =~ "something123"
@@ -520,7 +521,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert html =~ "/search"
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       html = view |> element("#logs-list-container") |> render()
       assert html =~ "some event message"
@@ -778,6 +779,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert_receive {:event_query, _query}
       assert_receive {:agg_query, _query}
 
+      TestUtils.retry_assert(fn ->
+        assert view |> element("#logs-list-container") |> render() =~ "Extend search"
+      end)
+
       html = view |> element("#logs-list-container") |> render()
 
       assert html =~ "No events matching your query"
@@ -817,7 +822,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       allow_sandbox(search_executor_pid)
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       html = view |> element("#logs-list-container") |> render()
       assert html =~ "some event message"
@@ -839,7 +844,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       })
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       render_change(view, :start_search, %{
         "querystring" => "c:count(*) c:group_by(t::minute) error crasher"
@@ -847,7 +852,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # wait for async search task to complete
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       html = view |> element("#logs-list-container") |> render()
 
@@ -923,7 +928,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       allow_sandbox(search_executor_pid)
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       # post-init fetching
       view
@@ -935,7 +940,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
         })
 
         view
-        |> TestUtils.wait_for_render("#logs-list-container li")
+        |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
         html = view |> element("#logs-list-container") |> render()
 
@@ -947,8 +952,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       stub(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, fn _conn, _proj_id, opts ->
         params = opts[:body].queryParameters
 
-        if length(params) > 2 do
-          assert Enum.any?(params, fn param -> param.parameterValue.value == "MINUTE" end)
+        if Enum.any?(params, fn param -> param.parameterValue.value == "MINUTE" end) do
           # truncate by 120 minutes
           assert Enum.any?(params, fn param -> param.parameterValue.value == 120 end)
         end
@@ -963,7 +967,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # post-init fetching
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       render_change(view, :start_search, %{
         "querystring" => @default_querystring
@@ -971,7 +975,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # wait for async search task to complete
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       html = view |> element("#logs-list-container") |> render()
       assert html =~ "some event message"
@@ -1037,16 +1041,16 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # wait for async search task to complete
       view
-      |> TestUtils.wait_for_render("#logs-list li:first-of-type a[href^='/sources']")
+      |> TestUtils.wait_for_render("#logs-list li[data-event-id] a[href^='/sources']")
 
       assert view
-             |> element("#logs-list li:first-of-type a[href^='/sources']", "permalink")
+             |> element("#logs-list li[data-event-id] a[href^='/sources']", "permalink")
              |> render() =~ ~r/timestamp=\d{4}-\d{2}-\d{2}/
 
       link =
         view
         |> element(
-          "#logs-list li:first-of-type a[phx-value-log-event-id='some-uuid']",
+          "#logs-list li[data-event-id] a[phx-value-log-event-id='some-uuid']",
           "view"
         )
         |> render()
@@ -1170,7 +1174,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # wait for async search task to complete
       view
-      |> TestUtils.wait_for_render("li:first-of-type a[phx-value-log-event-id='some-uuid']")
+      |> TestUtils.wait_for_render("li[data-event-id] a[phx-value-log-event-id='some-uuid']")
 
       pid = self()
 
@@ -1183,7 +1187,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       TestUtils.retry_assert(fn ->
         view
-        |> element("li:first-of-type a[phx-value-log-event-id='some-uuid']", "view")
+        |> element("li[data-event-id] a[phx-value-log-event-id='some-uuid']", "view")
         |> render_click()
       end)
 
@@ -1234,10 +1238,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       allow_sandbox(search_executor_pid)
 
       view
-      |> TestUtils.wait_for_render("li:first-of-type a[phx-value-log-event-id='some-uuid']")
+      |> TestUtils.wait_for_render("li[data-event-id] a[phx-value-log-event-id='some-uuid']")
 
       view
-      |> element("li:first-of-type a[phx-value-log-event-id='some-uuid']", "view")
+      |> element("li[data-event-id] a[phx-value-log-event-id='some-uuid']", "view")
       |> render_click()
 
       TestUtils.retry_assert(fn ->
@@ -1278,10 +1282,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       Ecto.Adapters.SQL.Sandbox.allow(Logflare.Repo, self(), search_executor_pid)
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       view
-      |> element("li:first-of-type a[phx-value-log-event-id='qf-uuid']", "view")
+      |> element("li[data-event-id] a[phx-value-log-event-id='qf-uuid']", "view")
       |> render_click()
 
       TestUtils.retry_assert(fn ->
@@ -1331,11 +1335,11 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # Wait for search to complete
       view
-      |> TestUtils.wait_for_render("li:first-of-type a[phx-value-log-event-id='some-uuid']")
+      |> TestUtils.wait_for_render("li[data-event-id] a[phx-value-log-event-id='some-uuid']")
 
       # First render builds a LogEvent and caches it
       view
-      |> element("li:first-of-type a[phx-value-log-event-id='some-uuid']", "view")
+      |> element("li[data-event-id] a[phx-value-log-event-id='some-uuid']", "view")
       |> render_click()
 
       # wait for cache to populate
@@ -1344,7 +1348,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # Second render loads the LogEvent from cache
       assert view
-             |> element("li:first-of-type a[phx-value-log-event-id='some-uuid']", "view")
+             |> element("li[data-event-id] a[phx-value-log-event-id='some-uuid']", "view")
              |> render_click()
     end
 
@@ -1581,7 +1585,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       # post-init fetching
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       assert get_view_assigns(view).tailing?
       render_click(view, "soft_pause", %{})
@@ -1624,7 +1628,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
     } do
       {:ok, view, _html} = live_with_redirect(conn, ~p"/sources/#{source.id}/search")
 
-      view |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
+      view |> TestUtils.wait_for_render("#logs-list li[data-event-id] a")
       assert get_view_assigns(view).tailing?
 
       render_click(view, "soft_pause", %{})
@@ -1643,7 +1647,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
     } do
       {:ok, view, _html} = live_with_redirect(conn, ~p"/sources/#{source.id}/search")
 
-      view |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
+      view |> TestUtils.wait_for_render("#logs-list li[data-event-id] a")
       assert get_view_assigns(view).tailing?
 
       render_click(view, "open_log_event_modal", %{})
@@ -1910,114 +1914,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       })
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       assert view |> element("#logs-list-container") |> render() =~ matching_message
       refute view |> element("#logs-list-container") |> render() =~ non_matching_message
-    end
-
-    test "tailing retains rows on an empty result", %{conn: conn, source: source} do
-      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
-
-      view
-      |> TestUtils.wait_for_render("#logs-list-container li")
-
-      events_op = get_view_assigns(view).search_op_log_events
-      initial_log_event_ids = log_event_ids(view)
-
-      send(view.pid, {:search_result, %{events: %{events_op | rows: []}}})
-
-      assert log_event_ids(view) == initial_log_event_ids
-    end
-
-    test "a page result preserves canonical search metadata", %{conn: conn, source: source} do
-      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
-
-      view
-      |> TestUtils.wait_for_render("#logs-list-container li")
-
-      canonical_search_op = get_view_assigns(view).search_op
-      canonical_events_op = get_view_assigns(view).search_op_log_events
-      request = %{intent: :within_range, boundary: nil, cursor: %{id: "event-1", timestamp: 1}}
-
-      page_event =
-        build(:log_event,
-          source: source,
-          id: "page-event",
-          timestamp: 0,
-          message: "older page event"
-        )
-
-      :sys.replace_state(view.pid, fn state ->
-        socket =
-          Phoenix.Component.assign(state.socket,
-            event_page_loading_request: %{intent: :within_range, cursor: request.cursor}
-          )
-
-        %{state | socket: socket}
-      end)
-
-      send(
-        view.pid,
-        {:search_result,
-         %{
-           event_page: %EventPage{
-             rows: [page_event],
-             request: request,
-             cursor: %{id: "page-event", timestamp: 0},
-             has_more?: false
-           }
-         }}
-      )
-
-      view
-      |> TestUtils.wait_for_render("#log-events-page-event-0")
-
-      assigns = get_view_assigns(view)
-      assert assigns.search_op == canonical_search_op
-      assert assigns.search_op_log_events == canonical_events_op
-      assert assigns.event_page_loading_request == nil
-      refute assigns.event_page_within_range_available?
-    end
-
-    test "an exhausted unbounded next page disables further pagination", %{
-      conn: conn,
-      source: source
-    } do
-      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
-
-      view
-      |> TestUtils.wait_for_render("#logs-list-container li")
-
-      request = %{intent: :extend_next, boundary: nil, cursor: %{id: "event-1", timestamp: 1}}
-
-      :sys.replace_state(view.pid, fn state ->
-        socket =
-          Phoenix.Component.assign(state.socket,
-            event_page_loading_request: %{intent: :extend_next, cursor: request.cursor}
-          )
-
-        %{state | socket: socket}
-      end)
-
-      send(
-        view.pid,
-        {:search_result,
-         %{
-           event_page: %EventPage{
-             rows: [],
-             request: request,
-             cursor: nil,
-             has_more?: false
-           }
-         }}
-      )
-
-      TestUtils.retry_assert(fn ->
-        assigns = get_view_assigns(view)
-        assert assigns.next_events_exhausted?
-        assert assigns.event_page_loading_request == nil
-      end)
     end
 
     test "tailing inserts a late event at its timestamp position", %{
@@ -2099,8 +1999,8 @@ defmodule LogflareWeb.Source.SearchLVTest do
       render_change(view, :start_search, %{"querystring" => matching_message})
 
       assert view
-             |> TestUtils.wait_for_render("#logs-list > li")
-             |> has_element?("#logs-list > li", matching_message)
+             |> TestUtils.wait_for_render("#logs-list > li[data-event-id]")
+             |> has_element?("#logs-list > li[data-event-id]", matching_message)
 
       html =
         view
@@ -2109,8 +2009,144 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       assert html
              |> Floki.parse_document!()
-             |> Floki.find("#logs-list > li")
+             |> Floki.find("#logs-list > li[data-event-id]")
              |> Enum.empty?()
+    end
+  end
+
+  describe "event pagination with postgres backend" do
+    TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
+
+    setup do
+      start_supervised!(Logflare.SystemMetricsSup)
+
+      user = SingleTenant.get_default_user()
+      source = insert(:source, user: user)
+      plan = SingleTenant.get_default_plan()
+      insert(:source_schema, source: source)
+
+      assert :ok = Backends.ensure_source_sup_started(source)
+
+      message_prefix = "postgres-pagination-#{System.unique_integer([:positive])}"
+
+      first_timestamp =
+        DateTime.utc_now()
+        |> DateTime.add(-1_000, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_unix(:microsecond)
+
+      events =
+        Enum.map(1..103, fn sequence ->
+          build(:log_event,
+            source: source,
+            id: "#{message_prefix}-#{sequence}",
+            timestamp: first_timestamp + sequence * 2_000_000,
+            message: "#{message_prefix} #{sequence}"
+          )
+        end)
+
+      assert {:ok, 103} = Backends.ingest_logs(events, source)
+      assert :ok = TestUtils.wait_for_postgres_events(source, user, message_prefix, 103)
+
+      range_start = div(Enum.at(events, 1).body["timestamp"], 1_000_000) - 1
+      range_end = div(Enum.at(events, 101).body["timestamp"], 1_000_000) + 1
+      querystring = "#{message_prefix} t:#{range_start}..#{range_end}"
+
+      %{
+        events: events,
+        message_prefix: message_prefix,
+        plan: plan,
+        querystring: querystring,
+        source: source,
+        user: user
+      }
+    end
+
+    setup [:setup_user_session]
+
+    test "loading the next page appends newer rows and updates the URL range", %{
+      conn: conn,
+      events: events,
+      querystring: querystring,
+      source: source
+    } do
+      view = open_pagination_search(conn, source, querystring, Enum.at(events, 101))
+
+      initial_ids = events |> Enum.slice(2, 100) |> log_event_dom_ids()
+      assert visible_log_event_ids(view) == initial_ids
+
+      view
+      |> element("#load-more-events-bottom")
+      |> render_click()
+
+      assert_timestamp_range_patch(view, source, querystring, :next, List.last(events))
+
+      view
+      |> TestUtils.wait_for_render(log_event_selector(List.last(events)))
+
+      expected_ids = events |> Enum.slice(2, 101) |> log_event_dom_ids()
+      assert visible_log_event_ids(view) == expected_ids
+    end
+
+    test "loading the previous page prepends older rows and updates the URL range", %{
+      conn: conn,
+      events: events,
+      querystring: querystring,
+      source: source
+    } do
+      view = open_pagination_search(conn, source, querystring, Enum.at(events, 101))
+
+      initial_ids = events |> Enum.slice(2, 100) |> log_event_dom_ids()
+      assert visible_log_event_ids(view) == initial_ids
+
+      view
+      |> element("#load-more-events-top")
+      |> render_click()
+
+      assert_timestamp_range_patch(view, source, querystring, :previous, List.first(events))
+
+      view
+      |> TestUtils.wait_for_render(log_event_selector(List.first(events)))
+
+      expected_ids = events |> Enum.take(102) |> log_event_dom_ids()
+      assert visible_log_event_ids(view) == expected_ids
+    end
+
+    test "the previous button is hidden after its page is exhausted", %{
+      conn: conn,
+      events: events,
+      querystring: querystring,
+      source: source
+    } do
+      view = open_pagination_search(conn, source, querystring, Enum.at(events, 101))
+
+      assert has_element?(view, "#load-more-events-top:not([disabled])")
+
+      view
+      |> element("#load-more-events-top")
+      |> render_click()
+
+      view
+      |> TestUtils.wait_for_render(log_event_selector(List.first(events)))
+
+      assert has_element?(view, "div.tw-hidden > #load-more-events-top[disabled]")
+    end
+
+    test "pagination buttons are hidden while tailing", %{
+      conn: conn,
+      events: events,
+      message_prefix: message_prefix,
+      source: source
+    } do
+      view =
+        open_pagination_search(conn, source, message_prefix, List.last(events), tailing?: true)
+
+      assert has_element?(view, "div.tw-hidden > #load-more-events-top[disabled]")
+      assert has_element?(view, "div.tw-hidden > #load-more-events-bottom[disabled]")
+
+      render_click(view, "soft_pause", %{})
+
+      assert has_element?(view, "#load-more-events-top:not([disabled])")
     end
   end
 
@@ -2267,7 +2303,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
 
       view
-      |> TestUtils.wait_for_render("#logs-list-container li")
+      |> TestUtils.wait_for_render("#logs-list-container li[data-event-id]")
 
       assert view
              |> render_change(:start_search, %{
@@ -2795,12 +2831,75 @@ defmodule LogflareWeb.Source.SearchLVTest do
     :sys.get_state(view.pid).socket.assigns
   end
 
+  defp open_pagination_search(conn, source, querystring, expected_event, options \\ []) do
+    tailing? = Keyword.get(options, :tailing?, false)
+
+    {:ok, view, _html} =
+      live_with_redirect(
+        conn,
+        Routes.live_path(conn, SearchLV, source.id,
+          querystring: querystring,
+          tailing?: tailing?
+        )
+      )
+
+    %{executor_pid: search_executor_pid} = get_view_assigns(view)
+    allow_sandbox(search_executor_pid)
+
+    TestUtils.wait_for_render(view, log_event_selector(expected_event))
+  end
+
+  defp assert_timestamp_range_patch(view, source, original_querystring, direction, event) do
+    %URI{path: path, query: query} =
+      assert_patch(view)
+      |> URI.parse()
+
+    params = URI.decode_query(query)
+    patched_querystring = params["querystring"]
+
+    assert path == "/sources/#{source.id}/search"
+    assert params["tailing?"] == "false"
+    refute patched_querystring == original_querystring
+
+    expected_timestamp =
+      event.body["timestamp"]
+      |> DateTime.from_unix!(:microsecond)
+      |> DateTime.to_naive()
+
+    TestUtils.retry_assert(fn ->
+      assigns = get_view_assigns(view)
+      assert assigns.querystring == patched_querystring
+
+      timestamp_range = Rules.effective_timestamp_range(assigns.lql_rules)
+      assert Map.fetch!(timestamp_range, range_edge(direction)) == expected_timestamp
+    end)
+  end
+
+  defp range_edge(:previous), do: :min
+  defp range_edge(:next), do: :max
+
+  defp log_event_selector(event) do
+    "#log-events-#{event.id}-#{event.body["timestamp"]}"
+  end
+
+  defp log_event_dom_ids(events) do
+    Enum.map(events, fn event ->
+      "log-events-#{event.id}-#{event.body["timestamp"]}"
+    end)
+  end
+
+  defp visible_log_event_ids(view) do
+    view
+    |> log_event_ids()
+    |> Enum.reverse()
+  end
+
   defp log_event_ids(view) do
     view
     |> element("#logs-list")
     |> render()
     |> Floki.parse_document!()
-    |> Floki.find("#logs-list > li")
+    |> Floki.find("#logs-list > li[data-event-id]")
     |> Floki.attribute("id")
   end
 

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1856,7 +1856,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
     end
   end
 
-  describe "single tenant searching with postgres backend" do
+  describe "search tasks with postgres backend" do
     TestUtils.setup_single_tenant(seed_user: true, backend_type: :postgres)
 
     setup do
@@ -1914,6 +1914,203 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
       assert view |> element("#logs-list-container") |> render() =~ matching_message
       refute view |> element("#logs-list-container") |> render() =~ non_matching_message
+    end
+
+    test "tailing retains rows on an empty result", %{conn: conn, source: source} do
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      view
+      |> TestUtils.wait_for_render("#logs-list-container li")
+
+      events_op = get_view_assigns(view).search_op_log_events
+      initial_log_event_ids = log_event_ids(view)
+
+      send(view.pid, {:search_result, %{events: %{events_op | rows: []}}})
+
+      assert log_event_ids(view) == initial_log_event_ids
+    end
+
+    test "a page result preserves canonical search metadata", %{conn: conn, source: source} do
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      view
+      |> TestUtils.wait_for_render("#logs-list-container li")
+
+      canonical_search_op = get_view_assigns(view).search_op
+      canonical_events_op = get_view_assigns(view).search_op_log_events
+      request = %{intent: :within_range, boundary: nil, cursor: %{id: "event-1", timestamp: 1}}
+
+      page_event =
+        build(:log_event,
+          source: source,
+          id: "page-event",
+          timestamp: 0,
+          message: "older page event"
+        )
+
+      :sys.replace_state(view.pid, fn state ->
+        socket =
+          Phoenix.Component.assign(state.socket,
+            event_page_loading_request: %{intent: :within_range, cursor: request.cursor}
+          )
+
+        %{state | socket: socket}
+      end)
+
+      send(
+        view.pid,
+        {:search_result,
+         %{
+           event_page: %EventPage{
+             rows: [page_event],
+             request: request,
+             cursor: %{id: "page-event", timestamp: 0},
+             has_more?: false
+           }
+         }}
+      )
+
+      view
+      |> TestUtils.wait_for_render("#log-events-page-event-0")
+
+      assigns = get_view_assigns(view)
+      assert assigns.search_op == canonical_search_op
+      assert assigns.search_op_log_events == canonical_events_op
+      assert assigns.event_page_loading_request == nil
+      refute assigns.event_page_within_range_available?
+    end
+
+    test "an exhausted unbounded next page disables further pagination", %{
+      conn: conn,
+      source: source
+    } do
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      view
+      |> TestUtils.wait_for_render("#logs-list-container li")
+
+      request = %{intent: :extend_next, boundary: nil, cursor: %{id: "event-1", timestamp: 1}}
+
+      :sys.replace_state(view.pid, fn state ->
+        socket =
+          Phoenix.Component.assign(state.socket,
+            event_page_loading_request: %{intent: :extend_next, cursor: request.cursor}
+          )
+
+        %{state | socket: socket}
+      end)
+
+      send(
+        view.pid,
+        {:search_result,
+         %{
+           event_page: %EventPage{
+             rows: [],
+             request: request,
+             cursor: nil,
+             has_more?: false
+           }
+         }}
+      )
+
+      TestUtils.retry_assert(fn ->
+        assigns = get_view_assigns(view)
+        assert assigns.next_events_exhausted?
+        assert assigns.event_page_loading_request == nil
+      end)
+    end
+
+    test "tailing inserts a late event at its timestamp position", %{
+      conn: conn,
+      source: source
+    } do
+      timestamp_a = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+      timestamp_b = timestamp_a + 1
+      timestamp_c = timestamp_a + 2
+      message_prefix = "postgres-tail-order-#{System.unique_integer([:positive])}"
+
+      event_a =
+        build(:log_event,
+          source: source,
+          id: "ordered-event-a",
+          timestamp: timestamp_a,
+          message: "#{message_prefix} A"
+        )
+
+      event_b =
+        build(:log_event,
+          source: source,
+          id: "ordered-event-b",
+          timestamp: timestamp_b,
+          message: "#{message_prefix} B"
+        )
+
+      event_c =
+        build(:log_event,
+          source: source,
+          id: "ordered-event-c",
+          timestamp: timestamp_c,
+          message: "#{message_prefix} C"
+        )
+
+      assert {:ok, 2} = Backends.ingest_logs([event_c, event_a], source)
+
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      render_change(view, :start_search, %{"querystring" => message_prefix})
+
+      view
+      |> TestUtils.wait_for_render("#log-events-ordered-event-a-#{timestamp_a}")
+
+      assert log_event_ids(view) ==
+               [
+                 "log-events-ordered-event-c-#{timestamp_c}",
+                 "log-events-ordered-event-a-#{timestamp_a}"
+               ]
+
+      assert {:ok, 1} = Backends.ingest_logs([event_b], source)
+
+      send(view.pid, :schedule_tail_search)
+
+      view
+      |> TestUtils.wait_for_render("#log-events-ordered-event-b-#{timestamp_b}")
+
+      assert log_event_ids(view) ==
+               [
+                 "log-events-ordered-event-c-#{timestamp_c}",
+                 "log-events-ordered-event-b-#{timestamp_b}",
+                 "log-events-ordered-event-a-#{timestamp_a}"
+               ]
+    end
+
+    test "changing timezone immediately clears displayed search results", %{
+      conn: conn,
+      source: source,
+      matching_message: matching_message
+    } do
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      render_change(view, :start_search, %{"querystring" => matching_message})
+
+      assert view
+             |> TestUtils.wait_for_render("#logs-list > li")
+             |> has_element?("#logs-list > li", matching_message)
+
+      html =
+        view
+        |> element("#results-actions")
+        |> render_change(%{search_timezone: "Singapore"})
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find("#logs-list > li")
+             |> Enum.empty?()
     end
   end
 
@@ -2596,6 +2793,15 @@ defmodule LogflareWeb.Source.SearchLVTest do
 
   defp get_view_assigns(view) do
     :sys.get_state(view.pid).socket.assigns
+  end
+
+  defp log_event_ids(view) do
+    view
+    |> element("#logs-list")
+    |> render()
+    |> Floki.parse_document!()
+    |> Floki.find("#logs-list > li")
+    |> Floki.attribute("id")
   end
 
   defp find_search_form_value(html, selector) do

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -3,11 +3,17 @@ defmodule Logflare.TestUtils do
   Testing utilities. Globally aliased under the `TestUtils` namespace.
   """
 
+  import ExUnit.Assertions, only: [assert: 1]
+
   alias GoogleApi.BigQuery.V2.Model.TableFieldSchema
   alias GoogleApi.BigQuery.V2.Model.TableSchema
 
+  alias Logflare.Backends
+  alias Logflare.Backends.Adaptor.PostgresAdaptor
   alias Logflare.SingleTenant
+  alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
+  alias Logflare.User
 
   @doc """
   Configures the following `:logflare` env keys:
@@ -481,6 +487,27 @@ defmodule Logflare.TestUtils do
     receive do
       :stop -> :ok
     end
+  end
+
+  @doc """
+  Waits until the expected number of matching events is queryable from a PostgreSQL backend.
+  """
+  @spec wait_for_postgres_events(Source.t(), User.t(), String.t(), pos_integer()) :: :ok
+  def wait_for_postgres_events(source, user, message_prefix, expected_count) do
+    backend = Backends.get_default_backend(user)
+    table_name = PostgresAdaptor.table_name(source)
+
+    retry_assert(fn ->
+      assert {:ok, %{rows: [%{"count" => ^expected_count}]}} =
+               PostgresAdaptor.execute_query(
+                 backend,
+                 {"SELECT count(*) AS count FROM #{table_name} WHERE event_message LIKE $1",
+                  ["#{message_prefix}%"]},
+                 []
+               )
+    end)
+
+    :ok
   end
 
   @doc """


### PR DESCRIPTION
This PR adds pagination support to the search results live view.

* load more buttons are added to the top and bottom of the search results list
* the top button loads earlier events. It will be hidden if there are no more previous events to load
* the bottom button loads later events. 
* the pagination buttons are hidden when tailing
* if the search query include a timestamp `t:` filter and the loaded page includes results outside the queried timestamp range the results are displayed. The `t:` filter is updated to reflect the fetched timestamp range.

Follows #3720 

- [x]  events are now rendered with LiveView stream
- [x] ~~scrolling to the top of the event list will fetch the next 100 previous events~~
- [x] add ‘load more’ buttons to extend search range earlier or later

<img width="3454" height="2460" alt="CleanShot 2026-07-24 at 15 04 24@2x" src="https://github.com/user-attachments/assets/e17c73a3-e7ed-4b39-a714-639b343a45a6" />


### Demo
#### Load earlier events



https://github.com/user-attachments/assets/e2e11b1f-7650-4acb-80de-e332e264cd71




#### Load next page, timestamp filter LQL updated
https://github.com/user-attachments/assets/ba83db80-f1ea-4388-a9c4-0154aea431f4



Fixes O11Y-286