### PR TITLE
fix(clickhouse): trip circuit breaker immediately on TOO_MANY_PARTS

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker.ex
@@ -81,6 +81,33 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker do
   end
 
   @doc """
+  Immediately opens the breaker, bypassing the failure-count threshold.
+
+  Intended for failures that are self-amplifying under retry — notably a
+  ClickHouse `TOO_MANY_PARTS` (error 252) response, where retrying inserts
+  creates more parts and worsens the condition. Opening at once sheds requeued
+  retries and lets background merges catch up.
+
+  Synchronously updates the breaker so callers can rely on `check/1` seeing it
+  open when this function returns. A missing or concurrently stopped breaker is
+  a no-op.
+  """
+  @spec trip(Backend.t()) :: :ok
+  def trip(%Backend{id: backend_id}) do
+    case Registry.lookup(BackendRegistry, {__MODULE__, backend_id}) do
+      [{pid, _table}] ->
+        try do
+          GenServer.call(pid, :trip)
+        catch
+          :exit, _ -> :ok
+        end
+
+      [] ->
+        :ok
+    end
+  end
+
+  @doc """
   Returns the breaker's current state, or `nil` if no breaker is running.
 
   Useful for introspection (_and tests_).
@@ -107,37 +134,43 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker do
     {:reply, state, state}
   end
 
+  def handle_call(:trip, _from, %__MODULE__{} = state) do
+    now = System.system_time(:millisecond)
+    {:reply, :ok, open_breaker(state, now, length(state.failures), :forced)}
+  end
+
   @impl true
   def handle_cast(:record_failure, %__MODULE__{} = state) do
     now = System.system_time(:millisecond)
     cutoff = now - window_ms()
     failures = Enum.filter([now | state.failures], &(&1 >= cutoff))
 
-    {:noreply, maybe_trip(state, failures, now)}
+    if length(failures) >= max_failures() do
+      {:noreply, open_breaker(state, now, length(failures), :threshold)}
+    else
+      {:noreply, %{state | failures: failures}}
+    end
   end
 
-  @spec maybe_trip(t(), [integer()], integer()) :: t()
-  defp maybe_trip(%__MODULE__{} = state, failures, now) do
-    if length(failures) >= max_failures() do
-      blocked_until = now + block_ms()
-      :ets.insert(state.table, {@blocked_key, blocked_until})
+  @spec open_breaker(t(), integer(), non_neg_integer(), :threshold | :forced) :: t()
+  defp open_breaker(%__MODULE__{} = state, now, failure_count, reason) do
+    blocked_until = now + block_ms()
+    :ets.insert(state.table, {@blocked_key, blocked_until})
 
-      Logger.warning("ClickHouse circuit breaker opened",
-        backend_id: state.backend_id,
-        blocked_until: blocked_until,
-        failures: length(failures)
-      )
+    Logger.warning("ClickHouse circuit breaker opened",
+      backend_id: state.backend_id,
+      blocked_until: blocked_until,
+      failures: failure_count,
+      reason: reason
+    )
 
-      :telemetry.execute(
-        [:logflare, :clickhouse, :circuit_breaker, :open],
-        %{failures: length(failures)},
-        %{backend_id: state.backend_id}
-      )
+    :telemetry.execute(
+      [:logflare, :clickhouse, :circuit_breaker, :open],
+      %{failures: failure_count},
+      %{backend_id: state.backend_id, reason: reason}
+    )
 
-      %{state | failures: []}
-    else
-      %{state | failures: failures}
-    end
+    %{state | failures: []}
   end
 
   @spec safe_lookup(:ets.table(), term()) :: [tuple()]

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -17,6 +17,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   @max_delay 5_000
   @pool_timeout 8_000
   @receive_timeout 20_000
+  @too_many_parts_marker "Code: 252."
 
   @doc """
   Inserts a list of `LogEvent` structs into ClickHouse.
@@ -75,6 +76,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
     end
   end
 
