### PR TITLE
test: speed up test suite

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   versions:
     name: Get versions

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,13 +7,16 @@ on:
   pull_request:
     branches: ["**"]
     paths:
+      - "assets/**"
       - "lib/**"
       - "config/**"
       - "*.exs"
       - "*.lock"
       - "native/**"
       - "priv/**"
-      - "test/**"
+      - "test/e2e/features/**"
+      - "test/support/**"
+      - "test/test_helper.exs"
       # Run suite when this file is changed
       - ".github/workflows/e2e-tests.yml"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -120,10 +120,10 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-e2e-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('native/**') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
-            cargo-${{ runner.os }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-e2e-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-e2e-
 
       - name: Restore Mix cache
         uses: actions/cache@v5
@@ -132,10 +132,10 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,10 +135,11 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
+            priv/docs
+          key: mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-e2e-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   versions:
     name: Get versions

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -21,6 +21,7 @@ on:
       - "priv/**"
       - "test/**"
       - "!test/e2e/supabase/**"
+      - ".github/scripts/**"
       # Run suite when this file is changed
       - ".github/workflows/elixir-ci.yml"
 
@@ -39,8 +40,14 @@ jobs:
       elixir: ${{ steps.v.outputs.elixir }}
       erlang: ${{ steps.v.outputs.erlang }}
       rust: ${{ steps.v.outputs.rust }}
+      backend: ${{ steps.changes.outputs.backend }}
+      frontend: ${{ steps.changes.outputs.frontend }}
+      rust_changed: ${{ steps.changes.outputs.rust }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Read versions from .tool-versions
         id: v
         run: |
@@ -48,10 +55,54 @@ jobs:
           echo "erlang=$(grep '^erlang '  .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
           echo "rust=$(grep   '^rust '    .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
+      - name: Detect affected checks
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          backend=false
+          frontend=false
+          rust=false
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            backend=true
+            frontend=true
+            rust=true
+          else
+            while IFS= read -r path; do
+              case "$path" in
+                .github/workflows/elixir-ci.yml)
+                  backend=true
+                  frontend=true
+                  rust=true
+                  ;;
+                assets/*)
+                  frontend=true
+                  ;;
+                Cargo.toml|Cargo.lock|native/mapper_ex/*)
+                  backend=true
+                  rust=true
+                  ;;
+                test/e2e/*)
+                  ;;
+                .github/scripts/*|config/*|lib/*|native/*|priv/*|test/*|*.exs|*.lock|Dockerfile.base|Dockerfile.runner|Dockerfile.multi-step)
+                  backend=true
+                  ;;
+              esac
+            done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          fi
+
+          echo "backend=$backend" >> "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+
   quality:
     name: Checks (${{ matrix.commands.name }}, ${{ matrix.commands.run }})
     runs-on: ubuntu-latest
     needs: versions
+    if: needs.versions.outputs.backend == 'true'
     strategy:
       matrix:
         commands:
@@ -93,6 +144,7 @@ jobs:
     name: Checks (Compilation Warnings, mix test.compile)
     runs-on: ubuntu-latest
     needs: versions
+    if: needs.versions.outputs.backend == 'true'
     env:
       MIX_ENV: test
       SHELL: /bin/bash
@@ -143,6 +195,7 @@ jobs:
     name: Checks (Typing check, mix test.typings)
     runs-on: ubuntu-latest
     needs: versions
+    if: needs.versions.outputs.backend == 'true'
     env:
       MIX_ENV: test
       SHELL: /bin/bash
@@ -202,6 +255,7 @@ jobs:
     name: Checks (Tests, epmd -daemon; mix do ecto.create + ecto.migrate + test.coverage.ci)
     runs-on: ubuntu-latest
     needs: versions
+    if: needs.versions.outputs.backend == 'true'
     services:
       postgres:
         image: bitnamilegacy/postgresql:15
@@ -299,6 +353,7 @@ jobs:
     name: Rust unit tests
     runs-on: ubuntu-latest
     needs: versions
+    if: needs.versions.outputs.rust_changed == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -324,6 +379,8 @@ jobs:
   frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    needs: versions
+    if: needs.versions.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -48,8 +48,8 @@ jobs:
           echo "erlang=$(grep '^erlang '  .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
           echo "rust=$(grep   '^rust '    .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
-  check:
-    name: Checks
+  quality:
+    name: Checks (${{ matrix.commands.name }}, ${{ matrix.commands.run }})
     runs-on: ubuntu-latest
     needs: versions
     strategy:
@@ -59,15 +59,149 @@ jobs:
             run: mix lint.all
           - name: Code Quality - Formatting
             run: mix test.format
-          - name: Compilation Warnings
-            run: mix test.compile
-          - name: Tests
-            # we start epmd for clustered tests
-            run: epmd -daemon; mix do ecto.create + ecto.migrate + test.coverage.ci
-          # - name: Security - Sobelow Code Scan
-          #   run: mix test.security
-          - name: Typing check
-            run: mix test.typings
+    env:
+      MIX_ENV: test
+      SHELL: /bin/bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Restore Mix cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          restore-keys: |
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+
+      - name: Install dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Run ${{ matrix.commands.name }}
+        run: ${{ matrix.commands.run }}
+
+  compile:
+    name: Checks (Compilation Warnings, mix test.compile)
+    runs-on: ubuntu-latest
+    needs: versions
+    env:
+      MIX_ENV: test
+      SHELL: /bin/bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.versions.outputs.rust }}
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
+            cargo-${{ runner.os }}-
+
+      - name: Restore Mix cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          restore-keys: |
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+
+      - name: Install dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Run compilation checks
+        run: mix test.compile
+
+  typing:
+    name: Checks (Typing check, mix test.typings)
+    runs-on: ubuntu-latest
+    needs: versions
+    env:
+      MIX_ENV: test
+      SHELL: /bin/bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.versions.outputs.rust }}
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
+            cargo-${{ runner.os }}-
+
+      - name: Restore Mix cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+            priv/native
+          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          restore-keys: |
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+
+      - name: Restore Dialyzer PLT cache
+        uses: actions/cache@v5
+        with:
+          path: dialyzer
+          key: plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
+            plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+
+      - name: Install dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Run typing checks
+        run: mix test.typings
+
+  test:
+    name: Checks (Tests, epmd -daemon; mix do ecto.create + ecto.migrate + test.coverage.ci)
+    runs-on: ubuntu-latest
+    needs: versions
     services:
       postgres:
         image: bitnamilegacy/postgresql:15
@@ -78,7 +212,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: logflare_test
           POSTGRESQL_WAL_LEVEL: logical
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd "pg_isready -d logflare_test -U postgres -p 5432"
           --health-interval 10s
@@ -109,7 +242,7 @@ jobs:
       MIX_ENV: test
       SHELL: /bin/bash
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      COVERALLS_SERVICE_JOB_ID: ${{ github.sha }}-${{ strategy.job-index }}-${{ github.run_id }}
+      COVERALLS_SERVICE_JOB_ID: ${{ github.sha }}-tests-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v6
 
@@ -156,21 +289,11 @@ jobs:
             mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
             mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
 
-      - name: Restore Dialyzer PLT cache
-        if: matrix.commands.name == 'Typing check'
-        uses: actions/cache@v5
-        with:
-          path: dialyzer
-          key: plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            plt-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
-
       - name: Install dependencies
         run: mix do deps.get + deps.compile
 
-      - name: Run ${{ matrix.commands.name }}
-        run: ${{ matrix.commands.run }}
+      - name: Run tests
+        run: epmd -daemon; mix do ecto.create + ecto.migrate + test.coverage.ci
 
   rust:
     name: Rust unit tests

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -78,10 +78,10 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -116,10 +116,10 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('native/**') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
-            cargo-${{ runner.os }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-
 
       - name: Restore Mix cache
         uses: actions/cache@v5
@@ -128,10 +128,10 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -166,10 +166,10 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('native/**') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
-            cargo-${{ runner.os }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-
 
       - name: Restore Mix cache
         uses: actions/cache@v5
@@ -178,10 +178,10 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Restore Dialyzer PLT cache
         uses: actions/cache@v5
@@ -272,10 +272,10 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('native/**') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
-            cargo-${{ runner.os }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-elixir-${{ github.job }}-
 
       - name: Restore Mix cache
         uses: actions/cache@v5
@@ -284,10 +284,10 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ hashFiles('mix.lock', '**/Cargo.lock', 'native/**') }}
+          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-
-            mix-v3-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -313,10 +313,10 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-rust-unit-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('native/mapper_ex/**') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ needs.versions.outputs.rust }}-
-            cargo-${{ runner.os }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-rust-unit-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-v2-${{ runner.os }}-${{ needs.versions.outputs.rust }}-rust-unit-
 
       - name: Run mapper Rust unit tests
         run: cargo test -p mapper_ex

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -129,10 +129,11 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
+            priv/docs
+          key: mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -180,10 +181,11 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
+            priv/docs
+          key: mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -231,10 +233,11 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
+            priv/docs
+          key: mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Restore Dialyzer PLT cache
         uses: actions/cache@v5
@@ -338,10 +341,11 @@ jobs:
             deps
             _build
             priv/native
-          key: mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
+            priv/docs
+          key: mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-${{ hashFiles('mix.exs', 'config/**', 'lib/**', 'native/**', 'priv/**', 'test/support/**') }}
           restore-keys: |
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
-            mix-v4-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-${{ hashFiles('mix.lock', '**/Cargo.lock') }}-
+            mix-v5-${{ runner.os }}-${{ needs.versions.outputs.erlang }}-${{ needs.versions.outputs.elixir }}-${{ github.job }}-
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -30,9 +30,39 @@ defaults:
     working-directory: test/e2e/supabase
 
 jobs:
+  build-image:
+    name: Build Logflare image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Logflare image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        tags: supabase/logflare:local
+        outputs: type=docker,dest=/tmp/logflare-image.tar
+        cache-from: type=gha,scope=integration-logflare
+        cache-to: type=gha,scope=integration-logflare,mode=max
+        pull: true
+
+    - name: Upload Logflare image
+      uses: actions/upload-artifact@v4
+      with:
+        name: logflare-image-${{ github.sha }}
+        path: /tmp/logflare-image.tar
+        compression-level: 0
+        retention-days: 1
+
   test:
     name: Playwright Tests
     runs-on: ubuntu-latest
+    needs: build-image
 
     strategy:
       matrix:
@@ -47,37 +77,16 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      uses: actions/cache@v4
+    - name: Download Logflare image
+      uses: actions/download-artifact@v4
       with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
+        name: logflare-image-${{ github.sha }}
+        path: /tmp/logflare-image
 
-    - name: Build and cache Logflare image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ./Dockerfile
-        tags: supabase/logflare:local
-        load: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-        pull: true
-
-    - name: Move Docker cache
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    - name: Load Logflare image
+      run: docker load --input /tmp/logflare-image/logflare-image.tar
       working-directory: .
 
     - uses: actions/setup-node@v4

--- a/lib/logflare/backends/adaptor/http_based/pipeline.ex
+++ b/lib/logflare/backends/adaptor/http_based/pipeline.ex
@@ -13,6 +13,9 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
+  @batch_timeout if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+  @producer_interval if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+
   @spec start_link(Source.t(), Backend.t(), module()) :: Broadway.on_start()
   def start_link(source, backend, client) do
     Broadway.start_link(__MODULE__,
@@ -26,7 +29,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
           {BufferProducer,
            [
              backend_id: backend.id,
-             source_id: source.id
+             source_id: source.id,
+             interval: @producer_interval
            ]},
         transformer: {__MODULE__, :transform, []},
         concurrency: 1
@@ -35,7 +39,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
         default: [concurrency: 3, min_demand: 1]
       ],
       batchers: [
-        http: [concurrency: 6, batch_size: 250]
+        http: [concurrency: 6, batch_size: 250, batch_timeout: @batch_timeout]
       ],
       context: %{
         source_id: source.id,

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -260,6 +260,9 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     alias Logflare.Backends.BufferProducer
     alias Logflare.Backends.Adaptor.WebhookAdaptor.Client
 
+    @batch_timeout if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+    @producer_interval if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+
     def start_link(args) do
       Broadway.start_link(__MODULE__,
         name: Backends.via_source(args.source, __MODULE__, args.backend),
@@ -272,7 +275,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
             {BufferProducer,
              [
                backend_id: Map.get(args.backend || %{}, :id),
-               source_id: args.source.id
+               source_id: args.source.id,
+               interval: @producer_interval
              ]},
           transformer: {__MODULE__, :transform, []},
           concurrency: 1
@@ -281,7 +285,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
           default: [concurrency: 3, min_demand: 1]
         ],
         batchers: [
-          http: [concurrency: 6, batch_size: 250]
+          http: [concurrency: 6, batch_size: 250, batch_timeout: @batch_timeout]
         ],
         context: %{
           startup_config: args.config,

--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -316,13 +316,13 @@ defmodule Logflare.Utils do
   iex> ip_version("127.0.0.1:8222")
   :nxdomain
 
-  iex> ip_version("1467:f4e1:7a77:756a:896c:dff5:ca48:cf3c")
-  :inet6
-
-  iex> ip_version("supabase.com")
+  iex> ip_version("localhost")
   :inet
 
-  iex> ip_version("ipv6.google.com")
+  iex> ip_version("::1")
+  :inet6
+
+  iex> ip_version("1467:f4e1:7a77:756a:896c:dff5:ca48:cf3c")
   :inet6
 
   iex> ip_version("not_an_address")

--- a/test/logflare/backends/adaptor/axiom_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/axiom_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
@@ -111,7 +110,6 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -141,7 +139,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert {:ok, _} = enqueue_backend_logs([log_event], source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [log] = Jason.decode!(json)
@@ -165,7 +163,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [_, _, _] = Jason.decode!(json)

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -28,9 +28,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       end
     end)
 
-    Process.sleep(200)
-
-    assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+    TestUtils.retry_assert(fn ->
+      assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+    end)
 
     context = %{backend_id: backend.id}
 
@@ -241,15 +241,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert backend_id == backend.id
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      assert {:ok, {[%{"count" => 2}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 2}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "handles empty messages list", %{context: context} do
@@ -344,17 +344,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      {:ok, {query_result, _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          "SELECT event_message, timestamp FROM #{table_name} ORDER BY timestamp DESC"
-        )
+      query_result =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {query_result, _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     "SELECT event_message, timestamp FROM #{table_name} ORDER BY timestamp DESC"
+                   )
 
-      assert length(query_result) == 2
+          assert length(query_result) == 2
+          query_result
+        end)
 
       [first_row, second_row] = query_result
 
@@ -395,15 +397,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      assert {:ok, {[%{"count" => 3}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 3}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "routes metric events to metrics table", %{
@@ -429,15 +431,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
-      assert {:ok, {[%{"count" => 1}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 1}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "routes trace events to traces table", %{
@@ -462,15 +464,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
-      assert {:ok, {[%{"count" => 1}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 1}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "inserts logs with all scalar fields readable via SELECT", %{
@@ -498,23 +500,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, trace_id, span_id, trace_flags,
-            severity_text, severity_number, service_name, event_message,
-            scope_name, scope_version, scope_schema_url, resource_schema_url,
-            resource_attributes, scope_attributes, log_attributes, timestamp
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, trace_id, span_id, trace_flags,
+                       severity_text, severity_number, service_name, event_message,
+                       scope_name, scope_version, scope_schema_url, resource_schema_url,
+                       resource_attributes, scope_attributes, log_attributes, timestamp
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])
@@ -563,28 +568,31 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, time_unix, start_time_unix,
-            metric_name, metric_description, metric_unit, metric_type,
-            service_name, event_message, scope_name, scope_version,
-            scope_schema_url, resource_schema_url,
-            resource_attributes, scope_attributes, attributes,
-            aggregation_temporality, is_monotonic, flags,
-            value, count, sum, min, max,
-            scale, zero_count, positive_offset, negative_offset,
-            timestamp
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, time_unix, start_time_unix,
+                       metric_name, metric_description, metric_unit, metric_type,
+                       service_name, event_message, scope_name, scope_version,
+                       scope_schema_url, resource_schema_url,
+                       resource_attributes, scope_attributes, attributes,
+                       aggregation_temporality, is_monotonic, flags,
+                       value, count, sum, min, max,
+                       scale, zero_count, positive_offset, negative_offset,
+                       timestamp
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])
@@ -620,25 +628,28 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, timestamp,
-            trace_id, span_id, parent_span_id, trace_state,
-            span_name, span_kind, service_name, event_message,
-            duration, status_code, status_message,
-            scope_name, scope_version,
-            resource_attributes, span_attributes
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, timestamp,
+                       trace_id, span_id, parent_span_id, trace_state,
+                       span_name, span_kind, service_name, event_message,
+                       duration, status_code, status_message,
+                       scope_name, scope_version,
+                       resource_attributes, span_attributes
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
@@ -67,23 +67,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ProvisionerTest do
 
   describe "connection test failure handling" do
     @tag capture_log: true
-    test "fails initialization when ClickHouse is unavailable" do
-      {_source, invalid_backend} =
-        setup_clickhouse_test(
-          config: %{
-            url: "http://localhost",
-            username: "invalid_user",
-            password: "invalid_pass",
-            port: 19_999
-          }
-        )
+    test "fails initialization when ClickHouse is unavailable", %{backend: backend} do
+      expect(ClickHouseAdaptor, :test_connection, fn ^backend ->
+        {:error, :grant_check_unknown_failure}
+      end)
 
-      pid = start_supervised!({Provisioner, invalid_backend}, restart: :transient)
+      pid = start_supervised!({Provisioner, backend}, restart: :transient)
       ref = Process.monitor(pid)
 
       assert_receive {:DOWN, ^ref, :process, ^pid,
                       {:shutdown, {:error, :grant_check_unknown_failure}}},
-                     5_000
+                     1_000
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -10,6 +10,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryConnectionSup
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates
   alias Logflare.Backends.Backend
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.Adaptor.QueryResult
@@ -373,20 +374,35 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert :ok = ClickHouseAdaptor.test_connection(backend)
     end
 
-    test "fails when ingest URL is unreachable" do
-      {_source, backend} =
-        setup_clickhouse_test(config: %{url: "http://localhost:19999"})
+    test "fails when the ingest cluster returns a connection error" do
+      {_source, backend} = setup_clickhouse_test(cleanup?: false)
 
-      start_supervised!({ClickHouseAdaptor, backend})
-      assert {:error, _} = ClickHouseAdaptor.test_connection(backend)
+      stub(Ch, :query, fn _pool, _statement, _params, _opts ->
+        {:error, %DBConnection.ConnectionError{message: "unreachable"}}
+      end)
+
+      assert {:error, :grant_check_unknown_failure} = ClickHouseAdaptor.test_connection(backend)
     end
 
-    test "fails when read_only_url is unreachable" do
+    test "fails when the read cluster returns a connection error" do
       {_source, backend} =
-        setup_clickhouse_test(config: %{read_only_url: "http://localhost:19999"})
+        setup_clickhouse_test(
+          config: %{read_only_url: "http://localhost:8123"},
+          cleanup?: false
+        )
 
-      start_supervised!({ClickHouseAdaptor, backend})
-      assert {:error, _} = ClickHouseAdaptor.test_connection(backend)
+      read_grant_statement = QueryTemplates.read_grant_check_statement()
+
+      stub(Ch, :query, fn pool, statement, params, opts ->
+        if statement == read_grant_statement do
+          {:error, %DBConnection.ConnectionError{message: "unreachable"}}
+        else
+          Mimic.call_original(Ch, :query, [pool, statement, params, opts])
+        end
+      end)
+
+      assert {:error, :grant_check_unknown_failure} = ClickHouseAdaptor.test_connection(backend)
+      QueryConnectionSup.terminate_backend_local(backend.id)
     end
 
     test "passes when async is enabled and async_insert_cluster_url points to a valid cluster" do
@@ -485,8 +501,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       result = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log, async: true)
       assert :ok = result
 
-      Process.sleep(500)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
       query_result =
@@ -518,8 +532,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       result = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
       assert :ok = result
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -587,8 +599,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log)
 
-      Process.sleep(100)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
       {:ok, {[row], _bytes}} =
@@ -618,8 +628,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [metric_event], :metric)
 
-      Process.sleep(100)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
       {:ok, {[row], _bytes}} =
@@ -646,8 +654,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         )
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [trace_event], :trace)
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
@@ -677,8 +683,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
         :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], event_type)
 
-        Process.sleep(100)
-
         table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, event_type)
 
         {:ok, {query_result, _bytes}} =
@@ -707,8 +711,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     test "executes a query with query-level SETTINGS", %{source: source, backend: backend} do
       log_event = build_mapped_log_event(source: source, message: "settings exec test")
       assert :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log)
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -786,7 +788,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       ]
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -863,7 +864,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         end
 
       assert :ok = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
