### PR TITLE
fix: Increase time before genertional janitor cleans

### DIFF
--- a/lib/logflare/backends/ingest_event_queue/generation_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/generation_janitor.ex
@@ -57,8 +57,8 @@ defmodule Logflare.Backends.IngestEventQueue.GenerationJanitor do
 
   alias Logflare.Backends.IngestEventQueue
 
-  @default_interval :timer.seconds(60)
-  @default_max_age_ms :timer.minutes(2)
+  @default_interval :timer.seconds(120)
+  @default_max_age_ms :timer.minutes(4)
   @default_recent_events_max_age_ms :timer.minutes(10)
 
   @spec start_link(keyword()) :: GenServer.on_start()


### PR DESCRIPTION
double the allowed event lifetime with generational janitor