### PR TITLE
fix(api): enforce and correct Management API OpenAPI contracts

### DIFF
--- a/lib/logflare_web/api_spec.ex
+++ b/lib/logflare_web/api_spec.ex
@@ -2,9 +2,12 @@ defmodule LogflareWeb.ApiSpec do
   alias LogflareWeb.Endpoint
   alias LogflareWeb.Router
 
+  alias LogflareWeb.OpenApi.Unauthorized
+
   alias OpenApiSpex.Components
   alias OpenApiSpex.Info
   alias OpenApiSpex.OpenApi
+  alias OpenApiSpex.Operation
   alias OpenApiSpex.Paths
   alias OpenApiSpex.SecurityScheme
   alias OpenApiSpex.Server
@@ -19,13 +22,69 @@ defmodule LogflareWeb.ApiSpec do
         title: to_string(Application.spec(:logflare, :description)),
         version: to_string(Application.spec(:logflare, :vsn))
       },
-      paths: Paths.from_router(Router) |> filter_routes(),
+      paths:
+        Router
+        |> Paths.from_router()
+        |> add_management_auth_responses()
+        |> filter_routes(),
       components: %Components{
         securitySchemes: %{
           "authorization" => %SecurityScheme{type: "http", scheme: "bearer", bearerFormat: "JWT"}
         }
       }
     })
+  end
+
+  @spec management_route_operations() :: [{String.t(), atom()}]
+  def management_route_operations do
+    Router.__routes__()
+    |> Enum.filter(&management_route?/1)
+    |> Enum.map(&{open_api_path(&1.path), &1.verb})
+  end
+
+  defp add_management_auth_responses(paths) do
+    Enum.reduce(management_route_operations(), paths, &add_management_auth_response/2)
+  end
+
+  defp add_management_auth_response({path, verb}, paths) do
+    access_path = [Access.key(path), Access.key(verb)]
+
+    case get_in(paths, access_path) do
+      %Operation{} = operation ->
+        operation = %{
+          operation
+          | responses: Map.put_new(operation.responses, 401, unauthorized_response())
+        }
+
+        put_in(paths, access_path, operation)
+
+      nil ->
+        paths
+    end
+  end
+
+  defp unauthorized_response do
+    Operation.response("Unauthorized", "application/json", Unauthorized)
+  end
+
+  defp management_route?(route) do
+    case route_info(route) do
+      %{pipe_through: pipe_through} -> :require_mgmt_api_auth in pipe_through
+      :error -> false
+    end
+  end
+
+  defp route_info(route) do
+    Phoenix.Router.route_info(
+      Router,
+      route.verb |> Atom.to_string() |> String.upcase(),
+      String.replace(route.path, ~r|:[^/]+|, "route-param"),
+      "localhost"
+    )
+  end
+
+  defp open_api_path(path) do
+    Regex.replace(~r|:([^/]+)|, path, fn _, parameter -> "{#{parameter}}" end)
   end
 
   defp filter_routes(routes_map) do

--- a/lib/logflare_web/controllers/api/access_token_controller.ex
+++ b/lib/logflare_web/controllers/api/access_token_controller.ex
@@ -22,7 +22,12 @@ defmodule LogflareWeb.Api.AccessTokenController do
   )
 
   def index(%{assigns: %{user: user}} = conn, _) do
-    tokens = Auth.list_valid_access_tokens(user) |> Enum.map(&maybe_redact_token/1)
+    tokens =
+      user
+      |> Auth.list_valid_access_tokens()
+      |> Enum.map(&maybe_redact_token/1)
+      |> Enum.map(&format_access_token/1)
+
     json(conn, tokens)
   end
 
@@ -42,7 +47,7 @@ defmodule LogflareWeb.Api.AccessTokenController do
            Auth.create_access_token(user, Map.take(params, ["description", "scopes"])) do
       conn
       |> put_status(201)
-      |> json(access_token)
+      |> json(format_access_token(access_token))
     end
   end
 
@@ -71,5 +76,9 @@ defmodule LogflareWeb.Api.AccessTokenController do
 
   defp maybe_redact_token(%{scopes: scopes} = t) do
     if "public" in String.split(scopes), do: t, else: %{t | token: nil}
+  end
+
+  defp format_access_token(%{inserted_at: inserted_at} = token) do
+    %{token | inserted_at: DateTime.from_naive!(inserted_at, "Etc/UTC")}
   end
 end

--- a/lib/logflare_web/controllers/api/backend_controller.ex
+++ b/lib/logflare_web/controllers/api/backend_controller.ex
@@ -8,6 +8,8 @@ defmodule LogflareWeb.Api.BackendController do
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
+  alias LogflareWeb.OpenApiSchemas.BackendApiParams
   alias LogflareWeb.OpenApiSchemas.BackendApiSchema
 
   action_fallback(LogflareWeb.Api.FallbackController)
