### PR TITLE
perf(clickhouse): keep batches large under bounded load

### DIFF
--- a/bench/clickhouse_batch_scaling_cpu.exs
+++ b/bench/clickhouse_batch_scaling_cpu.exs
@@ -1,0 +1,363 @@
+# CPU and correctness benchmark for ClickHouse's exact-key scaling path.
+#
+# The queue/encoding benchmark does not exercise the work added by batch-aware
+# scaling: scanning startup pointer metadata, filtered startup claims, or the
+# least-loaded routing sort. This benchmark covers those operations directly.
+#
+# Usage:
+#
+#   mix run --no-start bench/clickhouse_batch_scaling_cpu.exs
+#   BENCH_SECTION=scaling BENCH_TIME=5 BENCH_WARMUP=2 \
+#     mix run --no-start bench/clickhouse_batch_scaling_cpu.exs
+#
+# BENCH_SECTION may be all, scaling, claims, or routing.
+
+defmodule Logflare.Bench.ClickHouseBatchScaling do
+  @moduledoc false
+
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
+  alias Logflare.Backends.IngestEventQueue
+  alias Logflare.LogEvent
+
+  @batch_size 60_000
+  @routing_rows 100
+  @routing_queues 8
+
+  @type input :: map()
+
+  @spec setup_scaling_inputs() :: %{String.t() => input()}
+  def setup_scaling_inputs do
+    [
+      {"60k/one-complete-key", 31_000_001, 60_000, [{:fresh, :log, 20_000}], 2},
+      {"60k/three-partial-keys", 31_000_002, 60_000,
+       [{:fresh, :log, 20_000}, {:fresh, :metric, 20_000}, {:stale, :log, 19_999}], 1},
+      {"120k/two-complete-keys", 31_000_003, 120_000,
+       [{:fresh, :log, 20_000}, {:fresh, :metric, 20_000}], 2}
+    ]
+    |> Map.new(fn {label, backend_id, rows, keys, expected_desired} ->
+      input = setup_scaling_input(backend_id, rows, keys, expected_desired)
+      validate_scaling!(input)
+      {label, input}
+    end)
+  end
+
+  @spec setup_routing_inputs() :: %{String.t() => input()}
+  def setup_routing_inputs do
+    ensure_queue_started()
+
+    [
+      {"consolidated/eight-balanced-queues", :consolidated},
+      {"standard/eight-balanced-queues", :standard},
+      {"spool/eight-balanced-queues", :spool}
+    ]
+    |> Map.new(fn {label, kind} ->
+      {queues_key, startup_key, queue_key_fun} = routing_keys(kind)
+      upsert_queue(startup_key)
+
+      queue_keys =
+        Enum.map(1..@routing_queues, fn _index ->
+          pid = spawn(fn -> Process.sleep(:infinity) end)
+          key = queue_key_fun.(pid)
+          upsert_queue(key)
+          key
+        end)
+
+      events =
+        Enum.map(1..@routing_rows, fn index ->
+          event("route-#{kind}-#{index}", {:fresh, :log, 20_000})
+        end)
+
+      input = %{queues_key: queues_key, queue_keys: queue_keys, events: events}
+      validate_routing!(input)
+      {label, input}
+    end)
+  end
+
+  @spec scale_candidate?(input()) :: boolean()
+  def scale_candidate?(%{queues_key: queues_key, startup_key: startup_key}) do
+    IngestEventQueue.list_pending_counts(queues_key)
+    |> Enum.find_value(false, fn
+      {^startup_key, count} -> count >= @batch_size
+      _entry -> false
+    end)
+  end
+
+  @spec exact_key_scale_decision(input()) :: non_neg_integer()
+  def exact_key_scale_decision(%{queues_key: queues_key, startup_key: startup_key}) do
+    lens = IngestEventQueue.list_pending_counts(queues_key)
+
+    counts =
+      if startup_size(lens, startup_key) >= Pipeline.max_batch_size() do
+        IngestEventQueue.pending_batch_key_counts(startup_key)
+      else
+        %{}
+      end
+
+    ClickHouseAdaptor.resolve_pipeline_count(
+      %{pipeline_count: 1, max_pipelines: 8, last_count_decrease: nil},
+      lens,
+      counts
+    )
+  end
+
+  @spec pending_batch_key_counts(input()) :: map()
+  def pending_batch_key_counts(%{startup_key: startup_key}) do
+    IngestEventQueue.pending_batch_key_counts(startup_key)
+  end
+
+  @spec claim_and_reinsert(input(), :filtered | :unfiltered) :: non_neg_integer()
+  def claim_and_reinsert(
+        %{startup_key: startup_key, claim_key: claim_key, claim_size: claim_size},
+        mode
+      ) do
+    result =
+      case mode do
+        :filtered ->
+          IngestEventQueue.pop_pending_pointers_by_batch_key(
+            startup_key,
+            claim_key,
+            claim_size
+          )
+
+        :unfiltered ->
+          IngestEventQueue.pop_pending_pointers(startup_key, claim_size)
+      end
+
+    {:ok, pointers, _tid} = result
+    Enum.each(pointers, &IngestEventQueue.reinsert_pointer/1)
+    length(pointers)
+  end
+
+  @spec route_and_drain(input(), :direct | :least_loaded) :: non_neg_integer()
+  def route_and_drain(
+        %{queues_key: queues_key, queue_keys: [direct_key | _] = queue_keys, events: events},
+        mode
+      ) do
+    case mode do
+      :direct -> :ok = IngestEventQueue.add_to_table(direct_key, events)
+      :least_loaded -> :ok = IngestEventQueue.add_to_table(queues_key, events)
+    end
+
+    pointers =
+      Enum.flat_map(queue_keys, fn key ->
+        {:ok, claimed, _tid} = IngestEventQueue.pop_pending_pointers(key, length(events))
+        claimed
+      end)
+
+    if length(pointers) != length(events) do
+      raise "routing benchmark claimed #{length(pointers)} of #{length(events)} pointers"
+    end
+
+    Enum.each(pointers, fn pointer ->
+      IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
+    end)
+
+    length(pointers)
+  end
+
+  defp setup_scaling_input(backend_id, rows, keys, expected_desired) do
+    ensure_queue_started()
+    startup_key = {:consolidated, backend_id, nil}
+    upsert_queue(startup_key)
+
+    1..rows
+    |> Stream.chunk_every(1_000)
+    |> Enum.each(fn indexes ->
+      events =
+        Enum.map(indexes, fn index ->
+          key = Enum.at(keys, rem(index - 1, length(keys)))
+          event("#{backend_id}-#{index}", key)
+        end)
+
+      :ok = IngestEventQueue.add_to_table(startup_key, events)
+    end)
+
+    expected_counts =
+      1..rows
+      |> Enum.map(fn index -> Enum.at(keys, rem(index - 1, length(keys))) end)
+      |> Enum.frequencies()
+
+    {claim_key, claim_size} = Enum.max_by(expected_counts, &elem(&1, 1))
+
+    %{
+      backend_id: backend_id,
+      queues_key: {:consolidated, backend_id},
+      startup_key: startup_key,
+      rows: rows,
+      expected_counts: expected_counts,
+      expected_desired: expected_desired,
+      claim_key: claim_key,
+      claim_size: min(claim_size, @batch_size)
+    }
+  end
+
+  defp validate_scaling!(input) do
+    actual_counts = pending_batch_key_counts(input)
+
+    if actual_counts != input.expected_counts do
+      raise "batch-key count validation failed: #{inspect(actual_counts)}"
+    end
+
+    if exact_key_scale_decision(input) != input.expected_desired do
+      raise "scale decision validation failed for backend #{input.backend_id}"
+    end
+
+    for mode <- [:filtered, :unfiltered] do
+      claimed = claim_and_reinsert(input, mode)
+
+      if claimed != input.claim_size or pending_batch_key_counts(input) != input.expected_counts do
+        raise "#{mode} claim validation failed for backend #{input.backend_id}"
+      end
+    end
+
+    gen_tid = IngestEventQueue.current_generation_tid(input.queues_key)
+
+    if IngestEventQueue.total_pending(input.startup_key) != input.rows or
+         :ets.info(gen_tid, :size) != input.rows do
+      raise "queue preservation validation failed for backend #{input.backend_id}"
+    end
+
+    :ok
+  end
+
+  defp validate_routing!(input) do
+    for mode <- [:direct, :least_loaded] do
+      if route_and_drain(input, mode) != length(input.events) do
+        raise "#{mode} routing validation failed"
+      end
+
+      if Enum.any?(input.queue_keys, &(IngestEventQueue.total_pending(&1) != 0)) do
+        raise "#{mode} routing validation left pending pointers"
+      end
+
+      gen_tid = IngestEventQueue.current_generation_tid(input.queues_key)
+
+      if :ets.info(gen_tid, :size) != 0 do
+        raise "#{mode} routing validation left generation rows"
+      end
+    end
+
+    :ok
+  end
+
+  defp routing_keys(:consolidated) do
+    backend_id = 31_000_010
+
+    {
+      {:consolidated, backend_id},
+      {:consolidated, backend_id, nil},
+      &{:consolidated, backend_id, &1}
+    }
+  end
+
+  defp routing_keys(:standard) do
+    source_id = 31_000_011
+    backend_id = 31_000_012
+    {{source_id, backend_id}, {source_id, backend_id, nil}, &{source_id, backend_id, &1}}
+  end
+
+  defp routing_keys(:spool) do
+    {{:spool_producer, nil}, {:spool_producer, nil, nil}, &{:spool_producer, nil, &1}}
+  end
+
+  defp startup_size(lens, startup_key) do
+    Enum.find_value(lens, 0, fn
+      {^startup_key, count} -> count
+      _entry -> false
+    end)
+  end
+
+  defp event(id, {freshness, event_type, day_bucket}) do
+    %LogEvent{
+      id: id,
+      body: %{"value" => id},
+      retries: 0,
+      event_type: event_type,
+      day_bucket: day_bucket,
+      ingest_freshness: freshness
+    }
+  end
+
+  defp ensure_queue_started do
+    case Process.whereis(IngestEventQueue) do
+      nil ->
+        {:ok, _pid} = IngestEventQueue.start_link([])
+        :ok
+
+      _pid ->
+        :ok
+    end
+  end
+
+  defp upsert_queue(key) do
+    case IngestEventQueue.upsert_tid(key) do
+      {:ok, _tid} -> :ok
+      {:error, :already_exists, _tid} -> :ok
+    end
+  end
+end
+
+alias Logflare.Bench.ClickHouseBatchScaling, as: Scaling
+
+section = System.get_env("BENCH_SECTION", "all")
+time = System.get_env("BENCH_TIME", "3") |> String.to_integer()
+warmup = System.get_env("BENCH_WARMUP", "1") |> String.to_integer()
+memory_time = System.get_env("BENCH_MEMORY_TIME", "1") |> String.to_integer()
+reduction_time = System.get_env("BENCH_REDUCTION_TIME", "1") |> String.to_integer()
+
+run_benchmark = fn title, scenarios, inputs ->
+  IO.puts("\n== #{title} ==\n")
+
+  Benchee.run(scenarios,
+    inputs: inputs,
+    time: time,
+    warmup: warmup,
+    memory_time: memory_time,
+    reduction_time: reduction_time,
+    print: [configuration: false]
+  )
+end
+
+if section in ["all", "scaling", "claims"] do
+  scaling_inputs = Scaling.setup_scaling_inputs()
+
+  if section in ["all", "scaling"] do
+    run_benchmark.(
+      "10-second scaler tick",
+      %{
+        "aggregate candidate check" => &Scaling.scale_candidate?/1,
+        "exact-key scale decision" => &Scaling.exact_key_scale_decision/1,
+        "exact-key metadata scan only" => &Scaling.pending_batch_key_counts/1
+      },
+      scaling_inputs
+    )
+  end
+
+  if section in ["all", "claims"] do
+    claim_inputs =
+      Map.drop(scaling_inputs, ["60k/three-partial-keys"])
+
+    run_benchmark.(
+      "startup pointer claim and reinsert",
+      %{
+        "filtered exact-key claim" => &Scaling.claim_and_reinsert(&1, :filtered),
+        "unfiltered claim" => &Scaling.claim_and_reinsert(&1, :unfiltered)
+      },
+      claim_inputs
+    )
+  end
+end
+
+if section in ["all", "routing"] do
+  routing_inputs = Scaling.setup_routing_inputs()
+
+  run_benchmark.(
+    "100-row routing and drain across eight producer queues",
+    %{
+      "direct queue" => &Scaling.route_and_drain(&1, :direct),
+      "least-loaded routing" => &Scaling.route_and_drain(&1, :least_loaded)
+    },
+    routing_inputs
+  )
+end