-      Process.sleep(200)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -1032,7 +1032,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       {source, backend} = setup_clickhouse_test()
 
       start_supervised!({ClickHouseAdaptor, backend})
-      Process.sleep(100)
       [source: source, backend: backend]
     end
 
@@ -1100,7 +1099,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       {source, backend} = setup_clickhouse_test()
 
       start_supervised!({ClickHouseAdaptor, backend})
-      Process.sleep(100)
       [source: source, backend: backend]
     end
 

--- a/test/logflare/backends/adaptor/datadog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/datadog_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Backends.Adaptor.DatadogAdaptor
@@ -106,7 +105,6 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       start_supervised!({AdaptorSupervisor, {source, backend}}, id: :source1)
       start_supervised!({AdaptorSupervisor, {source_with_service_name, backend}}, id: :source2)
-      :timer.sleep(500)
 
       [
         backend: backend,
@@ -128,7 +126,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -144,7 +142,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source, message: nil, event_message: nil)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -160,7 +158,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.service_name
     end
@@ -177,7 +175,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.name
     end
@@ -194,7 +192,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["data"] == le.body
     end

--- a/test/logflare/backends/adaptor/elastic_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/elastic_adaptor_test.exs
@@ -3,7 +3,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
   alias Logflare.Backends.Adaptor
   alias Logflare.SystemMetrics.AllLogsLogged
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
 
   @subject Logflare.Backends.Adaptor.ElasticAdaptor
