### PR TITLE
feat:limit in flight

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -51,6 +51,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @stale_batch_timeout 12_000
   @stale_batcher_concurrency 2
   @max_retries 1
+  # Generous safety valve (2x total batcher capacity across ch_fresh + ch_stale), not a
+  # fine-grained flow-control knob — see BufferProducer's capped_fetch_amount/2. Should
+  # never engage during healthy operation; only caps genuinely runaway backlog.
+  @max_in_flight 2 *
+                   (@fresh_batch_size * @fresh_batcher_concurrency +
+                      @stale_batch_size * @stale_batcher_concurrency)
 
   @doc false
   @spec max_retries() :: non_neg_integer()
@@ -82,7 +88,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
            [
              backend_id: backend.id,
              consolidated: true,
-             id_passing: true
+             id_passing: true,
+             max_in_flight: @max_in_flight
            ]},
         transformer: {__MODULE__, :transform, [backend_id: backend.id]},
         concurrency: @producer_concurrency
@@ -119,9 +126,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec transform(pointer :: LogEventPointer.t(), opts :: keyword()) :: Message.t()
   def transform(%LogEventPointer{} = pointer, opts) do
+    # Runs in the same process as the producer itself (Broadway.Topology.ProducerStage
+    # calls the producer module's own callbacks, then the transformer, inline, in one
+    # process) — so self() here is the producer's pid, and this lookup always finds the
+    # ref the producer published at init.
+    in_flight_ref = :persistent_term.get({BufferProducer, :in_flight_ref, self()}, nil)
+
     %Message{
       data: pointer,
-      acknowledger: {__MODULE__, :ack_id, %{backend_id: opts[:backend_id]}}
+      acknowledger:
+        {__MODULE__, :ack_id, %{backend_id: opts[:backend_id], in_flight_ref: in_flight_ref}}
     }
   end
 
@@ -175,19 +189,38 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec ack(ack_ref :: term(), successful :: [Message.t()], failed :: [Message.t()]) :: :ok
   def ack(_ack_ref, successful, failed) do
+    decrement_in_flight(successful ++ failed)
+
     Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
       IngestEventQueue.delete_id(pointer.tid, pointer.id)
     end)
 
     if failed != [] do
       failed
-      |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} -> ack_data end)
-      |> Enum.each(fn {%{backend_id: backend_id}, messages} ->
+      |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} -> ack_data.backend_id end)
+      |> Enum.each(fn {backend_id, messages} ->
         maybe_requeue_failed(backend_id, messages)
       end)
     end
 
     :ok
+  end
+
+  # Decrements the claiming producer's in-flight counter directly via the atomics ref
+  # carried on each message's ack_data (see transform/2) — no message-passing, no
+  # cross-process call. By the time ack/3 fires for a message, Broadway has already
+  # finished handle_batch/4 for it, so it's no longer sitting in BatcherStage's
+  # (effectively unbounded) buffer regardless of what happens to it next.
+  @spec decrement_in_flight([Message.t()]) :: :ok
+  defp decrement_in_flight(messages) do
+    messages
+    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
+      Map.get(ack_data, :in_flight_ref)
+    end)
+    |> Enum.each(fn
+      {nil, _msgs} -> :ok
+      {ref, msgs} -> :atomics.sub(ref, 1, length(msgs))
+    end)
   end
 
   @spec emit_batch_telemetry(

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -24,7 +24,9 @@ defmodule Logflare.Backends.BufferProducer do
           source_token: atom() | nil,
           backend_id: pos_integer(),
           last_discard_log_dt: DateTime.t() | nil,
-          interval: pos_integer()
+          interval: pos_integer(),
+          in_flight_ref: :atomics.atomics_ref() | nil,
+          max_in_flight: non_neg_integer() | :infinity | nil
         }
 
   @type spool_producer_state :: %{
@@ -36,7 +38,9 @@ defmodule Logflare.Backends.BufferProducer do
           source_token: nil,
           backend_id: nil,
           last_discard_log_dt: DateTime.t() | nil,
-          interval: pos_integer()
+          interval: pos_integer(),
+          in_flight_ref: :atomics.atomics_ref() | nil,
+          max_in_flight: non_neg_integer() | :infinity | nil
         }
 
   @type state :: standard_state() | spool_producer_state()
