### PR TITLE
test(api): enforce OpenAPI response contracts

### DIFF
--- a/lib/logflare_web/api_spec.ex
+++ b/lib/logflare_web/api_spec.ex
@@ -2,9 +2,12 @@ defmodule LogflareWeb.ApiSpec do
   alias LogflareWeb.Endpoint
   alias LogflareWeb.Router
 
+  alias LogflareWeb.OpenApi.Unauthorized
+
   alias OpenApiSpex.Components
   alias OpenApiSpex.Info
   alias OpenApiSpex.OpenApi
+  alias OpenApiSpex.Operation
   alias OpenApiSpex.Paths
   alias OpenApiSpex.SecurityScheme
   alias OpenApiSpex.Server
@@ -19,13 +22,71 @@ defmodule LogflareWeb.ApiSpec do
         title: to_string(Application.spec(:logflare, :description)),
         version: to_string(Application.spec(:logflare, :vsn))
       },
-      paths: Paths.from_router(Router) |> filter_routes(),
+      paths:
+        Router
+        |> Paths.from_router()
+        |> add_management_auth_responses()
+        |> filter_routes(),
       components: %Components{
         securitySchemes: %{
           "authorization" => %SecurityScheme{type: "http", scheme: "bearer", bearerFormat: "JWT"}
         }
       }
     })
+  end
+
+  @spec management_route_operations() :: [{String.t(), atom()}]
+  def management_route_operations do
+    Router.__routes__()
+    |> Enum.filter(&management_route?/1)
+    |> Enum.map(&{open_api_path(&1.path), &1.verb})
+  end
+
+  defp add_management_auth_responses(paths) do
+    Enum.reduce(management_route_operations(), paths, fn {path, verb}, paths ->
+      case Map.get(paths, path) do
+        path_item when not is_nil(path_item) ->
+          case Map.get(path_item, verb) do
+            %Operation{} = operation ->
+              operation = %{
+                operation
+                | responses: Map.put_new(operation.responses, 401, unauthorized_response())
+              }
+
+              Map.put(paths, path, Map.put(path_item, verb, operation))
+
+            nil ->
+              paths
+          end
+
+        nil ->
+          paths
+      end
+    end)
+  end
+
+  defp unauthorized_response do
+    Operation.response("Unauthorized", "application/json", Unauthorized)
+  end
+
+  defp management_route?(route) do
+    case route_info(route) do
+      %{pipe_through: pipe_through} -> :require_mgmt_api_auth in pipe_through
+      :error -> false
+    end
+  end
+
+  defp route_info(route) do
+    Phoenix.Router.route_info(
+      Router,
+      route.verb |> Atom.to_string() |> String.upcase(),
+      String.replace(route.path, ~r|:[^/]+|, "route-param"),
+      "localhost"
+    )
+  end
+
+  defp open_api_path(path) do
+    Regex.replace(~r|:([^/]+)|, path, fn _, parameter -> "{#{parameter}}" end)
   end
 
   defp filter_routes(routes_map) do

--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -8,6 +8,7 @@ defmodule LogflareWeb.Api.BackendController do
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.BackendApiSchema
 
   action_fallback(LogflareWeb.Api.FallbackController)
@@ -44,7 +45,8 @@ defmodule LogflareWeb.Api.BackendController do
     request_body: BackendApiSchema.params(),
     responses: %{
       201 => Created.response(BackendApiSchema),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -63,7 +65,8 @@ defmodule LogflareWeb.Api.BackendController do
     responses: %{
       204 => Accepted.response(),
       200 => Accepted.response(BackendApiSchema),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/key_value_controller.ex
+++ b/lib/logflare_web/controllers/api/key_value_controller.ex
@@ -4,9 +4,11 @@ defmodule LogflareWeb.Api.KeyValueController do
 
   alias Logflare.Billing
   alias Logflare.KeyValues
+  alias LogflareWeb.OpenApi.BadRequest
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApiSchemas.KeyValueApiSchema
+  alias LogflareWeb.OpenApiSchemas.KeyValueBulkUpsertResponse
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -36,7 +38,8 @@ defmodule LogflareWeb.Api.KeyValueController do
          items: KeyValueApiSchema
        }},
     responses: %{
-      201 => Created.response(KeyValueApiSchema)
+      201 => Created.response(KeyValueBulkUpsertResponse),
+      400 => BadRequest.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/query_controller.ex
+++ b/lib/logflare_web/controllers/api/query_controller.ex
@@ -10,7 +10,6 @@ defmodule LogflareWeb.Api.QueryController do
   alias Logflare.Sql
   alias Logflare.User
   alias LogflareWeb.OpenApi.BadRequest
-  alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.One
   alias LogflareWeb.OpenApiSchemas.QueryParseResult
   alias LogflareWeb.OpenApiSchemas.QueryResult
@@ -112,7 +111,10 @@ defmodule LogflareWeb.Api.QueryController do
         required: false
       ]
     ],
