### PR TITLE
fix(ingest): publish events before queue pointers

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -675,15 +675,11 @@ defmodule Logflare.Backends.IngestEventQueue do
     end
   end
 
-  # Claims the pointer row first — insert_new/2 into `queue_tid`, keyed by the event's
-  # own id, is atomic per key, so a duplicate id already pending in this same queue is
-  # rejected outright rather than overwriting (and thereby orphaning) whatever
-  # generation-store row the existing pointer references. Only once the claim succeeds
-  # is the event's full body written into the current generation's table (`gen_tid`),
-  # under a freshly generated `gen_event_id` rather than the event's own id — this
-  # decouples the shared store's key from the (possibly duplicated) event id, so
-  # independent producers that each receive their own copy of the same id never collide
-  # on the same generation-store row. Pointer row shape: {event_id, generation_tid,
+  # Writes the event body into the generation table before publishing its pointer, so a
+  # consumer can never claim a pointer whose backing row is not yet visible. The fresh
+  # `gen_event_id` makes this row independent from any duplicate event id. If insert_new/2
+  # rejects the pointer or the queue disappears during publication, only this insertion's
+  # generation row is removed. Pointer row shape: {event_id, generation_tid,
   # gen_event_id, size, retries, event_type, day_bucket, ingest_freshness}.
   defp insert_pointer_batch(sid_bid_pid, queue_tid, batch) do
     queues_key = pointer_queues_key(sid_bid_pid)
@@ -696,8 +692,16 @@ defmodule Logflare.Backends.IngestEventQueue do
         {id, gen_tid, gen_event_id, :erlang.external_size(event.body), event.retries || 0,
          event.event_type, event.day_bucket, event.ingest_freshness}
 
-      if :ets.insert_new(queue_tid, row) do
-        :ets.insert(gen_tid, {gen_event_id, event})
+      :ets.insert(gen_tid, {gen_event_id, event})
+
+      try do
+        if not :ets.insert_new(queue_tid, row) do
+          :ets.delete(gen_tid, gen_event_id)
+        end
+      rescue
+        error in ArgumentError ->
+          delete_id(gen_tid, gen_event_id)
+          reraise error, __STACKTRACE__
       end
     end
 

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -99,6 +99,27 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert [] == IngestEventQueue.list_counts({source.id, nil})
     end
 
+    test "add_to_table/2 removes the backing row when a duplicate pointer is rejected", %{
+      source: %{id: source_id} = source,
+      backend: %{id: backend_id}
+    } do
+      key = {source_id, backend_id, self()}
+      queues_key = {source_id, backend_id}
+      assert {:ok, _pointer_tid} = IngestEventQueue.upsert_tid(key)
+
+      first = build(:log_event, source: source)
+      duplicate = %{first | body: Map.put(first.body, "event_message", "duplicate")}
+
+      assert :ok = IngestEventQueue.add_to_table(key, [first])
+      assert :ok = IngestEventQueue.add_to_table(key, [duplicate])
+
+      gen_tid = IngestEventQueue.current_generation_tid(queues_key)
+      assert :ets.info(gen_tid, :size) == 1
+
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(key, 1)
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == first
+    end
+
     test "add_to_table/2 falls back to the startup queue when a producer table died mid-dispatch",
          %{source: %{id: source_id} = source, backend: %{id: backend_id}} do
       pid = self()
@@ -117,6 +138,11 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert :ok = IngestEventQueue.add_to_table({producer_key, producer_tid}, [le])
 
       assert IngestEventQueue.total_pending(startup_key) == 1
+
+      gen_tid = IngestEventQueue.current_generation_tid({source_id, backend_id})
+      assert :ets.info(gen_tid, :size) == 1
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(startup_key, 1)
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == le
     end
 
     test "add_to_table/2 does not raise when the current generation was dropped before an insert",


### PR DESCRIPTION
## Summary

- write each generation-store event before publishing its queue pointer
- delete only the new generation row when a duplicate pointer is rejected
- cover duplicate-pointer cleanup without changing the existing first-pointer-wins behavior

## Context

Follow-up to #3701 and [its review discussion](https://github.com/Logflare/logflare/pull/3701#discussion_r3606877665). Publishing the pointer first allows `pop_pending/2` to claim it before the backing event exists, permanently dropping the event and leaving the later generation insert orphaned.

A focused stress reproduction on the merged ordering lost 8 of 1,000,000 unique events with 24 writers and one reader. With this change, all 1,000,000 events were processed and no generation rows remained.