@@ -60,7 +64,7 @@ defmodule Logflare.Backends.BufferProducer do
 
     state =
       cond do
-        spool_producer? -> init_spool_producer_state(interval)
+        spool_producer? -> init_spool_producer_state(interval, opts)
         consolidated? -> init_consolidated_state(backend_id, interval, opts)
         true -> init_standard_state(opts, interval)
       end
@@ -68,8 +72,61 @@ defmodule Logflare.Backends.BufferProducer do
     {:producer, state, buffer_size: Keyword.get(opts, :buffer_size, 10_000)}
   end
 
-  @spec init_spool_producer_state(pos_integer()) :: state()
-  defp init_spool_producer_state(interval) do
+  # Publishes a reference to a mutable :atomics counter (not the counter value itself)
+  # via :persistent_term, so transform/2 — which runs in this same process, per
+  # Broadway.Topology.ProducerStage — can look it up once and hand it to ack/3 through
+  # the message's ack_data. Only :persistent_term.put/2 (here, once per producer
+  # lifecycle) and :erase/1 (in terminate/2) are ever called; the actual claim/ack
+  # traffic goes straight through the atomics ref, since repeated :persistent_term
+  # writes would trigger a global VM-wide sweep on every single event.
+  @spec init_in_flight(id_passing :: boolean(), max_in_flight :: non_neg_integer() | nil) ::
+          {:atomics.atomics_ref() | nil, non_neg_integer() | :infinity | nil}
+  defp init_in_flight(true, max_in_flight) do
+    ref = :atomics.new(1, signed: true)
+    :persistent_term.put({__MODULE__, :in_flight_ref, self()}, ref)
+    {ref, max_in_flight || :infinity}
+  end
+
+  defp init_in_flight(false, _max_in_flight), do: {nil, nil}
+
+  # One-time, capped pre-seed of a freshly (re)started producer's own queue from the
+  # shared startup queue — bounded to max_in_flight so it never absorbs more backlog
+  # than it could ever claim anyway, while giving it real pending work immediately
+  # instead of waiting on however many ticks do_fetch's own startup fallback would take
+  # to reach the same amount. Uses pop_pending_pointers' atomic :ets.take-gated claim
+  # (safe even if another producer is concurrently draining the same startup table)
+  # then relocates each pointer's row into the new own table by overriding queue_tid
+  # before reinsert_pointer/1 — a one-off exception to that function's usual "reinsert
+  # where it was claimed from" contract. Only meaningful for id-passing producers with a
+  # finite cap; max_in_flight is nil for non-id-passing producers and :infinity for
+  # id-passing ones with no configured cap.
+  @spec seed_from_startup(table_key(), table_key(), non_neg_integer() | :infinity | nil) :: :ok
+  defp seed_from_startup(_startup_key, _own_key, nil), do: :ok
+  defp seed_from_startup(_startup_key, _own_key, :infinity), do: :ok
+
+  defp seed_from_startup(startup_key, own_key, max_in_flight) when is_integer(max_in_flight) do
+    case IngestEventQueue.pop_pending_pointers(startup_key, max_in_flight) do
+      {:error, :not_initialized} ->
+        :ok
+
+      {:ok, [], _tid} ->
+        :ok
+
+      {:ok, pointers, _tid} ->
+        own_tid = IngestEventQueue.get_tid(own_key)
+
+        Enum.each(pointers, fn pointer ->
+          IngestEventQueue.reinsert_pointer(%{pointer | queue_tid: own_tid})
+        end)
+
+        :ok
+    end
+  end
+
+  @spec init_spool_producer_state(pos_integer(), keyword()) :: state()
+  defp init_spool_producer_state(interval, opts) do
+    {in_flight_ref, max_in_flight} = init_in_flight(true, Keyword.get(opts, :max_in_flight))
+
     state = %{
       spool_producer: true,
       consolidated: false,
@@ -79,13 +136,15 @@ defmodule Logflare.Backends.BufferProducer do
       source_token: nil,
       backend_id: nil,
       last_discard_log_dt: nil,
-      interval: interval
+      interval: interval,
+      in_flight_ref: in_flight_ref,
+      max_in_flight: max_in_flight
     }
 
     table_key = {:spool_producer, nil, self()}
     startup_table_key = {:spool_producer, nil, nil}
     IngestEventQueue.upsert_tid(table_key)