-    responses: %{200 => List.response(QueryResult)}
+    responses: %{
+      200 => One.response(QueryResult),
+      400 => BadRequest.response()
+    }
   )
 
   def query(%{assigns: %{user: user}} = conn, params) do

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -6,10 +6,11 @@ defmodule LogflareWeb.Api.RuleController do
   alias Logflare.Sources
   alias Logflare.Rules
   alias LogflareWeb.OpenApi.Accepted
-  alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
   alias LogflareWeb.OpenApiSchemas.RuleApiSchema
+  alias LogflareWeb.OpenApiSchemas.RuleBatchResponse
+  alias LogflareWeb.OpenApiSchemas.RuleCreateResponse
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -53,7 +54,8 @@ defmodule LogflareWeb.Api.RuleController do
     summary: "Create rule. Allows batch creation if as a list.",
     request_body: RuleApiSchema.params(),
     responses: %{
-      201 => Created.response(RuleApiSchema),
+      201 => RuleCreateResponse.response(),
+      400 => RuleBatchResponse.response(),
       404 => NotFound.response()
     }
   )

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -9,6 +9,7 @@ defmodule LogflareWeb.Api.SourceController do
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.Event
 
   alias LogflareWeb.OpenApiSchemas.Source
@@ -49,7 +50,8 @@ defmodule LogflareWeb.Api.SourceController do
     request_body: Source.params(),
     responses: %{
       201 => Created.response(Source),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -69,8 +71,9 @@ defmodule LogflareWeb.Api.SourceController do
     request_body: Source.params(),
     responses: %{
       204 => Accepted.response(),
-      200 => Accepted.response(),
-      404 => NotFound.response()
+      200 => Source.response(),
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/user_controller.ex
+++ b/lib/logflare_web/controllers/user_controller.ex
@@ -1,5 +1,6 @@
 defmodule LogflareWeb.UserController do
   use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   use PhoenixHTMLHelpers
 
@@ -14,6 +15,8 @@ defmodule LogflareWeb.UserController do
   alias Logflare.TeamUsers
   alias Logflare.User
   alias Logflare.Users
+  alias LogflareWeb.OpenApi.One
+  alias LogflareWeb.OpenApiSchemas.User, as: UserSchema
 
   @bq_fields ~w(
     bigquery_project_id
@@ -25,6 +28,19 @@ defmodule LogflareWeb.UserController do
     bigquery_enable_managed_service_accounts
     bigquery_additional_projects
   )a
+
+  tags(["management"])
+
+  operation(:api_show,
+    summary: "Fetch account",
+    responses: %{200 => One.response(UserSchema)}
+  )
+
+  operation(:new_api_key, false)
+  operation(:edit, false)
+  operation(:update, false)
+  operation(:change_owner, false)
+  operation(:delete, false)
 
   def api_show(%{assigns: %{user: user}} = conn, _params) do
     conn

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -49,9 +49,7 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule Accepted do
-    def schema, do: %Schema{title: "AcceptedResponse"}
-
-    def response, do: {"Accepted Response", "text/plain", schema()}
+    def response, do: "Accepted Response"
     def response(module), do: {"Accepted Response", "application/json", module}
   end
 
@@ -65,7 +63,7 @@ defmodule LogflareWeb.OpenApi do
       }
     end
 
-    def response, do: {"Not found", "text/plain", schema()}
+    def response, do: {"Not found", "application/json", schema()}
   end
 
   defmodule UnprocessableEntity do
@@ -83,22 +81,37 @@ defmodule LogflareWeb.OpenApi do
 
   defmodule BadRequest do
     require OpenApiSpex
-    OpenApiSpex.schema(%{})
 
-    def response, do: {"Bad request", "text/plain", __MODULE__}
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{error: %Schema{type: :string}},
+      required: [:error]
+    })
+
+    def response, do: {"Bad request", "application/json", __MODULE__}
   end
 
   defmodule Unauthorized do
     require OpenApiSpex