@@ -44,10 +46,11 @@ defmodule LogflareWeb.Api.BackendController do
 
   operation(:create,
     summary: "Create backend",
-    request_body: BackendApiSchema.params(),
+    request_body: BackendApiParams.params(),
     responses: %{
       201 => Created.response(BackendApiSchema),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -62,11 +65,12 @@ defmodule LogflareWeb.Api.BackendController do
   operation(:update,
     summary: "Update backend",
     parameters: [token: [in: :path, description: "Backend Token", type: :string]],
-    request_body: BackendApiSchema.params(),
+    request_body: BackendApiParams.params(),
     responses: %{
       204 => Accepted.response(),
       200 => Accepted.response(BackendApiSchema),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/endpoint_controller.ex
+++ b/lib/logflare_web/controllers/api/endpoint_controller.ex
@@ -11,6 +11,7 @@ defmodule LogflareWeb.Api.EndpointController do
   alias LogflareWeb.OpenApi.NotFound
   alias LogflareWeb.OpenApi.UnprocessableEntity
 
+  alias LogflareWeb.OpenApiSchemas.EndpointApiParams
   alias LogflareWeb.OpenApiSchemas.EndpointApiSchema
 
   action_fallback(LogflareWeb.Api.FallbackController)
@@ -46,7 +47,7 @@ defmodule LogflareWeb.Api.EndpointController do
 
   operation(:create,
     summary: "Create endpoint",
-    request_body: EndpointApiSchema.params(),
+    request_body: EndpointApiParams.params(),
     responses: %{
       201 => Created.response(EndpointApiSchema),
       404 => NotFound.response(),
@@ -70,7 +71,7 @@ defmodule LogflareWeb.Api.EndpointController do
   operation(:update,
     summary: "Update endpoint",
     parameters: [token: [in: :path, description: "Endpoint UUID Token", type: :string]],
-    request_body: EndpointApiSchema.params(),
+    request_body: EndpointApiParams.params(),
     responses: %{
       200 => Accepted.response(EndpointApiSchema),
       204 => Accepted.response(),

--- a/lib/logflare_web/controllers/api/key_value_controller.ex
+++ b/lib/logflare_web/controllers/api/key_value_controller.ex
@@ -4,9 +4,11 @@ defmodule LogflareWeb.Api.KeyValueController do
 
   alias Logflare.Billing
   alias Logflare.KeyValues
+  alias LogflareWeb.OpenApi.BadRequest
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApiSchemas.KeyValueApiSchema
+  alias LogflareWeb.OpenApiSchemas.KeyValueBulkUpsertResponse
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -36,7 +38,8 @@ defmodule LogflareWeb.Api.KeyValueController do
          items: KeyValueApiSchema
        }},
     responses: %{
-      201 => Created.response(KeyValueApiSchema)
+      201 => Created.response(KeyValueBulkUpsertResponse),
+      400 => BadRequest.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -3,16 +3,16 @@ defmodule LogflareWeb.Api.RuleController do
   use OpenApiSpex.ControllerSpecs
 
   alias Logflare.Backends
-  alias Logflare.Sources
   alias Logflare.Rules
+  alias Logflare.Sources
   alias LogflareWeb.OpenApi.Accepted
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
   alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.RuleApiSchema
-  alias LogflareWeb.OpenApiSchemas.RuleParams
   alias LogflareWeb.OpenApiSchemas.RuleBatchResponse
   alias LogflareWeb.OpenApiSchemas.RuleCreateResponse
+  alias LogflareWeb.OpenApiSchemas.RuleParams
 
   action_fallback(LogflareWeb.Api.FallbackController)
 

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -6,10 +6,13 @@ defmodule LogflareWeb.Api.RuleController do
   alias Logflare.Sources
   alias Logflare.Rules
   alias LogflareWeb.OpenApi.Accepted
-  alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.RuleApiSchema
+  alias LogflareWeb.OpenApiSchemas.RuleParams
+  alias LogflareWeb.OpenApiSchemas.RuleBatchResponse
+  alias LogflareWeb.OpenApiSchemas.RuleCreateResponse
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -51,9 +54,11 @@ defmodule LogflareWeb.Api.RuleController do
 
   operation(:create,
     summary: "Create rule. Allows batch creation if as a list.",
-    request_body: RuleApiSchema.params(),
+    request_body: RuleParams.params(),
     responses: %{
-      201 => Created.response(RuleApiSchema),
+      201 => RuleCreateResponse.response(),
+      400 => RuleBatchResponse.response(),
+      422 => UnprocessableEntity.response(),
       404 => NotFound.response()
     }
   )
@@ -124,11 +129,12 @@ defmodule LogflareWeb.Api.RuleController do
   operation(:update,
     summary: "Update rule",
     parameters: [token: [in: :path, description: "Rule UUID", type: :string]],
-    request_body: RuleApiSchema.params(),
+    request_body: RuleParams.params(),
     responses: %{
       204 => Accepted.response(),
       200 => Accepted.response(RuleApiSchema),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/source_controller.ex
+++ b/lib/logflare_web/controllers/api/source_controller.ex
@@ -9,9 +9,11 @@ defmodule LogflareWeb.Api.SourceController do
   alias LogflareWeb.OpenApi.Created
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.Event
 
   alias LogflareWeb.OpenApiSchemas.Source
+  alias LogflareWeb.OpenApiSchemas.SourceParams
   alias LogflareWeb.OpenApiSchemas
 
   action_fallback(LogflareWeb.Api.FallbackController)
@@ -46,10 +48,11 @@ defmodule LogflareWeb.Api.SourceController do
 
   operation(:create,
     summary: "Create source",
-    request_body: Source.params(),
+    request_body: {"Source Parameters", "application/json", SourceParams.schema()},
     responses: %{
       201 => Created.response(Source),
-      404 => NotFound.response()
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 
@@ -66,11 +69,12 @@ defmodule LogflareWeb.Api.SourceController do
   operation(:update,
     summary: "Update source",
     parameters: [token: [in: :path, description: "Source Token", type: :string]],
-    request_body: Source.params(),
+    request_body: {"Source Parameters", "application/json", SourceParams.schema()},
     responses: %{
       204 => Accepted.response(),
-      200 => Accepted.response(),
-      404 => NotFound.response()
+      200 => Source.response(),
+      404 => NotFound.response(),
+      422 => UnprocessableEntity.response()
     }
   )
 

--- a/lib/logflare_web/controllers/api/team_controller.ex
+++ b/lib/logflare_web/controllers/api/team_controller.ex
@@ -11,6 +11,7 @@ defmodule LogflareWeb.Api.TeamController do
   alias LogflareWeb.OpenApi.UnprocessableEntity
 
   alias LogflareWeb.OpenApiSchemas.Team
+  alias LogflareWeb.OpenApiSchemas.TeamParams
 
   action_fallback(LogflareWeb.Api.FallbackController)
 
@@ -44,7 +45,7 @@ defmodule LogflareWeb.Api.TeamController do
 
   operation(:create,
     summary: "Create Team",
-    request_body: Team.params(),
+    request_body: TeamParams.params(),
     responses: %{
       201 => Created.response(Team),
       404 => NotFound.response(),
@@ -64,7 +65,7 @@ defmodule LogflareWeb.Api.TeamController do
   operation(:update,
     summary: "Update team",
     parameters: [token: [in: :path, description: "Team Token", type: :string]],
-    request_body: Team.params(),
+    request_body: TeamParams.params(),
     responses: %{
       201 => Created.response(Team),
       204 => Accepted.response(),

--- a/lib/logflare_web/controllers/user_controller.ex
+++ b/lib/logflare_web/controllers/user_controller.ex
@@ -1,5 +1,6 @@
 defmodule LogflareWeb.UserController do
   use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   use PhoenixHTMLHelpers
 
@@ -14,6 +15,8 @@ defmodule LogflareWeb.UserController do
   alias Logflare.TeamUsers
   alias Logflare.User
   alias Logflare.Users
+  alias LogflareWeb.OpenApi.One
+  alias LogflareWeb.OpenApiSchemas.User, as: UserSchema
 
   @bq_fields ~w(
     bigquery_project_id
@@ -25,6 +28,19 @@ defmodule LogflareWeb.UserController do
     bigquery_enable_managed_service_accounts
     bigquery_additional_projects
   )a
+
+  tags(["management"])
+
+  operation(:api_show,
+    summary: "Fetch account",
+    responses: %{200 => One.response(UserSchema)}
+  )
+
+  operation(:new_api_key, false)
+  operation(:edit, false)
+  operation(:update, false)
+  operation(:change_owner, false)
+  operation(:delete, false)
 
   def api_show(%{assigns: %{user: user}} = conn, _params) do
     conn

--- a/lib/logflare_web/open_api.ex
+++ b/lib/logflare_web/open_api.ex
@@ -49,9 +49,7 @@ defmodule LogflareWeb.OpenApi do
   end
 
   defmodule Accepted do
-    def schema, do: %Schema{title: "AcceptedResponse"}
-
-    def response, do: {"Accepted Response", "text/plain", schema()}
+    def response, do: "Accepted Response"
     def response(module), do: {"Accepted Response", "application/json", module}
   end
 
@@ -116,8 +114,13 @@ defmodule LogflareWeb.OpenApi do
 
   defmodule ServerError do
     require OpenApiSpex
-    OpenApiSpex.schema(%{})
 
-    def response, do: {"Server error", "text/plain", __MODULE__}
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{error: %Schema{type: :string}},
+      required: [:error]
+    })
+
+    def response, do: {"Server error", "application/json", __MODULE__}
   end
 end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -97,7 +97,7 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string, nullable: true},
       description: %Schema{type: :string, nullable: true},
       scopes: %Schema{type: :string},
-      inserted_at: %Schema{type: :string}
+      inserted_at: %Schema{type: :string, format: :"date-time"}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: []
   end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -71,13 +71,33 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query]
   end
 
+  defmodule EndpointApiParams do
+    @properties %{
+      description: %Schema{type: :string, nullable: true},
+      name: %Schema{type: :string},
+      query: %Schema{type: :string},
+      language: %Schema{type: :string},
+      sandboxable: %Schema{type: :boolean, nullable: true},
+      cache_duration_seconds: %Schema{type: :integer},
+      proactive_requerying_seconds: %Schema{type: :integer},
+      max_limit: %Schema{type: :integer},
+      enable_auth: %Schema{type: :boolean},
+      redact_pii: %Schema{type: :boolean},
+      enable_dynamic_reservation: %Schema{type: :boolean},
+      labels: %Schema{type: :string, nullable: true},
+      backend_id: %Schema{type: :integer, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :query]
+  end
+
   defmodule AccessToken do
     @properties %{
       id: %Schema{type: :integer},
-      token: %Schema{type: :string},
-      description: %Schema{type: :string},
+      token: %Schema{type: :string, nullable: true},
+      description: %Schema{type: :string, nullable: true},
       scopes: %Schema{type: :string},
-      inserted_at: %Schema{type: :string, format: :"date-time"}
+      inserted_at: %Schema{type: :string}
     }
     use LogflareWeb.OpenApi, properties: @properties, required: []
   end
@@ -103,16 +123,16 @@ defmodule LogflareWeb.OpenApiSchemas do
       token: %Schema{type: :string},
       id: %Schema{type: :integer},
       favorite: %Schema{type: :boolean},
-      webhook_notification_url: %Schema{type: :string},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
       api_quota: %Schema{type: :integer},
-      slack_hook_url: %Schema{type: :string},
-      bigquery_table_ttl: %Schema{type: :integer},
-      public_token: %Schema{type: :string},
-      bq_table_id: %Schema{type: :string},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      bigquery_table_ttl: %Schema{type: :integer, nullable: true},
+      public_token: %Schema{type: :string, nullable: true},
+      bq_table_id: %Schema{type: :string, nullable: true},
       has_rejected_events: %Schema{type: :boolean},
-      metrics: %Schema{type: :object},
-      notifications: %Schema{type: :object, items: Notification},
-      custom_event_message_keys: %Schema{type: :string},
+      metrics: %Schema{type: :object, nullable: true},
+      notifications: %Schema{type: :object, items: Notification, nullable: true},
+      custom_event_message_keys: %Schema{type: :string, nullable: true},
       backends: %Schema{type: :array, items: LogflareWeb.OpenApiSchemas.BackendApiSchema},
       retention_days: %Schema{type: :integer, nullable: true},
       transform_copy_fields: %Schema{type: :string, nullable: true},
@@ -127,6 +147,38 @@ defmodule LogflareWeb.OpenApiSchemas do
       default_search_lql: %Schema{type: :string, nullable: true},
       suggested_keys: %Schema{type: :string, nullable: true},
       disable_tailing: %Schema{type: :boolean, nullable: true},
+      bq_storage_write_api: %Schema{type: :boolean, nullable: true},
+      labels: %Schema{type: :string, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
+  end
+
+  defmodule SourceParams do
+    @properties %{
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      service_name: %Schema{type: :string, nullable: true},
+      favorite: %Schema{type: :boolean},
+      webhook_notification_url: %Schema{type: :string, nullable: true},
+      bigquery_table_ttl: %Schema{type: :integer, nullable: true},
+      slack_hook_url: %Schema{type: :string, nullable: true},
+      custom_event_message_keys: %Schema{type: :string, nullable: true},
+      notifications: Notification,
+      retention_days: %Schema{type: :integer, nullable: true},
+      transform_copy_fields: %Schema{type: :string, nullable: true},
+      transform_key_values: %Schema{type: :string, nullable: true},
+      transform_drop_fields: %Schema{type: :string, nullable: true},
+      bigquery_clustering_fields: %Schema{type: :string, nullable: true},
+      default_ingest_backend_enabled?: %Schema{type: :boolean},
+      notifications_every: %Schema{type: :integer},
+      lock_schema: %Schema{type: :boolean},
+      validate_schema: %Schema{type: :boolean},
+      drop_lql_string: %Schema{type: :string, nullable: true},
+      default_search_lql: %Schema{type: :string, nullable: true},
+      suggested_keys: %Schema{type: :string, nullable: true},
+      disable_tailing: %Schema{type: :boolean, nullable: true},
+      enable_spooling: %Schema{type: :boolean, nullable: true},
       bq_storage_write_api: %Schema{type: :boolean, nullable: true},
       labels: %Schema{type: :string, nullable: true}
     }
@@ -151,6 +203,34 @@ defmodule LogflareWeb.OpenApiSchemas do
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
+  end
+
+  defmodule RuleParams do
+    @properties %{
+      lql_string: %Schema{type: :string},
+      backend_id: %Schema{type: :integer},
+      source_id: %Schema{type: :integer},
+      sink: %Schema{type: :string, nullable: true}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:lql_string]
+  end
+
+  defmodule RuleBatchResponse do
+    @properties %{
+      errors: %Schema{type: :array, items: %Schema{type: :string}},
+      results: %Schema{type: :array, items: RuleApiSchema}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:errors, :results]
+  end
+
+  defmodule RuleCreateResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{anyOf: [RuleApiSchema, RuleBatchResponse]})
+
+    def response, do: {"Rule create response", "application/json", __MODULE__}
   end
 
   defmodule AlertApiCreateParams do
@@ -219,6 +299,12 @@ defmodule LogflareWeb.OpenApiSchemas do
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:key, :value]
+  end
+
+  defmodule KeyValueBulkUpsertResponse do
+    @properties %{inserted_count: %Schema{type: :integer}}
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:inserted_count]
   end
 
   defmodule WebhookConfigSchema do
@@ -413,6 +499,19 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: [:name, :type, :config]
   end
 
+  defmodule BackendApiParams do
+    @properties %{
+      name: %Schema{type: :string},
+      type: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      config: BackendApiSchema.schema().properties.config,
+      metadata: %Schema{type: :object, nullable: true},
+      default_ingest?: %Schema{type: :boolean}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name, :type, :config]
+  end
+
   defmodule BackendConnectionTest do
     @properties %{
       connected?: %Schema{type: :boolean},
@@ -448,6 +547,12 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi,
       properties: @properties,
       required: [:email, :provider, :token, :api_key]
+  end
+
+  defmodule TeamParams do
+    @properties %{name: %Schema{type: :string}}
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:name]
   end
 
   defmodule TeamUser do

--- a/test/logflare_web/api_spec_test.exs
+++ b/test/logflare_web/api_spec_test.exs
@@ -1,0 +1,90 @@
+defmodule LogflareWeb.ApiSpecTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.ApiSpec
+  alias LogflareWeb.OpenApiSchemas.BackendApiParams
+  alias LogflareWeb.OpenApiSchemas.BackendApiSchema
+  alias LogflareWeb.OpenApiSchemas.EndpointApiParams
+  alias LogflareWeb.OpenApiSchemas.EndpointApiSchema
+  alias LogflareWeb.OpenApiSchemas.RuleApiSchema
+  alias LogflareWeb.OpenApiSchemas.RuleParams
+  alias LogflareWeb.OpenApiSchemas.Source
+  alias LogflareWeb.OpenApiSchemas.SourceParams
+  alias LogflareWeb.OpenApiSchemas.Team
+  alias LogflareWeb.OpenApiSchemas.TeamParams
+  alias OpenApiSpex.Plug.PutApiSpec
+
+  test "resolves every schema reference" do
+    assert %OpenApiSpex.OpenApi{} = ApiSpec.spec()
+  end
+
+  test "rejects an undocumented response status" do
+    conn =
+      Phoenix.ConnTest.build_conn(:get, "/api/account")
+      |> PutApiSpec.call(ApiSpec)
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(418, "{}")
+
+    assert_raise ExUnit.AssertionError,
+                 ~r/No OpenAPI response is documented for GET \/api\/account with status 418/,
+                 fn -> LogflareWeb.ConnCase.assert_open_api_response(conn) end
+  end
+
+  test "documents every management API route" do
+    spec = ApiSpec.spec()
+
+    missing_operations =
+      for {path, verb} <- ApiSpec.management_route_operations(),
+          is_nil(spec.paths |> Map.fetch!(path) |> Map.get(verb)),
+          do: "#{verb |> Atom.to_string() |> String.upcase()} #{path}"
+
+    assert missing_operations == [],
+           "Management routes without an OpenAPI operation:\n#{Enum.join(missing_operations, "\n")}"
+  end
+
+  test "uses dedicated write schemas for management resource mutations" do
+    spec = ApiSpec.spec()
+
+    for {path, verb, request_schema, response_schema, output_only_fields} <- [
+          {"/api/sources", :post, SourceParams, Source, [:id, :token, :api_quota, :backends]},
+          {"/api/sources/{token}", :put, SourceParams, Source,
+           [:id, :token, :api_quota, :backends]},
+          {"/api/backends", :post, BackendApiParams, BackendApiSchema,
+           [:id, :token, :inserted_at, :updated_at]},
+          {"/api/backends/{token}", :put, BackendApiParams, BackendApiSchema,
+           [:id, :token, :inserted_at, :updated_at]},
+          {"/api/endpoints", :post, EndpointApiParams, EndpointApiSchema,
+           [:id, :token, :source_mapping]},
+          {"/api/endpoints/{token}", :put, EndpointApiParams, EndpointApiSchema,
+           [:id, :token, :source_mapping]},
+          {"/api/rules", :post, RuleParams, RuleApiSchema, [:id, :token]},
+          {"/api/rules/{token}", :put, RuleParams, RuleApiSchema, [:id, :token]},
+          {"/api/teams", :post, TeamParams, Team, [:token, :user, :team_users]},
+          {"/api/teams/{token}", :put, TeamParams, Team, [:token, :user, :team_users]}
+        ] do
+      assert request_schema(spec, path, verb).title == request_schema.schema().title
+      refute request_schema.schema().properties == response_schema.schema().properties
+
+      for field <- output_only_fields do
+        refute Map.has_key?(request_schema.schema().properties, field)
+      end
+    end
+  end
+
+  defp request_schema(spec, path, verb) do
+    spec.paths
+    |> Map.fetch!(path)
+    |> Map.fetch!(verb)
+    |> Map.fetch!(:requestBody)
+    |> Map.fetch!(:content)
+    |> Map.fetch!("application/json")
+    |> Map.fetch!(:schema)
+    |> resolve_schema(spec)
+  end
+
+  defp resolve_schema(%OpenApiSpex.Reference{} = ref, spec) do
+    OpenApiSpex.Reference.resolve_schema(ref, spec.components.schemas)
+  end
+
+  defp resolve_schema(%OpenApiSpex.Schema{} = schema, _spec), do: schema
+end

--- a/test/logflare_web/controllers/api/access_tokens_controller_test.exs
+++ b/test/logflare_web/controllers/api/access_tokens_controller_test.exs
@@ -17,6 +17,7 @@ defmodule LogflareWeb.Api.AccessTokensTest do
                |> json_response(200)
 
       assert token["scopes"] =~ "private"
+      assert_rfc3339_timestamp(token["inserted_at"])
       # don't reveal value of management tokens
       refute token["token"]
     end
@@ -45,13 +46,14 @@ defmodule LogflareWeb.Api.AccessTokensTest do
 
   describe "create/2" do
     test "creating a public token", %{conn: conn, user: user} do
-      assert %{"token" => token} =
+      assert %{"token" => token, "inserted_at" => inserted_at} =
                conn
                |> add_access_token(user, "private")
                |> post(~p"/api/access-tokens")
                |> json_response(201)
 
       assert token
+      assert_rfc3339_timestamp(inserted_at)
     end
 
     test "creates a new access token for an authenticated user", %{conn: conn, user: user} do
@@ -164,5 +166,9 @@ defmodule LogflareWeb.Api.AccessTokensTest do
              |> delete("/api/access-tokens/#{access_token.token}")
              |> response(404)
     end
+  end
+
+  defp assert_rfc3339_timestamp(timestamp) do
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(timestamp)
   end
 end

--- a/test/logflare_web/controllers/api/access_tokens_controller_test.exs
+++ b/test/logflare_web/controllers/api/access_tokens_controller_test.exs
@@ -112,10 +112,9 @@ defmodule LogflareWeb.Api.AccessTokensTest do
 
       assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
 
-      assert %{error: "Unauthorized"} =
+      assert %{"error" => "Unauthorized"} =
                conn
                |> json_response(401)
-               |> assert_schema("UnauthorizedResponse")
     end
   end
 

--- a/test/logflare_web/controllers/api/account_controller_test.exs
+++ b/test/logflare_web/controllers/api/account_controller_test.exs
@@ -1,0 +1,15 @@
+defmodule LogflareWeb.Api.AccountControllerTest do
+  use LogflareWeb.ConnCase
+
+  test "returns the authenticated account", %{conn: conn} do
+    user = insert(:user)
+
+    response =
+      conn
+      |> add_access_token(user, "private")
+      |> get(~p"/api/account")
+      |> json_response(200)
+
+    assert response["token"] == user.token
+  end
+end

--- a/test/logflare_web/controllers/api/alert_controller_test.exs
+++ b/test/logflare_web/controllers/api/alert_controller_test.exs
@@ -26,7 +26,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
       |> get(~p"/api/alerts")
       |> json_response(200)
 
-    assert_schema(response, "AlertApiSchemaListResponse")
     assert [result] = response
     assert result["id"] == alert.id
     assert result["token"] == alert.token
@@ -43,7 +42,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
       |> get(~p"/api/alerts/#{alert.token}")
       |> json_response(200)
 
-    assert_schema(result, "AlertApiSchema")
     assert result["id"] == alert.id
     assert result["token"] == alert.token
     assert result["name"] == alert.name
@@ -79,15 +77,11 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         })
         |> json_response(201)
 
-      assert_schema(response, "AlertApiSchema")
       assert %{"token" => alert_token} = response
 
-      response =
-        conn
-        |> get(~p"/api/alerts/#{alert_token}")
-        |> json_response(200)
-
-      assert_schema(response, "AlertApiSchema")
+      conn
+      |> get(~p"/api/alerts/#{alert_token}")
+      |> json_response(200)
     end
 
     test "create alert defaults language when omitted", %{conn: conn} do
@@ -113,7 +107,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         })
         |> json_response(201)
 
-      assert_schema(response, "AlertApiSchema")
       assert %{"token" => alert_token, "backends" => [%{"id" => backend_id}]} = response
       assert backend_id == backend.id
 
@@ -158,7 +151,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> post(~p"/api/alerts", %{name: "missing required fields"})
         |> json_response(422)
 
-      assert_schema(response, "UnprocessableEntityResponse")
       assert %{"errors" => %{"query" => _, "cron" => _}} = response
     end
 
@@ -170,7 +162,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> put(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
         |> json_response(200)
 
-      assert_schema(response, "AlertApiSchema")
       assert %{"token" => alert_token} = response
 
       assert %{"name" => "adjusted"} =
@@ -187,7 +178,7 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> patch(~p"/api/alerts/#{alert.token}", %{name: "adjusted"})
         |> text_response(204)
 
-      assert assert_schema(response, "AcceptedResponse") == ""
+      assert response == ""
 
       assert %{"name" => "adjusted"} =
                conn
@@ -203,7 +194,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> patch(~p"/api/alerts/#{alert.token}", %{cron: "not a cron expression"})
         |> json_response(422)
 
-      assert_schema(response, "UnprocessableEntityResponse")
       assert %{"errors" => %{"cron" => _}} = response
     end
 
@@ -219,8 +209,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         conn
         |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [backend.id, other_backend.id]})
         |> json_response(200)
-
-      assert_schema(response, "AlertApiSchema")
 
       assert MapSet.new(Enum.map(response["backends"], & &1["id"])) ==
                MapSet.new([backend.id, other_backend.id])
@@ -314,12 +302,9 @@ defmodule LogflareWeb.Api.AlertControllerTest do
       victim = insert(:user)
       victim_backend = insert(:backend, user: victim)
 
-      response =
-        conn
-        |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
-        |> json_response(404)
-
-      assert_schema(response, "NotFoundResponse")
+      conn
+      |> put(~p"/api/alerts/#{alert.token}", %{backend_ids: [victim_backend.id]})
+      |> json_response(404)
 
       reloaded =
         Logflare.Alerting.get_alert_query!(alert.id)
@@ -357,8 +342,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> get(~p"/api/alerts")
         |> json_response(200)
 
-      assert_schema(response, "AlertApiSchemaListResponse")
-
       assert MapSet.new(Enum.map(response, & &1["token"])) ==
                MapSet.new([managed_alert.token, deleted_alert.token])
 
@@ -367,7 +350,6 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> get(~p"/api/alerts/#{managed_alert.token}")
         |> json_response(200)
 
-      assert_schema(response, "AlertApiSchema")
       assert response["token"] == managed_alert.token
 
       assert conn
@@ -410,13 +392,10 @@ defmodule LogflareWeb.Api.AlertControllerTest do
     test "show alert with bad user", %{conn: conn, user: user} do
       alert = insert(:alert, user: user)
 
-      response =
-        conn
-        |> add_access_token(insert(:user), "private")
-        |> get(~p"/api/alerts/#{alert.token}")
-        |> json_response(404)
-
-      assert_schema(response, "NotFoundResponse")
+      conn
+      |> add_access_token(insert(:user), "private")
+      |> get(~p"/api/alerts/#{alert.token}")
+      |> json_response(404)
     end
 
     test "delete alert", %{conn: conn, user: user} do
@@ -427,14 +406,11 @@ defmodule LogflareWeb.Api.AlertControllerTest do
         |> delete(~p"/api/alerts/#{alert.token}")
         |> text_response(204)
 
-      assert assert_schema(response, "AcceptedResponse") == ""
+      assert response == ""
 
-      response =
-        conn
-        |> get(~p"/api/alerts/#{alert.token}")
-        |> json_response(404)
-
-      assert_schema(response, "NotFoundResponse")
+      conn
+      |> get(~p"/api/alerts/#{alert.token}")
+      |> json_response(404)
     end
 
     test "delete alert with bad user", %{conn: conn, user: user} do

--- a/test/logflare_web/controllers/api/endpoint_controller_test.exs
+++ b/test/logflare_web/controllers/api/endpoint_controller_test.exs
@@ -22,9 +22,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/endpoints")
         |> json_response(200)
-        |> assert_schema("EndpointApiSchemaListResponse")
 
-      response = response |> Enum.map(& &1.token) |> Enum.sort()
+      response = response |> Enum.map(& &1["token"]) |> Enum.sort()
       expected = endpoints |> Enum.map(& &1.token) |> Enum.sort()
 
       assert response == expected
@@ -93,9 +92,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> get(~p"/api/endpoints/#{endpoint.token}")
         |> json_response(200)
-        |> assert_schema("EndpointApiSchema")
 
-      assert response.token == endpoint.token
+      assert response["token"] == endpoint.token
     end
 
     test "returns not found if doesn't own the endpoint query", %{
@@ -108,7 +106,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> get(~p"/api/endpoints/#{endpoint.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 
@@ -125,12 +122,11 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints", %{name: name, language: "bq_sql", query: query})
         |> json_response(201)
-        |> assert_schema("EndpointApiSchema")
 
-      assert response.name == name
-      assert response.query == query
+      assert response["name"] == name
+      assert response["query"] == query
 
-      assert [version] = PaperTrail.get_versions(Endpoints.EndpointQuery, response.id)
+      assert [version] = PaperTrail.get_versions(Endpoints.EndpointQuery, response["id"])
       assert version.origin =~ "API: id"
     end
 
@@ -140,9 +136,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints")
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => _, "query" => _}} = response
+      assert %{"errors" => %{"name" => _, "query" => _}} = response
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
@@ -151,9 +146,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> post(~p"/api/endpoints", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => _, "query" => _}} = response
+      assert %{"errors" => %{"name" => _, "query" => _}} = response
     end
 
     test "attacker cannot create an endpoint with another user's backend", %{conn: conn} do
@@ -195,7 +189,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> patch(~p"/api/endpoints/#{token}", %{name: name})
         |> text_response(204)
-        |> assert_schema("AcceptedResponse")
 
       assert response == ""
 
@@ -206,9 +199,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> put(~p"/api/endpoints/#{token}", %{name: another_name})
         |> json_response(200)
-        |> assert_schema("EndpointApiSchema")
 
-      assert %{name: ^another_name, token: ^token} = response
+      assert %{"name" => ^another_name, "token" => ^token} = response
 
       assert_in_delta length(initial_versions),
                       length(PaperTrail.get_versions(Endpoints.EndpointQuery, endpoint.id)),
@@ -225,7 +217,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> patch(~p"/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
 
     test "returns 422 on bad arguments", %{
@@ -238,9 +229,8 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
         |> add_access_token(user, ~w(private))
         |> patch(~p"/api/endpoints/#{endpoint.token}", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert %{errors: %{"name" => ["is invalid"]}} = response
+      assert %{"errors" => %{"name" => ["is invalid"]}} = response
     end
 
     test "attacker cannot update their endpoint to use another user's backend", %{conn: conn} do
@@ -276,13 +266,11 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(user, ~w(private))
       |> delete(~p"/api/endpoints/#{endpoint.token}", %{name: name})
       |> text_response(204)
-      |> assert_schema("AcceptedResponse")
 
       conn
       |> add_access_token(user, ~w(private))
       |> get(~p"/api/endpoints/#{endpoint.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
 
       assert [%_{meta: meta, event: "delete"}] =
                PaperTrail.get_versions(Endpoints.EndpointQuery, endpoint.id)
@@ -300,7 +288,6 @@ defmodule LogflareWeb.Api.EndpointControllerTest do
       |> add_access_token(invalid_user, ~w(private))
       |> delete(~p"/api/endpoints/#{endpoint.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 end

--- a/test/logflare_web/controllers/api/query_controller_test.exs
+++ b/test/logflare_web/controllers/api/query_controller_test.exs
@@ -20,10 +20,9 @@ defmodule LogflareWeb.Api.QueryControllerTest do
 
     assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
 
-    assert %{error: message} =
+    assert %{"error" => message} =
              conn
              |> json_response(400)
-             |> assert_schema("BadRequestResponse")
 
     assert message =~ "No query params provided"
   end
@@ -55,10 +54,9 @@ defmodule LogflareWeb.Api.QueryControllerTest do
 
       assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
 
-      assert %{error: err} =
+      assert %{"error" => err} =
                conn
                |> json_response(400)
-               |> assert_schema("BadRequestResponse")
 
       assert err =~ "SELECT"
     end
@@ -81,7 +79,6 @@ defmodule LogflareWeb.Api.QueryControllerTest do
       assert ["application/json; charset=utf-8"] = get_resp_header(conn, "content-type")
 
       response = json_response(conn, 200)
-      assert_schema(response, "QueryResult")
 
       assert %{"result" => [%{"my_time" => "123"}]} = response
 
@@ -92,7 +89,6 @@ defmodule LogflareWeb.Api.QueryControllerTest do
         |> get(~p"/api/query?#{[sql: ~s|select current_datetime() as 'my_time'|]}")
         |> json_response(200)
 
-      assert_schema(response, "QueryResult")
       assert %{"result" => [%{"my_time" => "123"}]} = response
     end
 

--- a/test/logflare_web/controllers/api/rule_controller_test.exs
+++ b/test/logflare_web/controllers/api/rule_controller_test.exs
@@ -73,6 +73,21 @@ defmodule LogflareWeb.Api.RuleControllerTest do
                |> json_response(201)
     end
 
+    test "returns 422 when a single rule is invalid", %{
+      conn: conn,
+      backend: backend,
+      source: source
+    } do
+      assert %{"errors" => %{"lql_string" => _}} =
+               conn
+               |> post(~p"/api/rules", %{
+                 source_id: source.id,
+                 backend_id: backend.id,
+                 lql_string: ""
+               })
+               |> json_response(422)
+    end
+
     test "create rule with bad user", %{conn: conn, backend: backend, source: source} do
       user = insert(:user)
 
@@ -117,6 +132,19 @@ defmodule LogflareWeb.Api.RuleControllerTest do
                conn
                |> get(~p"/api/rules/#{rule_token}")
                |> json_response(200)
+    end
+
+    test "returns 422 when updating a rule with an invalid LQL expression", %{
+      conn: conn,
+      backend: backend,
+      source: source
+    } do
+      rule = insert(:rule, lql_string: "initial", source: source, backend: backend)
+
+      assert %{"errors" => %{"lql_string" => _}} =
+               conn
+               |> put(~p"/api/rules/#{rule.token}", %{lql_string: ""})
+               |> json_response(422)
     end
 
     test "attacker cannot repoint their rule to a victim's source or backend", %{

--- a/test/logflare_web/controllers/api/team_controller_test.exs
+++ b/test/logflare_web/controllers/api/team_controller_test.exs
@@ -33,10 +33,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams")
         |> json_response(200)
-        |> assert_schema("TeamListResponse")
 
-      assert Enum.any?(response, fn %{token: token} -> main_team_token == token end)
-      assert Enum.any?(response, fn %{token: token} -> non_owner_team_token == token end)
+      assert Enum.any?(response, fn %{"token" => token} -> main_team_token == token end)
+      assert Enum.any?(response, fn %{"token" => token} -> non_owner_team_token == token end)
     end
   end
 
@@ -51,9 +50,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams/#{token}")
         |> json_response(200)
-        |> assert_schema("Team")
 
-      assert response.token == token
+      assert response["token"] == token
     end
 
     test "returns a single team given user and team token where his not an owner but a member", %{
@@ -66,10 +64,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> get(~p"/api/teams/#{non_owner_team.token}")
         |> json_response(200)
-        |> assert_schema("Team")
 
-      assert response.token == non_owner_team.token
-      assert response.name == non_owner_team.name
+      assert response["token"] == non_owner_team.token
+      assert response["name"] == non_owner_team.name
     end
 
     test "returns not found if doesn't own the team or isn't part of it", %{
@@ -88,14 +85,12 @@ defmodule LogflareWeb.Api.TeamControllerTest do
 
       conn
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
 
       conn
       |> recycle()
       |> add_access_token(invalid_user, "private")
       |> get(~p"/api/teams/#{non_owner_team.token}")
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
   end
 
@@ -109,9 +104,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams", %{name: name})
         |> json_response(201)
-        |> assert_schema("Team")
 
-      assert response.name == name
+      assert response["name"] == name
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user} do
@@ -120,9 +114,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["is invalid"]}}
+      assert response == %{"errors" => %{"name" => ["is invalid"]}}
     end
 
     test "returns 422 on missing arguments", %{conn: conn, user: user} do
@@ -131,9 +124,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> post(~p"/api/teams")
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["can't be blank"]}}
+      assert response == %{"errors" => %{"name" => ["can't be blank"]}}
     end
   end
 
@@ -150,7 +142,6 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> patch(~p"/api/teams/#{main_team.token}", %{name: name})
         |> response(204)
-        |> assert_schema("AcceptedResponse")
 
       assert response == ""
 
@@ -161,10 +152,9 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> put(~p"/api/teams/#{main_team.token}", %{name: another_name})
         |> json_response(201)
-        |> assert_schema("Team")
 
-      assert response.token == main_team.token
-      assert response.name == another_name
+      assert response["token"] == main_team.token
+      assert response["name"] == another_name
     end
 
     test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
@@ -174,7 +164,6 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       |> add_access_token(invalid_user, "private")
       |> patch(~p"/api/teams/#{main_team.token}", %{name: TestUtils.random_string()})
       |> json_response(404)
-      |> assert_schema("NotFoundResponse")
     end
 
     test "returns 422 on bad arguments", %{conn: conn, user: user, main_team: main_team} do
@@ -183,9 +172,8 @@ defmodule LogflareWeb.Api.TeamControllerTest do
         |> add_access_token(user, "private")
         |> patch(~p"/api/teams/#{main_team.token}", %{name: 123})
         |> json_response(422)
-        |> assert_schema("UnprocessableEntityResponse")
 
-      assert response == %{errors: %{"name" => ["is invalid"]}}
+      assert response == %{"errors" => %{"name" => ["is invalid"]}}
     end
   end
 
@@ -198,8 +186,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       assert conn
              |> add_access_token(user, "private")
              |> delete(~p"/api/teams/#{main_team.token}")
-             |> response(204)
-             |> assert_schema("AcceptedResponse") == ""
+             |> response(204) == ""
     end
 
     test "returns not found if doesn't own the team", %{conn: conn, main_team: main_team} do
@@ -208,8 +195,7 @@ defmodule LogflareWeb.Api.TeamControllerTest do
       assert conn
              |> add_access_token(invalid_user, "private")
              |> delete(~p"/api/teams/#{main_team.token}")
-             |> json_response(404)
-             |> assert_schema("NotFoundResponse") == %{error: "Not Found"}
+             |> json_response(404) == %{"error" => "Not Found"}
     end
   end
 end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -41,10 +41,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error == QueryErrorHelpers.generic_query_error_message()
-      refute response.result
+      assert response["error"] == QueryErrorHelpers.generic_query_error_message()
+      refute response["result"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -67,7 +66,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -75,9 +73,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       reject(&BigQueryJobs.bigquery_jobs_query/3)
@@ -89,7 +87,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -97,9 +94,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
 
       refute conn.halted
     end
@@ -120,7 +117,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -128,9 +124,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -147,7 +143,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -155,9 +150,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -174,7 +169,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
@@ -182,9 +176,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                  "id" => _id,
                  "timestamp" => _timestamp
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -198,8 +192,7 @@ defmodule LogflareWeb.EndpointsControllerTest do
         |> get(~p"/endpoints/query/#{endpoint.token}")
 
       assert conn
-             |> json_response(401)
-             |> assert_schema("UnauthorizedResponse") == %{error: "Unauthorized"}
+             |> json_response(401) == %{"error" => "Unauthorized"}
 
       assert conn.halted == true
     end
@@ -225,7 +218,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
         response =
           conn
           |> json_response(200)
-          |> assert_schema("EndpointQuery")
 
         assert [
                  %{
@@ -233,9 +225,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
                    "id" => _id,
                    "timestamp" => _timestamp
                  }
-               ] = response.result
+               ] = response["result"]
 
-        refute response.error
+        refute response["error"]
         refute conn.halted
       end
     end
@@ -262,12 +254,11 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error =~
+      assert response["error"] =~
                LogflareWeb.QueryErrorHelpers.generic_query_error_message()
 
-      refute response.result
+      refute response["result"]
     end
 
     test "GET query with lql `f:table` overrides CTE fallback", %{
@@ -302,10 +293,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"col2" => "b"}] = response.result
-      refute response.error
+      assert [%{"col2" => "b"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql and single CTE uses that CTE", %{conn: init_conn, user: user} do
@@ -330,10 +320,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"value" => "test"}] = response.result
-      refute response.error
+      assert [%{"value" => "test"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql and single CTE with explicit `from:table`", %{
@@ -361,10 +350,9 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert [%{"value" => "test"}] = response.result
-      refute response.error
+      assert [%{"value" => "test"}] = response["result"]
+      refute response["error"]
     end
 
     test "GET query with lql `f:invalid_cte` returns error", %{conn: init_conn, user: user} do
@@ -385,12 +373,11 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
-      assert response.error =~
+      assert response["error"] =~
                LogflareWeb.QueryErrorHelpers.generic_query_error_message()
 
-      refute response.result
+      refute response["result"]
     end
   end
 
@@ -863,16 +850,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "REDACTED",
                  "event_message" => "User REDACTED connected"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -897,16 +883,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "REDACTED",
                  "event_message" => "User REDACTED connected REDACTED"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
 
@@ -933,16 +918,15 @@ defmodule LogflareWeb.EndpointsControllerTest do
       response =
         conn
         |> json_response(200)
-        |> assert_schema("EndpointQuery")
 
       assert [
                %{
                  "ip_address" => "192.168.1.1",
                  "message" => "User 10.0.0.1 connected"
                }
-             ] = response.result
+             ] = response["result"]
 
-      refute response.error
+      refute response["error"]
       refute conn.halted
     end
   end

--- a/test/logflare_web/open_api_test.exs
+++ b/test/logflare_web/open_api_test.exs
@@ -4,6 +4,7 @@ defmodule LogflareWeb.OpenApiTest do
   alias LogflareWeb.Api.AccessTokenController
   alias LogflareWeb.Api.QueryController
   alias LogflareWeb.Api.TeamController
+  alias LogflareWeb.OpenApiSchemas.AccessToken
   alias LogflareWeb.OpenApiSchemas.QueryResult
   alias OpenApiSpex.MediaType
   alias OpenApiSpex.Response
@@ -32,6 +33,11 @@ defmodule LogflareWeb.OpenApiTest do
              properties: %{result: %Schema{type: :array, items: %Schema{type: :object}}},
              required: [:result]
            } = QueryResult.schema()
+  end
+
+  test "Management API access token timestamps are documented as RFC3339" do
+    assert %Schema{type: :string, format: :"date-time"} =
+             AccessToken.schema().properties.inserted_at
   end
 
   test "Management API 400 errors are documented as JSON" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -11,6 +11,12 @@ defmodule LogflareWeb.ConnCase do
   it cannot be async. For this reason, every test runs
   inside a transaction which is reset at the beginning
   of the test unless the test case is marked as async.
+
+  The HTTP request helpers imported from this module (`get/3`, `post/3`, and
+  the other verbs) dispatch through `dispatch_and_assert_open_api_response/5`.
+  Responses from documented `/api` routes are therefore checked against their
+  OpenAPI operation and documented status. Tests that intentionally need to
+  bypass this validation can call `Phoenix.ConnTest.dispatch/5` directly.
   """
 
   @session Plug.Session.init(
@@ -128,6 +134,7 @@ defmodule LogflareWeb.ConnCase do
     Plug.Conn.put_req_header(conn, "authorization", "Bearer #{access_token.token}")
   end
 
+  # Preserve Phoenix.ConnTest's request helpers while adding OpenAPI response validation.
   for method <- @http_methods do
     defmacro unquote(method)(conn, path_or_action, params_or_body \\ nil) do
       method = unquote(method)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -166,33 +166,27 @@ defmodule LogflareWeb.ConnCase do
         params_or_body
       ) do
     conn = Phoenix.ConnTest.dispatch(conn, endpoint, method, path_or_action, params_or_body)
-    assert_open_api_response(conn)
+
+    if String.starts_with?(conn.request_path, "/api") do
+      assert_open_api_response(conn)
+    else
+      conn
+    end
   end
 
   @spec assert_open_api_response(Plug.Conn.t()) :: Plug.Conn.t()
   def assert_open_api_response(conn) do
-    case open_api_operation(conn) do
-      nil ->
-        conn
-
-      operation ->
-        assert_documented_response!(operation, conn)
-        OpenApiSpex.TestAssertions.assert_operation_response(conn, operation.operationId)
-        conn
-    end
-  end
-
-  defp open_api_operation(conn) do
     with %{route: route} <-
            Phoenix.Router.route_info(Router, conn.method, conn.request_path, conn.host),
-         true <- String.starts_with?(route, "/api"),
-         {spec, _operation_lookup} <-
-           PutApiSpec.get_spec_and_operation_lookup(conn),
-         path_item when not is_nil(path_item) <- Map.get(spec.paths, open_api_path(route)) do
-      Map.get(path_item, Map.fetch!(@open_api_methods, conn.method))
-    else
-      _ -> nil
+         {spec, _operation_lookup} <- PutApiSpec.get_spec_and_operation_lookup(conn),
+         path_item when not is_nil(path_item) <- Map.get(spec.paths, open_api_path(route)),
+         operation when not is_nil(operation) <-
+           Map.get(path_item, Map.fetch!(@open_api_methods, conn.method)) do
+      assert_documented_response!(operation, conn)
+      OpenApiSpex.TestAssertions.assert_operation_response(conn, operation.operationId)
     end
+
+    conn
   end
 
   defp assert_documented_response!(operation, conn) do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,7 +22,15 @@ defmodule LogflareWeb.ConnCase do
 
   use ExUnit.CaseTemplate
 
+  import ExUnit.Assertions
+
   alias Logflare.Partners.Partner
+  alias LogflareWeb.Router
+  alias OpenApiSpex.Plug.PutApiSpec
+
+  @http_methods [:get, :post, :put, :patch, :delete, :options, :connect, :trace, :head]
+  @conn_test_request_macros for method <- @http_methods, arity <- [2, 3], do: {method, arity}
+  @open_api_methods Map.new(@http_methods, &{&1 |> Atom.to_string() |> String.upcase(), &1})
 
   using _opts do
     quote do
@@ -32,7 +40,7 @@ defmodule LogflareWeb.ConnCase do
 
       import Logflare.Factory
       import LogflareWeb.Router.Helpers
-      import Phoenix.ConnTest
+      import Phoenix.ConnTest, except: unquote(@conn_test_request_macros)
       import Phoenix.LiveViewTest
       import Phoenix.VerifiedRoutes
       import PhoenixTest
@@ -120,8 +128,79 @@ defmodule LogflareWeb.ConnCase do
     Plug.Conn.put_req_header(conn, "authorization", "Bearer #{access_token.token}")
   end
 
-  def assert_schema(data, schema_name) do
-    OpenApiSpex.TestAssertions.assert_schema(data, schema_name, LogflareWeb.ApiSpec.spec())
+  for method <- @http_methods do
+    defmacro unquote(method)(conn, path_or_action, params_or_body \\ nil) do
+      method = unquote(method)
+
+      quote do
+        LogflareWeb.ConnCase.dispatch_and_assert_open_api_response(
+          unquote(conn),
+          @endpoint,
+          unquote(method),
+          unquote(path_or_action),
+          unquote(params_or_body)
+        )
+      end
+    end
+  end
+
+  @spec dispatch_and_assert_open_api_response(
+          Plug.Conn.t(),
+          module(),
+          atom(),
+          String.t() | atom(),
+          term()
+        ) :: Plug.Conn.t()
+  def dispatch_and_assert_open_api_response(
+        conn,
+        endpoint,
+        method,
+        path_or_action,
+        params_or_body
+      ) do
+    conn = Phoenix.ConnTest.dispatch(conn, endpoint, method, path_or_action, params_or_body)
+    assert_open_api_response(conn)
+  end
+
+  @spec assert_open_api_response(Plug.Conn.t()) :: Plug.Conn.t()
+  def assert_open_api_response(conn) do
+    case open_api_operation(conn) do
+      nil ->
+        conn
+
+      operation ->
+        assert_documented_response!(operation, conn)
+        OpenApiSpex.TestAssertions.assert_operation_response(conn, operation.operationId)
+        conn
+    end
+  end
+
+  defp open_api_operation(conn) do
+    with %{route: route} <-
+           Phoenix.Router.route_info(Router, conn.method, conn.request_path, conn.host),
+         true <- String.starts_with?(route, "/api"),
+         {spec, _operation_lookup} <-
+           PutApiSpec.get_spec_and_operation_lookup(conn),
+         path_item when not is_nil(path_item) <- Map.get(spec.paths, open_api_path(route)) do
+      Map.get(path_item, Map.fetch!(@open_api_methods, conn.method))
+    else
+      _ -> nil
+    end
+  end
+
+  defp assert_documented_response!(operation, conn) do
+    if Map.has_key?(operation.responses, conn.status) ||
+         Map.has_key?(operation.responses, :default) do
+      :ok
+    else
+      flunk(
+        "No OpenAPI response is documented for #{conn.method} #{conn.request_path} with status #{conn.status}"
+      )
+    end
+  end
+
+  defp open_api_path(path) do
+    Regex.replace(~r|:([^/]+)|, path, fn _, parameter -> "{#{parameter}}" end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- add generated-spec smoke and authenticated management-route coverage checks
- validate each dispatched, documented API response against its matched OpenAPI operation and status in `ConnCase`
- document the account endpoint and shared management-auth 401 responses
- correct response schema/content-type drift exposed by the new checks
- split source, backend, endpoint, rule, and team request schemas from response schemas
- document rule validation 422 responses and cover those response paths

## Carve-out
Route coverage is limited to routes behind `:require_mgmt_api_auth`; ingestion, partner, and spec-serving routes remain outside this management-API guardrail.