@@ -65,7 +64,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -81,7 +79,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -97,7 +95,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end
@@ -120,7 +118,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
         )
 
       pid = start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [pid: pid, backend: backend, source: source]
     end
 
@@ -137,7 +134,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Alerting
@@ -122,7 +121,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -137,7 +135,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
 
       %{body: %{"event_message" => message}} = le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive payload, 2000
 
       assert %{
@@ -170,7 +168,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source, user: user]
     end
 

--- a/test/logflare/backends/adaptor/last9_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/last9_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
   alias Logflare.Backends.AdaptorSupervisor
@@ -110,7 +109,6 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -130,7 +128,7 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
 
       log_events = build_list(3, :log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/loki_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/loki_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
 
@@ -120,7 +119,6 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -136,7 +134,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -152,7 +150,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, log_entry}, 2000
 
       assert %{streams: [%{stream: %{source: "supabase", service: ^source_name}}]} = log_entry
@@ -170,7 +168,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, payload}, 2000
 
       assert %{

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
   alias Logflare.Backends.AdaptorSupervisor
@@ -123,7 +122,6 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -152,7 +150,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: ts_us
         )
 
-      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert {:ok, _} = enqueue_backend_logs([log_event], source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
@@ -177,7 +175,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
@@ -91,7 +90,6 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -117,7 +115,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -192,7 +190,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           )
         end)
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -237,7 +235,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -288,7 +286,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -340,7 +338,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -380,7 +378,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -8,6 +8,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends
   alias Logflare.Backends.Backend
   alias Logflare.SystemMetrics.AllLogsLogged
+  alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.SourceSup
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
@@ -29,12 +30,11 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
           config: %{http: "http1", url: "https://example.com"}
         )
 
-      start_supervised!({SourceSup, source})
-      :timer.sleep(500)
       [source: source, backend: backend]
     end
 
-    test "ingest", %{source: source} do
+    test "ingest through the full source supervision tree", %{source: source} do
+      start_supervised!({SourceSup, source})
       this = self()
       ref = make_ref()
 
@@ -52,7 +52,9 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       assert_receive ^ref, 2000
     end
 
-    test "uses cache for config fetching", %{source: source} do
+    test "uses cache for config fetching", %{source: source, backend: backend} do
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+
       Logflare.Repo.update_all(Backend,
         set: [config_encrypted: %{http: "http1", url: "https://other-email.com"}]
       )
@@ -71,7 +73,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
   end

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -36,7 +36,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :streamed, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "does not use LF managed BQ if legacy user BQ config is set" do
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :ok, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "can query with parameters" do
@@ -78,10 +78,6 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
         {:ok, TestUtils.gen_bq_response([%{"test" => value}])}
       end)
-
-      user = insert(:user)
-      source = insert(:source, user: user)
-      start_supervised!({SourceSup, source})
 
       assert {:ok, %QueryResult{rows: [%{"test" => "input_data"}]}} =
                BigQueryAdaptor.execute_query(
@@ -102,10 +98,6 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
         {:ok, TestUtils.gen_bq_response([%{"test" => "1"}])}
       end)
-
-      user = insert(:user)
-      source = insert(:source, user: user)
-      start_supervised!({SourceSup, source})
 
       assert {:ok, %QueryResult{rows: [%{"test" => "1"}]}} =
                BigQueryAdaptor.execute_query(backend, "SELECT 1", [])
@@ -146,7 +138,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert {:ok, _} = Backends.ingest_logs([log_event], source)
 
       assert_receive :streamed, 2500
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "update table", %{source: source} do
@@ -174,7 +166,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert {:ok, _} = Backends.ingest_logs([log_event], source)
 
       assert_receive :patched, 2500
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "bug: invalid json encode update table", %{
@@ -209,25 +201,12 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
       assert {:ok, %{len: 1}} = Backends.cache_local_buffer_lens(source_id, nil)
       assert {:ok, %{len: 1}} = Backends.cache_local_buffer_lens(source_id, backend_id)
-      :timer.sleep(2000)
 
       TestUtils.retry_assert(fn ->
         assert_receive ^ref
       end)
 
-      {:ok, %{queues: queues}} = Backends.cache_local_buffer_lens(source_id, nil)
-
-      assert Enum.find_value(queues, fn
-               {{^source_id, nil, nil}, count} -> count
-               _ -> nil
-             end) == 0
-
-      {:ok, %{queues: queues}} = Backends.cache_local_buffer_lens(source_id, backend_id)
-
-      assert Enum.find_value(queues, fn
-               {{^source_id, ^backend_id, nil}, count} -> count
-               _ -> nil
-             end) == 0
+      assert_buffers_empty(source_id, backend_id)
     end
   end
 
@@ -330,8 +309,18 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :ok, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
+  end
+
+  defp assert_buffers_empty(source_id, backend_id \\ nil) do
+    TestUtils.retry_assert(fn ->
+      assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source_id)
+
+      if backend_id do
+        assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source_id, backend_id)
+      end
+    end)
   end
 
   describe "bq storage api benchmark" do

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -24,7 +24,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     [%LogEvent{id: id}] =
@@ -51,7 +50,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     PubSubRatesCache.cache_rates(source.token, %{
@@ -87,11 +85,9 @@ defmodule Logflare.Backends.BufferProducerTest do
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
     startup_table_key = {source.id, nil, nil}
     IngestEventQueue.upsert_tid(startup_table_key)
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
-    Process.exit(buffer_producer_pid, :normal)
-    :timer.sleep(200)
+    signal_exit_and_wait(buffer_producer_pid)
 
     assert IngestEventQueue.total_pending(startup_table_key) == 1
     assert IngestEventQueue.total_pending(sid_bid_pid) == 0
@@ -107,7 +103,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id, id_passing: true})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     tid = IngestEventQueue.get_tid(sid_bid_pid)
@@ -159,9 +154,9 @@ defmodule Logflare.Backends.BufferProducerTest do
     captured =
       capture_log(fn ->
         send(pid, {:add_to_buffer, items})
-        :timer.sleep(100)
+        :sys.get_state(pid)
         send(pid, {:add_to_buffer, items})
-        :timer.sleep(100)
+        :sys.get_state(pid)
       end)
 
     assert captured =~ source.name
@@ -192,7 +187,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
       sid_bid_pid = {source.id, nil, buffer_producer_pid}
-      :timer.sleep(100)
 
       own_event = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(sid_bid_pid, [own_event])
@@ -222,7 +216,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
       sid_bid_pid = {source.id, nil, buffer_producer_pid}
-      :timer.sleep(100)
 
       own_event = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(sid_bid_pid, [own_event])
@@ -262,8 +255,6 @@ defmodule Logflare.Backends.BufferProducerTest do
           {BufferProducer, backend_id: nil, source_id: source.id, id_passing: true},
           id: :producer_b
         )
-
-      :timer.sleep(100)
 
       events = [build(:log_event, source: source), build(:log_event, source: source)]
       :ok = IngestEventQueue.add_to_table(startup_key, events)
@@ -428,7 +419,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
@@ -473,13 +463,11 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
 
-      Process.exit(buffer_producer_pid, :normal)
-      :timer.sleep(200)
+      signal_exit_and_wait(buffer_producer_pid)
 
       assert IngestEventQueue.total_pending(startup_key) == 1
       assert IngestEventQueue.total_pending(consolidated_key) == 0
@@ -500,7 +488,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le =
         build(:log_event, source: source)
@@ -547,9 +534,9 @@ defmodule Logflare.Backends.BufferProducerTest do
       captured =
         capture_log(fn ->
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
         end)
 
       assert captured =~ "Consolidated GenStage producer has discarded"
@@ -573,7 +560,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, spool_producer: true, interval: 100})
 
       spool_key = {:spool_producer, nil, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event)
       :ok = IngestEventQueue.add_to_table(spool_key, [le])