-    OpenApiSpex.schema(%{})
 
-    def response, do: {"Unauthorized", "text/plain", __MODULE__}
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{error: %Schema{type: :string}},
+      required: [:error]
+    })
+
+    def response, do: {"Unauthorized", "application/json", __MODULE__}
   end
 
   defmodule ServerError do
     require OpenApiSpex
-    OpenApiSpex.schema(%{})
 
-    def response, do: {"Server error", "text/plain", __MODULE__}
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{error: %Schema{type: :string}},
+      required: [:error]
+    })
+
+    def response, do: {"Server error", "application/json", __MODULE__}
   end
 end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -44,7 +44,7 @@ defmodule LogflareWeb.OpenApiSchemas do
 
   defmodule QueryResult do
     @properties %{
-      result: %Schema{type: :object},
+      result: %Schema{type: :array, items: %Schema{type: :object}},
       errors: %Schema{
         oneOf: [
           %Schema{type: :object},
@@ -75,10 +75,10 @@ defmodule LogflareWeb.OpenApiSchemas do
   defmodule AccessToken do
     @properties %{
       id: %Schema{type: :integer},
-      token: %Schema{type: :string},
-      description: %Schema{type: :string},
+      token: %Schema{type: :string, nullable: true},
+      description: %Schema{type: :string, nullable: true},
       scopes: %Schema{type: :string},
-      inserted_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: []
   end
@@ -103,19 +103,19 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string},
       id: %Schema{type: :integer},
       favorite: %Schema{type: :boolean},
-      webhook_notification_url: %Schema{type: :string},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
       api_quota: %Schema{type: :integer},
-      slack_hook_url: %Schema{type: :string},
-      bigquery_table_ttl: %Schema{type: :integer},
-      public_token: %Schema{type: :string},
-      bq_table_id: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      bigquery_table_ttl: %Schema{type: :integer, nullable: true},
+      public_token: %Schema{type: :string, nullable: true},
+      bq_table_id: %Schema{type: :string, nullable: true},
       has_rejected_events: %Schema{type: :boolean},
-      metrics: %Schema{type: :object},
-      notifications: %Schema{type: :object, items: Notification},
-      custom_event_message_keys: %Schema{type: :string},
+      metrics: %Schema{type: :object, nullable: true},
+      notifications: %Schema{type: :object, items: Notification, nullable: true},
+      custom_event_message_keys: %Schema{type: :string, nullable: true},
       default_ingest_backend_enabled?: %Schema{type: :boolean},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string},
+      updated_at: %Schema{type: :string}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]
@@ -134,11 +134,28 @@ defmodule LogflareWeb.OpenApiSchemas do
       lql_string: %Schema{type: :string},
       backend_id: %Schema{type: :integer},
       source_id: %Schema{type: :integer},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string},
+      updated_at: %Schema{type: :string}
     }
 
-    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+    use LogflareWeb.OpenApi, properties: @properties, required: []
+  end
+
+  defmodule RuleBatchResponse do
+    @properties %{
+      errors: %Schema{type: :array, items: %Schema{type: :string}},
+      results: %Schema{type: :array, items: RuleApiSchema}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:errors, :results]
+  end
+
+  defmodule RuleCreateResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{anyOf: [RuleApiSchema, RuleBatchResponse]})
+
+    def response, do: {"Rule create response", "application/json", __MODULE__}
   end
 
   defmodule KeyValueApiSchema do
@@ -151,16 +168,22 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:key, :value]
   end
 