--- a/bench/clickhouse_pipeline_cpu_runner.exs
+++ b/bench/clickhouse_pipeline_cpu_runner.exs
@@ -96,8 +96,13 @@ IO.puts("rows=#{batch_size * batches}")
 IO.puts("uncompressed_rowbinary_bytes_per_batch=#{encoded_bytes}")
 IO.puts("uncompressed_rowbinary_bytes_per_row=#{Float.round(encoded_bytes / batch_size, 2)}")
 
-for _ <- 1..warmup_batches do
-  Data.run_scenario(scenario, input) |> byte_size()
+:ok = Data.validate_scenario!(scenario, input)
+IO.puts("validation=ok")
+
+if warmup_batches > 0 do
+  for _ <- 1..warmup_batches do
+    Data.run_scenario(scenario, input) |> byte_size()
+  end
 end
 
 :erlang.garbage_collect()

--- a/bench/clickhouse_pipeline_queue_cpu.exs
+++ b/bench/clickhouse_pipeline_queue_cpu.exs
@@ -4,7 +4,7 @@
 # intentionally omits:
 #
 #   old queue path: add_to_table -> pop_pending -> encode_batch -> gzip
-#   id queue path:  add_to_table -> take_pending_ids -> routing lookup ->
+#   id queue path:  add_to_table -> pop_pending_pointers -> routing lookup ->
 #                   per-row ETS lookup -> stream deflate -> delete_id ack
 #
 # It still avoids ClickHouse/network I/O so the result is focused on local CPU,
@@ -54,15 +54,17 @@ inputs =
         "(#{Float.round(encoded_bytes / batch_size, 1)} bytes/event)"
     )
 
-    {label,
-     %{
-       events: events,
-       type: type,
-       compiled: compiled,
-       config_id: config_id,
-       queue_key: queue_key,
-       queue_tid: queue_tid
-     }}
+    input = %{
+      events: events,
+      type: type,
+      compiled: compiled,
+      config_id: config_id,
+      queue_key: queue_key,
+      queue_tid: queue_tid
+    }
+
+    :ok = Data.validate_scenarios!(input)
+    {label, input}
   end
 
 IO.puts("")

--- a/bench/support/clickhouse_pipeline_bench_data.exs
+++ b/bench/support/clickhouse_pipeline_bench_data.exs
@@ -52,10 +52,12 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   @spec stream_deflate_events([LogEvent.t()], event_type(), reference(), String.t()) :: binary()
   def stream_deflate_events(events, type, compiled, config_id) do
     gzip_stream(fn z ->
-      Enum.reduce(events, [], fn event, chunks ->
+      events
+      |> Enum.reduce([], fn event, chunks ->
         mapped = map_event(event, type, compiled, config_id)
-        [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type))]
+        [:zlib.deflate(z, Ingester.encode_row(mapped, type)) | chunks]
       end)
+      |> Enum.reverse()
     end)
   end
 
@@ -65,10 +67,12 @@ defmodule Logflare.Bench.ClickHousePipelineData do
     mapping_config_id = Ingester.encode_mapping_config_id(config_id)
 
     gzip_stream(fn z ->
-      Enum.reduce(events, [], fn event, chunks ->
-        mapped = map_event(event, type, compiled, config_id)
-        [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id))]
+      events
+      |> Enum.reduce([], fn event, chunks ->
+        mapped = map_event_without_config(event, type, compiled)
+        [:zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id)) | chunks]
       end)
+      |> Enum.reverse()
     end)
   end
 
@@ -79,7 +83,7 @@ defmodule Logflare.Bench.ClickHousePipelineData do
 
     gzip_stream_chunked(events, fn event ->
       event
-      |> map_event(type, compiled, config_id)
+      |> map_event_without_config(type, compiled)
       |> Ingester.encode_row(type, mapping_config_id)
     end)
   end
@@ -87,13 +91,9 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   @spec setup_processing_ets([LogEvent.t()]) :: :ets.tid()
   def setup_processing_ets(events) do
     tid = :ets.new(:clickhouse_pipeline_bench_queue, [:set, :public, read_concurrency: true])
-    claimed_at = System.monotonic_time(:millisecond)
 
     for event <- events do
-      :ets.insert(
-        tid,
-        {event.id, :processing, event, :erlang.external_size(event.body), 1, claimed_at}
-      )
+      :ets.insert(tid, {event.id, event})
     end
 
     tid
@@ -103,16 +103,18 @@ defmodule Logflare.Bench.ClickHousePipelineData do
           binary()
   def stream_deflate_ets(id_tid_pairs, type, compiled, config_id) do
     gzip_stream(fn z ->
-      Enum.reduce(id_tid_pairs, [], fn {id, tid}, chunks ->
-        case IngestEventQueue.lookup_id(tid, id) do
-          {^id, :processing, %LogEvent{} = event, _size} ->
+      id_tid_pairs
+      |> Enum.reduce([], fn {id, tid}, chunks ->
+        case IngestEventQueue.lookup_event(tid, id) do
+          %LogEvent{event_type: ^type} = event ->
             mapped = map_event(event, type, compiled, config_id)
-            [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type))]
+            [:zlib.deflate(z, Ingester.encode_row(mapped, type)) | chunks]
 
           _ ->
             chunks
         end
       end)
+      |> Enum.reverse()
     end)
   end
 
@@ -122,16 +124,18 @@ defmodule Logflare.Bench.ClickHousePipelineData do
     mapping_config_id = Ingester.encode_mapping_config_id(config_id)
 
     gzip_stream(fn z ->
-      Enum.reduce(id_tid_pairs, [], fn {id, tid}, chunks ->
-        case IngestEventQueue.lookup_id(tid, id) do
-          {^id, :processing, %LogEvent{} = event, _size} ->
-            mapped = map_event(event, type, compiled, config_id)
-            [chunks, :zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id))]
+      id_tid_pairs
+      |> Enum.reduce([], fn {id, tid}, chunks ->
+        case IngestEventQueue.lookup_event(tid, id) do
+          %LogEvent{event_type: ^type} = event ->
+            mapped = map_event_without_config(event, type, compiled)
+            [:zlib.deflate(z, Ingester.encode_row(mapped, type, mapping_config_id)) | chunks]
 
           _ ->
             chunks
         end
       end)
+      |> Enum.reverse()
     end)
   end
 