@@ -621,16 +607,14 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, spool_producer: true, interval: 100})
 
       spool_key = {:spool_producer, nil, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event)
       :ok = IngestEventQueue.add_to_table(spool_key, [le])
 
-      Process.exit(buffer_producer_pid, :normal)
-      :timer.sleep(200)
+      stop_and_wait(buffer_producer_pid)
 
       assert IngestEventQueue.total_pending(startup_key) == 1
-      assert IngestEventQueue.total_pending(spool_key) == 0
+      assert IngestEventQueue.total_pending(spool_key) == {:error, :not_initialized}
     end
 
     test "format_discarded logs a spool-specific message" do
@@ -646,9 +630,9 @@ defmodule Logflare.Backends.BufferProducerTest do
       captured =
         capture_log(fn ->
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
         end)
 
       assert captured =~ "Spool producer GenStage has discarded"
@@ -873,5 +857,17 @@ defmodule Logflare.Backends.BufferProducerTest do
       assert_receive :scheduled_resolve, 400
       refute_receive :scheduled_resolve, 400
     end
+  end
+
+  defp signal_exit_and_wait(pid) do
+    Process.exit(pid, :normal)
+    :sys.get_state(pid)
+    assert Process.alive?(pid)
+  end
+
+  defp stop_and_wait(pid) do
+    monitor_ref = Process.monitor(pid)
+    :ok = GenServer.stop(pid, :normal, 1_000)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 1_000
   end
 end

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -29,6 +29,12 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     ]
   end
 
+  defp wait_for_stop do
+    receive do
+      :stop -> :ok
+    end
+  end
+
   test "add_pipeline/1 can scale up pipelines", %{name: name, pipeline_args: pipeline_args} do
     start_supervised!(
       {DynamicPipeline,
@@ -84,10 +90,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
 
   test ":resolve_count and :resolve_interval option will determine number of pipelines to start periodically",
        %{name: name, pipeline_args: pipeline_args} do
-    pid =
-      spawn(fn ->
-        :timer.sleep(400)
-      end)
+    pid = spawn(&wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,
@@ -116,6 +119,10 @@ defmodule Logflare.Backends.DynamicPipelineTest do
       assert DynamicPipeline.pipeline_count(name) == 5
     end)
 
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 10
     end)
@@ -136,7 +143,9 @@ defmodule Logflare.Backends.DynamicPipelineTest do
                   resolve_interval: 100}
                )
 
-             :timer.sleep(300)
+             coordinator = DynamicPipeline.find_coordinator_name(name)
+             send(coordinator, :check)
+             :sys.get_state(coordinator)
              assert Process.alive?(pid)
            end) =~ "some error"
   end
@@ -190,10 +199,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
         [:logflare, :backends, :dynamic_pipeline, :decrement]
       ])
 
-    pid =
-      spawn(fn ->
-        :timer.sleep(400)
-      end)
+    pid = spawn(&wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,
@@ -221,6 +227,10 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 10
     end)
+
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
 
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 5

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -924,7 +924,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_queue_size()
-      full_batch = build_list(max_size, :log_event, source: source)
+      full_batch = build_queue_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1019,13 +1019,13 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {source.id, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_list(max_size, :log_event))
+          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
           queue
         end
 
       # every existing queue is at the hard cap — nothing eligible remains, so the
       # whole new batch falls through to the startup queue instead
-      new_events = build_list(10_000, :log_event)
+      new_events = build_queue_events(10_000)
       :ok = IngestEventQueue.add_to_table({source.id, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
@@ -1124,7 +1124,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_consolidated_queue_size()
-      full_batch = build_list(max_size, :log_event, source: source)
+      full_batch = build_queue_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1168,10 +1168,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(queue1)
       IngestEventQueue.upsert_tid(queue2)
 
-      :ok = IngestEventQueue.add_to_table(queue1, build_list(1_000, :log_event))
-      :ok = IngestEventQueue.add_to_table(queue2, build_list(1_010, :log_event))
+      :ok = IngestEventQueue.add_to_table(queue1, build_queue_events(1_000))
+      :ok = IngestEventQueue.add_to_table(queue2, build_queue_events(1_010))
 
-      new_events = build_list(200, :log_event)
+      new_events = build_queue_events(200)
 
       :ok =
         IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events, chunk_size: 50)
@@ -1194,16 +1194,21 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_list(max_size, :log_event))
+          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
           queue
         end
 
-      new_events = build_list(10_000, :log_event)
+      new_events = build_queue_events(10_000)
       :ok = IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
       for queue <- queues, do: assert(IngestEventQueue.get_table_size(queue) == max_size)
     end
+  end
+
+  defp build_queue_events(count, attrs \\ []) do
+    event = build(:log_event, attrs)
+    for id <- 1..count, do: %{event | id: {event.id, id}}
   end
 
   describe "pop_pending/2" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -1343,11 +1343,12 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     le = build(:log_event, source: source)
     IngestEventQueue.add_to_table(table, [le])
     IngestEventQueue.add_to_table(other_table, [le])
-    :timer.sleep(300)
 
     # Verify worker cached the values automatically (without manual cache calls)
-    assert PubSubRates.Cache.get_cluster_buffers(source.id, backend.id) == 1
-    assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 1
+    TestUtils.retry_assert(fn ->
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, backend.id) == 1
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 1
+    end)
   end
 
   test "QueueJanitor purges if exceeds max" do
@@ -1364,7 +1365,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       {QueueJanitor, source: source, backend: backend, interval: 50, max: 100, purge_ratio: 1.0}
     )
 
-    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == 0
   end
 
@@ -1382,7 +1382,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       {QueueJanitor, source: source, backend: backend, interval: 50, max: 90, purge_ratio: 0.5}
     )
 
-    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == 50
   end
 
@@ -1421,7 +1420,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
          consolidated_key: queues_key}
       )
 
-      :timer.sleep(550)
       assert IngestEventQueue.get_table_size(consolidated_key) == 0
       assert IngestEventQueue.list_recent_events(queues_key, 10) == []
     end
@@ -1453,7 +1451,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
          consolidated_key: {:consolidated, backend.id}}
       )
 
-      :timer.sleep(550)
       # Events should remain because 150 < 1000 (consolidated max = 100 * 10)
       assert IngestEventQueue.get_table_size(consolidated_key) == 150
     end
@@ -1517,9 +1514,11 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     tid = IngestEventQueue.get_tid({source.id, backend.id, pid})
     :ets.delete(tid)
     start_supervised!({MapperJanitor, interval: 100})
-    :timer.sleep(500)
-    assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == nil
-    assert :ets.info(:ingest_event_queue_mapping, :size) == 0
+
+    TestUtils.retry_assert(fn ->
+      assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == nil
+      assert :ets.info(:ingest_event_queue_mapping, :size) == 0
+    end)
   end
 
   describe "recent-events cache" do

--- a/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
+++ b/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
@@ -35,7 +35,7 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     :ok
   end
@@ -117,7 +117,8 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 0.0
     )
 
-    Process.sleep(1_100)
+    send(MemoryMonitor, :refresh)
+    :sys.get_state(MemoryMonitor)
     assert MemoryMonitor.throttled?() == true
   end
 
@@ -127,7 +128,8 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 1.0
     )
 
-    Process.sleep(1_100)
+    send(MemoryMonitor, :refresh)
+    :sys.get_state(MemoryMonitor)
     assert MemoryMonitor.throttled?() == false
   end
 
@@ -190,12 +192,11 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       pid = start_producer()
       Task.async(fn -> GenStage.stream([{pid, max_demand: 1}]) |> Enum.take(1) end)
 
-      Process.sleep(50)
-
-      poll_timer = :sys.get_state(pid).state.poll_timer
-
-      refute is_nil(poll_timer)
-      assert Process.read_timer(poll_timer)
+      TestUtils.retry_assert(fn ->
+        poll_timer = :sys.get_state(pid).state.poll_timer
+        refute is_nil(poll_timer)
+        assert Process.read_timer(poll_timer)
+      end)
     end
 
     test "recovers automatically once memory pressure drops, without any new demand arriving" do
@@ -229,12 +230,11 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       pid = start_producer()
       Task.async(fn -> GenStage.stream([{pid, max_demand: 1}]) |> Enum.take(1) end)
 
-      Process.sleep(50)
-
-      poll_timer = :sys.get_state(pid).state.poll_timer
-
-      refute is_nil(poll_timer)
-      assert Process.read_timer(poll_timer)
+      TestUtils.retry_assert(fn ->
+        poll_timer = :sys.get_state(pid).state.poll_timer
+        refute is_nil(poll_timer)
+        assert Process.read_timer(poll_timer)
+      end)
     end
 
     test "recovers automatically once consumer backlog clears, without any new demand arriving" do

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -92,6 +92,17 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       :sys.get_state(pid)
     end
 
+    defp fill_queue(table_key) do
+      event = build(:log_event)
+
+      events =
+        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
+          %{event | id: {event.id, id}}
+        end
+
+      IngestEventQueue.add_to_table(table_key, events)
+    end
+
     test "is true once a registered source's destination buffer is full", %{
       source: source,
       table_key: table_key,
@@ -99,10 +110,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     } do
       assert MemoryMonitor.consumer_throttled?() == false
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)
@@ -115,10 +123,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       table_key: table_key,
       pid: pid
     } do
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)
@@ -134,10 +139,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       table_key: table_key,
       pid: pid
     } do
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       # never registered
       force_refresh(pid)
@@ -164,10 +166,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       MemoryMonitor.register_source(source.id)
       MemoryMonitor.register_source(source.id)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       force_refresh(pid)
 
@@ -189,10 +188,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       backend_table_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(backend_table_key, [le])
-      end
+      fill_queue(backend_table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -27,7 +27,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     assert MemoryMonitor.throttled?() == true
   end
@@ -39,9 +39,29 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     assert MemoryMonitor.throttled?() == false
+  end
+
+  test "periodically refreshes cached memory pressure without an explicit message" do
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 1.0,
+      spool_max_ets_percent: 1.0
+    )
+
+    start_supervised!(MemoryMonitor)
+    :sys.get_state(MemoryMonitor)
+    assert MemoryMonitor.throttled?() == false
+
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 0.0,
+      spool_max_ets_percent: 0.0
+    )
+
+    TestUtils.retry_assert([duration: 1_500, sleep: 25], fn ->
+      assert MemoryMonitor.throttled?() == true
+    end)
   end
 
   test "refresh/0 emits a [:logflare, :backends, :spool, :throttled] telemetry event on every refresh" do
