### PR TITLE
perf: stop clickhouse from scaling up and down

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -637,7 +637,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
             pipeline: Pipeline,
             pipeline_args: [backend: backend],
             min_pipelines: @min_pipelines,
-            max_pipelines: System.schedulers_online(),
+            max_pipelines: 1,
             initial_count: @min_pipelines,
             resolve_interval: @resolve_interval,
             resolve_count: fn state ->

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,10 +46,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @processor_max_demand 1_000
   @fresh_batch_size 60_000
   @fresh_batch_timeout 5_000
-  @fresh_batcher_concurrency 64
+  @fresh_batcher_concurrency 32
   @stale_batch_size 60_000
   @stale_batch_timeout 12_000
-  @stale_batcher_concurrency 16
+  @stale_batcher_concurrency 8
   @max_retries 1
   # One full batch per fresh/stale batcher lane, used as a generous safety valve rather
   # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,10 +46,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @processor_max_demand 1_000
   @fresh_batch_size 60_000
   @fresh_batch_timeout 5_000
-  @fresh_batcher_concurrency 4
+  @fresh_batcher_concurrency 64
   @stale_batch_size 60_000
   @stale_batch_timeout 12_000
-  @stale_batcher_concurrency 2
+  @stale_batcher_concurrency 16
   @max_retries 1
   # One full batch per fresh/stale batcher lane, used as a generous safety valve rather
   # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -30,7 +30,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   @ets_current_generation :ingest_event_queue_current_generation
   @ets_recent_events :ingest_event_queue_recent_events
   @max_queue_size 30_000
-  @consolidated_max_queue_size 30_000
+  @consolidated_max_queue_size 120_000
   @pointer_batch_key_match_spec (for freshness <- [:fresh, :stale],
                                      event_type <- [:log, :metric, :trace] do
                                    {{:_, :_, :_, :_, :_, event_type, :"$1", freshness},


### PR DESCRIPTION
Set clickhouse max pipelines to 1 and increase batcher concurrency