@@ -141,10 +145,10 @@ defmodule Logflare.Bench.ClickHousePipelineData do
     mapping_config_id = Ingester.encode_mapping_config_id(config_id)
 
     gzip_stream_chunked(id_tid_pairs, fn {id, tid} ->
-      case IngestEventQueue.lookup_id(tid, id) do
-        {^id, :processing, %LogEvent{} = event, _size} ->
+      case IngestEventQueue.lookup_event(tid, id) do
+        %LogEvent{event_type: ^type} = event ->
           event
-          |> map_event(type, compiled, config_id)
+          |> map_event_without_config(type, compiled)
           |> Ingester.encode_row(type, mapping_config_id)
 
         _ ->
@@ -234,17 +238,17 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   defp id_passing_queue_stream(key, tid, events, type, compiled, config_id, mode) do
     :ets.delete_all_objects(tid)
     :ok = IngestEventQueue.add_to_table({key, tid}, events)
-    {:ok, id_size_pairs, ^tid} = IngestEventQueue.take_pending_ids(key, length(events))
+    {:ok, pointers, ^tid} = IngestEventQueue.pop_pending_pointers(key, length(events))
 
     routed_pairs =
-      Enum.reduce(id_size_pairs, [], fn {id, _size}, acc ->
-        case IngestEventQueue.lookup_id(tid, id) do
-          {^id, :processing, %LogEvent{event_type: ^type}, _size} -> [{id, tid} | acc]
+      Enum.reduce(pointers, [], fn pointer, acc ->
+        case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
+          %LogEvent{event_type: ^type} -> [{pointer.gen_event_id, pointer.tid} | acc]
           _ -> acc
         end
       end)
 
-    compress_and_delete(routed_pairs, tid, type, compiled, config_id, mode)
+    compress_and_delete(routed_pairs, type, compiled, config_id, mode)
   end
 
   @spec id_passing_queue_stream_metadata(
@@ -259,19 +263,21 @@ defmodule Logflare.Bench.ClickHousePipelineData do
     :ets.delete_all_objects(tid)
     :ok = IngestEventQueue.add_to_table({key, tid}, events)
 
-    {:ok, metadata, ^tid} =
-      IngestEventQueue.take_pending_ids_with_metadata(key, length(events))
+    {:ok, pointers, ^tid} = IngestEventQueue.pop_pending_pointers(key, length(events))
 
     routed_pairs =
-      Enum.reduce(metadata, [], fn
-        {id, _size, ^type, _day_bucket, _freshness}, acc -> [{id, tid} | acc]
-        _other, acc -> acc
+      Enum.reduce(pointers, [], fn
+        %{event_type: ^type, tid: gen_tid, gen_event_id: gen_event_id}, acc ->
+          [{gen_event_id, gen_tid} | acc]
+
+        _other, acc ->
+          acc
       end)
 
-    compress_and_delete(routed_pairs, tid, type, compiled, config_id, :hoisted)
+    compress_and_delete(routed_pairs, type, compiled, config_id, :hoisted)
   end
 
-  defp compress_and_delete(routed_pairs, tid, type, compiled, config_id, mode) do
+  defp compress_and_delete(routed_pairs, type, compiled, config_id, mode) do
     compressed =
       case mode do
         :per_row -> stream_deflate_ets(routed_pairs, type, compiled, config_id)
@@ -279,9 +285,72 @@ defmodule Logflare.Bench.ClickHousePipelineData do
         :chunked -> stream_deflate_ets_chunked(routed_pairs, type, compiled, config_id)
       end
 
-    Enum.each(routed_pairs, fn {id, ^tid} -> IngestEventQueue.delete_id(tid, id) end)
+    Enum.each(routed_pairs, fn {id, tid} -> IngestEventQueue.delete_id(tid, id) end)
 
     compressed
+  end
+
+  @spec validate_scenario!(atom(), map()) :: :ok
+  def validate_scenario!(
+        scenario,
+        %{events: events, type: type, compiled: compiled, config_id: config_id} = input
+      ) do
+    expected = old_encode_gzip(events, type, compiled, config_id) |> :zlib.gunzip()
+    validate_scenario!(scenario, input, expected)
+  end
+
+  @spec validate_scenarios!(map()) :: :ok
+  def validate_scenarios!(
+        %{events: events, type: type, compiled: compiled, config_id: config_id} = input
+      ) do
+    expected = old_encode_gzip(events, type, compiled, config_id) |> :zlib.gunzip()
+
+    for scenario <- [
+          :stream,
+          :stream_hoisted,
+          :stream_chunked,
+          :old_queue,
+          :id_queue,
+          :id_queue_hoisted,
+          :id_queue_chunked,
+          :id_queue_metadata
+        ] do
+      validate_scenario!(scenario, input, expected)
+    end
+
+    :ok
+  end
+
+  defp validate_scenario!(scenario, input, expected)
+       when scenario in [
+              :old_queue,
+              :id_queue,
+              :id_queue_hoisted,
+              :id_queue_chunked,
+              :id_queue_metadata
+            ] do
+    %{queue_key: {:consolidated, backend_id, _pid} = queue_key} = input
+    actual_size = scenario |> run_scenario(input) |> :zlib.gunzip() |> byte_size()
+    pending = IngestEventQueue.total_pending(queue_key)
+    gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend_id})
+    generation_size = :ets.info(gen_tid, :size)
+
+    if actual_size != byte_size(expected) or pending != 0 or generation_size != 0 do
+      raise "#{scenario} failed queue benchmark validation: " <>
+              "encoded_size=#{actual_size}, pending=#{pending}, generation_size=#{generation_size}"
+    end
+
+    :ok
+  end
+
+  defp validate_scenario!(scenario, input, expected) do
+    actual = scenario |> run_scenario(input) |> :zlib.gunzip()
+
+    if actual != expected do
+      raise "#{scenario} produced different RowBinary bytes from the reference encoder"
+    end
+
+    :ok
   end
 
   @spec run_scenario(atom(), map()) :: binary()
@@ -451,14 +520,21 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   end
 
   defp map_event(%LogEvent{} = event, type, compiled, config_id) do
-    mapped_body =
-      event.body
-      |> Mapper.map(compiled)
-      |> Map.put("mapping_config_id", config_id)
-      |> maybe_compute_duration(type)
-      |> resolve_severity_number(type)
+    %{
+      event
+      | body: map_body(event.body, type, compiled) |> Map.put("mapping_config_id", config_id)
+    }
+  end
 
-    %{event | body: mapped_body}
+  defp map_event_without_config(%LogEvent{} = event, type, compiled) do
+    %{event | body: map_body(event.body, type, compiled)}
+  end
+
+  defp map_body(body, type, compiled) do
+    body
+    |> Mapper.map(compiled)
+    |> maybe_compute_duration(type)
+    |> resolve_severity_number(type)
   end
 
   defp maybe_compute_duration(

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -42,8 +42,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
   @pipelines_per_scheduler 4
-  # TODO: Share config with clickhouse pipeline
-  @max_in_flight 120_000
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 
@@ -642,9 +640,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
             initial_count: @min_pipelines,
             resolve_interval: @resolve_interval,
             resolve_count: fn state ->
-              lens = IngestEventQueue.list_pending_counts({:consolidated, backend.id})
+              queues_key = {:consolidated, backend.id}
+              startup_key = {:consolidated, backend.id, nil}
+              lens = IngestEventQueue.list_pending_counts(queues_key)
 
-              resolve_pipeline_count(state, lens)
+              startup_batch_key_counts =
+                if startup_queue_size(lens) >= Pipeline.max_batch_size() do
+                  IngestEventQueue.pending_batch_key_counts(startup_key)
+                else
+                  %{}
+                end
+
+              resolve_pipeline_count(state, lens, startup_batch_key_counts)
             end
           }
         ]
@@ -652,60 +659,80 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  # produce fewer, larger batches for ClickHouse efficiency
+  # Produce fewer, larger batches for ClickHouse efficiency. A new pipeline is useful
+  # only when the shared startup queue contains at least one complete Broadway batch
+  # for an exact `{freshness, event_type, day_bucket}` key. Aggregate queue size is not
+  # sufficient: 60k rows split across two keys would create two timeout-sized batches.
+  # The new producer's batch-aware seed mirrors this decision and moves only complete
+  # key groups, leaving partial groups for an existing producer to combine with its own
+  # pending work.
   #
   # Exposed (not private) so it can be unit tested directly, same convention as
   # Backends.handle_resolve_count/3 (BigQuery's counterpart).
   @doc false
-  @spec resolve_pipeline_count(map(), [{term(), non_neg_integer()}]) :: non_neg_integer()
-  def resolve_pipeline_count(state, lens) do
-    startup_size =
-      Enum.find_value(lens, 0, fn
-        {{:consolidated, _bid, nil}, val} -> val
-        _ -> false
+  @spec resolve_pipeline_count(
+          map(),
+          [{term(), non_neg_integer()}],
+          %{optional(IngestEventQueue.pointer_batch_key()) => non_neg_integer()}
+        ) :: non_neg_integer()
+  def resolve_pipeline_count(state, lens, startup_batch_key_counts) do
+    startup_size = startup_queue_size(lens)
+
+    lens_no_startup_values =
+      for {key, value} <- lens,
+          not match?({:consolidated, _bid, nil}, key),
+          do: value
+
+    pending_size = startup_size + Enum.sum(lens_no_startup_values)
+    pipeline_count = state.pipeline_count
+    batch_size = Pipeline.max_batch_size()
+    max_pipelines = Map.get(state, :max_pipelines)
+
+    complete_startup_batches =
+      Enum.reduce(startup_batch_key_counts, 0, fn {_batch_key, count}, total ->
+        total + div(count, batch_size)
       end)
 
-    lens_no_startup =
-      Enum.filter(lens, fn
-        {{:consolidated, _bid, nil}, _val} -> false
-        _ -> true
-      end)
+    batches_per_pipeline = max(div(Pipeline.max_in_flight(), batch_size), 1)
 
-    lens_no_startup_values = Enum.map(lens_no_startup, fn {_, v} -> v end)
-    len = Enum.map(lens, fn {_, v} -> v end) |> Enum.sum()
+    additional_pipelines =
+      if complete_startup_batches > 0 do
+        max(div(complete_startup_batches, batches_per_pipeline), 1)
+      else
+        0
+      end
 
     last_decr = state.last_count_decrease || NaiveDateTime.utc_now()
     sec_since_last_decr = NaiveDateTime.diff(NaiveDateTime.utc_now(), last_decr)
 
-    # Gated on every queue being above threshold, not the average: an average can
-    # still be dragged over threshold by a single large outlier while every other
-    # queue sits idle (e.g. [30_000, 0] and [60_000, 0, 0, 0] both average to
-    # exactly @scaling_threshold with empty queues in the mix). Weighted routing
-    # (see IngestEventQueue.weight_by_load/2) already fills the least-loaded queue
-    # preferentially, so if even that one is over threshold the fleet genuinely
-    # needs the extra pipeline.
-    fleet_above_threshold? =
-      lens_no_startup_values != [] and
-        Enum.all?(lens_no_startup_values, &(&1 >= @scaling_threshold))
+    desired_count =
+      cond do
+        additional_pipelines > 0 ->
+          pipeline_count + additional_pipelines
 
-    cond do
-      # Scale up if startup queue has events (pipeline not yet ready)
-      startup_size > 0 ->
-        state.pipeline_count + max(div(startup_size, @max_in_flight), 1)
+        startup_size == 0 and
+          Enum.all?(lens_no_startup_values, &(&1 < div(@scaling_threshold, 10))) and
+          pending_size < @scaling_threshold and pipeline_count > 1 and
+            (sec_since_last_decr > 30 or state.last_count_decrease == nil) ->
+          pipeline_count - 1
 
-      # Scale up only if the fleet is loaded on average, not just one outlier
-      fleet_above_threshold? and len > 0 ->
-        state.pipeline_count + 1
+        true ->
+          pipeline_count
+      end
 
-      # Faster decrease when queues are low
-      Enum.all?(lens_no_startup_values, &(&1 < div(@scaling_threshold, 10))) and
-        len < @scaling_threshold and state.pipeline_count > 1 and
-          (sec_since_last_decr > 30 or state.last_count_decrease == nil) ->
-        state.pipeline_count - 1
-
-      true ->
-        state.pipeline_count
+    if is_integer(max_pipelines) do
+      min(desired_count, max_pipelines)
+    else
+      desired_count
     end
+  end
+
+  @spec startup_queue_size([{term(), non_neg_integer()}]) :: non_neg_integer()
+  defp startup_queue_size(lens) do
+    Enum.find_value(lens, 0, fn
+      {{:consolidated, _bid, nil}, value} -> value
+      _ -> false
+    end)
   end
 
   defp validate_user_pass(changeset) do

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -51,14 +51,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @stale_batch_timeout 12_000
   @stale_batcher_concurrency 1
   @max_retries 1
-  # Generous safety valve (2x total batcher capacity across ch_fresh + ch_stale), not a
-  # fine-grained flow-control knob — see BufferProducer's capped_fetch_amount/2. Should
-  # never engage during healthy operation; only caps genuinely runaway backlog.
-  @max_in_flight 2 * (@fresh_batch_size * @fresh_batcher_concurrency)
+  # One full batch per fresh/stale batcher lane, used as a generous safety valve rather
+  # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
+  # It should only cap genuinely runaway backlog during healthy operation.
+  @max_in_flight @fresh_batch_size * @fresh_batcher_concurrency +
+                   @stale_batch_size * @stale_batcher_concurrency
 
   @doc false
   @spec max_retries() :: non_neg_integer()
   def max_retries, do: @max_retries
+
+  @doc false
+  @spec max_batch_size() :: pos_integer()
+  def max_batch_size, do: @fresh_batch_size
+
+  @doc false
+  @spec max_in_flight() :: pos_integer()
+  def max_in_flight, do: @max_in_flight
 
   @doc false
   @spec child_spec(arg :: term()) :: Supervisor.child_spec()
@@ -87,7 +96,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
              backend_id: backend.id,
              consolidated: true,
              id_passing: true,
-             max_in_flight: @max_in_flight
+             max_in_flight: @max_in_flight,
+             seed_batch_size: @fresh_batch_size
            ]},
         transformer: {__MODULE__, :transform, [backend_id: backend.id]},
         concurrency: @producer_concurrency