@@ -82,7 +102,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       )
 
       pid = start_supervised!(MemoryMonitor)
-      Process.sleep(50)
+      :sys.get_state(pid)
 
       {:ok, user: user, source: source, table_key: table_key, pid: pid}
     end

--- a/test/logflare/backends/spool/producer_pipeline_test.exs
+++ b/test/logflare/backends/spool/producer_pipeline_test.exs
@@ -99,7 +99,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
   end
 
   defp throttled! do
@@ -109,7 +109,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
   end
 
   describe "spool_batch_size_splitter/0 when not throttled" do
@@ -161,7 +161,8 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
         spool_max_ets_percent: 1.0
       )
 
-      Process.sleep(1_100)
+      send(MemoryMonitor, :refresh)
+      :sys.get_state(MemoryMonitor)
       assert MemoryMonitor.throttled?() == false
 
       # 5MB + 8MB = 13MB, over the locked-in 12MB budget (would NOT emit under

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -11,6 +11,7 @@ defmodule Logflare.Backends.UserMonitoringTest do
   alias Logflare.Backends.QueryError
   alias Logflare.Backends.SourceSup
   alias Logflare.Backends.UserMonitoring
+  alias Logflare.Backends.UserMonitoring.IngestPipeline
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.LogEvent
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
@@ -28,7 +29,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
     start_supervised!({SourceSup, source}, id: :source)
     start_supervised!({SourceSup, source_b}, id: :source_b)
 
-    :timer.sleep(250)
     [source: source, source_b: source_b, user: user]
   end
 
@@ -181,8 +181,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
       start_supervised!({SourceSup, metrics_source}, id: :metrics_source)
       start_supervised!({SourceSup, source}, id: :source)
 
-      :timer.sleep(1000)
-
       assert {:ok, _} = Backends.ingest_logs([%{"metadata" => %{"value" => "test"}}], source)
 
       TestUtils.retry_assert(fn ->
@@ -230,6 +228,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                  )
                )
       end)
+
+      stop_supervised!(IngestPipeline)
     end
 
     test "other users metrics" do
@@ -308,6 +308,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
         refute attr["source_id"] in [source_id, metrics_source_id]
         refute attr["my_label"] == "test"
       end
+
+      stop_supervised!(IngestPipeline)
     end
   end
 
@@ -350,8 +352,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
       {:ok, _} = Backends.update_source_backends(source, [webhook_backend])
       Backends.Cache.get_backend(webhook_backend.id)
 
-      :timer.sleep(1000)
-
       assert {:ok, _} = Backends.ingest_logs([%{"message" => "test webhook egress"}], source)
 
       assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 15_000
@@ -374,6 +374,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
       assert attributes["backend_id"] == webhook_backend.id
       assert attributes["_backend_environment"] == "test"
       assert attributes["_backend_region"] == "us-west"
+
+      stop_supervised!(IngestPipeline)
     end
   end
 
@@ -416,7 +418,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
         )
 
       assert {:ok, _} = Endpoints.run_query(endpoint)
-      :timer.sleep(1000)
       endpoint_id = endpoint.id
 
       assert_receive {:insert_all,
@@ -436,6 +437,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
+
+      stop_supervised!(IngestPipeline)
     end
 
     test "endpoints.query emits backend_id and backend_type in attributes" do
@@ -470,7 +473,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
         )
 
       assert {:ok, _} = Endpoints.run_query(endpoint)
-      :timer.sleep(1000)
 
       backend_id = backend.id
 
@@ -489,6 +491,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
+
+      stop_supervised!(IngestPipeline)
     end
   end
 

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -111,12 +111,16 @@ defmodule Logflare.Backends.UserMonitoringTest do
         backend: Logflare.Backends.Adaptor.BigQueryAdaptor
       }
 
-      assert capture_log(fn ->
-               QueryError.log(error,
-                 user_id: user.id,
-                 source_token: source.token
-               )
-             end) == ""
+      log =
+        capture_log(fn ->
+          QueryError.log(error,
+            user_id: user.id,
+            source_token: source.token
+          )
+        end)
+
+      refute log =~ "Backend query error"
+      refute log =~ "raw user query detail"
 
       refute Enum.any?(
                Backends.list_recent_logs(system_source),

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -23,6 +23,7 @@ defmodule Logflare.BackendsTest do
   alias Logflare.Repo
   alias Logflare.Rules
   alias Logflare.Sources
+  alias Logflare.Sources.Counters
   alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.Pipeline
   alias Logflare.Sources.SourceRouter
@@ -584,8 +585,6 @@ defmodule Logflare.BackendsTest do
 
       # unchanged
       assert %Backend{config: %{url: "http" <> _}} = Backends.get_backend(backend.id)
-
-      :timer.sleep(1000)
     end
 
     test "partial config update preserves existing fields", %{user: user} do
@@ -753,25 +752,25 @@ defmodule Logflare.BackendsTest do
 
       # start an out-of-tree SourceSupWorker
       start_supervised({SourceSupWorker, [source: source, interval: 100]})
-      :timer.sleep(200)
-      new_length = Supervisor.which_children(via) |> length()
-      assert new_length > prev_length
-      assert new_length - prev_length == 3
+
+      TestUtils.retry_assert(fn ->
+        new_length = Supervisor.which_children(via) |> length()
+        assert new_length - prev_length == 3
+      end)
 
       Logflare.Repo.delete_all(Logflare.Rules.Rule)
       Logflare.Repo.delete_all(Logflare.Backends.SourcesBackend)
       Logflare.Repo.delete_all(Logflare.Backends.Backend)
 
-      :timer.sleep(200)
       # removal
-      new_length = Supervisor.which_children(via) |> length()
-      assert new_length == prev_length
+      TestUtils.retry_assert(fn ->
+        assert Supervisor.which_children(via) |> length() == prev_length
+      end)
     end
 
     test "source_sup_started?/1, lookup/2", %{source: source} do
       assert false == Backends.source_sup_started?(source)
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
       assert true == Backends.source_sup_started?(source)
     end
 
@@ -823,7 +822,6 @@ defmodule Logflare.BackendsTest do
       Backends.clear_list_backends_cache(source.id)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       via = Backends.via_source(source, SourceSup)
 
@@ -857,7 +855,6 @@ defmodule Logflare.BackendsTest do
       assert backend.consolidated_ingest? == true
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       assert :noop = SourceSup.start_backend_child(source, backend)
     end
@@ -869,7 +866,6 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user_id: user.id)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
       {:ok, source: source}
     end
 
@@ -904,15 +900,17 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) == 0
       le = build(:log_event, source: source, some: "event")
       assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, 1} = Counters.get_inserts(source.token)
 
       # RecentInsertsCacher bridges Counters.increment/2 (called by ingest_logs)
       # → Counters.increment_source_changed_at_unix_ts/2 (read by
-      # fetch_latest_timestamp/1). Trigger it explicitly and use :sys.get_state/1
-      # as a sync fence so the test doesn't depend on the cacher's timer.
+      # fetch_latest_timestamp/1). Exercise the callback synchronously so this
+      # assertion doesn't depend on the periodic process's mailbox latency.
       cacher = GenServer.whereis(Backends.via_source(source, RecentInsertsCacher))
-      send(cacher, :do_cache)
-      :sys.get_state(cacher)
+      state = :sys.get_state(cacher)
+      assert {:noreply, ^state} = RecentInsertsCacher.handle_info(:do_cache, state)
 
+      assert Counters.get_inserts_since_boot(source.token) == 1
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
@@ -1026,7 +1024,6 @@ defmodule Logflare.BackendsTest do
         insert(:source, user: user, drop_lql_string: "testing", drop_lql_filters: lql_filters)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
 
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_lql])
 
@@ -1040,8 +1037,6 @@ defmodule Logflare.BackendsTest do
 
       assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_lql], %{count: 1},
                       %{source_id: ^source_id, source_token: ^source_token}}
-
-      :timer.sleep(1000)
     end
 
     test "emits rejected telemetry for events with pipeline_error", %{user: user} do
@@ -1077,7 +1072,6 @@ defmodule Logflare.BackendsTest do
         insert(:source, user: user, drop_lql_string: "testing", drop_lql_filters: lql_filters)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
 
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_lql])
 
@@ -1093,8 +1087,6 @@ defmodule Logflare.BackendsTest do
                       %{source_id: ^source_id, source_token: ^source_token}}
 
       refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_lql], _, _}
-
-      :timer.sleep(1000)
     end
 
     test "route to source with lql", %{user: user} do
@@ -1103,7 +1095,6 @@ defmodule Logflare.BackendsTest do
       source = Logflare.Repo.preload(source, :rules, force: true)
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
-      :timer.sleep(500)
 
       assert {:ok, 2} =
                Backends.ingest_logs(
@@ -1131,7 +1122,6 @@ defmodule Logflare.BackendsTest do
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
       start_supervised!({SourceSup, other_target}, id: :other_target)
-      :timer.sleep(500)
 
       assert {:ok, 1} = Backends.ingest_logs([%{"event_message" => "testing 123"}], source)
 
@@ -1151,7 +1141,6 @@ defmodule Logflare.BackendsTest do
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
       start_supervised!({SourceSup, other_target}, id: :other_target)
-      :timer.sleep(500)
 
       assert {:ok, 1} = Backends.ingest_logs([%{"event_message" => "testing 123"}], source)
 
@@ -1301,8 +1290,6 @@ defmodule Logflare.BackendsTest do
       TestUtils.retry_assert(fn ->
         assert_received ^ref
       end)
-
-      :timer.sleep(1000)
     end
 
     test "cascade delete for rules on backend deletion", %{user: user} do
@@ -1486,7 +1473,6 @@ defmodule Logflare.BackendsTest do
       )
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
       {:ok, source: source}
     end
 
