### PR TITLE
feat(telemetry): export ClickHouse batching dimensions

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -169,6 +169,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   defp ingest_freshness_to_batcher(:fresh), do: :ch_fresh
   defp ingest_freshness_to_batcher(:stale), do: :ch_stale
 
+  @spec batcher_to_freshness(:ch_fresh | :ch_stale) :: :fresh | :stale
+  defp batcher_to_freshness(:ch_fresh), do: :fresh
+  defp batcher_to_freshness(:ch_stale), do: :stale
+
   @spec batcher_async?(:ch_fresh | :ch_stale) :: boolean()
   defp batcher_async?(:ch_stale), do: true
   defp batcher_async?(:ch_fresh), do: false
@@ -252,6 +256,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         backend_id: backend_id,
         event_type: event_type,
         batcher: batcher,
+        freshness: batcher_to_freshness(batcher),
+        batch_trigger: batch_info.trigger,
         day_bucket: day_bucket
       }
     )

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -206,6 +206,22 @@ defmodule Logflare.Telemetry do
         tags: [:backend_type],
         description: "Sum of batch sizes for broadway pipeline by backend type"
       ),
+      distribution("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
+        event_name: [:logflare, :backends, :pipeline, :handle_batch],
+        measurement: :batch_size,
+        tags: [:event_type, :freshness, :batch_trigger],
+        keep: &clickhouse_batch?/1,
+        reporter_options: batch_size_reporter_opts(),
+        description:
+          "Distribution of ClickHouse batch sizes by event type, freshness, and trigger"
+      ),
+      sum("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
+        event_name: [:logflare, :backends, :pipeline, :handle_batch],
+        measurement: :batch_size,
+        tags: [:event_type, :freshness, :batch_trigger],
+        keep: &clickhouse_batch?/1,
+        description: "Sum of ClickHouse batch sizes by event type, freshness, and trigger"
+      ),
       counter("logflare.cache_buster.to_bust.count", tags: []),
       sum("logflare.logs.ingest_logs.drop_lql",
         event_name: [:logflare, :logs, :ingest_logs, :drop_lql],
@@ -577,6 +593,9 @@ defmodule Logflare.Telemetry do
     |> inspect()
     |> String.replace(@number_suffix_regex, "")
   end
+
+  defp clickhouse_batch?(%{backend_type: :clickhouse}), do: true
+  defp clickhouse_batch?(_metadata), do: false
 
   defp batch_size_reporter_opts do
     [buckets: [0, 1, 50, 100, 250, 500, 1_000, 5_000, 10_000, 20_000, 50_000]]

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -9,6 +9,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.Backends.IngestEventQueue.LogEventPointer
+  alias Logflare.TestUtils
 
   # Arbitrary day bucket value — pipeline only passes it through telemetry/OTEL
   # attributes, so these tests assert tuple shape, not the value itself.
@@ -235,12 +236,28 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         batcher: :ch_fresh,
         batch_key: {:log, @day_bucket},
         size: 2,
-        trigger: :flush
+        trigger: :size
       }
+
+      telemetry_event = [:logflare, :backends, :pipeline, :handle_batch]
+      TestUtils.attach_forwarder(telemetry_event)
 
       result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
 
       assert_same_messages(result, messages)
+
+      assert_receive {:telemetry_event, ^telemetry_event, %{batch_size: 2, batch_trigger: :size},
+                      %{
+                        backend_type: :clickhouse,
+                        backend_id: backend_id,
+                        event_type: :log,
+                        batcher: :ch_fresh,
+                        freshness: :fresh,
+                        batch_trigger: :size,
+                        day_bucket: @day_bucket
+                      }}
+
+      assert backend_id == backend.id
 
       Process.sleep(200)
 
@@ -912,7 +929,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
     test "routes stale batches through async inserts", %{
       context: context,
-      messages: messages
+      messages: messages,
+      backend: backend
     } do
       test_pid = self()
 
@@ -931,10 +949,27 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         trigger: :timeout
       }
 
+      telemetry_event = [:logflare, :backends, :pipeline, :handle_batch]
+      TestUtils.attach_forwarder(telemetry_event)
+
       Pipeline.handle_batch(:ch_stale, messages, batch_info, context)
 
       assert_receive {:insert_opts, opts}
       assert Keyword.get(opts, :async) == true