@@ -187,7 +197,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec ack(ack_ref :: term(), successful :: [Message.t()], failed :: [Message.t()]) :: :ok
   def ack(_ack_ref, successful, failed) do
-    decrement_in_flight(successful ++ failed)
+    decrement_in_flight(successful, failed)
 
     Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
       IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
@@ -209,15 +219,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   # cross-process call. By the time ack/3 fires for a message, Broadway has already
   # finished handle_batch/4 for it, so it's no longer sitting in BatcherStage's
   # (effectively unbounded) buffer regardless of what happens to it next.
-  @spec decrement_in_flight([Message.t()]) :: :ok
-  defp decrement_in_flight(messages) do
-    messages
-    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
-      Map.get(ack_data, :in_flight_ref)
-    end)
-    |> Enum.each(fn
-      {nil, _msgs} -> :ok
-      {ref, msgs} -> :atomics.sub(ref, 1, length(msgs))
+  @spec decrement_in_flight([Message.t()], [Message.t()]) :: :ok
+  defp decrement_in_flight(successful, failed) do
+    counts = count_in_flight(successful, %{})
+    counts = count_in_flight(failed, counts)
+
+    Enum.each(counts, fn {ref, count} -> :atomics.sub(ref, 1, count) end)
+  end
+
+  defp count_in_flight(messages, counts) do
+    Enum.reduce(messages, counts, fn %{acknowledger: {_, _, ack_data}}, counts ->
+      case Map.get(ack_data, :in_flight_ref) do
+        nil -> counts
+        ref -> Map.update(counts, ref, 1, &(&1 + 1))
+      end
     end)
   end
 
@@ -286,15 +301,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       # good/bad end up reversed relative to `messages`; that's fine — Broadway
       # partitions and re-reverses handle_batch/4's return by status internally,
       # and neither the acknowledger nor ClickHouse cares about row order.
+      # This value is constant for the batch. Keep it out of every mapped body and
+      # pass its already-encoded form directly to the row encoder.
       mapping_config_id = Ingester.encode_mapping_config_id(config_id)
 
       {good, bad, chunks} =
         Enum.reduce(messages, {[], [], []}, fn message, acc ->
-          encode_message(z, event_type, compiled, config_id, mapping_config_id, message, acc)
+          encode_message(z, event_type, compiled, mapping_config_id, message, acc)
         end)
 
       final_chunk = :zlib.deflate(z, "", :finish)
-      {good, bad, IO.iodata_to_binary([chunks, final_chunk])}
+      {good, bad, IO.iodata_to_binary([Enum.reverse(chunks), final_chunk])}
     after
       :zlib.deflateEnd(z)
       :zlib.close(z)
@@ -305,7 +322,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           term(),
           TypeDetection.event_type(),
           reference(),
-          String.t(),
           iodata(),
           Message.t(),
           {[Message.t()], [Message.t()], iodata()}
@@ -314,7 +330,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
          z,
          event_type,
          compiled,
-         config_id,
          mapping_config_id,
          %{data: %LogEventPointer{event_type: msg_event_type} = pointer} = message,
          {good, bad, chunks}
@@ -325,7 +340,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         mapped_body =
           event.body
           |> Mapper.map(compiled)
-          |> Map.put("mapping_config_id", config_id)
           |> maybe_compute_duration(event_type)
           |> resolve_severity_number(event_type)
 
@@ -335,7 +349,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
             Ingester.encode_row(%{event | body: mapped_body}, event_type, mapping_config_id)
           )
 
-        {[message | good], bad, [chunks, row_chunk]}
+        {[message | good], bad, [row_chunk | chunks]}
 
       nil ->
         {good, [message | bad], chunks}
@@ -346,7 +360,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
          _z,
          _event_type,
          _compiled,
-         _config_id,
          _mapping_config_id,
          message,
          {good, bad, chunks}

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -97,38 +97,87 @@ defmodule Logflare.Backends.BufferProducer do
   defp init_in_flight(false, _max_in_flight), do: {nil, nil}
 
   # One-time, capped pre-seed of a freshly (re)started producer's own queue from the
-  # shared startup queue — bounded to max_in_flight so it never absorbs more backlog
-  # than it could ever claim anyway, while giving it real pending work immediately
-  # instead of waiting on however many ticks do_fetch's own startup fallback would take
-  # to reach the same amount. Uses pop_pending_pointers' atomic :ets.take-gated claim
-  # (safe even if another producer is concurrently draining the same startup table)
-  # then relocates each pointer's row into the new own table by overriding queue_tid
-  # before reinsert_pointer/1 — a one-off exception to that function's usual "reinsert
-  # where it was claimed from" contract. Only meaningful for id-passing producers with a
-  # finite cap; max_in_flight is nil for non-id-passing producers and :infinity for
-  # id-passing ones with no configured cap.
-  @spec seed_from_startup(table_key(), table_key(), non_neg_integer() | :infinity | nil) :: :ok
-  defp seed_from_startup(_startup_key, _own_key, nil), do: :ok
-  defp seed_from_startup(_startup_key, _own_key, :infinity), do: :ok
+  # shared startup queue. ID-passing producers normally claim any pointers up to their
+  # max_in_flight cap. A producer configured with seed_batch_size instead claims only
+  # complete ClickHouse batch-key groups, so scaling cannot split partial groups into a
+  # newly-created cold pipeline. Every claim still uses the atomic :ets.take-gated
+  # pointer APIs before relocating the pointer to the new queue.
+  @spec seed_from_startup(
+          table_key(),
+          table_key(),
+          non_neg_integer() | :infinity | nil,
+          pos_integer() | nil
+        ) :: :ok
+  defp seed_from_startup(_startup_key, _own_key, nil, _seed_batch_size), do: :ok
+  defp seed_from_startup(_startup_key, _own_key, :infinity, _seed_batch_size), do: :ok
 
-  defp seed_from_startup(startup_key, own_key, max_in_flight) when is_integer(max_in_flight) do
+  defp seed_from_startup(startup_key, own_key, max_in_flight, seed_batch_size)
+       when is_integer(max_in_flight) do
+    pointers = claim_seed_pointers(startup_key, max_in_flight, seed_batch_size)
+    own_tid = IngestEventQueue.get_tid(own_key)
+
+    Enum.each(pointers, fn pointer ->
+      IngestEventQueue.reinsert_pointer(%{pointer | queue_tid: own_tid})
+    end)
+
+    :ok
+  end
+
+  @spec claim_seed_pointers(table_key(), non_neg_integer(), pos_integer() | nil) ::
+          [LogEventPointer.t()]
+  defp claim_seed_pointers(startup_key, max_in_flight, nil) do
     case IngestEventQueue.pop_pending_pointers(startup_key, max_in_flight) do
-      {:error, :not_initialized} ->
-        :ok
-
-      {:ok, [], _tid} ->
-        :ok
-
-      {:ok, pointers, _tid} ->
-        own_tid = IngestEventQueue.get_tid(own_key)
-
-        Enum.each(pointers, fn pointer ->
-          IngestEventQueue.reinsert_pointer(%{pointer | queue_tid: own_tid})
-        end)
-
-        :ok
+      {:ok, pointers, _tid} -> pointers
+      {:error, :not_initialized} -> []
     end
   end
+
+  defp claim_seed_pointers(startup_key, max_in_flight, batch_size)
+       when is_integer(batch_size) and batch_size > 0 do
+    {chunks, _remaining} =
+      startup_key
+      |> IngestEventQueue.pending_batch_key_counts()
+      |> Enum.sort_by(fn {batch_key, count} -> {-count, batch_key} end)
+      |> Enum.reduce_while(
+        {[], max_in_flight},
+        &claim_seed_batch(&1, &2, startup_key, batch_size)
+      )
+
+    chunks |> Enum.reverse() |> List.flatten()
+  end
+
+  @spec claim_seed_batch(
+          {IngestEventQueue.pointer_batch_key(), non_neg_integer()},
+          {[[LogEventPointer.t()]], non_neg_integer()},
+          table_key(),
+          pos_integer()
+        ) :: {:cont | :halt, {[[LogEventPointer.t()]], non_neg_integer()}}
+  defp claim_seed_batch({batch_key, count}, {chunks, remaining}, startup_key, batch_size) do
+    claimable =
+      min(div(count, batch_size) * batch_size, div(remaining, batch_size) * batch_size)
+
+    if claimable < batch_size do
+      {:halt, {chunks, remaining}}
+    else
+      case IngestEventQueue.pop_pending_pointers_by_batch_key(startup_key, batch_key, claimable) do
+        {:ok, pointers, _tid} ->
+          {complete, partial} =
+            Enum.split(pointers, div(length(pointers), batch_size) * batch_size)
+
+          Enum.each(partial, &IngestEventQueue.reinsert_pointer/1)
+          chunks = prepend_seed_chunk(complete, chunks)
+          {:cont, {chunks, remaining - length(complete)}}
+
+        {:error, :not_initialized} ->
+          {:halt, {chunks, remaining}}
+      end
+    end
+  end
+
+  @spec prepend_seed_chunk([LogEventPointer.t()], [[LogEventPointer.t()]]) ::
+          [[LogEventPointer.t()]]
+  defp prepend_seed_chunk([], chunks), do: chunks
+  defp prepend_seed_chunk(complete, chunks), do: [complete | chunks]
 
   @spec init_spool_producer_state(pos_integer(), keyword()) :: state()
   defp init_spool_producer_state(interval, opts) do
@@ -152,7 +201,7 @@ defmodule Logflare.Backends.BufferProducer do
     table_key = {:spool_producer, nil, self()}
     startup_table_key = {:spool_producer, nil, nil}
     IngestEventQueue.upsert_tid(table_key)
-    seed_from_startup(startup_table_key, table_key, max_in_flight)
+    seed_from_startup(startup_table_key, table_key, max_in_flight, opts[:seed_batch_size])
     reschedule(state, false, false)
   end
 