-    IngestEventQueue.move(startup_table_key, table_key)
+    seed_from_startup(startup_table_key, table_key, max_in_flight)
     schedule(state, false)
 
     state
@@ -95,6 +154,7 @@ defmodule Logflare.Backends.BufferProducer do
   defp init_standard_state(opts, interval) do
     source = Sources.Cache.get_by_id(opts[:source_id])
     id_passing = Keyword.get(opts, :id_passing, false)
+    {in_flight_ref, max_in_flight} = init_in_flight(id_passing, Keyword.get(opts, :max_in_flight))
 
     state = %{
       consolidated: false,
@@ -104,13 +164,15 @@ defmodule Logflare.Backends.BufferProducer do
       source_token: source.token,
       backend_id: opts[:backend_id],
       last_discard_log_dt: nil,
-      interval: interval
+      interval: interval,
+      in_flight_ref: in_flight_ref,
+      max_in_flight: max_in_flight
     }
 
     table_key = {state.source_id, state.backend_id, self()}
     startup_table_key = {state.source_id, state.backend_id, nil}
     IngestEventQueue.upsert_tid(table_key)
-    IngestEventQueue.move(startup_table_key, table_key)
+    seed_from_startup(startup_table_key, table_key, max_in_flight)
     schedule(state, false)
 
     state
@@ -119,6 +181,7 @@ defmodule Logflare.Backends.BufferProducer do
   @spec init_consolidated_state(pos_integer(), pos_integer(), keyword()) :: state()
   defp init_consolidated_state(backend_id, interval, opts) do
     id_passing = Keyword.get(opts, :id_passing, false)
+    {in_flight_ref, max_in_flight} = init_in_flight(id_passing, Keyword.get(opts, :max_in_flight))
 
     state = %{
       consolidated: true,
@@ -128,13 +191,15 @@ defmodule Logflare.Backends.BufferProducer do
       source_token: nil,
       backend_id: backend_id,
       last_discard_log_dt: nil,
-      interval: interval
+      interval: interval,
+      in_flight_ref: in_flight_ref,
+      max_in_flight: max_in_flight
     }
 
     table_key = {:consolidated, backend_id, self()}
     startup_table_key = {:consolidated, backend_id, nil}
     IngestEventQueue.upsert_tid(table_key)
-    IngestEventQueue.move(startup_table_key, table_key)
+    seed_from_startup(startup_table_key, table_key, max_in_flight)
 
     schedule(state, Keyword.get(opts, :scale, false))
 
@@ -231,13 +296,35 @@ defmodule Logflare.Backends.BufferProducer do
 
   @impl GenStage
   def terminate(_reason, %{spool_producer: true} = state) do
+    cleanup_in_flight_ref(state)
     table_key = {:spool_producer, nil, self()}
     startup_table_key = {:spool_producer, nil, nil}
     IngestEventQueue.move(table_key, startup_table_key)
     state
   end
 
-  def terminate(_reason, state), do: state
+  def terminate(_reason, state) do
+    cleanup_in_flight_ref(state)
+    state
+  end
+
+  defp cleanup_in_flight_ref(%{in_flight_ref: ref}) when not is_nil(ref) do
+    :persistent_term.erase({__MODULE__, :in_flight_ref, self()})
+  end
+
+  defp cleanup_in_flight_ref(_state), do: :ok
+
+  # Diagnostic getter only — atomics refs can't be sent across a distributed
+  # connection and read remotely (unlike the plain integer this returns), so callers
+  # inspecting a producer's in-flight count from another node must do it in one
+  # :rpc.call that runs entirely on the producer's own node.
+  @spec in_flight_count(pid()) :: non_neg_integer() | nil
+  def in_flight_count(pid) do
+    case :persistent_term.get({__MODULE__, :in_flight_ref, pid}, nil) do
+      nil -> nil
+      ref -> :atomics.get(ref, 1)
+    end
+  end
 
   @impl GenStage
   def handle_demand(demand, state) do