@@ -1506,8 +1492,6 @@ defmodule Logflare.BackendsTest do
       TestUtils.retry_assert(fn ->
         assert_received {^ref, %{"event_message" => "some event"}}
       end)
-
-      :timer.sleep(1000)
     end
   end
 
@@ -1661,7 +1645,6 @@ defmodule Logflare.BackendsTest do
     } do
       # Start actual SourceSup process
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       via = Backends.via_source(source, SourceSup)
 
@@ -1736,7 +1719,6 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user: user)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       {:ok, source: source}
     end
@@ -1904,7 +1886,6 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user: user, enable_spooling: false)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       prev_spool_config = Application.get_env(:logflare, :spool)
 

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -916,6 +916,17 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
+    defp fill_queue_over_limit(table_key) do
+      event = build(:log_event)
+
+      events =
+        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
+          %{event | id: {event.id, id}}
+        end
+
+      IngestEventQueue.add_to_table(table_key, events)
+    end
+
     test "any_ingest_queue_over_limit?/1 is false when no queues exist for the source", %{
       source: source
     } do
@@ -927,10 +938,7 @@ defmodule Logflare.BackendsTest do
       table_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue_over_limit(table_key)
 
       assert Backends.any_ingest_queue_over_limit?(source.id)
     end
@@ -944,10 +952,7 @@ defmodule Logflare.BackendsTest do
       table_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue_over_limit(table_key)
 
       assert Backends.any_ingest_queue_over_limit?(source.id)
     end

--- a/test/logflare/endpoints/cache_test.exs
+++ b/test/logflare/endpoints/cache_test.exs
@@ -13,7 +13,7 @@ defmodule Logflare.Endpoints.CacheTest do
           user: user,
           query: "select current_datetime() as testing",
           proactive_requerying_seconds: 1,
-          cache_duration_seconds: 3
+          cache_duration_seconds: 2
         )
 
       endpoint_2 =
@@ -69,6 +69,7 @@ defmodule Logflare.Endpoints.CacheTest do
     end
 
     test "cache dies on timeout from query task", %{endpoint: endpoint} do
+      endpoint = %{endpoint | proactive_requerying_seconds: 3}
       test_response = [%{"testing" => "123"}]
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -88,10 +89,9 @@ defmodule Logflare.Endpoints.CacheTest do
         {:error, :timeout}
       end)
 
-      # should be larger than :proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
-
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+      send(cache_pid, :refresh)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal}, 1_500
     end
 
     test "cache handles BigQuery error response bodies", %{endpoint: endpoint} do
@@ -124,22 +124,23 @@ defmodule Logflare.Endpoints.CacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
+      started_at = System.monotonic_time(:millisecond)
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
+      monitor_ref = Process.monitor(cache_pid)
       assert Process.alive?(cache_pid)
 
       # First query should succeed
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
-      # Cache should still be alive before cache_duration_seconds
-      Process.sleep(endpoint.cache_duration_seconds * 1000 - 100)
-      assert Process.alive?(cache_pid)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1_000 + 500
 
-      # Cache should die after cache_duration_seconds
-      Process.sleep(endpoint.cache_duration_seconds * 1000 + 100)
-      refute Process.alive?(cache_pid)
+      elapsed = System.monotonic_time(:millisecond) - started_at
+      assert elapsed >= endpoint.cache_duration_seconds * 1_000
     end
 
     test "cache dies after cache_duration_seconds gets set to 0", %{endpoint: endpoint} do
+      endpoint = %{endpoint | proactive_requerying_seconds: 3}
       test_response = [%{"testing" => "123"}]
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -159,9 +160,9 @@ defmodule Logflare.Endpoints.CacheTest do
 
       assert Logflare.ContextCache.bust_keys([{Logflare.Endpoints, endpoint.id}]) == {:ok, 1}
 
-      # Cache should still be alive before cache_duration_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 * 2)
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+      send(cache_pid, :refresh)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal}, 1_500
     end
 
     test "cache updates cached results after proactive_requerying_seconds", %{endpoint: endpoint} do
@@ -172,6 +173,7 @@ defmodule Logflare.Endpoints.CacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
+      started_at = System.monotonic_time(:millisecond)
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
       assert Process.alive?(cache_pid)
 
@@ -179,22 +181,27 @@ defmodule Logflare.Endpoints.CacheTest do
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       # Cache should still return first response before proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 500)
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       test_response = [%{"testing" => "456"}]
+      test_pid = self()
+      refresh_ref = make_ref()
 
       GoogleApi.BigQuery.V2.Api.Jobs
       |> stub(:bigquery_jobs_query, fn _conn, _proj_id, _opts ->
+        send(test_pid, {refresh_ref, System.monotonic_time(:millisecond)})
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      # After proactive_requerying_seconds, should return updated response
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
-      assert {:ok, %{rows: [%{"testing" => "456"}]}} = Endpoints.run_cached_query(endpoint)
+      assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
+
+      assert_receive {^refresh_ref, refreshed_at},
+                     endpoint.proactive_requerying_seconds * 1_000 + 500
+
+      assert refreshed_at - started_at >= endpoint.proactive_requerying_seconds * 1_000
 
       TestUtils.retry_assert(fn ->
-        refute Process.alive?(cache_pid)
+        assert {:ok, %{rows: [%{"testing" => "456"}]}} = Endpoints.run_cached_query(endpoint)
       end)
     end
 
@@ -207,7 +214,7 @@ defmodule Logflare.Endpoints.CacheTest do
           cache_duration_seconds: 3
         )
 
-      # perform at most 2 queries before dying
+      # The initial query and two proactive refreshes must run before expiry.
       GoogleApi.BigQuery.V2.Api.Jobs
       |> expect(:bigquery_jobs_query, 3, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response()}
@@ -221,8 +228,10 @@ defmodule Logflare.Endpoints.CacheTest do
       assert {:ok, %{rows: [_]}} = Endpoints.run_cached_query(endpoint)
 
       # should terminate after cache_duration_seconds
-      Process.sleep(2500)
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1000
     end
 
     test "endpoint 2: cache dies before proactive query", %{endpoint_2: endpoint} do
@@ -241,10 +250,10 @@ defmodule Logflare.Endpoints.CacheTest do
 
       reject(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 4)
 
-      # should be larger than :proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
+      monitor_ref = Process.monitor(cache_pid)
 
-      refute Process.alive?(cache_pid)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1000 + 500
     end
   end
 end

--- a/test/logflare/slack_hook_server_test.exs
+++ b/test/logflare/slack_hook_server_test.exs
@@ -48,10 +48,8 @@ defmodule Logflare.SlackHookServerTest do
 
       start_supervised!({SlackHookServer, source: source})
 
-      :timer.sleep(500)
       Counters.increment(source.token)
       Counters.increment(source.token)
-      :timer.sleep(500)
 
       assert_receive {^ref, %{blocks: [_section, rtf]}}, 2_000
       assert inspect(rtf) =~ "new event"

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -310,12 +310,12 @@ defmodule Logflare.SourcesTest do
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
-      :timer.sleep(500)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, token)
-      :timer.sleep(1_000)
+      TestUtils.retry_assert(fn -> assert {:ok, _pid} = Backends.lookup(SourceSup, token) end)
       assert {:ok, ^token} = Source.Supervisor.delete_source(token)
-      :timer.sleep(1000)
-      assert {:error, :not_started} = Backends.lookup(SourceSup, token)
+
+      TestUtils.retry_assert(fn ->
+        assert {:error, :not_started} = Backends.lookup(SourceSup, token)
+      end)
     end
 
     test "reset_source/1", %{user: user} do
@@ -323,12 +323,19 @@ defmodule Logflare.SourcesTest do
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
-      :timer.sleep(500)
-      assert {:ok, pid} = Backends.lookup(SourceSup, token)
+
+      pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, pid} = Backends.lookup(SourceSup, token)
+          pid
+        end)
+
       assert {:ok, ^token} = Source.Supervisor.reset_source(token)
-      :timer.sleep(1500)
-      assert {:ok, new_pid} = Backends.lookup(SourceSup, token)
-      assert new_pid != pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, new_pid} = Backends.lookup(SourceSup, token)
+        assert new_pid != pid
+      end)
     end
 
     test "able to start supervision tree", %{user: user} do
@@ -336,9 +343,11 @@ defmodule Logflare.SourcesTest do
 
       start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(1000)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "able to reset supervision tree", %{user: user} do
@@ -346,14 +355,21 @@ defmodule Logflare.SourcesTest do
 
       start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+
+      pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+          pid
+        end)
+
       assert {:ok, _} = Source.Supervisor.reset_source(source.token)
       assert {:ok, _} = Source.Supervisor.reset_source(source.token)
-      :timer.sleep(3000)
-      assert {:ok, new_pid} = Backends.lookup(SourceSup, source.token)
-      assert pid != new_pid
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, new_pid} = Backends.lookup(SourceSup, source.token)
+        assert pid != new_pid
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "concurrent start attempts", %{user: user} do
@@ -365,31 +381,49 @@ defmodule Logflare.SourcesTest do
       assert :ok = Source.Supervisor.ensure_started(source)
       assert :ok = Source.Supervisor.ensure_started(source)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "terminating Source.Supervisor does not bring everything down", %{user: user} do
       source = insert(:source, user_id: user.id)
       pid = start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+
+      prev_pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+          prev_pid
+        end)
+
       Process.exit(pid, :kill)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
-      assert prev_pid == pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+        assert prev_pid == pid
+      end)
     end
 
     test "should start broadcasting metrics on ingest", %{user: user} do
       source = insert(:source, user_id: user.id)
       pid = start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+
+      prev_pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+          prev_pid
+        end)
+
       Process.exit(pid, :kill)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
-      assert prev_pid == pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+        assert prev_pid == pid
+      end)
     end
   end
 
@@ -676,7 +710,6 @@ defmodule Logflare.SourcesTest do
       source = insert(:source, user_id: user.id, log_events_updated_at: timestamp)
       Sources.Cache.get_by_id(source.id)
       start_supervised!({SourceSup, source})
