### PR TITLE
perf: increase clickhouse batcher concurrency.

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -37,7 +37,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @min_pipelines 1
   @resolve_interval 10_000
-  @scaling_threshold 15_000
+  @scaling_threshold 30_000
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,15 +46,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @processor_max_demand 1_000
   @fresh_batch_size 60_000
   @fresh_batch_timeout 5_000
-  @fresh_batcher_concurrency 1
+  @fresh_batcher_concurrency 16
   @stale_batch_size 60_000
   @stale_batch_timeout 12_000
-  @stale_batcher_concurrency 1
+  @stale_batcher_concurrency 4
   @max_retries 1
   # One full batch per fresh/stale batcher lane, used as a generous safety valve rather
   # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
   # It should only cap genuinely runaway backlog during healthy operation.
-  @max_in_flight @fresh_batch_size * @fresh_batcher_concurrency +
+  @max_in_flight 2 * @fresh_batch_size * @fresh_batcher_concurrency +
                    @stale_batch_size * @stale_batcher_concurrency
 
   @doc false

--- a/lib/logflare/backends/buffer_producer.ex
+++ b/lib/logflare/backends/buffer_producer.ex
@@ -413,10 +413,16 @@ defmodule Logflare.Backends.BufferProducer do
   @spec schedule(state :: state(), scale? :: boolean(), capped? :: boolean()) :: reference()
   defp schedule(state, scale?, capped?)
 
-  # Takes priority over every other clause below, regardless of producer kind —
-  # capacity freed up by an ack can happen at any moment, so this always gets a short,
-  # fixed retry instead of whatever the normal per-kind interval/backoff would give it.
-  defp schedule(_state, _scale?, true) do
+  # Consolidated/spool producers, regardless of capped?: a bounded, small instance
+  # count (DynamicPipeline's max_pipelines, or a single spool producer) means firing
+  # the fast retry unconditionally on capped? has negligible aggregate cost — and
+  # unlike standard producers below, there's no single source to read an avg
+  # ingest rate from anyway.
+  defp schedule(%{spool_producer: true}, _scale?, true) do
+    Process.send_after(self(), :scheduled_resolve, @min_in_flight_retry_ms)
+  end
+
+  defp schedule(%{consolidated: true}, _scale?, true) do
     Process.send_after(self(), :scheduled_resolve, @min_in_flight_retry_ms)
   end
 
@@ -428,7 +434,7 @@ defmodule Logflare.Backends.BufferProducer do
     Process.send_after(self(), :scheduled_resolve, state.interval)
   end
 
-  defp schedule(state, scale?, false) do
+  defp schedule(state, scale?, _capped?) do
     metrics = Sources.get_source_metrics_for_ingest(state.source_token)
 
     interval =
@@ -464,9 +470,10 @@ defmodule Logflare.Backends.BufferProducer do
   defp resolve_demand(%{demand: prev_demand} = state, new_demand \\ 0) do
     total_demand = prev_demand + new_demand
     fetch_amount = capped_fetch_amount(state, total_demand)
-    capped? = fetch_amount < total_demand
 
     {events, event_count} = do_fetch(state, fetch_amount)
+
+    capped? = event_count < total_demand
 
     if state.in_flight_ref != nil and event_count > 0 do
       :atomics.add(state.in_flight_ref, 1, event_count)

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -31,13 +31,6 @@ defmodule Logflare.Backends.IngestEventQueue do
   @ets_recent_events :ingest_event_queue_recent_events
   @max_queue_size 30_000
   @consolidated_max_queue_size 60_000