+  defmodule KeyValueBulkUpsertResponse do
+    @properties %{inserted_count: %Schema{type: :integer}}
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:inserted_count]
+  end
+
   defmodule BackendApiSchema do
     @properties %{
       name: %Schema{type: :string},
       id: %Schema{type: :integer},
       token: %Schema{type: :string},
       config: %Schema{type: :object},
-      metadata: %Schema{type: :object},
+      metadata: %Schema{type: :object, nullable: true},
       default_ingest?: %Schema{type: :boolean},
-      inserted_at: %Schema{type: :string, format: :"date-time"},
-      updated_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string},
+      updated_at: %Schema{type: :string}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:name]

--- a/test/logflare_web/api_spec_test.exs
+++ b/test/logflare_web/api_spec_test.exs
@@ -1,0 +1,33 @@
+defmodule LogflareWeb.ApiSpecTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.ApiSpec
+
+  test "resolves every schema reference" do
+    assert %OpenApiSpex.OpenApi{} = ApiSpec.spec()
+  end
+
+  test "rejects an undocumented response status" do
+    conn =
+      Phoenix.ConnTest.build_conn(:get, "/api/account")
+      |> OpenApiSpex.Plug.PutApiSpec.call(ApiSpec)
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(418, "{}")
+
+    assert_raise ExUnit.AssertionError,
+                 ~r/No OpenAPI response is documented for GET \/api\/account with status 418/,
+                 fn -> LogflareWeb.ConnCase.assert_open_api_response(conn) end
+  end
+
+  test "documents every management API route" do
+    spec = ApiSpec.spec()
+
+    missing_operations =
+      for {path, verb} <- ApiSpec.management_route_operations(),
+          is_nil(spec.paths |> Map.fetch!(path) |> Map.get(verb)),
+          do: "#{verb |> Atom.to_string() |> String.upcase()} #{path}"
+
+    assert missing_operations == [],
+           "Management routes without an OpenAPI operation:\n#{Enum.join(missing_operations, "\n")}"
+  end
+end

--- a/test/logflare_web/controllers/api/account_controller_test.exs
+++ b/test/logflare_web/controllers/api/account_controller_test.exs
@@ -1,0 +1,15 @@
+defmodule LogflareWeb.Api.AccountControllerTest do
+  use LogflareWeb.ConnCase
+
+  test "returns the authenticated account", %{conn: conn} do
+    user = insert(:user)
+
+    response =
+      conn
+      |> add_access_token(user, "private")
+      |> get(~p"/api/account")
+      |> json_response(200)
+
+    assert response["token"] == user.token
+  end
+end

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -22,9 +22,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/endpoints")
         |> json_response(200)
-        |> assert_schema("EndpointApiSchemaListResponse")
 
-      response = response |> Enum.map(& &1.token) |> Enum.sort()
+      response = response |> Enum.map(& &1["token"]) |> Enum.sort()
       expected = endpoints |> Enum.map(& &1.token) |> Enum.sort()
 
       assert response == expected
@@ -42,9 +41,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/endpoints/#{endpoint.token}")
         |> json_response(200)
-        |> assert_schema("EndpointApiSchema")
 
-      assert response.token == endpoint.token
+      assert response["token"] == endpoint.token
     end
 
     test "returns not found if doesn't own the endpoint query", %{
@@ -57,7 +55,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> get(~p"/api/endpoints/#{endpoint.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 
@@ -74,12 +71,11 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints", %{name: name, language: "bq_sql", query: query})
         |> json_response(201)
-        |> assert_schema("EndpointApiSchema")
 
-      assert response.name == name
-      assert response.query == query
+      assert response["name"] == name
+      assert response["query"] == query
 
-      assert [version] = PaperTrail.get_versions(Endpoints.EndpointQuery, response.id)
+      assert [version] = PaperTrail.get_versions(Endpoints.EndpointQuery, response["id"])
       assert version.origin =~ "API: id"
     end
 
@@ -89,9 +85,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints")
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => _, "query" => _}} = response
+      assert %{"errors" => %{"name" => _, "query" => _}} = response
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
@@ -100,9 +95,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => _, "query" => _}} = response
+      assert %{"errors" => %{"name" => _, "query" => _}} = response
     end
 
     test "attacker cannot create an endpoint with another user's backend", %{conn: conn} do
@@ -144,7 +138,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> patch(~p"/api/endpoints/#{token}", %{name: name})
         |> text_response(204)