-      :timer.sleep(800)
       timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
       assert {:ok, 1} = Sources.recent_events_touch(timestamp)
       updated = Sources.get_by(id: source.id)
@@ -684,8 +717,7 @@ defmodule Logflare.SourcesTest do
 
       # does not update again if recently updated
       Sources.Cache.get_by_id(source.id)
-      :timer.sleep(1_000)
-      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      timestamp = NaiveDateTime.add(timestamp, 1, :second)
       assert {:ok, 0} = Sources.recent_events_touch(timestamp)
 
       updated = Sources.get_by(id: source.id)

--- a/test/logflare/utils_test.exs
+++ b/test/logflare/utils_test.exs
@@ -14,6 +14,8 @@ defmodule Logflare.Utils.FlagTest do
   alias Logflare.User
   alias Logflare.Utils
 
+  setup :set_mimic_global
+
   setup do
     start_supervised!(ConfigCatCache)
 
@@ -338,7 +340,7 @@ defmodule Logflare.UtilsSyncTest do
 
           ref = Process.monitor(pid)
           assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1000
-          Process.sleep(500)
+          Logger.flush()
         end)
 
       refute log =~ "secret_bearer_token_789"
@@ -361,7 +363,7 @@ defmodule Logflare.UtilsSyncTest do
 
           ref = Process.monitor(pid)
           assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1000
-          Process.sleep(500)
+          Logger.flush()
         end)
 
       assert log =~ "UndefinedError"

--- a/test/logflare_web/conn_case_test.exs
+++ b/test/logflare_web/conn_case_test.exs
@@ -1,0 +1,32 @@
+defmodule LogflareWeb.ConnCaseTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.ConnCase
+
+  test "put_default_team_param/2 adds the selected team without losing query parameters" do
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:logflare_test_team_id, "team-123")
+
+    result = ConnCase.put_default_team_param(conn, "/search?tailing=false")
+    uri = URI.parse(result)
+
+    assert uri.path == "/search"
+    assert URI.decode_query(uri.query) == %{"t" => "team-123", "tailing" => "false"}
+  end
+
+  test "put_default_team_param/2 preserves an explicitly selected team" do
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:logflare_test_team_id, "team-123")
+
+    path = "/search?t=team-456&tailing=false"
+    assert ConnCase.put_default_team_param(conn, path) == path
+  end
+
+  test "redirected_to_different_team?/2 only follows a different selected team" do
+    assert ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-456")
+    refute ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-123")
+    refute ConnCase.redirected_to_different_team?("/search?t=team-123", "/search")
+  end
+end

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -723,8 +723,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
         )
       end
 
-      :timer.sleep(2_000)
-
       params = %{
         iso_timestamp_start:
           DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.to_iso8601(),
@@ -733,13 +731,18 @@ defmodule LogflareWeb.EndpointsControllerTest do
         sql: "select  timestamp,  event_message, metadata from edge_logs"
       }
 
-      conn =
-        initial_conn
-        |> put_req_header("x-api-key", user.api_key)
-        |> get(~p"/endpoints/query/logs.all?#{params}")
+      {conn, timestamp} =
+        TestUtils.retry_assert(fn ->
+          conn =
+            initial_conn
+            |> put_req_header("x-api-key", user.api_key)
+            |> get(~p"/endpoints/query/logs.all?#{params}")
 
-      assert [%{"event_message" => "some message", "timestamp" => timestamp}] =
-               json_response(conn, 200)["result"]
+          assert [%{"event_message" => "some message", "timestamp" => timestamp}] =
+                   json_response(conn, 200)["result"]
+
+          {conn, timestamp}
+        end)
 
       # render as unix microsecond
       assert inspect(timestamp) |> String.length() == 16

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -15,7 +15,6 @@ defmodule LogflareWeb.HealthCheckControllerTest do
 
   test "normal node health check", %{conn: conn} do
     start_supervised!(Source.Supervisor)
-    :timer.sleep(1000)
 
     conn = get(conn, "/health")
 

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -6,6 +6,7 @@ defmodule LogflareWeb.LogControllerTest do
   alias Logflare.SingleTenant
   alias Logflare.Users
   alias Logflare.Sources
+  alias Logflare.Backends
   alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
 
@@ -633,7 +634,6 @@ defmodule LogflareWeb.LogControllerTest do
 
       # ingestion setup
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       conn =
         conn
@@ -649,7 +649,10 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert_logged_successfully(conn)
 
-      :timer.sleep(3000)
+      TestUtils.retry_assert(fn ->
+        assert [_event] = Backends.list_recent_logs_local(source)
+        assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source.id)
+      end)
     end
   end
 
@@ -658,7 +661,6 @@ defmodule LogflareWeb.LogControllerTest do
     user = insert(:user)
     source = insert(:source, user: user)
     start_supervised!({SourceSup, source})
-    :timer.sleep(500)
 
     {:ok, source: source, user: user, conn: conn}
   end

--- a/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
@@ -15,6 +15,16 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     {:ok, conn: conn, source: source, table_key: table_key}
   end
 
+  defp queue_events(source, count) do
+    event = build(:log_event, source: source)
+    for id <- 1..count, do: %{event | id: {event.id, id}}
+  end
+
+  defp fill_queue(table_key, source) do
+    events = queue_events(source, Backends.max_buffer_queue_len() + 500)
+    IngestEventQueue.add_to_table(table_key, events)
+  end
+
   test "returns 429 when memory utilization is at or over 85%", %{conn: conn, source: source} do
     SystemCache
     |> stub(:memory_utilization, fn -> 0.85 end)
@@ -46,10 +56,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     source: source,
     table_key: table_key
   } do
-    for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-    end
+    fill_queue(table_key, source)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -72,11 +79,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     other_table_key = {source.id, nil, self()}
     IngestEventQueue.upsert_tid(other_table_key)
 
-    for _ <- 1..round(Backends.max_buffer_queue_len() / 2) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.add_to_table(other_table_key, [le])
-    end
+    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2))
+    IngestEventQueue.add_to_table(table_key, events)
+    IngestEventQueue.add_to_table(other_table_key, events)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -88,11 +93,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     assert conn.halted == false
 
-    for _ <- 1..(round(Backends.max_buffer_queue_len() / 2) + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.add_to_table(other_table_key, [le])
-    end
+    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2) + 500)
+    IngestEventQueue.add_to_table(table_key, events)
+    IngestEventQueue.add_to_table(other_table_key, events)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -108,11 +111,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   end
 
   test "200 if most events are ingested", %{conn: conn, source: source, table_key: table_key} do
-    for _ <- 1..(Backends.max_buffer_queue_len() - 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.pop_pending(table_key, 1)
-    end
+    count = Backends.max_buffer_queue_len() - 500
+    IngestEventQueue.add_to_table(table_key, queue_events(source, count))
+    IngestEventQueue.pop_pending(table_key, count)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -162,10 +163,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     refute_receive {:telemetry_event, [:logflare, :ingest, :requests, :buffer_full], _, _}
 
-    for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-    end
+    fill_queue(table_key, source)
 
     Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -220,10 +218,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       table_key_webhook = {source.id, backend2.id, self()}
       IngestEventQueue.upsert_tid(table_key_webhook)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key_webhook, [le])
-      end
+      fill_queue(table_key_webhook, source)
 
       table_key_bigquery = {source.id, backend1.id, self()}
       IngestEventQueue.upsert_tid(table_key_bigquery)