@@ -289,9 +376,14 @@ defmodule Logflare.Backends.BufferProducer do
           {[LogEvent.t()], state()}
   defp resolve_demand(%{demand: prev_demand} = state, new_demand \\ 0) do
     total_demand = prev_demand + new_demand
+    fetch_amount = capped_fetch_amount(state, total_demand)
 
-    events = do_fetch(state, total_demand)
+    events = do_fetch(state, fetch_amount)
     event_count = Enum.count(events)
+
+    if state.in_flight_ref != nil and event_count > 0 do
+      :atomics.add(state.in_flight_ref, 1, event_count)
+    end
 
     new_demand =
       if total_demand < event_count do
@@ -301,6 +393,22 @@ defmodule Logflare.Backends.BufferProducer do
       end
 
     {events, %{state | demand: new_demand}}
+  end
+
+  # A generous safety valve, not a fine-grained flow-control knob: caps how much a
+  # producer will claim from IngestEventQueue once too much already-claimed work is
+  # sitting unacked (e.g. stuck deep in Broadway's own, effectively unbounded batcher
+  # buffering — see BufferProducer moduledoc/callers for context). Non-id-passing
+  # producers have no in_flight_ref and are never throttled.
+  @spec capped_fetch_amount(state :: state(), requested :: non_neg_integer()) ::
+          non_neg_integer()
+  defp capped_fetch_amount(%{in_flight_ref: nil}, requested), do: requested
+  defp capped_fetch_amount(%{max_in_flight: :infinity}, requested), do: requested
+
+  defp capped_fetch_amount(%{in_flight_ref: ref, max_in_flight: max_in_flight}, requested) do
+    current = :atomics.get(ref, 1)
+    available = max(max_in_flight - current, 0)
+    min(requested, available)
   end
 
   # Every producer services its own queue first — a producer that's over

--- a/lib/logflare/backends/spool/producer_pipeline.ex
+++ b/lib/logflare/backends/spool/producer_pipeline.ex
@@ -26,6 +26,10 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
   @processor_concurrency 6
   @batcher_concurrency 4
   @producer_concurrency 1
+  # Generous safety valve (2x total batcher capacity), not a fine-grained flow-control
+  # knob — see BufferProducer's capped_fetch_amount/2. Should never engage during
+  # healthy operation; only caps genuinely runaway backlog.
+  @max_in_flight 2 * @max_batch_size * @batcher_concurrency
 
   @spec start_link(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_link(args) do
@@ -45,7 +49,9 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
       hibernate_after: 5_000,
       spawn_opt: [fullsweep_after: 10],
       producer: [
-        module: {BufferProducer, [spool_producer: true, id_passing: true]},
+        module:
+          {BufferProducer,
+           [spool_producer: true, id_passing: true, max_in_flight: @max_in_flight]},
         transformer: {__MODULE__, :transform, []},
         concurrency: @producer_concurrency
       ],
@@ -72,14 +78,18 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
 
   @spec transform(term(), keyword()) :: Message.t()
   def transform(event, _opts) do
+    in_flight_ref = :persistent_term.get({BufferProducer, :in_flight_ref, self()}, nil)
+
     %Message{
       data: event,
-      acknowledger: {__MODULE__, :no_ack_ref, :ack_data}
+      acknowledger: {__MODULE__, :no_ack_ref, %{in_flight_ref: in_flight_ref}}
     }
   end
 
   @impl Broadway.Acknowledger
   def ack(_ref, successful, failed) do
+    decrement_in_flight(successful ++ failed)
+
     # The pointer was already removed from its queue at claim time
     # (pop_pending_pointers/2 claims via :ets.take/2); ack still has to delete the
     # event row from the generation store itself — GenerationJanitor's rotation is a
@@ -91,6 +101,18 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
     maybe_requeue_failed(failed)
 
     :ok
+  end
+
+  @spec decrement_in_flight([Message.t()]) :: :ok
+  defp decrement_in_flight(messages) do
+    messages
+    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
+      Map.get(ack_data, :in_flight_ref)
+    end)
+    |> Enum.each(fn
+      {nil, _msgs} -> :ok
+      {ref, msgs} -> :atomics.sub(ref, 1, length(msgs))
+    end)
   end
 
   # Requeue failed spool writes for retry — same bounded-retry pattern as

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -34,10 +34,10 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   @max_batch_size 500
   @max_retries 0
   @batcher_concurrency 16