+  @doc false
+  @spec too_many_parts?(term()) :: boolean()
+  def too_many_parts?(reason) when is_binary(reason),
+    do: String.contains?(reason, @too_many_parts_marker)
+
+  def too_many_parts?(_reason), do: false
+
   @spec build_client(Keyword.t()) :: Tesla.Client.t()
   defp build_client(connection_opts) do
     middleware = [
@@ -100,6 +108,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   end
 
   @spec retriable?({:ok, Tesla.Env.t()} | {:error, term()}) :: boolean()
+  defp retriable?({:ok, %Tesla.Env{status: status, body: body}})
+       when status >= 500 and is_binary(body),
+       do: not too_many_parts?(body)
+
   defp retriable?({:ok, %Tesla.Env{status: status}}) when status >= 500, do: true
   defp retriable?({:ok, %Tesla.Env{status: 429}}), do: true
   defp retriable?({:ok, _env}), do: false

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -413,8 +413,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         Enum.map(bad, &Message.failed(&1, :not_found)) ++ good
 
       {:error, reason} ->
-        CircuitBreaker.record_failure(backend)
+        record_insert_failure(backend, reason)
         Enum.map(bad, &Message.failed(&1, reason)) ++ Enum.map(good, &Message.failed(&1, reason))
+    end
+  end
+
+  @spec record_insert_failure(Backend.t(), term()) :: :ok
+  defp record_insert_failure(backend, reason) do
+    if Ingester.too_many_parts?(reason) do
+      CircuitBreaker.trip(backend)
+    else
+      CircuitBreaker.record_failure(backend)
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
@@ -72,6 +72,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreakerTest do
     end
   end
 
+  describe "trip/1" do
+    test "opens immediately regardless of failure count", %{backend: backend} do
+      start_supervised!({CircuitBreaker, backend})
+
+      assert :ok = CircuitBreaker.check(backend)
+
+      assert :ok = CircuitBreaker.trip(backend)
+
+      assert {:error, :circuit_open, blocked_until} = CircuitBreaker.check(backend)
+      assert is_integer(blocked_until)
+    end
+
+    test "is a no-op when no breaker is running (fail-safe)", %{backend: backend} do
+      assert :ok = CircuitBreaker.trip(backend)
+      assert :ok = CircuitBreaker.check(backend)
+    end
+  end
+
   describe "fail-safe on process death" do
     test "reads as closed after the breaker process crashes", %{backend: backend} do
       pid = start_supervised!({CircuitBreaker, backend})

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -315,6 +315,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
     end
   end
 
+  describe "too_many_parts?/1" do
+    test "matches only the exact ClickHouse error code" do
+      assert Ingester.too_many_parts?("Code: 252. DB::Exception: Too many parts in table.")
+      refute Ingester.too_many_parts?("Code: 2529. DB::Exception: A hypothetical future error.")
+    end
+  end
+
   describe "insert/4" do
     setup do
       insert(:plan, name: "Free")
@@ -350,6 +357,21 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
       end)
 
       assert :ok = Ingester.insert(backend, table_name, [log_event], :log)
+    end
+
+    test "does not retry TOO_MANY_PARTS responses", %{
+      backend: backend,
+      table_name: table_name
+    } do
+      response_body = "Code: 252. DB::Exception: Too many parts in table."
+
+      Finch
+      |> expect(:request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 500, body: response_body}}
+      end)
+
+      assert {:error, "HTTP 500: " <> ^response_body} =
+               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
     end
 
     test "includes column list in INSERT query", %{

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1071,9 +1071,89 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_received {:recorded_failure, ^expected_backend_id}
     end
+
+    test "trips the circuit breaker immediately on a TOO_MANY_PARTS (252) failure", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      test_pid = self()
+      expected_backend_id = backend.id
+
+      too_many_parts_error =
+        "HTTP 500: Code: 252. DB::Exception: Too many parts (600 with average size of 1.00 MiB) in table."
+
+      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
+                                                                        _event_type,
+                                                                        _compressed,
+                                                                        _opts ->
+        {:error, too_many_parts_error}
+      end)
+
+      # A 252 must trip immediately, not accumulate toward the failure-count threshold.
+      Mimic.reject(CircuitBreaker, :record_failure, 1)
+
+      Mimic.expect(CircuitBreaker, :trip, fn %{id: id} ->
+        send(test_pid, {:tripped, id})
+        :ok
+      end)
+
+      log_event = build(:log_event, source: source, message: "Test message")
+      gen_tid = setup_generation_events([log_event])
+      messages = [batch_message(log_event, gen_tid, backend.id)]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch_fresh,
+        batch_key: {:log, @day_bucket},
+        size: 1,
+        trigger: :flush
+      }
+
+      assert [%Message{status: {:failed, ^too_many_parts_error}}] =
+               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+
+      assert_received {:tripped, ^expected_backend_id}
+    end
   end
 
   describe "ack/3 circuit breaker" do
+    test "sheds a TOO_MANY_PARTS failure on its first acknowledgement", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      too_many_parts_error = "HTTP 500: Code: 252. DB::Exception: Too many parts in table."
+
+      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
+                                                                        _event_type,
+                                                                        _compressed,
+                                                                        _opts ->
+        {:error, too_many_parts_error}
+      end)
+
+      Mimic.reject(CircuitBreaker, :record_failure, 1)
+      Mimic.reject(IngestEventQueue, :add_to_table, 2)
+
+      event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+      gen_tid = setup_generation_events([event])
+      messages = [batch_message(event, gen_tid, backend.id)]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch_fresh,
+        batch_key: {:log, @day_bucket},
+        size: 1,
+        trigger: :flush
+      }
+
+      assert [failed_message = %Message{status: {:failed, ^too_many_parts_error}}] =
+               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+
+      log = capture_log(fn -> Pipeline.ack(:ack_ref, [], [failed_message]) end)
+
+      assert log =~ "circuit breaker open"
+      assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+    end
+
     test "sheds retriable messages instead of requeuing when the breaker is open", %{
       source: source,
       backend: backend


### PR DESCRIPTION
## Context

Incident analysis of a ClickHouse parts explosion showed parts climbing through `parts_to_throw_insert`, followed by error 252 (`TOO_MANY_PARTS`) and a large insert-retry storm. Once a partition is over the throw threshold, retrying inserts only adds load while background merges need time to catch up.

## Changes

- Do not retry `TOO_MANY_PARTS` responses in the Tesla HTTP retry middleware.
- Add synchronous `CircuitBreaker.trip/1` to open the breaker immediately, bypassing the normal failure-count threshold.
- Share ClickHouse error classification between the HTTP ingester and pipeline so code 252 trips immediately while other errors retain existing failure counting.
- Record the open reason (`:threshold` or `:forced`) in logs and telemetry.
- Cover the current generation-pointer pipeline and verify error 252 results in only one HTTP request.