### PR TITLE
fix: decouple event id in gen table from actual log event id

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -190,7 +190,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     decrement_in_flight(successful ++ failed)
 
     Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
-      IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
 
     if failed != [] do
@@ -320,7 +320,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
          {good, bad, chunks}
        )
        when msg_event_type == event_type do
-    case IngestEventQueue.lookup_event(pointer.tid, pointer.id) do
+    case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
       %LogEvent{} = event ->
         mapped_body =
           event.body
@@ -433,9 +433,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
     events =
       for pointer <- retriable,
-          event = IngestEventQueue.lookup_event(pointer.tid, pointer.id),
+          event = IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id),
           not is_nil(event) do
-        IngestEventQueue.delete_id(pointer.tid, pointer.id)
+        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
         %{event | retries: pointer.retries + 1}
       end
 
@@ -479,7 +479,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       backend_id: backend_id
     )
 
-    Enum.each(pointers, fn pointer -> IngestEventQueue.delete_id(pointer.tid, pointer.id) end)
+    Enum.each(pointers, fn pointer ->
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
+    end)
   end
 
   @spec maybe_compute_duration(map(), TypeDetection.event_type()) :: map()

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -675,24 +675,32 @@ defmodule Logflare.Backends.IngestEventQueue do
     end
   end
 
-  # Writes each event's full body into its current generation's table first, then the
-  # lightweight pointer row into `queue_tid` (the target pipeline's own table) — in that
-  # order, so a crash mid-batch can only leave an inert orphaned event (cleaned up by
-  # generation rotation), never a pointer with no backing data. Pointer row shape:
-  # {event_id, generation_tid, size, retries, event_type, day_bucket, ingest_freshness}.
+  # Claims the pointer row first — insert_new/2 into `queue_tid`, keyed by the event's
+  # own id, is atomic per key, so a duplicate id already pending in this same queue is
+  # rejected outright rather than overwriting (and thereby orphaning) whatever
+  # generation-store row the existing pointer references. Only once the claim succeeds
+  # is the event's full body written into the current generation's table (`gen_tid`),
+  # under a freshly generated `gen_event_id` rather than the event's own id — this
+  # decouples the shared store's key from the (possibly duplicated) event id, so
+  # independent producers that each receive their own copy of the same id never collide
+  # on the same generation-store row. Pointer row shape: {event_id, generation_tid,
+  # gen_event_id, size, retries, event_type, day_bucket, ingest_freshness}.
   defp insert_pointer_batch(sid_bid_pid, queue_tid, batch) do
     queues_key = pointer_queues_key(sid_bid_pid)
     gen_tid = current_generation_tid(queues_key)
 
-    objects =
-      for %{id: id} = event <- batch do
-        :ets.insert(gen_tid, {id, event})
+    for %{id: id} = event <- batch do
+      gen_event_id = make_ref()
 
-        {id, gen_tid, :erlang.external_size(event.body), event.retries || 0, event.event_type,
-         event.day_bucket, event.ingest_freshness}
+      row =
+        {id, gen_tid, gen_event_id, :erlang.external_size(event.body), event.retries || 0,
+         event.event_type, event.day_bucket, event.ingest_freshness}
+
+      if :ets.insert_new(queue_tid, row) do
+        :ets.insert(gen_tid, {gen_event_id, event})
       end
+    end
 
-    :ets.insert(queue_tid, objects)
     :ok
   rescue
     ArgumentError ->
@@ -762,7 +770,7 @@ defmodule Logflare.Backends.IngestEventQueue do
          to_tid when to_tid != nil <- get_tid(to) do
       moved =
         :ets.foldl(
-          fn {id, _, _, _, _, _, _}, acc -> acc + take_and_insert(from_tid, to_tid, id) end,
+          fn {id, _, _, _, _, _, _, _}, acc -> acc + take_and_insert(from_tid, to_tid, id) end,
           0,
           from_tid
         )
@@ -928,13 +936,15 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   def pop_pending_pointers(sid_bid_pid, n) when is_integer(n) do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [],
-       [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}}]}
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7", :"$8"}, [],
+       [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7", :"$8"}}]}
     ]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {selected, _cont} <- :ets.select(tid, ms, n) do
