### PR TITLE
fix(telemetry): standardize initialization spelling

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1474,7 +1474,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   defp maybe_emit_not_initialized({:error, :not_initialized}, backend_type, batch) do
     :telemetry.execute(
-      [:logflare, :ingest_event_queue, :not_initialised, :dropped],
+      [:logflare, :ingest_event_queue, :not_initialized, :dropped],
       %{count: length(batch)},
       %{backend_type: backend_type}
     )

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -382,8 +382,8 @@ defmodule Logflare.Telemetry do
         tags: [:backend_type],
         description: "Count of event IDs not found in ETS during handle_batch fetch"
       ),
-      sum("logflare.ingest_event_queue.not_initialised.dropped.count",
-        event_name: [:logflare, :ingest_event_queue, :not_initialised, :dropped],
+      sum("logflare.ingest_event_queue.not_initialized.dropped.count",
+        event_name: [:logflare, :ingest_event_queue, :not_initialized, :dropped],
         tags: [:backend_type],
         description:
           "Count of events dropped because a backend had no live producer queue with capacity and its startup queue was never initialized"


### PR DESCRIPTION
## Summary

- standardize the dropped-event telemetry event and exported metric on `initialized`
- align the names with the existing `:not_initialized` error atom and metric description

Follow-up to #3712.