@@ -179,7 +228,7 @@ defmodule Logflare.Backends.BufferProducer do
     table_key = {state.source_id, state.backend_id, self()}
     startup_table_key = {state.source_id, state.backend_id, nil}
     IngestEventQueue.upsert_tid(table_key)
-    seed_from_startup(startup_table_key, table_key, max_in_flight)
+    seed_from_startup(startup_table_key, table_key, max_in_flight, opts[:seed_batch_size])
     reschedule(state, false, false)
   end
 
@@ -205,7 +254,7 @@ defmodule Logflare.Backends.BufferProducer do
     table_key = {:consolidated, backend_id, self()}
     startup_table_key = {:consolidated, backend_id, nil}
     IngestEventQueue.upsert_tid(table_key)
-    seed_from_startup(startup_table_key, table_key, max_in_flight)
+    seed_from_startup(startup_table_key, table_key, max_in_flight, opts[:seed_batch_size])
 
     reschedule(state, Keyword.get(opts, :scale, false), false)
   end
@@ -417,8 +466,7 @@ defmodule Logflare.Backends.BufferProducer do
     fetch_amount = capped_fetch_amount(state, total_demand)
     capped? = fetch_amount < total_demand
 
-    events = do_fetch(state, fetch_amount)
-    event_count = Enum.count(events)
+    {events, event_count} = do_fetch(state, fetch_amount)
 
     if state.in_flight_ref != nil and event_count > 0 do
       :atomics.add(state.in_flight_ref, 1, event_count)
@@ -458,9 +506,8 @@ defmodule Logflare.Backends.BufferProducer do
   # queue couldn't satisfy — a brand-new producer's own queue is empty anyway, so it
   # falls through to startup immediately regardless; an already-loaded producer just
   # keeps grinding its own queue down instead of competing for the shared one.
-  @spec do_fetch(state :: state(), count :: non_neg_integer()) :: [
-          LogEvent.t() | LogEventPointer.t()
-        ]
+  @spec do_fetch(state :: state(), count :: non_neg_integer()) ::
+          {[LogEvent.t() | LogEventPointer.t()], non_neg_integer()}
   defp do_fetch(%{consolidated: true, id_passing: true, backend_id: bid}, n) do
     own_key = {:consolidated, bid, self()}
     startup_key = {:consolidated, bid, nil}
@@ -500,23 +547,24 @@ defmodule Logflare.Backends.BufferProducer do
           own_key :: table_key(),
           startup_key :: table_key(),
           n :: non_neg_integer(),
-          fetch_fn :: (table_key(), non_neg_integer() -> [term()])
-        ) :: [term()]
+          fetch_fn :: (table_key(), non_neg_integer() -> {[term()], non_neg_integer()})
+        ) :: {[term()], non_neg_integer()}
   defp fetch_own_first(own_key, startup_key, n, fetch_fn) do
-    own_events = fetch_fn.(own_key, n)
-    remaining = n - length(own_events)
+    {own_events, own_count} = fetch_fn.(own_key, n)
+    remaining = n - own_count
 
     if remaining > 0 do
-      own_events ++ fetch_fn.(startup_key, remaining)
+      {startup_events, startup_count} = fetch_fn.(startup_key, remaining)
+      {own_events ++ startup_events, own_count + startup_count}
     else
-      own_events
+      {own_events, own_count}
     end
   end
 
   defp fetch_pointers(key, n) do
     case IngestEventQueue.pop_pending_pointers(key, n) do
-      {:error, :not_initialized} -> []
-      {:ok, pointers, _tid} -> pointers
+      {:error, :not_initialized} -> {[], 0}
+      {:ok, pointers, _tid} -> {pointers, length(pointers)}
     end
   end
 
@@ -528,9 +576,8 @@ defmodule Logflare.Backends.BufferProducer do
   # the way BigQuery's ack does, and pop_pending has already deleted the
   # generation-store row as part of claiming anyway, so there'd be nothing left to defer
   # deleting even if they did.
-  @spec do_pop_key(key :: table_key(), count :: non_neg_integer()) :: [
-          LogEvent.t()
-        ]
+  @spec do_pop_key(key :: table_key(), count :: non_neg_integer()) ::
+          {[LogEvent.t()], non_neg_integer()}
   defp do_pop_key({sid, bid, _pid} = key, n) do
     case IngestEventQueue.pop_pending(key, n) do
       {:error, :not_initialized} ->
@@ -539,12 +586,15 @@ defmodule Logflare.Backends.BufferProducer do
           backend_id: bid
         )
 
-        []
+        {[], 0}
 
       {:ok, events} ->
-        Enum.map(events, fn %LogEvent{} = e ->
-          %{e | is_popped: true}
-        end)
+        {events, event_count} =
+          Enum.map_reduce(events, 0, fn %LogEvent{} = e, count ->
+            {%{e | is_popped: true}, count + 1}
+          end)
+
+        {events, event_count}
     end
   end
 end

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -38,6 +38,11 @@ defmodule Logflare.Backends.IngestEventQueue do
   # traffic without ever being fully excluded (excluding it entirely risks dumping
   # bursts into the startup queue with no guaranteed prompt drain — see add_to_table/3).
   @max_queue_weight 5
+  @pointer_batch_key_match_spec (for freshness <- [:fresh, :stale],
+                                     event_type <- [:log, :metric, :trace] do
+                                   {{:_, :_, :_, :_, :_, event_type, :"$1", freshness},
+                                    [{:is_integer, :"$1"}], [{{freshness, event_type, :"$1"}}]}
+                                 end)
 
   @type source_backend :: {Source.t() | pos_integer(), Backend.t() | pos_integer() | nil}
   @type source_backend_pid ::
@@ -49,6 +54,8 @@ defmodule Logflare.Backends.IngestEventQueue do
   @type consolidated_table_key :: {:consolidated, pos_integer(), pid() | nil}
   @type spool_producer_queues_key :: {:spool_producer, nil}
   @type spool_producer_table_key :: {:spool_producer, nil, pid() | nil}
+  @type pointer_batch_key ::
+          {:fresh | :stale, LogEvent.TypeDetection.event_type(), integer()}
 
   defguardp is_pid_or_nil(value) when is_pid(value) or is_nil(value)
 
@@ -522,13 +529,13 @@ defmodule Logflare.Backends.IngestEventQueue do
     chunk_size = Keyword.get(opts, :chunk_size, 100)
     startup_queue = {:spool_producer, nil, nil}
 
-    reducer = fn
-      {{:spool_producer, nil, nil}, _}, acc -> acc
-      {obj, _count}, acc -> [obj | acc]
+    eligible? = fn
+      {{:spool_producer, nil, nil}, _} -> false
+      _ -> true
     end
 
     with all = [_ | _] <- list_counts_with_tids(key),