-      confirmed = Enum.flat_map(selected, fn {id, _, _, _, _, _, _} -> take_pointer(tid, id) end)
+      confirmed =
+        Enum.flat_map(selected, fn {id, _, _, _, _, _, _, _} -> take_pointer(tid, id) end)
+
       {:ok, confirmed, tid}
     else
       nil -> {:error, :not_initialized}
@@ -944,11 +954,12 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   defp take_pointer(tid, id) do
     case :ets.take(tid, id) do
-      [{^id, gen_tid, size, retries, event_type, day_bucket, freshness}] ->
+      [{^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket, freshness}] ->
         [
           %LogEventPointer{
             id: id,
             tid: gen_tid,
+            gen_event_id: gen_event_id,
             queue_tid: tid,
             size: size,
             retries: retries,
@@ -975,8 +986,8 @@ defmodule Logflare.Backends.IngestEventQueue do
   @spec reinsert_pointer(LogEventPointer.t()) :: :ok
   def reinsert_pointer(%LogEventPointer{} = pointer) do
     row =
-      {pointer.id, pointer.tid, pointer.size, pointer.retries, pointer.event_type,
-       pointer.day_bucket, pointer.ingest_freshness}
+      {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
+       pointer.event_type, pointer.day_bucket, pointer.ingest_freshness}
 
     :ets.insert(pointer.queue_tid, row)
     :ok
@@ -997,7 +1008,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending(_, 0), do: {:ok, []}
 
   def pop_pending(sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2"}}]}]
+    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
          size when is_integer(size) <- :ets.info(tid, :size),
@@ -1014,11 +1025,11 @@ defmodule Logflare.Backends.IngestEventQueue do
     end
   end
 
-  defp resolve_and_delete_pending(tid, {id, gen_tid}) do
+  defp resolve_and_delete_pending(tid, {id, gen_tid, gen_event_id}) do
     :ets.delete(tid, id)
 
-    case :ets.take(gen_tid, id) do
-      [{^id, event}] -> event
+    case :ets.take(gen_tid, gen_event_id) do
+      [{^gen_event_id, event}] -> event
       [] -> nil
     end
   rescue
@@ -1115,7 +1126,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   def truncate_tid(tid, status, n) when status in [:all, :pending] do
-    ms = [{{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$_"]}]
+    ms = [{{:"$1", :_, :_, :_, :_, :_, :_, :_}, [], [:"$_"]}]
 
     with size when is_integer(size) <- :ets.info(tid, :size) do
       to_keep = select_to_insert(tid, ms, size, n)
@@ -1248,13 +1259,13 @@ defmodule Logflare.Backends.IngestEventQueue do
   @spec drop_pending(source_backend_pid() | consolidated_table_key(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:error, :not_initialized}
   def drop_pending({_, _, _} = sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2"}}]}]
+    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {taken, _cont} <- :ets.select(tid, ms, n) do
-      for {id, gen_tid} <- taken do
+      for {id, gen_tid, gen_event_id} <- taken do
         :ets.delete(tid, id)
-        delete_id(gen_tid, id)
+        delete_id(gen_tid, gen_event_id)
       end
 
       {:ok, Enum.count(taken)}

--- a/lib/logflare/backends/ingest_event_queue/log_event_pointer.ex
+++ b/lib/logflare/backends/ingest_event_queue/log_event_pointer.ex
@@ -3,12 +3,18 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
   A lightweight pointer to a claimed event, returned by
   `Logflare.Backends.IngestEventQueue.pop_pending_pointers/2`.
 
-  `tid` is the generation table the actual `LogEvent` body lives in — resolving it is a
-  direct `:ets.lookup(tid, id)`, no separate id-to-table lookup needed. `queue_tid` is
-  the pending-queue table this pointer was claimed from, carried only so a retry can
-  reinsert directly into it (see `Logflare.Backends.IngestEventQueue.reinsert_pointer/1`)
-  without going through round-robin redistribution — the producer that owns `queue_tid`
-  just proved itself alive by claiming this.
+  `id` is the event's own id — kept as the pointer table's key so a duplicate insert of
+  the same id into the same queue is naturally rejected rather than silently claiming a
+  second pointer for it (see `Logflare.Backends.IngestEventQueue.insert_pointer_batch/3`).
+  `gen_event_id` is the *actual* key the event body lives under in the generation table
+  (`tid`) — a fresh, unique reference generated per insert rather than reusing `id`, so
+  independent producers that happen to receive duplicate copies of the same event id
+  never collide on the same generation-store row. Resolving the event body is a direct
+  `:ets.lookup(tid, gen_event_id)`. `queue_tid` is the pending-queue table this pointer
+  was claimed from, carried only so a retry can reinsert directly into it (see
+  `Logflare.Backends.IngestEventQueue.reinsert_pointer/1`) without going through
+  round-robin redistribution — the producer that owns `queue_tid` just proved itself
+  alive by claiming this.
   """
 
   alias Logflare.LogEvent.TypeDetection
@@ -16,6 +22,7 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
   @enforce_keys [
     :id,
     :tid,
+    :gen_event_id,
     :queue_tid,
     :size,
     :retries,
@@ -26,6 +33,7 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
   defstruct [
     :id,
     :tid,
+    :gen_event_id,
     :queue_tid,
     :size,
     :retries,
@@ -37,6 +45,7 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
   @type t :: %__MODULE__{
           id: term(),
           tid: :ets.tid(),
+          gen_event_id: reference(),
           queue_tid: :ets.tid(),
           size: non_neg_integer(),
           retries: non_neg_integer(),

--- a/lib/logflare/backends/spool/producer_pipeline.ex
+++ b/lib/logflare/backends/spool/producer_pipeline.ex
@@ -95,7 +95,7 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
     # event row from the generation store itself — GenerationJanitor's rotation is a
     # failsafe for abandoned claims, not the primary cleanup path.
     Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
-      IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
 
     maybe_requeue_failed(failed)
@@ -136,7 +136,9 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
         "spool_producer_pipeline: dropping #{length(exhausted)} events: exhausted #{max_retries} retries"
       )
 
-      Enum.each(exhausted, fn pointer -> IngestEventQueue.delete_id(pointer.tid, pointer.id) end)
+      Enum.each(exhausted, fn pointer ->
+        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
+      end)
     end
 
     requeue_retriable(retriable)
@@ -297,8 +299,8 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
     result
   end
 
-  defp lookup_message_event(%{data: %LogEventPointer{tid: tid, id: id}}) do
-    IngestEventQueue.lookup_event(tid, id)
+  defp lookup_message_event(%{data: %LogEventPointer{tid: tid, gen_event_id: gen_event_id}}) do
+    IngestEventQueue.lookup_event(tid, gen_event_id)
   end
 
   defp upload_plain(messages, bucket, file_key, storage_mod) do

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -171,12 +171,12 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
     Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
       if record?, do: record_recent_copy(queues_key, pointer)
-      IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
   end
 
   defp record_recent_copy(queues_key, %LogEventPointer{} = pointer) do
-    case IngestEventQueue.lookup_event(pointer.tid, pointer.id) do
+    case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
       nil -> :ok
       event -> IngestEventQueue.record_recent_event(queues_key, event)
     end
@@ -320,8 +320,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     end)
   end
 
-  defp lookup_message_event(%{data: %LogEventPointer{tid: tid, id: id}}) do
-    IngestEventQueue.lookup_event(tid, id)
+  defp lookup_message_event(%{data: %LogEventPointer{tid: tid, gen_event_id: gen_event_id}}) do
+    IngestEventQueue.lookup_event(tid, gen_event_id)
   end
 
   # Single pass collecting log events + batch metrics. Separate accumulator args (rather
@@ -576,9 +576,9 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
 
     events =
       for pointer <- retriable,
-          event = IngestEventQueue.lookup_event(pointer.tid, pointer.id),
+          event = IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id),
           not is_nil(event) do
-        IngestEventQueue.delete_id(pointer.tid, pointer.id)
+        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
         %{event | retries: pointer.retries + 1}
       end
 
@@ -616,7 +616,9 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   defp drop_pointers(pointers, reason) do
     Logger.warning("Dropping #{length(pointers)} BigQuery events: #{reason}")
 
-    Enum.each(pointers, fn pointer -> IngestEventQueue.delete_id(pointer.tid, pointer.id) end)
+    Enum.each(pointers, fn pointer ->
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
+    end)
   end
 
   # Emit per-event ingest telemetry from handle_batch, where the full LogEvent is

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -50,6 +50,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     tid
   end
 
+  # A real requeue (via IngestEventQueue.add_to_table/2) inserts the retried event under
+  # a freshly generated gen_event_id, not the event's own id — so a post-requeue
+  # generation table can't be looked up by event id directly. Scans by the event's own
+  # id in the stored value instead of assuming it's the table's key.
+  defp lookup_by_event_id(tid, event_id) do
+    tid
+    |> :ets.tab2list()
+    |> Enum.find_value(fn {_gen_event_id, event} -> if event.id == event_id, do: event end)
+  end
+
   # Builds a LogEventPointer for `event`, resolvable via `gen_tid` (see
   # setup_generation_events/1). `queue_tid` defaults to a fresh, otherwise-unused table
   # since most tests only care about claim/retry behavior driven off other fields.
@@ -57,6 +67,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     %LogEventPointer{
       id: event.id,
       tid: gen_tid,
+      gen_event_id: event.id,
       queue_tid: queue_tid || :ets.new(:test_pipeline_queue, [:set, :public]),
       size: :erlang.external_size(event.body),
       retries: event.retries || 0,
@@ -717,7 +728,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
         # ... and re-added to the current generation with incremented retries
         current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-        assert %{retries: 1} = IngestEventQueue.lookup_event(current_gen_tid, event.id)
+        assert %{retries: 1} = lookup_by_event_id(current_gen_tid, event.id)
       end
 
       test "increments retry count on each re-queue", %{
@@ -743,7 +754,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
 
         assert %{retries: ^initial_retries} = event
-        assert %{retries: retries} = IngestEventQueue.lookup_event(current_gen_tid, event.id)
+        assert %{retries: retries} = lookup_by_event_id(current_gen_tid, event.id)
         assert retries == initial_retries + 1
       end
 
@@ -786,12 +797,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         assert IngestEventQueue.lookup_event(gen_tid, exhausted_event.id) == nil
 
         current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-        assert IngestEventQueue.lookup_event(current_gen_tid, exhausted_event.id) == nil
+        assert lookup_by_event_id(current_gen_tid, exhausted_event.id) == nil
 
         # retriable event's old copy is deleted too, but re-added to the current
         # generation with incremented retries
         assert IngestEventQueue.lookup_event(gen_tid, retriable_event.id) == nil
-        assert %{retries: 1} = IngestEventQueue.lookup_event(current_gen_tid, retriable_event.id)
+        assert %{retries: 1} = lookup_by_event_id(current_gen_tid, retriable_event.id)
       end
 
       test "emits telemetry and logs a warning when a retriable event's generation is already gone",
@@ -822,7 +833,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         # nothing landed in the current generation — the event was already gone at
         # lookup time
         current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-        assert IngestEventQueue.lookup_event(current_gen_tid, event.id) == nil
+        assert lookup_by_event_id(current_gen_tid, event.id) == nil
       end
     end
   end
@@ -1036,7 +1047,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
 
       current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-      assert %{retries: 1} = IngestEventQueue.lookup_event(current_gen_tid, event.id)
+      assert %{retries: 1} = lookup_by_event_id(current_gen_tid, event.id)
     end
   end
 end

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -407,7 +407,7 @@ defmodule Logflare.Backends.BufferProducerTest do
 
       # The claimed pointer row is already deleted (pop_pending_pointers/2 claims via
       # :ets.take/2), so the full event is resolved lazily via the pointer's own tid.
-      assert IngestEventQueue.lookup_event(pointer.tid, event_id) == le
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == le
 
       assert IngestEventQueue.total_pending(consolidated_key) == 0
     end

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -391,7 +391,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       # schedule — it only ever evicts the cache row, never the generation store
       assert :ok = IngestEventQueue.truncate_recent(queues_key, 0)
       assert IngestEventQueue.list_recent_events(queues_key, 10) == []
-      assert IngestEventQueue.lookup_event(pointer.tid, pointer.id) == le
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == le
     end
 
     test "drop n items from a queue", %{source: source, source_backend_pid: sbp} do
@@ -401,7 +401,14 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       queues_key = Tuple.delete_at(sbp, 2)
       gen_tid = IngestEventQueue.current_generation_tid(queues_key)
       pointer_tid = IngestEventQueue.get_tid(sbp)
-      ids_before = pointer_tid |> :ets.tab2list() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+      rows_before = pointer_tid |> :ets.tab2list()
+
+      gen_event_id_by_id =
+        Map.new(rows_before, fn {id, _gen_tid, gen_event_id, _, _, _, _, _} ->
+          {id, gen_event_id}
+        end)
+
+      ids_before = rows_before |> Enum.map(&elem(&1, 0)) |> MapSet.new()
 
       assert {:ok, 2} = IngestEventQueue.drop_pending(sbp, 2)
       assert IngestEventQueue.get_table_size(sbp) == 498
@@ -414,11 +421,12 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       # otherwise the memory it's meant to relieve sits until GenerationJanitor's next
       # rotation instead of being freed immediately
       for id <- dropped_ids do
-        assert IngestEventQueue.lookup_event(gen_tid, id) == nil
+        assert IngestEventQueue.lookup_event(gen_tid, Map.fetch!(gen_event_id_by_id, id)) == nil
       end
 
       remaining_id = ids_after |> MapSet.to_list() |> hd()
-      assert %LogEvent{} = IngestEventQueue.lookup_event(gen_tid, remaining_id)
+      remaining_gen_event_id = Map.fetch!(gen_event_id_by_id, remaining_id)
+      assert %LogEvent{} = IngestEventQueue.lookup_event(gen_tid, remaining_gen_event_id)
     end
 
     test "truncate all events in a queue", %{source: source, source_backend_pid: sbp} do
@@ -565,7 +573,9 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert fresh_pointer.day_bucket == 12_345
       assert fresh_pointer.ingest_freshness == :fresh
       assert fresh_pointer.size == :erlang.external_size(fresh.body)
-      assert IngestEventQueue.lookup_event(fresh_pointer.tid, fresh_pointer.id).id == fresh.id
+
+      assert IngestEventQueue.lookup_event(fresh_pointer.tid, fresh_pointer.gen_event_id).id ==
+               fresh.id
 
       stale_pointer = Map.fetch!(by_id, stale.id)
       assert stale_pointer.event_type == :trace
@@ -727,6 +737,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       pointer = %LogEventPointer{
         id: "some-id",
         tid: tid,
+        gen_event_id: make_ref(),
         queue_tid: tid,
         size: 0,
         retries: 0,
@@ -1453,7 +1464,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(key, 1)
       IngestEventQueue.record_recent_event(queues_key, le)
-      IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
 
       assert [{gen_tid, _created_at}] = IngestEventQueue.list_generations(queues_key)
       :ok = IngestEventQueue.drop_generation(queues_key, gen_tid)
@@ -1461,7 +1472,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       # the generation-store row is long gone, but the independent copy survives —
       # this is the exact case github.com/Logflare/logflare/pull/3690#discussion_r3597505520
       # flagged against the old pointer-based cache
-      assert IngestEventQueue.lookup_event(pointer.tid, pointer.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
       assert IngestEventQueue.list_recent_events(queues_key, 10) == [le]
     end
 
@@ -1514,12 +1525,13 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       # claiming the still-present pointer now resolves to a dead generation — the same
       # "not found" outcome as any other lookup miss, not a crash
-      assert {:ok, [%LogEventPointer{id: claimed_id, tid: claimed_tid}], _tid} =
-               IngestEventQueue.pop_pending_pointers(consolidated_key, 1)
+      assert {:ok,
+              [%LogEventPointer{id: claimed_id, tid: claimed_tid, gen_event_id: gen_event_id}],
+              _tid} = IngestEventQueue.pop_pending_pointers(consolidated_key, 1)
 
       assert claimed_id == le.id
       assert claimed_tid == gen_tid
-      assert IngestEventQueue.lookup_event(claimed_tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(claimed_tid, gen_event_id) == nil
 
       # rotation keeps producing fresh generations for a queues_key with live traffic —
       # do_rotate/2 already created this synchronously above, so no polling needed

--- a/test/logflare/backends/spool/producer_pipeline_test.exs
+++ b/test/logflare/backends/spool/producer_pipeline_test.exs
@@ -37,6 +37,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
       data: %LogEventPointer{
         id: Ecto.UUID.generate(),
         tid: :fake_tid,
+        gen_event_id: make_ref(),
         queue_tid: :fake_tid,
         size: size,
         retries: 0,

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -107,7 +107,7 @@ defmodule Logflare.BigQuery.PipelineTest do
       # Event is NOT requeued (retries == max_retries); its event row is deleted
       # from the generation store since nothing will ever ack it
       assert IngestEventQueue.total_pending(sid_bid_pid) == 0
-      assert IngestEventQueue.lookup_event(pointer.tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
     end
 
     test "ack deletes the generation-store row immediately but records an independent copy into the recent-events cache",
@@ -128,7 +128,7 @@ defmodule Logflare.BigQuery.PipelineTest do
       # the generation-store row is gone immediately — the recent-events cache holds
       # an independent copy instead, so it stays visible even after the originating
       # generation is later rotated out and dropped by GenerationJanitor
-      assert IngestEventQueue.lookup_event(pointer.tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
       assert IngestEventQueue.list_recent_events({source.id, nil}, 10) == [le]
     end
 
@@ -149,7 +149,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       mod.ack(ref, [message], [])
 
-      assert IngestEventQueue.lookup_event(pointer.tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
       assert IngestEventQueue.list_recent_events({source.id, nil}, 10) == []
     end
 
@@ -171,7 +171,7 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       mod.ack(ref, [message], [])
 
-      assert IngestEventQueue.lookup_event(pointer.tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
       assert IngestEventQueue.list_recent_events({deleted_source_id, nil}, 10) == []
     end
 
@@ -194,7 +194,7 @@ defmodule Logflare.BigQuery.PipelineTest do
       # ack still deletes the generation-store row as normal — only the recent-events
       # write is skipped, since list_recent_logs_local/2 hardcodes {source_id, nil} and
       # would never read a row recorded under this explicit backend_id anyway
-      assert IngestEventQueue.lookup_event(pointer.tid, le.id) == nil
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
       assert IngestEventQueue.list_recent_events({source.id, backend.id}, 10) == []
       assert IngestEventQueue.list_recent_events({source.id, nil}, 10) == []
     end
@@ -658,7 +658,7 @@ defmodule Logflare.BigQuery.PipelineTest do
       pointer = message.data
 
       # Delete the event from the generation store so the id cannot be resolved
-      :ets.delete(pointer.tid, le.id)
+      :ets.delete(pointer.tid, pointer.gen_event_id)
 
       ref = make_ref()
 

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -415,7 +415,7 @@ defmodule Logflare.SourcesTest do
         Backends.IngestEventQueue.pop_pending_pointers({source.id, nil, nil}, 1)
 
       Backends.IngestEventQueue.record_recent_event({source.id, nil}, old_event)
-      Backends.IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      Backends.IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
 
       TestUtils.retry_assert(fn ->
         assert Backends.source_sup_started?(source)
@@ -456,7 +456,7 @@ defmodule Logflare.SourcesTest do
         Backends.IngestEventQueue.pop_pending_pointers({source.id, nil, nil}, 1)
 
       Backends.IngestEventQueue.record_recent_event({source.id, nil}, event)
-      Backends.IngestEventQueue.delete_id(pointer.tid, pointer.id)
+      Backends.IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
 
       TestUtils.retry_assert(fn ->
         assert [_event] = Backends.list_recent_logs_local(source, 1)


### PR DESCRIPTION
Decouple gen event id from the real event id to allow duplicates in loadtest