-  # How many round-robin slots the currently-emptiest eligible queue gets per cycle,
-  # relative to the currently-most-loaded eligible queue's one slot — see
-  # weight_by_load/2. Self-normalizing against the fleet's own current spread rather
-  # than any fixed threshold, so a single clogged queue gets proportionally less new
-  # traffic without ever being fully excluded (excluding it entirely risks dumping
-  # bursts into the startup queue with no guaranteed prompt drain — see add_to_table/3).
-  @max_queue_weight 5
   @pointer_batch_key_match_spec (for freshness <- [:fresh, :stale],
                                      event_type <- [:log, :metric, :trace] do
                                    {{:_, :_, :_, :_, :_, event_type, :"$1", freshness},
@@ -529,13 +522,13 @@ defmodule Logflare.Backends.IngestEventQueue do
     chunk_size = Keyword.get(opts, :chunk_size, 100)
     startup_queue = {:spool_producer, nil, nil}
 
-    eligible? = fn
-      {{:spool_producer, nil, nil}, _} -> false
-      _ -> true
+    reducer = fn
+      {{:spool_producer, nil, nil}, _}, acc -> acc
+      {obj, _count}, acc -> [obj | acc]
     end
 
     with all = [_ | _] <- list_counts_with_tids(key),
-         available_queues = [_ | _] <- targets_by_load(all, eligible?) do
+         available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
       Logflare.Utils.chunked_round_robin(
         batch,
         available_queues,
@@ -556,25 +549,26 @@ defmodule Logflare.Backends.IngestEventQueue do
     check_queue_size = Keyword.get(opts, :check_queue_size, true)
     startup_queue = {:consolidated, bid, nil}
 
-    filter_fn =
+    reducer =
       if check_queue_size do
         fn
-          {{:consolidated, _, nil}, _} -> false
-          {_obj, count} -> count < @consolidated_max_queue_size
+          {{:consolidated, _, nil}, _}, acc -> acc
+          {_obj, count}, acc when count >= @consolidated_max_queue_size -> acc
+          {obj, _count}, acc -> [obj | acc]
         end
       else
         fn
-          {{:consolidated, _, nil}, _} -> false
-          _ -> true
+          {{:consolidated, _, nil}, _}, acc -> acc
+          {obj, _count}, acc -> [obj | acc]
         end
       end
 
     if no_get_tid do
       with all = [_ | _] <- list_counts_with_tids(key),
-           eligible = [_ | _] <- Enum.filter(all, filter_fn) do
+           available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
         Logflare.Utils.chunked_round_robin(
           batch,
-          weight_by_load(eligible, 100),
+          available_queues,
           chunk_size,
           &add_to_target_table/2
         )
@@ -614,22 +608,23 @@ defmodule Logflare.Backends.IngestEventQueue do
     check_queue_size = Keyword.get(opts, :check_queue_size, true)
     startup_queue = {sid, bid, nil}
 
-    eligible? =
+    reducer =
       if check_queue_size do
         fn
-          {{_, _, nil}, _} -> false
-          {_obj, count} -> count < @max_queue_size
+          {{_, _, nil}, _}, acc -> acc
+          {_obj, count}, acc when count >= @max_queue_size -> acc
+          {obj, _count}, acc -> [obj | acc]
         end
       else
         fn
-          {{_, _, nil}, _} -> false
-          _ -> true
+          {{_, _, nil}, _}, acc -> acc
+          {obj, _count}, acc -> [obj | acc]
         end
       end
 
     if no_get_tid do
       with all = [_ | _] <- list_counts_with_tids(sid_bid),
-           available_queues = [_ | _] <- targets_by_load(all, eligible?) do
+           available_queues = [_ | _] <- Enum.reduce(all, [], reducer) do
         Logflare.Utils.chunked_round_robin(
           batch,
           available_queues,
@@ -725,50 +720,6 @@ defmodule Logflare.Backends.IngestEventQueue do
   defp pointer_queues_key({sid, bid, _pid}), do: {sid, bid}
 
   defp add_to_target_table(chunk, target), do: add_to_table(target, chunk)
-
-  @spec targets_by_load(
-          [{term(), non_neg_integer()}],
-          ({term(), non_neg_integer()} -> boolean())
-        ) :: [term()]
-  defp targets_by_load(entries, eligible?) do
-    entries
-    |> Enum.filter(eligible?)
-    |> Enum.sort_by(&elem(&1, 1), :asc)
-    |> Enum.map(&elem(&1, 0))
-  end
-
-  # Expands `entries` (already filtered down to eligible, non-startup, non-hard-capped
-  # queues) into a weighted target list for chunked_round_robin/4 — a queue appears
-  # more than once per cycle to get more than one chunk_size-sized share. Weight is
-  # relative to the CURRENT spread between the least- and most-loaded eligible queue,
-  # not any fixed threshold: the most-loaded one always gets exactly 1 slot (still a
-  # real, actively-consumed target — never zero, unlike fully excluding it, which would
-  # risk dumping a burst into the startup queue with no guaranteed prompt drain), while
-  # the least-loaded one gets up to @max_queue_weight slots.
-  #
-  # `noise_floor` is an absolute row count below which the fleet is treated as
-  # balanced and round-robin stays plain: normalizing against the spread alone would
-  # amplify a merely-noisy difference (e.g. 990 vs. 1010) up to the full weight range
-  # just as readily as a genuinely clogged queue.
-  @spec weight_by_load([{term(), non_neg_integer()}], non_neg_integer()) :: [term()]
-  defp weight_by_load([{_, first_count} | rest] = entries, noise_floor) do
-    {min_count, max_count} =
-      Enum.reduce(rest, {first_count, first_count}, fn {_, count}, {min_count, max_count} ->
-        {min(min_count, count), max(max_count, count)}
-      end)
-
-    spread = max_count - min_count
-    entries = Enum.sort_by(entries, &elem(&1, 1), :asc)
-
-    if spread <= noise_floor do
-      Enum.map(entries, &elem(&1, 0))
-    else
-      Enum.flat_map(entries, fn {obj, count} ->
-        weight = 1 + round((max_count - count) / spread * (@max_queue_weight - 1))
-        List.duplicate(obj, weight)
-      end)
-    end
-  end
 
   @doc """
   Moves an entire queue from an origin to a target.

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/batching_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/batching_test.exs
@@ -71,7 +71,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.BatchingTest do
     lens = [{@pipeline_key, Pipeline.max_batch_size()}, {@startup_key, 40_000}]
 
     assert resolve(state(1), lens, %{@log_key => 40_000}) == 1
-    assert Pipeline.max_in_flight() == 120_000
+    assert Pipeline.max_in_flight() == 2_160_000
   end
 
   test "two complete startup batches fit in one new pipeline's in-flight budget" do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -1193,11 +1193,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     test "holds steady when nothing warrants scaling up or down" do
       state = %{pipeline_count: 3, last_count_decrease: nil}
 
+      # each queue must sit above @scaling_threshold / 10 (the scale-down cutoff) to
+      # avoid scaling down, and total pending must stay under @scaling_threshold to
+      # avoid scaling up
       lens = [
         {{:consolidated, 1, nil}, 0},
-        {{:consolidated, 1, self()}, 2_000},
-        {{:consolidated, 1, self()}, 2_000},
-        {{:consolidated, 1, self()}, 2_000}
+        {{:consolidated, 1, self()}, 10_000},
+        {{:consolidated, 1, self()}, 10_000},
+        {{:consolidated, 1, self()}, 10_000}
       ]
 
       assert ClickHouseAdaptor.resolve_pipeline_count(state, lens, %{}) == 3

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -719,17 +719,17 @@ defmodule Logflare.Backends.BufferProducerTest do
       Process.cancel_timer(state.timer_ref)
     end
 
-    test "handle_info(:scheduled_resolve, _) schedules a short retry when a fetch is capped",
-         %{source: source, backend: backend} do
+    test "handle_info(:scheduled_resolve, _) schedules a short retry when a fetch is capped, for a consolidated producer",
+         %{backend: backend} do
       ref = :atomics.new(1, signed: true)
       :atomics.put(ref, 1, 1)
 
       state = %{
-        consolidated: false,
+        consolidated: true,
         id_passing: true,
         demand: 1,
-        source_id: source.id,
-        source_token: source.token,
+        source_id: nil,
+        source_token: nil,
         backend_id: backend.id,
         last_discard_log_dt: nil,
         interval: 5_000,
@@ -741,6 +741,38 @@ defmodule Logflare.Backends.BufferProducerTest do
       assert {:noreply, [], _state} = BufferProducer.handle_info(:scheduled_resolve, state)
 
       assert_receive :scheduled_resolve, 400
+    end
+
+    test "handle_info(:scheduled_resolve, _) never fast-retries a capped fetch for a standard (BigQuery) producer, regardless of source volume",
+         %{source: source, backend: backend} do
+      # The fast in-flight retry is scoped to consolidated/spool producers only — a
+      # bounded, small instance count each. Standard producers have no such bound
+      # (potentially many thousands of low-traffic sources fleet-wide), so a capped
+      # fetch there always falls through to the normal avg-tiered backoff instead,
+      # regardless of how busy the source is.
+      stub(Logflare.Sources, :get_source_metrics_for_ingest, fn _ -> %{avg: 300} end)
+
+      ref = :atomics.new(1, signed: true)
+      :atomics.put(ref, 1, 1)
+
+      state = %{
+        consolidated: false,
+        id_passing: true,
+        demand: 1,
+        source_id: source.id,
+        source_token: source.token,
+        backend_id: backend.id,
+        last_discard_log_dt: nil,
+        interval: 1_000,
+        in_flight_ref: ref,
+        max_in_flight: 1,
+        timer_ref: nil
+      }
+
+      assert {:noreply, [], _state} = BufferProducer.handle_info(:scheduled_resolve, state)
+
+      refute_receive :scheduled_resolve, 400
+      assert_receive :scheduled_resolve, 1_100
     end
 
     test "handle_info(:scheduled_resolve, _) keeps the normal interval when genuinely empty, not capped",
@@ -768,16 +800,16 @@ defmodule Logflare.Backends.BufferProducerTest do
     end
 
     test "handle_demand/2 proactively schedules a short retry when capped, instead of waiting for the pending timer",
-         %{source: source, backend: backend} do
+         %{backend: backend} do
       ref = :atomics.new(1, signed: true)
       :atomics.put(ref, 1, 1)
 
       state = %{
-        consolidated: false,
+        consolidated: true,
         id_passing: true,
         demand: 0,
-        source_id: source.id,
-        source_token: source.token,
+        source_id: nil,
+        source_token: nil,
         backend_id: backend.id,
         last_discard_log_dt: nil,
         interval: 5_000,
@@ -795,14 +827,18 @@ defmodule Logflare.Backends.BufferProducerTest do
       source: source,
       backend: backend
     } do
+      own_key = {:consolidated, backend.id, self()}
+      IngestEventQueue.upsert_tid(own_key)
+      :ok = IngestEventQueue.add_to_table(own_key, [build(:log_event, source: source)])
+
       ref = :atomics.new(1, signed: true)
 
       state = %{
-        consolidated: false,
+        consolidated: true,
         id_passing: true,
         demand: 0,
-        source_id: source.id,
-        source_token: source.token,
+        source_id: nil,
+        source_token: nil,
         backend_id: backend.id,
         last_discard_log_dt: nil,
         interval: 5_000,
@@ -811,22 +847,22 @@ defmodule Logflare.Backends.BufferProducerTest do
         timer_ref: nil
       }
 
-      assert {:noreply, [], _state} = BufferProducer.handle_demand(1, state)
+      assert {:noreply, [_fetched], _state} = BufferProducer.handle_demand(1, state)
 
       refute_receive :scheduled_resolve, 400
     end
 
     test "handle_demand/2 cancels the previous timer instead of forking a second parallel loop when called again while still capped",
-         %{source: source, backend: backend} do
+         %{backend: backend} do
       ref = :atomics.new(1, signed: true)
       :atomics.put(ref, 1, 1)
 
       state = %{
-        consolidated: false,
+        consolidated: true,
         id_passing: true,
         demand: 0,
-        source_id: source.id,
-        source_token: source.token,
+        source_id: nil,
+        source_token: nil,
         backend_id: backend.id,
         last_discard_log_dt: nil,
         interval: 5_000,

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -1107,7 +1107,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(full_queue)
       IngestEventQueue.upsert_tid(available_queue)
 
-      max_size = IngestEventQueue.max_queue_size()
+      max_size = IngestEventQueue.max_consolidated_queue_size()
       full_batch = build_list(max_size, :log_event, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
@@ -1142,33 +1142,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert size1 + size2 == 10
     end
 
-    test "weights round-robin toward the less-loaded consolidated queue once the spread exceeds the noise floor",
-         %{backend: backend} do
-      pid1 = :erlang.list_to_pid(~c"<0.100.1>")
-      pid2 = :erlang.list_to_pid(~c"<0.100.2>")
-      loaded_queue = {:consolidated, backend.id, pid1}
-      empty_queue = {:consolidated, backend.id, pid2}
-
-      IngestEventQueue.upsert_tid(loaded_queue)
-      IngestEventQueue.upsert_tid(empty_queue)
-
-      # pre-load one queue well past the noise floor (chunk_size, 100 here) so
-      # weight_by_load/2 kicks in instead of falling back to plain round-robin
-      :ok = IngestEventQueue.add_to_table(loaded_queue, build_list(40_000, :log_event))
-
-      new_events = build_list(6_000, :log_event)
-
-      :ok =
-        IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events, chunk_size: 50)
-
-      loaded_added = IngestEventQueue.get_table_size(loaded_queue) - 40_000
-      empty_added = IngestEventQueue.get_table_size(empty_queue)
-
-      assert loaded_added + empty_added == 6_000
-      assert empty_added > loaded_added * 3
-    end
-
-    test "falls back to plain round-robin for consolidated queues when the spread is within the noise floor",
+    test "splits evenly across consolidated queues regardless of their current load",
          %{backend: backend} do
       pid1 = :erlang.list_to_pid(~c"<0.100.1>")
       pid2 = :erlang.list_to_pid(~c"<0.100.2>")
@@ -1178,7 +1152,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(queue1)
       IngestEventQueue.upsert_tid(queue2)
 
-      # a 10-event difference is far below the noise floor (chunk_size, 100 here)
       :ok = IngestEventQueue.add_to_table(queue1, build_list(1_000, :log_event))
       :ok = IngestEventQueue.add_to_table(queue2, build_list(1_010, :log_event))
 
@@ -1192,23 +1165,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
       assert added1 == 100
       assert added2 == 100
-    end
-
-    test "starts a sub-cycle burst with the least-loaded queue inside the noise floor", %{
-      backend: backend
-    } do
-      lighter_queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.100.5>")}
-      heavier_queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.100.6>")}
-
-      IngestEventQueue.upsert_tid(lighter_queue)
-      IngestEventQueue.upsert_tid(heavier_queue)
-      :ok = IngestEventQueue.add_to_table(lighter_queue, build_list(10, :log_event))
-      :ok = IngestEventQueue.add_to_table(heavier_queue, build_list(20, :log_event))
-
-      :ok = IngestEventQueue.add_to_table({:consolidated, backend.id}, [build(:log_event)])
-
-      assert IngestEventQueue.get_table_size(lighter_queue) == 11
-      assert IngestEventQueue.get_table_size(heavier_queue) == 20
     end
 
     test "routes an entire incoming batch to the startup queue when every consolidated queue is at the hard cap",


### PR DESCRIPTION
Encourage clickhouse to have only 1 pipeline with more batch concurrency. Bufferproducer will try to pull at faster intervals if it exhausts the pending table and still has demand.