+
+      assert_receive {:telemetry_event, ^telemetry_event,
+                      %{batch_size: 1, batch_trigger: :timeout},
+                      %{
+                        backend_type: :clickhouse,
+                        backend_id: backend_id,
+                        event_type: :log,
+                        batcher: :ch_stale,
+                        freshness: :stale,
+                        batch_trigger: :timeout,
+                        day_bucket: @day_bucket
+                      }}
+
+      assert backend_id == backend.id
     end
 
     test "routes fresh batches through synchronous inserts", %{

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -5,6 +5,18 @@ defmodule Logflare.TelemetryTest do
   alias Logflare.SystemMetrics.Schedulers
   alias Logflare.Telemetry
   alias Logflare.TestUtils
+  alias OtelMetricExporter.MetricStore
+
+  @clickhouse_batch_exporter :logflare_clickhouse_batch_metrics_test
+  @clickhouse_batch_metric_name [
+    :logflare,
+    :backends,
+    :clickhouse,
+    :pipeline,
+    :handle_batch,
+    :batch_size
+  ]
+  @clickhouse_batch_metric_string "logflare.backends.clickhouse.pipeline.handle_batch.batch_size"
 
   describe "metrics/0" do
     test "returns only well-formed Telemetry.Metrics definitions" do
@@ -42,6 +54,73 @@ defmodule Logflare.TelemetryTest do
           ] do
         assert expected in names, "expected #{inspect(expected)} to be a defined metric"
       end
+    end
+
+    test "defines ClickHouse batch distribution and throughput metrics" do
+      metrics = clickhouse_batch_metrics()
+
+      assert length(metrics) == 2
+
+      assert Enum.sort(Enum.map(metrics, &to_string(&1.__struct__))) == [
+               "Elixir.Telemetry.Metrics.Distribution",
+               "Elixir.Telemetry.Metrics.Sum"
+             ]
+
+      for metric <- metrics do
+        assert metric.event_name == [:logflare, :backends, :pipeline, :handle_batch]
+        assert metric.measurement == :batch_size
+        assert metric.tags == [:event_type, :freshness, :batch_trigger]
+        assert metric.keep.(%{backend_type: :clickhouse})
+        refute metric.keep.(%{backend_type: :bigquery})
+      end
+    end
+
+    test "aggregates ClickHouse batches by event type, freshness, and trigger" do
+      start_supervised!(
+        {OtelMetricExporter,
+         name: @clickhouse_batch_exporter,
+         metrics: clickhouse_batch_metrics(),
+         export_period: :timer.minutes(5),
+         otlp_protocol: :http_protobuf,
+         otlp_endpoint: "http://localhost:4318",
+         otlp_headers: %{},
+         otlp_compression: nil}
+      )
+
+      event = [:logflare, :backends, :pipeline, :handle_batch]
+      log_tags = %{event_type: :log, freshness: :fresh, batch_trigger: :size}
+      metric_tags = %{event_type: :metric, freshness: :fresh, batch_trigger: :timeout}
+      trace_tags = %{event_type: :trace, freshness: :stale, batch_trigger: :timeout}
+
+      :telemetry.execute(
+        event,
+        %{batch_size: 20_000},
+        Map.put(log_tags, :backend_type, :clickhouse)
+      )
+
+      :telemetry.execute(
+        event,
+        %{batch_size: 500},
+        Map.put(metric_tags, :backend_type, :clickhouse)
+      )
+
+      :telemetry.execute(
+        event,
+        %{batch_size: 125},
+        Map.put(trace_tags, :backend_type, :clickhouse)
+      )
+
+      :telemetry.execute(event, %{batch_size: 999}, %{backend_type: :bigquery})
+
+      assert %{
+               {:distribution, @clickhouse_batch_metric_string} => distributions,
+               {:sum, @clickhouse_batch_metric_string} => sums
+             } = MetricStore.get_metrics(@clickhouse_batch_exporter)
+
+      assert sums == %{log_tags => 20_000, metric_tags => 500, trace_tags => 125}
+      assert [{_bucket, {1, 20_000}}] = distributions |> Map.fetch!(log_tags) |> Map.to_list()
+      assert [{_bucket, {1, 500}}] = distributions |> Map.fetch!(metric_tags) |> Map.to_list()
+      assert [{_bucket, {1, 125}}] = distributions |> Map.fetch!(trace_tags) |> Map.to_list()
     end
   end
 
@@ -261,5 +340,9 @@ defmodule Logflare.TelemetryTest do
 
       refute_received _anything_else
     end
+  end
+
+  defp clickhouse_batch_metrics do
+    Enum.filter(Telemetry.metrics(), &(&1.name == @clickhouse_batch_metric_name))
   end
 end


### PR DESCRIPTION
## Summary

- export ClickHouse-specific batch-size distribution and event-throughput metrics by event type, freshness, and batch trigger
- normalize the fresh/stale Broadway batchers into low-cardinality freshness tags while retaining existing raw telemetry metadata
- filter the new metrics to ClickHouse so shared pipeline metrics and other backends remain unchanged
- preserve the existing histogram boundaries

## Testing

- `MIX_ENV=test ../bin/x mix format --check-formatted`
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `../bin/test test/logflare/telemetry_test.exs test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs`
- `MIX_ENV=test ../bin/x mix lint.all`

Linear: [O11Y-1944](https://linear.app/supabase/issue/O11Y-1944/clickhouse-ingest-export-batching-metrics-by-event-type-freshness-and)