-        |> assert_schema("AcceptedResponse")
 
       assert response == ""
 
@@ -155,9 +148,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> put(~p"/api/endpoints/#{token}", %{name: another_name})
         |> json_response(200)
-        |> assert_schema("EndpointApiSchema")
 
-      assert %{name: ^another_name, token: ^token} = response
+      assert %{"name" => ^another_name, "token" => ^token} = response
 
       assert_in_delta length(initial_versions),
                       length(PaperTrail.get_versions(Endpoints.EndpointQuery, endpoint.id)),
@@ -174,7 +166,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> patch(~p"/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
 
     test "returns 422 on bad arguments", %{
@@ -187,9 +178,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> patch(~p"/api/endpoints/#{endpoint.token}", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => ["is invalid"]}} = response
+      assert %{"errors" => %{"name" => ["is invalid"]}} = response
     end
 
     test "attacker cannot update their endpoint to use another user's backend", %{conn: conn} do
@@ -225,13 +215,11 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(user, ~w(private))
       |> delete(~p"/api/endpoints/#{endpoint.token}", %{name: name})
       |> text_response(204)
-      |> assert_schema("AcceptedResponse")
 
       conn
       |> add_access_token(user, ~w(private))
       |> get(~p"/api/endpoints/#{endpoint.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
 
       assert [%_{meta: meta, event: "delete"}] =
                PaperTrail.get_versions(Endpoints.EndpointQuery, endpoint.id)
@@ -249,7 +237,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> delete(~p"/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 end

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -33,10 +33,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams")
         |> json_response(200)
-        |> assert_schema("TeamListResponse")
 
-      assert Enum.any?(response, fn %{token: token} -> main_team_token == token end)
-      assert Enum.any?(response, fn %{token: token} -> non_owner_team_token == token end)
+      assert Enum.any?(response, fn %{"token" => token} -> main_team_token == token end)
+      assert Enum.any?(response, fn %{"token" => token} -> non_owner_team_token == token end)
     end
   end
 
@@ -51,9 +50,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams/#{token}")
         |> json_response(200)
-        |> assert_schema("Team")
 
-      assert response.token == token
+      assert response["token"] == token
     end
 
     test "returns a single team given user and team token where his not an owner but a member", %{
@@ -66,10 +64,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams/#{non_owner_team.token}")
         |> json_response(200)
-        |> assert_schema("Team")
 
-      assert response.token == non_owner_team.token
-      assert response.name == non_owner_team.name
+      assert response["token"] == non_owner_team.token
+      assert response["name"] == non_owner_team.name
     end
 
     test "returns not found if doesn't own the team or isn't part of it", %{
@@ -83,13 +80,11 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       |> add_access_token(invalid_user, "private")
       |> get(~p"/api/teams/#{main_team.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
 
       conn
       |> add_access_token(invalid_user, "private")
       |> get(~p"/api/teams/#{non_owner_team.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 
@@ -103,9 +98,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams", %{name: name})
         |> json_response(201)
-        |> assert_schema("Team")
 
-      assert response.name == name
+      assert response["name"] == name
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
@@ -114,9 +108,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["is invalid"]}}
+      assert response == %{"errors" => %{"name" => ["is invalid"]}}
     end
 
     test "returns 422 on missing arguments", %{conn: conn, user: user} do
@@ -125,9 +118,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams")
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["can't be blank"]}}
+      assert response == %{"errors" => %{"name" => ["can't be blank"]}}
     end
   end
 
@@ -144,7 +136,6 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> patch(~p"/api/teams/#{main_team.token}", %{name: name})
         |> response(204)
-        |> assert_schema("AcceptedResponse")
 
       assert response == ""
 
@@ -155,10 +146,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> put(~p"/api/teams/#{main_team.token}", %{name: another_name})
         |> json_response(201)
-        |> assert_schema("Team")
 
-      assert response.token == main_team.token
-      assert response.name == another_name
+      assert response["token"] == main_team.token
+      assert response["name"] == another_name
     end
 
     test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
@@ -168,7 +158,6 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       |> add_access_token(invalid_user, "private")
       |> patch(~p"/api/teams/#{main_team.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user, main_team: main_team} do
@@ -177,9 +166,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> patch(~p"/api/teams/#{main_team.token}", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["is invalid"]}}
+      assert response == %{"errors" => %{"name" => ["is invalid"]}}
     end
   end
 
@@ -192,8 +180,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       assert conn
              |> add_access_token(user, "private")
              |> delete(~p"/api/teams/#{main_team.token}")
-             |> response(204)
-             |> assert_schema("AcceptedResponse") == ""
+             |> response(204) == ""
     end
 
     test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
@@ -202,8 +189,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       assert conn
              |> add_access_token(invalid_user, "private")
              |> delete(~p"/api/teams/#{main_team.token}")
-             |> json_response(404)
-             |> assert_schema("NotFoundResponse") == %{error: "Not Found"}
+             |> json_response(404) == %{"error" => "Not Found"}
     end
   end
 end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -41,10 +41,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error == QueryErrorHelpers.generic_query_error_message()
-      refute response.result
+      assert response["error"] == QueryErrorHelpers.generic_query_error_message()
+      refute response["result"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -67,7 +66,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -75,9 +73,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       reject(&BigQueryJobs.bigquery_jobs_query/3)
@@ -89,7 +87,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -97,9 +94,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
 
       refute conn.halted
     end
@@ -120,7 +117,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -128,9 +124,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -147,7 +143,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -155,9 +150,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -174,7 +169,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -182,9 +176,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -198,8 +192,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
         |> get(~p"/endpoints/query/#{endpoint.token}")
 
       assert conn
-             |> json_response(401)
-             |> assert_schema("Unauthorized") == %{"error" => "Unauthorized"}
+             |> json_response(401) == %{"error" => "Unauthorized"}
 
       assert conn.halted == true
     end
@@ -225,7 +218,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
         response =
           conn
           |> json_response(200)
-          |> assert_schema("EndpointQuery")
 
         assert [
                  %{
@@ -233,9 +225,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                    "id" => _id,
                    "timestamp" => _timestamp
                  }
-               ] = response.result
+               ] = response["result"]
 
-        refute response.error
+        refute response["error"]
         refute conn.halted
       end
     end
@@ -262,12 +254,11 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error =~
+      assert response["error"] =~
                LogflareWeb.QueryErrorHelpers.generic_query_error_message()
 
-      refute response.result
+      refute response["result"]
     end
 
     test "GET query with lql `f:table` overrides CTE fallback", %{
@@ -302,10 +293,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"col2" => "b"}] = response.result
-      refute response.error
+      assert [%{"col2" => "b"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql and single CTE uses that CTE", %{conn: init_conn, user: user} do
@@ -330,10 +320,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"value" => "test"}] = response.result
-      refute response.error
+      assert [%{"value" => "test"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql and single CTE with explicit `from:table`", %{
@@ -361,10 +350,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"value" => "test"}] = response.result
-      refute response.error
+      assert [%{"value" => "test"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql `f:invalid_cte` returns error", %{conn: init_conn, user: user} do
@@ -385,12 +373,11 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error =~
+      assert response["error"] =~
                LogflareWeb.QueryErrorHelpers.generic_query_error_message()
 
-      refute response.result
+      refute response["result"]
     end
   end
 
@@ -863,16 +850,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "REDACTED",
                  "event_message" => "User REDACTED connected"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -897,16 +883,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "REDACTED",
                  "event_message" => "User REDACTED connected REDACTED"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -933,16 +918,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "192.168.1.1",
                  "message" => "User 10.0.0.1 connected"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,7 +22,14 @@ defmodule LogflareWeb.ConnCase do
 
   use ExUnit.CaseTemplate
 
+  import ExUnit.Assertions
+
   alias Logflare.Partners.Partner
+  alias LogflareWeb.Router
+
+  @http_methods [:get, :post, :put, :patch, :delete, :options, :connect, :trace, :head]
+  @conn_test_request_macros for method <- @http_methods, arity <- [2, 3], do: {method, arity}
+  @open_api_methods Map.new(@http_methods, &{&1 |> Atom.to_string() |> String.upcase(), &1})
 
   using _opts do
     quote do
@@ -32,7 +39,7 @@ defmodule LogflareWeb.ConnCase do
 
       import Logflare.Factory
       import LogflareWeb.Router.Helpers
-      import Phoenix.ConnTest
+      import Phoenix.ConnTest, except: unquote(@conn_test_request_macros)
       import Phoenix.LiveViewTest
       import Phoenix.VerifiedRoutes
       import PhoenixTest
@@ -120,8 +127,79 @@ defmodule LogflareWeb.ConnCase do
     Plug.Conn.put_req_header(conn, "authorization", "Bearer #{access_token.token}")
   end
 
-  def assert_schema(data, schema_name) do
-    OpenApiSpex.TestAssertions.assert_schema(data, schema_name, LogflareWeb.ApiSpec.spec())
+  for method <- @http_methods do
+    defmacro unquote(method)(conn, path_or_action, params_or_body \\ nil) do
+      method = unquote(method)
+
+      quote do
+        LogflareWeb.ConnCase.dispatch_and_assert_open_api_response(
+          unquote(conn),
+          @endpoint,
+          unquote(method),
+          unquote(path_or_action),
+          unquote(params_or_body)
+        )
+      end
+    end
+  end
+
+  @spec dispatch_and_assert_open_api_response(
+          Plug.Conn.t(),
+          module(),
+          atom(),
+          String.t() | atom(),
+          term()
+        ) :: Plug.Conn.t()
+  def dispatch_and_assert_open_api_response(
+        conn,
+        endpoint,
+        method,
+        path_or_action,
+        params_or_body
+      ) do
+    conn = Phoenix.ConnTest.dispatch(conn, endpoint, method, path_or_action, params_or_body)
+    assert_open_api_response(conn)
+  end
+
+  @spec assert_open_api_response(Plug.Conn.t()) :: Plug.Conn.t()
+  def assert_open_api_response(conn) do
+    case open_api_operation(conn) do
+      nil ->
+        conn
+
+      operation ->
+        assert_documented_response!(operation, conn)
+        OpenApiSpex.TestAssertions.assert_operation_response(conn, operation.operationId)
+        conn
+    end
+  end
+
+  defp open_api_operation(conn) do
+    with %{route: route} <-
+           Phoenix.Router.route_info(Router, conn.method, conn.request_path, conn.host),
+         true <- String.starts_with?(route, "/api"),
+         {spec, _operation_lookup} <-
+           OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn),
+         path_item when not is_nil(path_item) <- Map.get(spec.paths, open_api_path(route)) do
+      Map.get(path_item, Map.fetch!(@open_api_methods, conn.method))
+    else
+      _ -> nil
+    end
+  end
+
+  defp assert_documented_response!(operation, conn) do
+    if Map.has_key?(operation.responses, conn.status) ||
+         Map.has_key?(operation.responses, :default) do
+      :ok
+    else
+      flunk(
+        "No OpenAPI response is documented for #{conn.method} #{conn.request_path} with status #{conn.status}"
+      )
+    end
+  end
+
+  defp open_api_path(path) do
+    Regex.replace(~r|:([^/]+)|, path, fn _, parameter -> "{#{parameter}}" end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- add generated-spec smoke and authenticated management-route coverage checks
- validate each dispatched, documented API response against its matched OpenAPI operation and status in `ConnCase`
- document the account endpoint and shared management-auth 401 responses
- correct response schema/content-type drift exposed by the new checks

## Carve-out
Route coverage is limited to routes behind `:require_mgmt_api_auth`; ingestion, partner, and spec-serving routes remain outside this management-API guardrail.

## Validation
- `../bin/test test/logflare_web/api_spec_test.exs test/logflare_web/controllers/api/account_controller_test.exs test/logflare_web/controllers/api/access_tokens_controller_test.exs test/logflare_web/controllers/api/backend_controller_test.exs test/logflare_web/controllers/api/endpoint_controller_test.exs test/logflare_web/controllers/api/key_value_controller_test.exs test/logflare_web/controllers/api/query_controller_test.exs test/logflare_web/controllers/api/rule_controller_test.exs test/logflare_web/controllers/api/source_controller_test.exs test/logflare_web/controllers/api/team_controller_test.exs test/logflare_web/controllers/endpoints_controller_test.exs`
- `../bin/test test/logflare_web/controllers/log_controller_test.exs`