-  # Generous safety valve (2x total batcher capacity), not a fine-grained flow-control
+  # Generous safety valve (4x total batcher capacity), not a fine-grained flow-control
   # knob — see BufferProducer's capped_fetch_amount/2. Should never engage during
   # healthy operation; only caps genuinely runaway backlog.
-  @max_in_flight 2 * @max_batch_size * @batcher_concurrency
+  @max_in_flight 4 * @max_batch_size * @batcher_concurrency
 
   def start_link(args, opts \\ []) do
     {name, args} = Keyword.pop(args, :name)

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -33,6 +33,11 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   @max_batch_length 6_000_000
   @max_batch_size 500
   @max_retries 0
+  @batcher_concurrency 16
+  # Generous safety valve (2x total batcher capacity), not a fine-grained flow-control
+  # knob — see BufferProducer's capped_fetch_amount/2. Should never engage during
+  # healthy operation; only caps genuinely runaway backlog.
+  @max_in_flight 2 * @max_batch_size * @batcher_concurrency
 
   def start_link(args, opts \\ []) do
     {name, args} = Keyword.pop(args, :name)
@@ -60,7 +65,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
                [
                  source_id: source.id,
                  backend_id: backend.id,
-                 id_passing: true
+                 id_passing: true,
+                 max_in_flight: @max_in_flight
                ]},
             transformer:
               {__MODULE__, :transform,
@@ -73,7 +79,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
           ],
           batchers: [
             bq: [
-              concurrency: 16,
+              concurrency: @batcher_concurrency,
               batch_size: bq_batch_size_splitter(),
               batch_timeout: 1_500,
               # required when using a custom batch_size splitter
@@ -110,13 +116,17 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     String.to_atom("#{proc_name}-#{base_name}")
   end
 
-  # Broadway transformer for custom producer
+  # Broadway transformer for custom producer. Runs in the same process as the producer
+  # itself (Broadway.Topology.ProducerStage calls the producer module's own callbacks,
+  # then the transformer, inline, in one process) — so self() here is the producer's
+  # pid, and this lookup always finds the ref the producer published at init.
   def transform(event, args) do
     ref = args[:ref]
+    in_flight_ref = :persistent_term.get({BufferProducer, :in_flight_ref, self()}, nil)
 
     %Message{
       data: event,
-      acknowledger: {__MODULE__, ref, :ack_data}
+      acknowledger: {__MODULE__, ref, %{in_flight_ref: in_flight_ref}}
     }
   end
 
@@ -124,6 +134,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   def ack({queue, config}, successful, failed) do
     {sid, bid, _pipeline_ref} = queue
 
+    decrement_in_flight(successful ++ failed)
     finalize_acked_events({sid, bid}, successful)
     maybe_requeue_failed({sid, bid}, failed, config)
 
@@ -134,6 +145,18 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     )
 
     :ok
+  end
+
+  @spec decrement_in_flight([Message.t()]) :: :ok
+  defp decrement_in_flight(messages) do
+    messages
+    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
+      Map.get(ack_data, :in_flight_ref)
+    end)
+    |> Enum.each(fn
+      {nil, _msgs} -> :ok
+      {ref, msgs} -> :atomics.sub(ref, 1, length(msgs))
+    end)
   end
 
   # Always deletes the generation-store row. If the source's ingest rate is low, also


### PR DESCRIPTION
It appears as though clickhouse can buffer events much faster than it can handle_batches leading to a large backlog of inflight events. 

This pr limits the number of events in flight for a pipeline and will throttle buffer producer if it gets overloaded. This allows pending counts to increase and pipelines to scale up.