### PR TITLE
fix(api): make rules list valid and documented

### DIFF
--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -30,6 +30,24 @@ defmodule Logflare.Rules do
     |> Repo.all()
   end
 
+  @doc "Lists rules owned by a user through their source."
+  @spec list_rules_by_user_id(pos_integer(), non_neg_integer() | nil) :: [Rule.t()]
+  def list_rules_by_user_id(user_id, backend_id \\ nil) do
+    from(r in Rule,
+      join: s in Source,
+      on: r.source_id == s.id,
+      where: s.user_id == ^user_id
+    )
+    |> maybe_filter_by_backend_id(backend_id)
+    |> Repo.all()
+  end
+
+  defp maybe_filter_by_backend_id(query, nil), do: query
+
+  defp maybe_filter_by_backend_id(query, backend_id) do
+    where(query, [r], r.backend_id == ^backend_id)
+  end
+
   def rules_tree_by_source_id(id) do
     rules = list_by_source_id(id)
     RulesTree.build(rules)

--- a/lib/logflare_web/controllers/api/rule_controller.ex
+++ b/lib/logflare_web/controllers/api/rule_controller.ex
@@ -8,6 +8,7 @@ defmodule LogflareWeb.Api.RuleController do
   alias LogflareWeb.OpenApi.Accepted
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.NotFound
+  alias LogflareWeb.OpenApi.Unauthorized
   alias LogflareWeb.OpenApi.UnprocessableEntity
   alias LogflareWeb.OpenApiSchemas.RuleApiSchema
   alias LogflareWeb.OpenApiSchemas.RuleBatchResponse
@@ -19,22 +20,42 @@ defmodule LogflareWeb.Api.RuleController do
   tags(["management"])
 
   operation(:index,
-    summary: "List rules",
-    responses: %{200 => List.response(RuleApiSchema)}
+    summary: "List rules owned by the authenticated user",
+    parameters: [
+      backend_id: [
+        in: :query,
+        description: "Optional backend ID to filter the rule list",
+        type: :integer,
+        required: false
+      ],
+      backend_token: [
+        in: :query,
+        description: "Optional backend UUID to filter the rule list",
+        type: :string,
+        required: false
+      ]
+    ],
+    responses: %{
+      200 => List.response(RuleApiSchema),
+      401 => Unauthorized.response(),
+      404 => NotFound.response()
+    }
   )
 
-  def index(%{assigns: %{user: user}} = conn, filters)
-      when is_map_key(filters, "backend_id") or is_map_key(filters, "backend_token") do
-    kw =
-      case filters do
-        %{"backend_id" => bid} -> [id: bid]
-        %{"backend_token" => token} -> [token: token]
-      end
-
-    with {:ok, backend} <- Backends.fetch_backend_by([{:user_id, user.id} | kw]) do
-      rules = Rules.list_rules(backend)
-      json(conn, rules)
+  def index(%{assigns: %{user: user}} = conn, %{"backend_id" => backend_id}) do
+    with {:ok, backend} <- Backends.fetch_backend_by(user_id: user.id, id: backend_id) do
+      json(conn, Rules.list_rules_by_user_id(user.id, backend.id))
     end
+  end
+
+  def index(%{assigns: %{user: user}} = conn, %{"backend_token" => backend_token}) do
+    with {:ok, backend} <- Backends.fetch_backend_by(user_id: user.id, token: backend_token) do
+      json(conn, Rules.list_rules_by_user_id(user.id, backend.id))
+    end
+  end
+
+  def index(%{assigns: %{user: user}} = conn, _params) do
+    json(conn, Rules.list_rules_by_user_id(user.id))
   end
 
   operation(:show,

--- a/test/logflare_web/controllers/api/rule_controller_test.exs
+++ b/test/logflare_web/controllers/api/rule_controller_test.exs
@@ -2,6 +2,10 @@ defmodule LogflareWeb.Api.RuleControllerTest do
   @moduledoc false
   use LogflareWeb.ConnCase
 
+  alias LogflareWeb.Api.RuleController
+  alias OpenApiSpex.Parameter
+  alias OpenApiSpex.Schema
+
   setup %{conn: conn} do
     insert(:plan, name: "Free")
     user = insert(:user)
@@ -11,17 +15,90 @@ defmodule LogflareWeb.Api.RuleControllerTest do
     {:ok, conn: conn, user: user, backend: backend, source: source}
   end
 
-  test "list rules", %{conn: conn, source: source, backend: backend, user: user} do
-    insert(:rule, backend: insert(:backend, user: user), source: source)
+  test "lists rules owned by the authenticated user", %{
+    conn: conn,
+    source: source,
+    backend: backend,
+    user: user
+  } do
+    first_rule = insert(:rule, backend: backend, source: source)
+    second_rule = insert(:rule, backend: insert(:backend, user: user), source: source)
+
+    other_user = insert(:user)
+
+    insert(:rule,
+      backend: insert(:backend, user: other_user),
+      source: insert(:source, user: other_user)
+    )
+
+    response =
+      conn
+      |> get(~p"/api/rules")
+      |> json_response(200)
+
+    assert MapSet.new(Enum.map(response, & &1["id"])) ==
+             MapSet.new([first_rule.id, second_rule.id])
+  end
+
+  test "filters rules by backend ID or token", %{
+    conn: conn,
+    source: source,
+    backend: backend,
+    user: user
+  } do
     rule = insert(:rule, backend: backend, source: source)
+    insert(:rule, backend: insert(:backend, user: user), source: source)
 
-    assert [result] =
+    for filters <- [%{backend_id: backend.id}, %{backend_token: backend.token}] do
+      assert [result] =
+               conn
+               |> get(~p"/api/rules?#{filters}")
+               |> json_response(200)
+
+      assert result["id"] == rule.id
+      assert result["token"] == rule.token
+    end
+  end
+
+  test "does not list rules for an unauthorized backend", %{conn: conn} do
+    other_user = insert(:user)
+    other_backend = insert(:backend, user: other_user)
+    other_source = insert(:source, user: other_user)
+    insert(:rule, backend: other_backend, source: other_source)
+
+    assert %{"error" => "Not Found"} =
              conn
-             |> get(~p"/api/rules?#{%{backend_token: backend.token}}")
-             |> json_response(200)
+             |> get(~p"/api/rules?#{%{backend_id: other_backend.id}}")
+             |> json_response(404)
+  end
 
-    assert result["id"] == rule.id
-    assert result["token"] == rule.token
+  test "list rules requires a private token", %{conn: conn, user: user} do
+    assert %{"error" => "Unauthorized"} =
+             conn
+             |> add_access_token(user, "public")
+             |> get(~p"/api/rules")
+             |> json_response(401)
+  end
+
+  test "documents optional backend filters for rule discovery" do
+    parameters =
+      RuleController.open_api_operation(:index).parameters
+      |> Map.new(&{&1.name, &1})
+
+    assert %{
+             backend_id: %Parameter{
+               in: :query,
+               description: "Optional backend ID to filter the rule list",
+               required: false,
+               schema: %Schema{type: :integer}
+             },
+             backend_token: %Parameter{
+               in: :query,
+               description: "Optional backend UUID to filter the rule list",
+               required: false,
+               schema: %Schema{type: :string}
+             }
+           } = parameters
   end
 
   test "show rules", %{conn: conn, source: source, backend: backend} do


### PR DESCRIPTION
## Summary
- make `GET /api/rules` list rules owned by the authenticated user when no filter is supplied
- retain and document optional `backend_id` and `backend_token` filters
- cover unfiltered, filtered, unauthorized, and OpenAPI response-contract behavior

Stacked on #3692.