@@ -251,10 +246,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       IngestEventQueue.upsert_tid(table_key)
 
       # Fill up the default ingest backend
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -275,10 +267,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       table_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -299,10 +288,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       system_queue_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(system_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(system_queue_key, [le])
-      end
+      fill_queue(system_queue_key, source)
 
       user_queue_key = {source.id, backend1.id, self()}
       IngestEventQueue.upsert_tid(user_queue_key)
@@ -341,10 +327,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       user_queue_key = {source.id, backend1.id, spawn(fn -> :ok end)}
       IngestEventQueue.upsert_tid(user_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(user_queue_key, [le])
-      end
+      fill_queue(user_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
       Backends.cache_local_buffer_lens(source.id, backend1.id)
@@ -407,10 +390,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       unlinked_queue_key = {source.id, unlinked_backend.id, self()}
       IngestEventQueue.upsert_tid(unlinked_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(unlinked_queue_key, [le])
-      end
+      fill_queue(unlinked_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, unlinked_backend.id)
 
@@ -441,20 +421,14 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       backend_queue_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(backend_queue_key, [le])
-      end
+      fill_queue(backend_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, backend.id)
 
       other_queue_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(other_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(other_queue_key, [le])
-      end
+      fill_queue(other_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -486,10 +460,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       backend_queue_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(backend_queue_key, [le])
-      end
+      fill_queue(backend_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, backend.id)
 
@@ -534,10 +505,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       clickhouse_queue_key = {source.id, clickhouse_backend.id, self()}
       IngestEventQueue.upsert_tid(clickhouse_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(clickhouse_queue_key, [le])
-      end
+      fill_queue(clickhouse_queue_key, source)
 
       # Cache buffer stats for both backends
       Backends.cache_local_buffer_lens(source.id, nil)

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1891,6 +1891,18 @@ defmodule LogflareWeb.Source.SearchLVTest do
       included_for_today = Enum.max([one_second_ago, today_start], DateTime)
       seconds_since_today_start = DateTime.diff(now, today_start, :second)
 
+      yesterday_start = DateTime.add(today_start, -1, :day)
+      yesterday_end = DateTime.add(today_start, -1, :second)
+      stale_boundary = DateTime.add(now, -Backends.max_event_age_us(), :microsecond)
+      overlap_start = Enum.max([stale_boundary, yesterday_start], DateTime)
+
+      included_for_yesterday =
+        DateTime.add(
+          overlap_start,
+          div(DateTime.diff(yesterday_end, overlap_start, :second), 2),
+          :second
+        )
+
       today_chart_period =
         cond do
           seconds_since_today_start <= 1_000 -> :second
@@ -1899,40 +1911,49 @@ defmodule LogflareWeb.Source.SearchLVTest do
         end
 
       cases = [
+        {"t:last@5m", :second, {DateTime.add(now, -1, :minute), DateTime.add(now, 30, :second)}},
         {"t:this@day", today_chart_period,
-         {included_for_today, DateTime.add(today_start, -1, :minute)}}
+         {included_for_today, DateTime.add(today_start, -1, :minute)}},
+        {"t:yesterday", :hour, {included_for_yesterday, now}}
       ]
 
-      Enum.each(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->
-        matching_message = "included-#{System.unique_integer([:positive])}"
-        non_matching_message = "excluded-#{System.unique_integer([:positive])}"
+      cases =
+        Enum.map(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->
+          matching_message = "included-#{System.unique_integer([:positive])}"
+          non_matching_message = "excluded-#{System.unique_integer([:positive])}"
 
-        {:ok, 2} =
-          [
-            %{
-              "event_message" => matching_message,
-              "timestamp" => included_timestamp |> DateTime.to_iso8601()
-            },
-            %{
-              "event_message" => non_matching_message,
-              "timestamp" => excluded_timestamp |> DateTime.to_iso8601()
-            }
-          ]
-          |> Backends.ingest_logs(source)
+          assert {:ok, 2} =
+                   Backends.ingest_logs(
+                     [
+                       %{
+                         "event_message" => matching_message,
+                         "timestamp" => DateTime.to_iso8601(included_timestamp)
+                       },
+                       %{
+                         "event_message" => non_matching_message,
+                         "timestamp" => DateTime.to_iso8601(excluded_timestamp)
+                       }
+                     ],
+                     source
+                   )
 
-        Enum.each(["UTC", "Singapore"], fn timezone ->
-          {:ok, view, _html} =
-            live_with_redirect(
-              conn,
-              Routes.live_path(conn, SearchLV, source.id,
-                tailing?: false,
-                tz: timezone
-              )
+          {querystring, chart_period, matching_message, non_matching_message}
+        end)
+
+      Enum.each(["UTC", "Singapore"], fn timezone ->
+        {:ok, view, _html} =
+          live_with_redirect(
+            conn,
+            Routes.live_path(conn, SearchLV, source.id,
+              tailing?: false,
+              tz: timezone
             )
+          )
 
-          %{executor_pid: search_executor_pid} = get_view_assigns(view)
-          allow_sandbox(search_executor_pid)
+        %{executor_pid: search_executor_pid} = get_view_assigns(view)
+        allow_sandbox(search_executor_pid)
 
+        Enum.each(cases, fn {querystring, chart_period, matching_message, non_matching_message} ->
           TestUtils.retry_assert(fn ->
             prev_completed_at = get_view_assigns(view)[:last_query_completed_at]
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -104,14 +104,20 @@ defmodule LogflareWeb.ConnCase do
   def login_user(conn, user, team_user) do
     conn
     |> login_user(user)
+    |> Plug.Conn.put_private(:logflare_test_team_id, team_user.team_id)
     |> Plug.Conn.assign(:team_user, team_user)
     |> Plug.Conn.put_session(:current_email, team_user.email)
   end
 
   def login_user(conn, user) do
     conn
+    |> Plug.Conn.put_private(:logflare_test_team_id, loaded_team_id(user))
+    |> Plug.Conn.put_private(:logflare_test_user_id, user.id)
     |> Plug.Test.init_test_session(%{current_email: user.email})
   end
+
+  defp loaded_team_id(%{team: %Logflare.Teams.Team{id: id}}), do: id
+  defp loaded_team_id(_user), do: nil
 
   # for api use
   def add_partner_access_token(conn, partner) do
@@ -205,12 +211,15 @@ defmodule LogflareWeb.ConnCase do
   end
 
   @doc """
-  Call live/3 and automatically follow the first live redirect.
+  Calls `live/3` with the signed-in user's selected team and follows the first
+  application redirect when the resource belongs to another team.
 
-  Useful for the common case of a live view redirecting to add the `t=` param.
+  Supplying the common `t=` parameter up front avoids mounting the LiveView
+  twice solely to discover the default team.
   """
   defmacro live_with_redirect(conn, path \\ nil, opts \\ []) do
     quote bind_quoted: [conn: conn, path: path, opts: opts] do
+      path = LogflareWeb.ConnCase.put_default_team_param(conn, path)
       result = Phoenix.LiveViewTest.live(conn, path, opts)
 
       case result do
@@ -218,7 +227,11 @@ defmodule LogflareWeb.ConnCase do
           result
 
         {:error, {:live_redirect, %{to: to}}} ->
-          Phoenix.LiveViewTest.live(conn, to, opts)
+          if LogflareWeb.ConnCase.redirected_to_different_team?(path, to) do
+            Phoenix.LiveViewTest.live(conn, to, opts)
+          else
+            result
+          end
 
         {:error, {:redirect, %{to: to}}} ->
           {:ok, Phoenix.ConnTest.get(conn, to)}
@@ -226,6 +239,63 @@ defmodule LogflareWeb.ConnCase do
         _ ->
           result
       end
+    end
+  end
+
+  @doc false
+  def redirected_to_different_team?(from, to) when is_binary(from) and is_binary(to) do
+    from_team = from |> URI.parse() |> then(&URI.decode_query(&1.query || "")) |> Map.get("t")
+    to_team = to |> URI.parse() |> then(&URI.decode_query(&1.query || "")) |> Map.get("t")
+
+    not is_nil(to_team) and to_team != from_team
+  end
+
+  def redirected_to_different_team?(_from, _to), do: false
+
+  @doc false
+  def put_default_team_param(_conn, nil), do: nil
+
+  def put_default_team_param(conn, path) when is_binary(path) do
+    uri = URI.parse(path)
+    query = URI.decode_query(uri.query || "")
+
+    if Map.has_key?(query, "t") do
+      path
+    else
+      case default_team_id(conn) do
+        nil -> path
+        team_id -> %{uri | query: URI.encode_query(Map.put(query, "t", team_id))} |> to_string()
+      end
+    end
+  end
+
+  defp default_team_id(conn) do
+    conn.private[:logflare_test_team_id] || default_user_team_id(conn)
+  end
+
+  defp default_user_team_id(conn) do
+    case conn.private[:logflare_test_user_id] do
+      nil ->
+        nil
+
+      user_id ->
+        case Logflare.Teams.get_team_by(user_id: user_id) do
+          nil -> create_default_team(user_id)
+          team -> team.id
+        end
+    end
+  end
+
+  defp create_default_team(user_id) do
+    case Logflare.Users.get(user_id) do
+      nil ->
+        nil
+
+      user ->
+        {:ok, team} =
+          Logflare.Teams.create_team(user, %{name: Logflare.Generators.team_name()})
+
+        team.id
     end
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -128,6 +128,7 @@ defmodule Logflare.DataCase do
   - `:user` - Existing user to use (creates one if not provided)
   - `:source` - Existing source to use (creates one if not provided)
   - `:default_ingest_backend?` - Whether to set the backend as the default ingest backend (requires a source to be provided with the default ingest backend option set to true)
+  - `:cleanup?` - Whether to drop the backend's ClickHouse tables on exit (defaults to true)
   """
   def setup_clickhouse_test(opts \\ []) do
     config = Keyword.get(opts, :config, %{})
@@ -163,7 +164,9 @@ defmodule Logflare.DataCase do
         sources: [source]
       )
 
-    on_exit(fn -> cleanup_clickhouse_tables(backend) end)
+    if Keyword.get(opts, :cleanup?, true) do
+      on_exit(fn -> cleanup_clickhouse_tables(backend) end)
+    end
 
     {source, backend}
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,8 +15,11 @@ defmodule Logflare.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL
+  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+  alias Logflare.Backends.Cache, as: BackendsCache
   alias Logflare.Backends.ConsolidatedSup
+  alias Logflare.Backends.IngestEventQueue
 
   using do
     quote do
@@ -116,6 +119,32 @@ defmodule Logflare.DataCase do
         String.replace(acc, "%{#{key}}", to_string(value))
       end)
     end)
+  end
+
+  @doc """
+  Enqueues already-built log events directly into a source's configured backend pipeline.
+
+  Adaptor tests use this to exercise the adaptor without starting the unrelated full
+  source supervision tree through `Backends.ingest_logs/2`.
+  """
+  def enqueue_backend_logs(events, source) do
+    [backend | _] = BackendsCache.list_backends(source_id: source.id)
+    adaptor = Adaptor.get_adaptor(backend)
+
+    events =
+      if function_exported?(adaptor, :pre_ingest, 3) do
+        adaptor.pre_ingest(source, backend, events)
+      else
+        events
+      end
+
+    queue_key =
+      if backend.consolidated_ingest?,
+        do: {:consolidated, backend.id},
+        else: {source.id, backend.id}
+
+    :ok = IngestEventQueue.add_to_table(queue_key, events)
+    {:ok, length(events)}
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- replace fixed sleeps and incidental timing with process monitors, messages, state synchronization, and retry assertions
- reduce expensive test setup by reusing valid event fixtures and enqueueing backend logs without starting unrelated source supervision
- shorten producer and Broadway batching latency only in the test environment
- make ClickHouse error paths, provisioner checks, and hostname parsing tests deterministic
- preserve integration boundaries, queue assertions, timer/lifecycle behavior, shorthand timestamp cases, and backend-specific telemetry coverage

## Hosted CI results

Compared with the immediately preceding [`main` run #7488](https://github.com/Logflare/logflare/actions/runs/29620407155), the passing [PR run #7492](https://github.com/Logflare/logflare/actions/runs/29648368405) produced these results:

| Metric | `main` | This PR | Improvement |
| --- | ---: | ---: | ---: |
| ExUnit suite | 9m 6.1s | 4m 47.6s | **47% faster** |
| Synchronous phase | 8m 36.9s | 4m 20.2s | **50% faster** |
| Full test/coverage command | 13m 29s | 9m 4s | **33% faster** |
| Entire test job | 15m 28s | 10m 50s | **30% faster** |

The PR run completed 4,512 tests, 49 properties, and 125 doctests with no failures. It ran one more test than the `main` baseline while reducing the ExUnit phase by 4m 18.5s and the complete test job by 4m 38s.

