### PR TITLE
Tune/clickhouse scale

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -41,6 +41,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
+  @pipelines_per_scheduler 4
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 
@@ -635,7 +636,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
             pipeline: Pipeline,
             pipeline_args: [backend: backend],
             min_pipelines: @min_pipelines,
-            max_pipelines: System.schedulers_online(),
+            max_pipelines: System.schedulers_online() * @pipelines_per_scheduler,
             initial_count: @min_pipelines,
             resolve_interval: @resolve_interval,
             resolve_count: fn state ->

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -37,11 +37,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @min_pipelines 1
   @resolve_interval 10_000
-  @scaling_threshold 15_000
+  @scaling_threshold 1_000
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
   @pipelines_per_scheduler 4
+  @max_in_flight 120_000 #TODO: Share config with clickhouse pipeline
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 
@@ -689,7 +690,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     cond do
       # Scale up if startup queue has events (pipeline not yet ready)
       startup_size > 0 ->
-        state.pipeline_count + 1
+        state.pipeline_count + max(div(startup_size, @max_in_flight), 1)
 
       # Scale up only if the fleet is loaded on average, not just one outlier
       fleet_above_threshold? and len > 0 ->
@@ -704,6 +705,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       true ->
         state.pipeline_count
     end
+    |> dbg()
   end
 
   defp validate_user_pass(changeset) do

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -42,7 +42,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
   @pipelines_per_scheduler 4
-  @max_in_flight 120_000 #TODO: Share config with clickhouse pipeline
+  # TODO: Share config with clickhouse pipeline
+  @max_in_flight 120_000
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -37,7 +37,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @min_pipelines 1
   @resolve_interval 10_000
-  @scaling_threshold 1_000
+  @scaling_threshold 15_000
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -706,7 +706,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       true ->
         state.pipeline_count
     end
-    |> dbg()
   end
 
   defp validate_user_pass(changeset) do

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -182,8 +182,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
     backend = Backends.Cache.get_backend(backend_id)
 
-    Process.sleep(10000)
-
     encode_and_insert(backend, messages, event_type, batcher, batch_info, day_bucket)
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,17 +46,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @processor_max_demand 1_000
   @fresh_batch_size 60_000
   @fresh_batch_timeout 5_000
-  @fresh_batcher_concurrency 4
+  @fresh_batcher_concurrency 1
   @stale_batch_size 60_000
   @stale_batch_timeout 12_000
-  @stale_batcher_concurrency 2
+  @stale_batcher_concurrency 1
   @max_retries 1
   # Generous safety valve (2x total batcher capacity across ch_fresh + ch_stale), not a
   # fine-grained flow-control knob — see BufferProducer's capped_fetch_amount/2. Should
   # never engage during healthy operation; only caps genuinely runaway backlog.
-  @max_in_flight 2 *
-                   (@fresh_batch_size * @fresh_batcher_concurrency +
-                      @stale_batch_size * @stale_batcher_concurrency)
+  @max_in_flight 2 * (@fresh_batch_size * @fresh_batcher_concurrency)
 
   @doc false
   @spec max_retries() :: non_neg_integer()
@@ -183,6 +181,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket)
 
     backend = Backends.Cache.get_backend(backend_id)
+
+    Process.sleep(10000)
 
     encode_and_insert(backend, messages, event_type, batcher, batch_info, day_bucket)
   end

--- a/lib/logflare/backends/ingest_event_queue/generation_janitor.ex
+++ b/lib/logflare/backends/ingest_event_queue/generation_janitor.ex
@@ -57,8 +57,8 @@ defmodule Logflare.Backends.IngestEventQueue.GenerationJanitor do
 
   alias Logflare.Backends.IngestEventQueue
 
-  @default_interval :timer.seconds(60)
-  @default_max_age_ms :timer.minutes(2)
+  @default_interval :timer.seconds(120)
+  @default_max_age_ms :timer.minutes(4)
   @default_recent_events_max_age_ms :timer.minutes(10)
 
   @spec start_link(keyword()) :: GenServer.on_start()

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -48,6 +48,25 @@ defmodule Logflare.DataCase do
         Enum.each(caches, &Cachex.reset(&1, hooks: [Cachex.Stats]))
 
         on_exit(fn ->
+          # Deterministic, not timer-based: IngestEventQueue's generation-store
+          # tables are owned by its own long-lived GenServer, not by this (ephemeral)
+          # test process, so nothing but an explicit :ets.delete ever reclaims them —
+          # unlike delete_all_mappings/0 below, which only clears the mapper's rows.
+          # Without this, that data is a global, never-restarted-between-tests
+          # singleton that only GenerationJanitor's production-tuned timer ever
+          # sweeps, letting residue from every prior test accumulate for the rest of
+          # the suite run. Pruning here, keyed off the same liveness check
+          # GenerationJanitor's own pruning uses, converges that to near-zero
+          # regardless of how that timer happens to be tuned. Order matters: this
+          # must run before delete_all_mappings/0 wipes the mapper, so "live" is
+          # judged against genuinely-still-live state — including other concurrently
+          # running tests' own queues_keys — not a mapper this same callback is about
+          # to clear out from under them.
+          for queues_key <- IngestEventQueue.list_generation_queues_keys(),
+              IngestEventQueue.list_queues(queues_key) == [] do
+            IngestEventQueue.prune_generations(queues_key)
+          end
+
           IngestEventQueue.delete_all_mappings()
           PubSubRates.Cache.clear()
           ClickHouseAdaptor.QueryConnectionSup.terminate_all()


### PR DESCRIPTION
Reduce the number of batchers per clickhouse pipeline and increase the number of pipelines. This should enable pipelines to scale more dynamically.

Also fixes issue with test cleanup from generational janitor.