-         available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
+         available_queues = [_ | _] <- targets_by_load(all, eligible?) do
       Logflare.Utils.chunked_round_robin(
         batch,
         available_queues,
@@ -607,23 +614,22 @@ defmodule Logflare.Backends.IngestEventQueue do
     check_queue_size = Keyword.get(opts, :check_queue_size, true)
     startup_queue = {sid, bid, nil}
 
-    reducer =
+    eligible? =
       if check_queue_size do
         fn
-          {{_, _, nil}, _}, acc -> acc
-          {_obj, count}, acc when count >= @max_queue_size -> acc
-          {obj, _count}, acc -> [obj | acc]
+          {{_, _, nil}, _} -> false
+          {_obj, count} -> count < @max_queue_size
         end
       else
         fn
-          {{_, _, nil}, _}, acc -> acc
-          {obj, _count}, acc -> [obj | acc]
+          {{_, _, nil}, _} -> false
+          _ -> true
         end
       end
 
     if no_get_tid do
       with all = [_ | _] <- list_counts_with_tids(sid_bid),
-           available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
+           available_queues = [_ | _] <- targets_by_load(all, eligible?) do
         Logflare.Utils.chunked_round_robin(
           batch,
           available_queues,
@@ -720,6 +726,17 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   defp add_to_target_table(chunk, target), do: add_to_table(target, chunk)
 
+  @spec targets_by_load(
+          [{term(), non_neg_integer()}],
+          ({term(), non_neg_integer()} -> boolean())
+        ) :: [term()]
+  defp targets_by_load(entries, eligible?) do
+    entries
+    |> Enum.filter(eligible?)
+    |> Enum.sort_by(&elem(&1, 1), :asc)
+    |> Enum.map(&elem(&1, 0))
+  end
+
   # Expands `entries` (already filtered down to eligible, non-startup, non-hard-capped
   # queues) into a weighted target list for chunked_round_robin/4 — a queue appears
   # more than once per cycle to get more than one chunk_size-sized share. Weight is
@@ -734,18 +751,19 @@ defmodule Logflare.Backends.IngestEventQueue do
   # amplify a merely-noisy difference (e.g. 990 vs. 1010) up to the full weight range
   # just as readily as a genuinely clogged queue.
   @spec weight_by_load([{term(), non_neg_integer()}], non_neg_integer()) :: [term()]
-  defp weight_by_load(entries, noise_floor) do
-    counts = Enum.map(entries, &elem(&1, 1))
-    max_count = Enum.max(counts)
-    min_count = Enum.min(counts)
+  defp weight_by_load([{_, first_count} | rest] = entries, noise_floor) do
+    {min_count, max_count} =
+      Enum.reduce(rest, {first_count, first_count}, fn {_, count}, {min_count, max_count} ->
+        {min(min_count, count), max(max_count, count)}
+      end)
+
     spread = max_count - min_count
+    entries = Enum.sort_by(entries, &elem(&1, 1), :asc)
 
     if spread <= noise_floor do
       Enum.map(entries, &elem(&1, 0))
     else
-      entries
-      |> Enum.sort_by(&elem(&1, 1), :asc)
-      |> Enum.flat_map(fn {obj, count} ->
+      Enum.flat_map(entries, fn {obj, count} ->
         weight = 1 + round((max_count - count) / spread * (@max_queue_weight - 1))
         List.duplicate(obj, weight)
       end)
@@ -860,7 +878,6 @@ defmodule Logflare.Backends.IngestEventQueue do
         is_integer(size) do
       {table_key, size}
     end
-    |> Enum.sort_by(&elem(&1, 1), :desc)
   end
 
   @doc """
@@ -940,6 +957,68 @@ defmodule Logflare.Backends.IngestEventQueue do
        [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7", :"$8"}}]}
     ]
 
+    pop_selected_pointers(sid_bid_pid, n, ms)
+  end
+
+  @doc """
+  Counts pending pointers in one queue by the exact Broadway batch identity used by
+  the ClickHouse pipeline: `{ingest_freshness, event_type, day_bucket}`.
+
+  This scans pointer metadata only; full events remain in the generation store.
+  """
+  @spec pending_batch_key_counts(
+          source_backend_pid()
+          | spool_producer_table_key()
+          | consolidated_table_key()
+        ) :: %{optional(pointer_batch_key()) => non_neg_integer()}
+  def pending_batch_key_counts(sid_bid_pid) do
+    case get_tid(sid_bid_pid) do
+      nil ->
+        %{}
+
+      tid ->
+        tid
+        |> :ets.select(@pointer_batch_key_match_spec)
+        |> Enum.frequencies()
+    end
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      %{}
+  end
+
+  @doc """
+  Atomically claims up to `n` pointers for one ClickHouse batch key.
+
+  As with `pop_pending_pointers/2`, the select is only a candidate snapshot. Each
+  pointer is returned only when the following `:ets.take/2` wins its claim.
+  """
+  @spec pop_pending_pointers_by_batch_key(
+          source_backend_pid() | spool_producer_table_key() | consolidated_table_key(),
+          pointer_batch_key(),
+          non_neg_integer()
+        ) ::
+          {:ok, [LogEventPointer.t()], :ets.tid() | nil} | {:error, :not_initialized}
+  def pop_pending_pointers_by_batch_key(_sid_bid_pid, _batch_key, 0),
+    do: {:ok, [], nil}
+
+  def pop_pending_pointers_by_batch_key(
+        sid_bid_pid,
+        {freshness, event_type, day_bucket},
+        n
+      )
+      when freshness in [:fresh, :stale] and
+             event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
+             is_integer(n) and n > 0 do
+    ms = [
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket, freshness}, [],
+       [{{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket, freshness}}]}
+    ]
+
+    pop_selected_pointers(sid_bid_pid, n, ms)
+  end
+
+  defp pop_selected_pointers(sid_bid_pid, n, ms) do
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {selected, _cont} <- :ets.select(tid, ms, n) do
       confirmed =

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/batching_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/batching_test.exs
@@ -1,0 +1,91 @@
+defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.BatchingTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
+
+  @backend_id 42
+  @pipeline_key {:consolidated, @backend_id, self()}
+  @startup_key {:consolidated, @backend_id, nil}
+  @log_key {:fresh, :log, 20_594}
+  @metric_key {:fresh, :metric, 20_594}
+  @other_day_key {:fresh, :log, 20_593}
+  @stale_key {:stale, :log, 20_594}
+
+  defp state(pipeline_count, max_pipelines \\ 8) do
+    %{
+      pipeline_count: pipeline_count,
+      max_pipelines: max_pipelines,
+      last_count_decrease: nil
+    }
+  end
+
+  defp resolve(state, lens, startup_batch_key_counts \\ %{}) do
+    ClickHouseAdaptor.resolve_pipeline_count(state, lens, startup_batch_key_counts)
+  end
+
+  test "keeps a single pipeline when only one batch-sized queue is pending" do
+    lens = [{@pipeline_key, Pipeline.max_batch_size()}]
+
+    assert resolve(state(1), lens) == 1
+  end
+
+  test "does not scale at the old per-queue threshold" do
+    lens = [{@pipeline_key, 30_000}]
+
+    assert resolve(state(1), lens) == 1
+  end
+
+  test "scales when startup contains a complete batch for one exact batch key" do
+    batch_size = Pipeline.max_batch_size()
+    lens = [{@pipeline_key, batch_size}, {@startup_key, batch_size}]
+
+    assert resolve(state(1), lens, %{@log_key => batch_size}) == 2
+  end
+
+  test "does not scale when one batch worth of startup rows is split across batch keys" do
+    batch_size = Pipeline.max_batch_size()
+    half_batch = div(batch_size, 2)
+    lens = [{@pipeline_key, batch_size}, {@startup_key, batch_size}]
+
+    assert resolve(state(1), lens, %{@log_key => half_batch, @metric_key => half_batch}) == 1
+  end
+
+  test "does not combine freshness or day buckets when deciding a batch is complete" do
+    batch_size = Pipeline.max_batch_size()
+    partial = div(batch_size, 3)
+    lens = [{@startup_key, partial * 3}]
+
+    counts = %{@log_key => partial, @other_day_key => partial, @stale_key => partial}
+    assert resolve(state(1), lens, counts) == 1
+  end
+
+  test "does not create a cold pipeline for a small startup burst" do
+    count = Pipeline.max_batch_size() - 1
+    lens = [{@startup_key, count}]
+
+    assert resolve(state(1), lens, %{@log_key => count}) == 1
+  end
+
+  test "at 100k pending events it keeps the existing pipeline and in-flight budget" do
+    lens = [{@pipeline_key, Pipeline.max_batch_size()}, {@startup_key, 40_000}]
+
+    assert resolve(state(1), lens, %{@log_key => 40_000}) == 1
+    assert Pipeline.max_in_flight() == 120_000
+  end
+
+  test "two complete startup batches fit in one new pipeline's in-flight budget" do
+    batch_size = Pipeline.max_batch_size()
+    lens = [{@startup_key, batch_size * 2}]
+
+    counts = %{@log_key => batch_size, @metric_key => batch_size}
+    assert resolve(state(1), lens, counts) == 2
+  end
+
+  test "respects the dynamic pipeline maximum when startup has multiple complete batches" do
+    pending = Pipeline.max_in_flight() * 2
+    lens = [{@startup_key, pending}]
+
+    assert resolve(state(1, 2), lens, %{@log_key => pending}) == 2
+  end
+end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -85,6 +85,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
       assert binary =~ "custom_field"
       assert binary =~ "custom_value"
     end
+
+    test "encodes a batch-constant mapping config without storing it in every body" do
+      event = build_mapped_log_event(message: "test message")
+      config_id = Ingester.encode_mapping_config_id(event.body["mapping_config_id"])
+      event_without_config = %{event | body: Map.delete(event.body, "mapping_config_id")}
+
+      assert IO.iodata_to_binary(Ingester.encode_row(event, :log)) ==
+               IO.iodata_to_binary(Ingester.encode_row(event_without_config, :log, config_id))
+    end
   end
 
   describe "encode_row/2 for metrics" do
@@ -94,6 +103,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
       encoded = Ingester.encode_row(event, :metric)
       assert is_list(encoded)
       assert IO.iodata_length(encoded) > 0
+    end
+
+    test "encodes a batch-constant mapping config without storing it in every body" do
+      event = build_mapped_metric_event()
+      config_id = Ingester.encode_mapping_config_id(event.body["mapping_config_id"])
+      event_without_config = %{event | body: Map.delete(event.body, "mapping_config_id")}
+
+      assert IO.iodata_to_binary(Ingester.encode_row(event, :metric)) ==
+               IO.iodata_to_binary(Ingester.encode_row(event_without_config, :metric, config_id))
     end
 
     test "includes metric fields in encoded output" do
@@ -123,6 +141,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
       encoded = Ingester.encode_row(event, :trace)
       assert is_list(encoded)
       assert IO.iodata_length(encoded) > 0
+    end
+
+    test "encodes a batch-constant mapping config without storing it in every body" do
+      event = build_mapped_trace_event()
+      config_id = Ingester.encode_mapping_config_id(event.body["mapping_config_id"])
+      event_without_config = %{event | body: Map.delete(event.body, "mapping_config_id")}
+
+      assert IO.iodata_to_binary(Ingester.encode_row(event, :trace)) ==
+               IO.iodata_to_binary(Ingester.encode_row(event_without_config, :trace, config_id))
     end
 
     test "includes trace fields in encoded output" do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -79,10 +79,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
   # Builds a message in the format produced by handle_message/3, for use in
   # handle_batch/4 and ack/3 tests.
-  defp batch_message(event, gen_tid, backend_id, queue_tid \\ nil) do
+  defp batch_message(event, gen_tid, backend_id, queue_tid \\ nil, in_flight_ref \\ nil) do
     %Message{
       data: pointer_for(event, gen_tid, queue_tid),
-      acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id}}
+      acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id, in_flight_ref: in_flight_ref}}
     }
   end
 
@@ -659,6 +659,40 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   describe "ack/3" do
     test "returns :ok when both lists are empty" do
       assert Pipeline.ack(:ack_ref, [], []) == :ok
+    end
+
+    test "decrements each producer's atomics ref across successful and failed messages", %{
+      source: source,
+      backend: backend
+    } do
+      ref_a = :atomics.new(1, signed: true)
+      ref_b = :atomics.new(1, signed: true)
+      :atomics.put(ref_a, 1, 2)
+      :atomics.put(ref_b, 1, 1)
+
+      successful_event = build(:log_event, source: source)
+
+      failed_event_a =
+        build(:log_event, source: source) |> Map.put(:retries, Pipeline.max_retries())
+
+      failed_event_b =
+        build(:log_event, source: source) |> Map.put(:retries, Pipeline.max_retries())
+
+      gen_tid = setup_generation_events([successful_event, failed_event_a, failed_event_b])
+
+      successful = [batch_message(successful_event, gen_tid, backend.id, nil, ref_a)]
+
+      failed = [
+        batch_message(failed_event_a, gen_tid, backend.id, nil, ref_a)
+        |> Message.failed(:insert_failed),
+        batch_message(failed_event_b, gen_tid, backend.id, nil, ref_b)
+        |> Message.failed(:insert_failed)
+      ]
+
+      capture_log(fn -> assert :ok = Pipeline.ack(:ack_ref, successful, failed) end)
+
+      assert :atomics.get(ref_a, 1) == 0
+      assert :atomics.get(ref_b, 1) == 0
     end
 
     test "deletes the event from the generation store for successful messages, without recording it into the recent-events cache",

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -8,6 +8,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.NativeIngester.PoolSup, as: NativePoolSup
@@ -1108,18 +1109,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
-  describe "resolve_pipeline_count/2" do
-    test "scales up when every queue is above the scaling threshold" do
+  describe "resolve_pipeline_count/3" do
+    test "scales up when startup contains a complete batch-key group" do
       state = %{pipeline_count: 3, last_count_decrease: nil}
+      batch_size = Pipeline.max_batch_size()
 
       lens = [
-        {{:consolidated, 1, nil}, 0},
-        {{:consolidated, 1, self()}, 16_000},
-        {{:consolidated, 1, self()}, 16_000},
-        {{:consolidated, 1, self()}, 16_000}
+        {{:consolidated, 1, nil}, batch_size},
+        {{:consolidated, 1, self()}, batch_size},
+        {{:consolidated, 1, self()}, batch_size},
+        {{:consolidated, 1, self()}, batch_size}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 4
+      counts = %{{:fresh, :log, 20_594} => batch_size}
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, counts) == 4
     end
 
     test "does not scale up when only one queue is over threshold and the rest are idle" do
@@ -1133,24 +1136,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         {{:consolidated, 1, self()}, 0}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 4
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 4
     end
 
     test "does not scale up on a single outlier even when it drags the fleet average over threshold" do
       state = %{pipeline_count: 2, last_count_decrease: nil}
 
-      # [30_000, 0] averages to exactly @scaling_threshold despite one queue being
-      # completely idle — averaging alone would incorrectly scale up here.
       lens = [
         {{:consolidated, 1, nil}, 0},
         {{:consolidated, 1, self()}, 30_000},
         {{:consolidated, 1, self()}, 0}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 2
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 2
     end
 
-    test "scales up when the startup queue has events, regardless of the average" do
+    test "does not scale up for a startup burst smaller than one full batch" do
       state = %{pipeline_count: 2, last_count_decrease: nil}
 
       lens = [
@@ -1158,7 +1159,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         {{:consolidated, 1, self()}, 0}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 3
+      counts = %{{:fresh, :log, 20_594} => 500}
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, counts) == 2
     end
 
     test "scales down when every queue is well below threshold and enough time has passed" do
@@ -1173,7 +1175,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         {{:consolidated, 1, self()}, 0}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 2
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 2
     end
 
     test "does not scale down again within 30 seconds of the last decrease" do
@@ -1185,7 +1187,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         {{:consolidated, 1, self()}, 0}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 3
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 3
     end
 
     test "holds steady when nothing warrants scaling up or down" do
@@ -1198,13 +1200,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         {{:consolidated, 1, self()}, 2_000}
       ]
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens) == 3
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 3
     end
 
     test "handles an empty lens list without dividing by zero" do
       state = %{pipeline_count: 1, last_count_decrease: nil}
 
-      assert ClickHouseAdaptor.resolve_pipeline_count(state, []) == 1
+      assert ClickHouseAdaptor.resolve_pipeline_count(state, [], %{}) == 1
     end
   end
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -297,6 +297,131 @@ defmodule Logflare.Backends.BufferProducerTest do
       [user: user, source: source, backend: backend]
     end
 
+    test "batch-aware startup seeding moves complete keys and leaves partial keys", %{
+      source: source,
+      backend: backend
+    } do
+      startup_key = {:consolidated, backend.id, nil}
+      IngestEventQueue.upsert_tid(startup_key)
+
+      complete_group =
+        for _ <- 1..2 do
+          build(:log_event, source: source)
+          |> Map.put(:event_type, :log)
+          |> Map.put(:day_bucket, 12_345)
+          |> Map.put(:ingest_freshness, :fresh)
+        end
+
+      partial =
+        build(:log_event, source: source)
+        |> Map.put(:event_type, :metric)
+        |> Map.put(:day_bucket, 12_345)
+        |> Map.put(:ingest_freshness, :fresh)
+
+      :ok = IngestEventQueue.add_to_table(startup_key, complete_group ++ [partial])
+
+      producer =
+        start_supervised!(
+          {BufferProducer,
+           backend_id: backend.id,
+           consolidated: true,
+           id_passing: true,
+           max_in_flight: 4,
+           seed_batch_size: 2,
+           interval: 5_000}
+        )
+
+      own_key = {:consolidated, backend.id, producer}
+
+      assert IngestEventQueue.pending_batch_key_counts(own_key) == %{
+               {:fresh, :log, 12_345} => 2
+             }
+
+      assert IngestEventQueue.pending_batch_key_counts(startup_key) == %{
+               {:fresh, :metric, 12_345} => 1
+             }
+    end
+
+    test "batch-aware startup seeding does not move aggregate-only partial groups", %{
+      source: source,
+      backend: backend
+    } do
+      startup_key = {:consolidated, backend.id, nil}
+      IngestEventQueue.upsert_tid(startup_key)
+
+      events =
+        for event_type <- [:log, :metric] do
+          build(:log_event, source: source)
+          |> Map.put(:event_type, event_type)
+          |> Map.put(:day_bucket, 12_345)
+          |> Map.put(:ingest_freshness, :fresh)
+        end
+
+      :ok = IngestEventQueue.add_to_table(startup_key, events)
+
+      producer =
+        start_supervised!(
+          {BufferProducer,
+           backend_id: backend.id,
+           consolidated: true,
+           id_passing: true,
+           max_in_flight: 4,
+           seed_batch_size: 2,
+           interval: 5_000}
+        )
+
+      own_key = {:consolidated, backend.id, producer}
+      assert IngestEventQueue.total_pending(own_key) == 0
+      assert IngestEventQueue.total_pending(startup_key) == 2
+    end
+
+    test "returns a raced partial seed claim to startup", %{
+      source: source,
+      backend: backend
+    } do
+      startup_key = {:consolidated, backend.id, nil}
+      batch_key = {:fresh, :log, 12_345}
+      IngestEventQueue.upsert_tid(startup_key)
+
+      events =
+        for _ <- 1..2 do
+          build(:log_event, source: source)
+          |> Map.put(:event_type, :log)
+          |> Map.put(:day_bucket, 12_345)
+          |> Map.put(:ingest_freshness, :fresh)
+        end
+
+      :ok = IngestEventQueue.add_to_table(startup_key, events)
+      test_pid = self()
+
+      expect(IngestEventQueue, :pending_batch_key_counts, fn ^startup_key ->
+        {:ok, [raced_pointer], _tid} =
+          IngestEventQueue.pop_pending_pointers_by_batch_key(startup_key, batch_key, 1)
+
+        send(test_pid, {:raced_pointer, raced_pointer})
+        %{batch_key => 2}
+      end)
+
+      producer =
+        start_supervised!(
+          {BufferProducer,
+           backend_id: backend.id,
+           consolidated: true,
+           id_passing: true,
+           max_in_flight: 2,
+           seed_batch_size: 2,
+           interval: 5_000}
+        )
+
+      own_key = {:consolidated, backend.id, producer}
+      assert_receive {:raced_pointer, raced_pointer}
+      assert IngestEventQueue.total_pending(own_key) == 0
+      assert IngestEventQueue.total_pending(startup_key) == 1
+
+      IngestEventQueue.reinsert_pointer(raced_pointer)
+      assert IngestEventQueue.total_pending(startup_key) == 2
+    end
+
     test "pulls events from consolidated queue", %{source: source, backend: backend} do
       startup_key = {:consolidated, backend.id, nil}
       IngestEventQueue.upsert_tid(startup_key)
@@ -549,6 +674,50 @@ defmodule Logflare.Backends.BufferProducerTest do
     # Process.send_after(self(), ...) inside them schedules to whichever process calls
     # them, so calling them from the test process directly lets us assert on the
     # resulting timing without a full running pipeline.
+
+    test "counts real pointer fetches against the cap and resumes after ack capacity is freed", %{
+      source: source,
+      backend: backend
+    } do
+      own_key = {:consolidated, backend.id, self()}
+      startup_key = {:consolidated, backend.id, nil}
+      IngestEventQueue.upsert_tid(own_key)
+      IngestEventQueue.upsert_tid(startup_key)
+
+      events = for _ <- 1..3, do: build(:log_event, source: source)
+      :ok = IngestEventQueue.add_to_table(own_key, events)
+
+      ref = :atomics.new(1, signed: true)
+
+      state = %{
+        consolidated: true,
+        id_passing: true,
+        demand: 0,
+        source_id: nil,
+        source_token: nil,
+        backend_id: backend.id,
+        last_discard_log_dt: nil,
+        interval: 5_000,
+        in_flight_ref: ref,
+        max_in_flight: 2,
+        timer_ref: nil
+      }
+
+      assert {:noreply, first, state} = BufferProducer.handle_demand(3, state)
+      assert length(first) == 2
+      assert :atomics.get(ref, 1) == 2
+      assert state.demand == 1
+      assert IngestEventQueue.total_pending(own_key) == 1
+
+      :atomics.sub(ref, 1, 2)
+
+      assert {:noreply, [last], state} = BufferProducer.handle_info(:scheduled_resolve, state)
+      assert %LogEventPointer{} = last
+      assert :atomics.get(ref, 1) == 1
+      assert state.demand == 0
+      assert IngestEventQueue.total_pending(own_key) == 0
+      Process.cancel_timer(state.timer_ref)
+    end
 
     test "handle_info(:scheduled_resolve, _) schedules a short retry when a fetch is capped",
          %{source: source, backend: backend} do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -585,6 +585,86 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
+    test "counts and claims pointers by exact ClickHouse batch key", %{
+      source: source,
+      sbp: sbp
+    } do
+      events =
+        for {event_type, day_bucket, freshness, count} <- [
+              {:log, 12_345, :fresh, 3},
+              {:metric, 12_345, :fresh, 2},
+              {:log, 54_321, :stale, 1}
+            ],
+            _ <- 1..count do
+          build(:log_event, source: source)
+          |> Map.put(:event_type, event_type)
+          |> Map.put(:day_bucket, day_bucket)
+          |> Map.put(:ingest_freshness, freshness)
+        end
+
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      assert IngestEventQueue.pending_batch_key_counts(sbp) == %{
+               {:fresh, :log, 12_345} => 3,
+               {:fresh, :metric, 12_345} => 2,
+               {:stale, :log, 54_321} => 1
+             }
+
+      assert {:ok, pointers, _tid} =
+               IngestEventQueue.pop_pending_pointers_by_batch_key(
+                 sbp,
+                 {:fresh, :log, 12_345},
+                 2
+               )
+
+      assert length(pointers) == 2
+      assert Enum.all?(pointers, &match?(%{event_type: :log, day_bucket: 12_345}, &1))
+      assert Enum.all?(pointers, &(&1.ingest_freshness == :fresh))
+      assert IngestEventQueue.total_pending(sbp) == 4
+
+      assert IngestEventQueue.pending_batch_key_counts(sbp) == %{
+               {:fresh, :log, 12_345} => 1,
+               {:fresh, :metric, 12_345} => 2,
+               {:stale, :log, 54_321} => 1
+             }
+    end
+
+    @tag :race
+    test "concurrent batch-key claims never claim a pointer twice", %{
+      source: source,
+      sbp: sbp
+    } do
+      events =
+        for _ <- 1..500 do
+          build(:log_event, source: source)
+          |> Map.put(:event_type, :log)
+          |> Map.put(:day_bucket, 12_345)
+          |> Map.put(:ingest_freshness, :fresh)
+        end
+
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      claimed_ids =
+        for _ <- 1..4 do
+          Task.async(fn ->
+            {:ok, pointers, _tid} =
+              IngestEventQueue.pop_pending_pointers_by_batch_key(
+                sbp,
+                {:fresh, :log, 12_345},
+                500
+              )
+
+            Enum.map(pointers, & &1.id)
+          end)
+        end
+        |> Task.await_many(10_000)
+        |> List.flatten()
+
+      assert length(claimed_ids) == 500
+      assert length(Enum.uniq(claimed_ids)) == 500
+      assert IngestEventQueue.total_pending(sbp) == 0
+    end
+
     test "returns empty without claiming when count is 0", %{
       source: source,
       sbp: sbp
@@ -785,6 +865,23 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert active2_size > 0
     end
 
+    test "sends a sub-cycle burst to the least-loaded active queue first", %{
+      source: source,
+      backend: backend
+    } do
+      loaded_queue = {source.id, backend.id, :erlang.list_to_pid(~c"<0.100.3>")}
+      empty_queue = {source.id, backend.id, :erlang.list_to_pid(~c"<0.100.4>")}
+
+      IngestEventQueue.upsert_tid(loaded_queue)
+      IngestEventQueue.upsert_tid(empty_queue)
+      :ok = IngestEventQueue.add_to_table(loaded_queue, build_list(101, :log_event))
+
+      :ok = IngestEventQueue.add_to_table({source.id, backend.id}, [build(:log_event)])
+
+      assert IngestEventQueue.get_table_size(loaded_queue) == 101
+      assert IngestEventQueue.get_table_size(empty_queue) == 1
+    end
+
     test "falls back to startup queue when no active queues exist", %{
       source: source,
       backend: backend
@@ -917,6 +1014,36 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
       for queue <- queues, do: assert(IngestEventQueue.get_table_size(queue) == max_size)
+    end
+  end
+
+  describe "`add_to_table/3` distribution with spool queues" do
+    setup do
+      for key <- IngestEventQueue.list_queues({:spool_producer, nil}) do
+        IngestEventQueue.delete_queue(key)
+      end
+
+      on_exit(fn ->
+        for key <- IngestEventQueue.list_queues({:spool_producer, nil}) do
+          IngestEventQueue.delete_queue(key)
+        end
+      end)
+
+      :ok
+    end
+
+    test "sends a sub-cycle burst to the least-loaded spool queue first" do
+      loaded_queue = {:spool_producer, nil, :erlang.list_to_pid(~c"<0.110.1>")}
+      empty_queue = {:spool_producer, nil, :erlang.list_to_pid(~c"<0.110.2>")}
+
+      IngestEventQueue.upsert_tid(loaded_queue)
+      IngestEventQueue.upsert_tid(empty_queue)
+      :ok = IngestEventQueue.add_to_table(loaded_queue, build_list(101, :log_event))
+
+      :ok = IngestEventQueue.add_to_table({:spool_producer, nil}, [build(:log_event)])
+
+      assert IngestEventQueue.get_table_size(loaded_queue) == 101
+      assert IngestEventQueue.get_table_size(empty_queue) == 1
     end
   end
 
@@ -1065,6 +1192,23 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       assert added1 == 100
       assert added2 == 100
+    end
+
+    test "starts a sub-cycle burst with the least-loaded queue inside the noise floor", %{
+      backend: backend
+    } do
+      lighter_queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.100.5>")}
+      heavier_queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.100.6>")}
+
+      IngestEventQueue.upsert_tid(lighter_queue)
+      IngestEventQueue.upsert_tid(heavier_queue)
+      :ok = IngestEventQueue.add_to_table(lighter_queue, build_list(10, :log_event))
+      :ok = IngestEventQueue.add_to_table(heavier_queue, build_list(20, :log_event))
+
+      :ok = IngestEventQueue.add_to_table({:consolidated, backend.id}, [build(:log_event)])
+
+      assert IngestEventQueue.get_table_size(lighter_queue) == 11
+      assert IngestEventQueue.get_table_size(heavier_queue) == 20
     end
 
     test "routes an entire incoming batch to the startup queue when every consolidated queue is at the hard cap",


### PR DESCRIPTION
## Summary

- keep ClickHouse batches large by scaling only from complete startup groups for the exact `{freshness, event_type, day_bucket}` Broadway batch key
- seed new producers with complete key groups without increasing the 120k per-pipeline in-flight limit
- preserve least-loaded-first routing for standard, spool, and consolidated queues
- reduce allocation and repeated enumeration in pointer fetching, acknowledgements, queue weighting, mapping, encoding, and compression
- add correctness-checked benchmarks for encoding, exact-key scaler ticks, filtered startup claims, and queue routing

## Batch-aware scaling and startup seeding

```mermaid
flowchart TB
  subgraph Before["Before: aggregate startup backlog"]
    direction LR
    B1["30k logs +<br/>30k metrics"] --> B2["Backlog triggers<br/>scale-up"]
    B2 --> B3["New producer claims<br/>mixed keys"]
    B3 --> B4["Two partial<br/>timeout batches"]
  end

  subgraph After["This PR: exact Broadway batch keys"]
    direction LR
    A1["Count by {freshness,<br/>event_type, day_bucket}"] --> A2{"Complete<br/>60k key?"}
    A2 -- No --> A3["Keep pipeline count;<br/>partial groups stay"]
    A2 -- Yes --> A4["Atomically seed complete groups ≤120k;<br/>return any race-shortened partial"]
    A4 --> A5["Full-key<br/>60k batches"]
  end
```


## Benchmarks

All comparisons below were rerun on the latest branch in the same local environment. Full output is intentionally not checked into the repository; the benchmark scripts and correctness preflights are.

### Fixed work: pointer queue → map → RowBinary → gzip → ack

Command shape:

```sh
SCENARIO=<id_queue|id_queue_metadata> EVENT_TYPE=log SHAPE=realistic \
BATCH_SIZE=60000 BATCHES=20 WARMUP_BATCHES=2 \
  mix run --no-start bench/clickhouse_pipeline_cpu_runner.exs
```

Each run processes 1.2M realistic log rows. Results are medians of two reference and three optimized runs.

| Metric | Reference id queue | Metadata routing + hoisted UUID | Change |
| --- | ---: | ---: | ---: |
| Wall time | 61.5 s | 50.9 s | **-17.3%** |
| BEAM runtime | 66.2 s | 55.8 s | **-15.7%** |
| Throughput | 19,543 rows/s | 23,590 rows/s | **+20.7%** |
| Reductions | 1.864B | 1.714B | **-8.0%** |
| Reductions/row | 1,552.9 | 1,428.1 | **-8.0%** |

The latest review fixes do not touch this hot encode/ack path, and the rerun retains the original improvement.

### Exact-key scaler tick

New benchmark:

```sh
BENCH_SECTION=scaling mix run --no-start bench/clickhouse_batch_scaling_cpu.exs
```

The exact-key scan is only reached when startup already has at least 60k rows, and the dynamic scaler runs every 10 seconds.

| Startup shape | Desired pipelines | Median | p99 | Allocation/op | One-core interval share |
| --- | ---: | ---: | ---: | ---: | ---: |
| 60k, one complete key | 2 | 2.40 ms | 3.02 ms | 4.33 MiB | 0.024% |
| 60k, three 20k partial keys | 1 | 4.50 ms | 7.51 ms | 5.27 MiB | 0.045% |
| 120k, two complete keys | 2 | 12.36 ms | 16.38 ms | 9.89 MiB | 0.124% |

The benchmark's correctness preflight also asserts the intended decisions: one complete 60k key scales, three partial keys do not combine, and two complete 60k keys fit one new pipeline's 120k cap.

### Batch-aware startup claim

The same benchmark compares the new exact-key claim with the prior unfiltered claim, including atomic takes and reinsertion:

| Table shape / claim | Unfiltered median | Exact-key median | Exact-key allocation |
| --- | ---: | ---: | ---: |
| 60k one-key / claim 60k | 53.38 ms | 43.11 ms | 34.00 MiB |
| 120k two-key / claim one 60k key | 43.41 ms | 61.83 ms | 33.95 MiB |

The mixed 120k table pays about 18.4 ms to filter one key. This is a one-time producer-start/scale cost, not a per-batch cost, and remains below 62 ms. The correctness preflight restores every claimed pointer and verifies exact counts and generation-store size.

## 100k events/s batch-formation analysis

The policy probe was rerun at measured offer rates of 100.2–100.6k events/s. It uses real queue routing with 100-row chunks every millisecond and compares current `main`'s 15k scale policy with this branch.

| Initial rows on existing pipeline | Incoming rows | Main queue outputs | Latest branch output |
| ---: | ---: | ---: | ---: |
| 15k | 45k | 30k + 30k | 60k |
| 30k | 30k | 30k + 30k | 60k |
| 45k | 15k | 45k + 15k | 60k |


## In-flight analysis at 100k events/s

The real Broadway probe was also rerun with six processors, 60k batches, 5s fresh and 12s stale timeouts, real pointer fetch accounting, and no ClickHouse I/O. Terminal partial batches are shown explicitly; they are expected when a finite run ends with fewer than 60k rows per key.

| Traffic / cap | Result after observation window |
| --- | --- |
| one fresh log key / 120k | all 500k accounted and drained; 8 full batches + one terminal 20k timeout |
| three fresh keys / 120k | 240k acked, 120k active, 140k pending; six 40k timeout batches — cap still engages badly for this fan-out |
| three fresh keys / 180k | all 500k drained; six full batches + three terminal ~46.7k timeouts |
| 95% one fresh log key + 5% stale / 120k | all 1.2M drained; 20/20 batches full |
| 99% across three fresh keys + 1% stale / 180k | 1,079,805 acked, 120,195 active; no queue backlog, but timeout pressure remains |
| same traffic / 192k | all 1.2M drained; 18 full fresh batches, one 12k stale timeout, and three terminal 36k fresh timeouts |
| 95% across three fresh keys + 5% stale / 200k | all 1.2M drained; 15 full and 8 timeout batches |
| same traffic / 240k | all 1.2M drained; 19 full batches and three terminal 20k fresh timeouts |

Conclusions:

1. Keep 120k for the dominant current-day log-key workload; it handles one fresh key plus a realistic stale trickle without queue growth.
2. 120k is insufficient if fresh traffic commonly fans out across log/metric/trace simultaneously.
3. Do not raise the global cap from this PR alone. Add cap-engagement/active-key telemetry first, then make the cap configurable if production fan-out warrants it.
4. The useful sizing rule remains `sum(full-batch budget per active fresh key) + stale accumulation over 12s`, bounded by the desired memory tradeoff.

## Correctness and validation

- exact-key pointer claims retain `:ets.take/2` as the atomic ownership gate; concurrent claims have no duplicates
- raced partial seed claims are returned to startup and never seed a new cold pipeline
- real pointer fetching respects `max_in_flight` and resumes after ack capacity is freed
- successful and failed messages decrement the correct per-producer atomics refs
- log, metric, and trace hoisted `mapping_config_id` encoding remains equivalent
- all benchmark scenarios run a correctness preflight before timing
- **249 focused tests passed, 0 failures (3 excluded)**
- `MIX_ENV=test mix compile --warnings-as-errors` passed
- `MIX_ENV=test mix format --check-formatted` passed
- `MIX_ENV=test mix lint.all` passed
- latest head `9ee629aa` passed compile, full test/coverage, typing, lint, format, frontend, all Playwright jobs, and the WIP check
