### PR TITLE
fix: show source TTL plan limit errors

### DIFF
--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -325,7 +325,7 @@ defmodule Logflare.Sources.Source do
       user = Users.get(source.user_id)
       plan = Billing.get_plan_by_user(user)
 
-      validate_change(changeset, :bigquery_table_ttl, fn :bigquery_table_ttl, ttl ->
+      validate_change(changeset, :retention_days, fn :retention_days, ttl ->
         days = round(plan.limit_source_ttl / :timer.hours(24))
 
         cond do
@@ -333,7 +333,7 @@ defmodule Logflare.Sources.Source do
             []
 
           ttl > days ->
-            [bigquery_table_ttl: "ttl is over your plan limit"]
+            [retention_days: "ttl is over your plan limit"]
 
           true ->
             []

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -125,7 +125,9 @@ defmodule Logflare.SourcesTest do
     test "retention days exceeds", %{user: user} do
       insert(:plan, name: "Free", limit_source_ttl: :timer.hours(24))
       source = insert(:source, user: user)
-      assert {:error, %Ecto.Changeset{}} = Sources.update_source(source, %{retention_days: 12})
+
+      assert {:error, changeset} = Sources.update_source(source, %{retention_days: 12})
+      assert {"ttl is over your plan limit", []} = changeset.errors[:retention_days]
     end
   end
 

--- a/test/logflare_web/controllers/source_controller_test.exs
+++ b/test/logflare_web/controllers/source_controller_test.exs
@@ -510,6 +510,22 @@ defmodule LogflareWeb.SourceControllerTest do
       assert html_response(conn, 406) =~ "Source Name"
     end
 
+    test "shows the plan limit error when retention days exceeds the plan", %{
+      conn: conn,
+      users: [u1, _u2],
+      sources: [s1, _s2 | _]
+    } do
+      conn =
+        conn
+        |> login_user(u1)
+        |> patch(~p"/sources/#{s1}", %{
+          "source" => %{"retention_days" => "7"}
+        })
+
+      assert html_response(conn, 406) =~ "ttl is over your plan limit"
+      assert Sources.get(s1.id).retention_days == 3
+    end
+
     test "updates description when valid", %{
       conn: conn,
       users: [u1, _u2],


### PR DESCRIPTION
Fixes the source edit form to render the TTL limit validation message.

Without the field validation message, it is not clear why the user's update was rejected.

<img width="5878" height="1688" alt="CleanShot 2026-07-21 at 09 56 11@2x" src="https://github.com/user-attachments/assets/f56c98b3-7f4c-4aab-9164-f33e9925e5b6" />


