### PR TITLE
chore: remove stale batcher lane from ClickHouse pipeline

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -6,10 +6,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   consolidated queue and inserting them into the backend's type-specific
   ingest tables (otel_logs, otel_metrics, otel_traces).
 
-  Events are routed to one of two batchers (`:ch_fresh` or `:ch_stale`)
-  based on `LogEvent.ingest_freshness`, and batched by a composite key of
-  `{event_type, day_bucket}` so each insert targets a single ClickHouse
-  partition. Multiple sources are processed together in a single pipeline.
+  Events are batched by a composite key of `{event_type, day_bucket}` so each
+  insert targets a single ClickHouse partition.
 
   Uses ID-passing: the producer emits `LogEventPointer`s (id + routing metadata)
   while the full events live in a separate generation store (see
@@ -44,18 +42,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @processor_concurrency 6
   @processor_min_demand 100
   @processor_max_demand 1_000
-  @fresh_batch_size 60_000
-  @fresh_batch_timeout 5_000
-  @fresh_batcher_concurrency 32
-  @stale_batch_size 60_000
-  @stale_batch_timeout 12_000
-  @stale_batcher_concurrency 8
+  @batch_size 60_000
+  @batch_timeout 5_000
+  @batcher_concurrency 32
   @max_retries 1
-  # One full batch per fresh/stale batcher lane, used as a generous safety valve rather
+  # Two full batches across every batcher, used as a generous safety valve rather
   # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
   # It should only cap genuinely runaway backlog during healthy operation.
-  @max_in_flight 2 * @fresh_batch_size * @fresh_batcher_concurrency +
-                   @stale_batch_size * @stale_batcher_concurrency
+  @max_in_flight 2 * @batch_size * @batcher_concurrency
 
   @doc false
   @spec max_retries() :: non_neg_integer()
@@ -63,7 +57,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @doc false
   @spec max_batch_size() :: pos_integer()
-  def max_batch_size, do: @fresh_batch_size
+  def max_batch_size, do: @batch_size
 
   @doc false
   @spec max_in_flight() :: pos_integer()
@@ -97,7 +91,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
              consolidated: true,
              id_passing: true,
              max_in_flight: @max_in_flight,
-             seed_batch_size: @fresh_batch_size
+             seed_batch_size: @batch_size
            ]},
         transformer: {__MODULE__, :transform, [backend_id: backend.id]},
         concurrency: @producer_concurrency
@@ -110,15 +104,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         ]
       ],
       batchers: [
-        ch_fresh: [
-          concurrency: @fresh_batcher_concurrency,
-          batch_size: @fresh_batch_size,
-          batch_timeout: @fresh_batch_timeout
-        ],
-        ch_stale: [
-          concurrency: @stale_batcher_concurrency,
-          batch_size: @stale_batch_size,
-          batch_timeout: @stale_batch_timeout
+        ch: [
+          concurrency: @batcher_concurrency,
+          batch_size: @batch_size,
+          batch_timeout: @batch_timeout
         ]
       ],
       context: %{backend_id: backend.id}
@@ -151,31 +140,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           Message.t()
   def handle_message(
         _processor_name,
-        %Message{data: %LogEventPointer{event_type: event_type, ingest_freshness: freshness}} =
-          message,
+        %Message{data: %LogEventPointer{event_type: event_type, day_bucket: day_bucket}} = message,
         _context
       )
-      when is_event_type(event_type) and freshness in [:fresh, :stale] do
+      when is_event_type(event_type) do
     message
-    |> Message.put_batcher(ingest_freshness_to_batcher(freshness))
-    |> Message.put_batch_key({event_type, message.data.day_bucket})
+    |> Message.put_batcher(:ch)
+    |> Message.put_batch_key({event_type, day_bucket})
   end
 
   def handle_message(_processor_name, message, _context) do
     Message.failed(message, :not_found)
   end
-
-  @spec ingest_freshness_to_batcher(:fresh | :stale) :: :ch_fresh | :ch_stale
-  defp ingest_freshness_to_batcher(:fresh), do: :ch_fresh
-  defp ingest_freshness_to_batcher(:stale), do: :ch_stale
-
-  @spec batcher_to_freshness(:ch_fresh | :ch_stale) :: :fresh | :stale
-  defp batcher_to_freshness(:ch_fresh), do: :fresh
-  defp batcher_to_freshness(:ch_stale), do: :stale
-
-  @spec batcher_async?(:ch_fresh | :ch_stale) :: boolean()
-  defp batcher_async?(:ch_stale), do: true
-  defp batcher_async?(:ch_fresh), do: false
 
   @spec handle_batch(
           batcher :: atom(),
@@ -186,17 +162,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   def handle_batch(_batcher, [], _batch_info, _context), do: []
 
   def handle_batch(
-        batcher,
+        :ch,
         messages,
         %{batch_key: {event_type, day_bucket}} = batch_info,
         %{backend_id: backend_id}
       )
-      when batcher in [:ch_fresh, :ch_stale] and is_event_type(event_type) do
-    emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket)
+      when is_event_type(event_type) do
+    emit_batch_telemetry(batch_info, backend_id, event_type, day_bucket)
 
     backend = Backends.Cache.get_backend(backend_id)
 
-    encode_and_insert(backend, messages, event_type, batcher, batch_info, day_bucket)
+    encode_and_insert(backend, messages, event_type, batch_info, day_bucket)
   end
 
   @spec ack(ack_ref :: term(), successful :: [Message.t()], failed :: [Message.t()]) :: :ok
@@ -244,10 +220,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           Broadway.BatchInfo.t(),
           pos_integer(),
           TypeDetection.event_type(),
-          atom(),
           integer()
         ) :: :ok
-  defp emit_batch_telemetry(batch_info, backend_id, event_type, batcher, day_bucket) do
+  defp emit_batch_telemetry(batch_info, backend_id, event_type, day_bucket) do
     :telemetry.execute(
       [:logflare, :backends, :pipeline, :handle_batch],
       %{batch_size: batch_info.size, batch_trigger: batch_info.trigger},
@@ -255,8 +230,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         backend_type: :clickhouse,
         backend_id: backend_id,
         event_type: event_type,
-        batcher: batcher,
-        freshness: batcher_to_freshness(batcher),
         batch_trigger: batch_info.trigger,
         day_bucket: day_bucket
       }
@@ -267,25 +240,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           Backend.t(),
           [Message.t()],
           TypeDetection.event_type(),
-          atom(),
           Broadway.BatchInfo.t(),
           integer()
         ) :: [Message.t()]
-  defp encode_and_insert(backend, messages, event_type, batcher, batch_info, day_bucket) do
+  defp encode_and_insert(backend, messages, event_type, batch_info, day_bucket) do
     OpenTelemetry.Tracer.with_span :clickhouse_pipeline, %{
       attributes: %{
         backend_id: backend.id,
         ingest_batch_size: batch_info.size,
         ingest_batch_trigger: batch_info.trigger,
         event_type: event_type,
-        batcher: batcher,
         day_bucket: day_bucket
       }
     } do
       with {:ok, compiled, config_id} <- MappingConfigStore.get_compiled(event_type) do
         {good, bad, compressed} = stream_compress(messages, event_type, compiled, config_id)
         emit_missing_ids_telemetry(bad, backend, event_type)
-        finalize_insert(backend, event_type, batcher, compressed, good, bad)
+        finalize_insert(backend, event_type, compressed, good, bad)
       else
         {:error, reason} -> Enum.map(messages, &Message.failed(&1, reason))
       end
@@ -387,24 +358,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @spec finalize_insert(
           Backend.t(),
           TypeDetection.event_type(),
-          atom(),
           binary(),
           [Message.t()],
           [Message.t()]
         ) :: [Message.t()]
-  defp finalize_insert(_backend, _event_type, _batcher, _compressed, [] = _good, bad) do
+  defp finalize_insert(_backend, _event_type, _compressed, [] = _good, bad) do
     # No rows encoded (every event was missing from ETS by batch time), so the
     # compressed payload carries zero RowBinary rows. Skip the empty ClickHouse
     # insert and fail the missing messages, mirroring Ingester.insert/5's empty guard.
     Enum.map(bad, &Message.failed(&1, :not_found))
   end
 
-  defp finalize_insert(backend, event_type, batcher, compressed, good, bad) do
+  defp finalize_insert(backend, event_type, compressed, good, bad) do
     case ClickHouseAdaptor.insert_log_events_compressed(
            backend,
            event_type,
-           compressed,
-           async: batcher_async?(batcher)
+           compressed
          ) do
       :ok ->
         # `bad` (rare, typically empty) goes on the left of `++` so the cons cells

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -31,10 +31,9 @@ defmodule Logflare.Backends.IngestEventQueue do
   @ets_recent_events :ingest_event_queue_recent_events
   @max_queue_size 30_000
   @consolidated_max_queue_size 120_000
-  @pointer_batch_key_match_spec (for freshness <- [:fresh, :stale],
-                                     event_type <- [:log, :metric, :trace] do
-                                   {{:_, :_, :_, :_, :_, event_type, :"$1", freshness},
-                                    [{:is_integer, :"$1"}], [{{freshness, event_type, :"$1"}}]}
+  @pointer_batch_key_match_spec (for event_type <- [:log, :metric, :trace] do
+                                   {{:_, :_, :_, :_, :_, event_type, :"$1"},
+                                    [{:is_integer, :"$1"}], [{{event_type, :"$1"}}]}
                                  end)
 
   @type source_backend :: {Source.t() | pos_integer(), Backend.t() | pos_integer() | nil}
@@ -48,7 +47,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   @type spool_producer_queues_key :: {:spool_producer, nil}
   @type spool_producer_table_key :: {:spool_producer, nil, pid() | nil}
   @type pointer_batch_key ::
-          {:fresh | :stale, LogEvent.TypeDetection.event_type(), integer()}
+          {LogEvent.TypeDetection.event_type(), integer()}
 
   defguardp is_pid_or_nil(value) when is_pid(value) or is_nil(value)
 
@@ -682,8 +681,8 @@ defmodule Logflare.Backends.IngestEventQueue do
   # consumer can never claim a pointer whose backing row is not yet visible. The fresh
   # `gen_event_id` makes this row independent from any duplicate event id. If insert_new/2
   # rejects the pointer or the queue disappears during publication, only this insertion's
-  # generation row is removed. Pointer row shape: {event_id, generation_tid,
-  # gen_event_id, size, retries, event_type, day_bucket, ingest_freshness}.
+  # generation row is removed.
+  # Pointer row shape: {event_id, generation_tid, gen_event_id, size, retries, event_type, day_bucket}.
   defp insert_pointer_batch(sid_bid_pid, queue_tid, batch) do
     queues_key = pointer_queues_key(sid_bid_pid)
     gen_tid = current_generation_tid(queues_key)
@@ -693,7 +692,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
       row =
         {id, gen_tid, gen_event_id, :erlang.external_size(event.body), event.retries || 0,
-         event.event_type, event.day_bucket, event.ingest_freshness}
+         event.event_type, event.day_bucket}
 
       :ets.insert(gen_tid, {gen_event_id, event})
 
@@ -745,7 +744,7 @@ defmodule Logflare.Backends.IngestEventQueue do
          to_tid when to_tid != nil <- get_tid(to) do
       moved =
         :ets.foldl(
-          fn {id, _, _, _, _, _, _, _}, acc -> acc + take_and_insert(from_tid, to_tid, id) end,
+          fn {id, _, _, _, _, _, _}, acc -> acc + take_and_insert(from_tid, to_tid, id) end,
           0,
           from_tid
         )
@@ -910,8 +909,8 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   def pop_pending_pointers(sid_bid_pid, n) when is_integer(n) do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7", :"$8"}, [],
-       [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7", :"$8"}}]}
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [],
+       [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}}]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
@@ -919,7 +918,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   @doc """
   Counts pending pointers in one queue by the exact Broadway batch identity used by
-  the ClickHouse pipeline: `{ingest_freshness, event_type, day_bucket}`.
+  the ClickHouse pipeline: `{event_type, day_bucket}`.
 
   This scans pointer metadata only; full events remain in the generation store.
   """
@@ -961,15 +960,14 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   def pop_pending_pointers_by_batch_key(
         sid_bid_pid,
-        {freshness, event_type, day_bucket},
+        {event_type, day_bucket},
         n
       )
-      when freshness in [:fresh, :stale] and
-             event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
+      when event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
              is_integer(n) and n > 0 do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket, freshness}, [],
-       [{{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket, freshness}}]}
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}, [],
+       [{{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}}]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
@@ -979,7 +977,7 @@ defmodule Logflare.Backends.IngestEventQueue do
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {selected, _cont} <- :ets.select(tid, ms, n) do
       confirmed =
-        Enum.flat_map(selected, fn {id, _, _, _, _, _, _, _} -> take_pointer(tid, id) end)
+        Enum.flat_map(selected, fn {id, _, _, _, _, _, _} -> take_pointer(tid, id) end)
 
       {:ok, confirmed, tid}
     else
@@ -990,7 +988,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   defp take_pointer(tid, id) do
     case :ets.take(tid, id) do
-      [{^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket, freshness}] ->
+      [{^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket}] ->
         [
           %LogEventPointer{
             id: id,
@@ -1000,8 +998,7 @@ defmodule Logflare.Backends.IngestEventQueue do
             size: size,
             retries: retries,
             event_type: event_type,
-            day_bucket: day_bucket,
-            ingest_freshness: freshness
+            day_bucket: day_bucket
           }
         ]
 
@@ -1023,7 +1020,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def reinsert_pointer(%LogEventPointer{} = pointer) do
     row =
       {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
-       pointer.event_type, pointer.day_bucket, pointer.ingest_freshness}
+       pointer.event_type, pointer.day_bucket}
 
     :ets.insert(pointer.queue_tid, row)
     :ok
@@ -1044,7 +1041,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending(_, 0), do: {:ok, []}
 
   def pop_pending(sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
+    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
          size when is_integer(size) <- :ets.info(tid, :size),
@@ -1162,7 +1159,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   def truncate_tid(tid, status, n) when status in [:all, :pending] do
-    ms = [{{:"$1", :_, :_, :_, :_, :_, :_, :_}, [], [:"$_"]}]
+    ms = [{{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$_"]}]
 
     with size when is_integer(size) <- :ets.info(tid, :size) do
       to_keep = select_to_insert(tid, ms, size, n)
@@ -1295,7 +1292,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   @spec drop_pending(source_backend_pid() | consolidated_table_key(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:error, :not_initialized}
   def drop_pending({_, _, _} = sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
+    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
          {taken, _cont} <- :ets.select(tid, ms, n) do

--- a/lib/logflare/backends/ingest_event_queue/log_event_pointer.ex
+++ b/lib/logflare/backends/ingest_event_queue/log_event_pointer.ex
@@ -27,8 +27,7 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
     :size,
     :retries,
     :event_type,
-    :day_bucket,
-    :ingest_freshness
+    :day_bucket
   ]
   defstruct [
     :id,
@@ -38,8 +37,7 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
     :size,
     :retries,
     :event_type,
-    :day_bucket,
-    :ingest_freshness
+    :day_bucket
   ]
 
   @type t :: %__MODULE__{
@@ -50,7 +48,6 @@ defmodule Logflare.Backends.IngestEventQueue.LogEventPointer do
           size: non_neg_integer(),
           retries: non_neg_integer(),
           event_type: TypeDetection.event_type(),
-          day_bucket: integer(),
-          ingest_freshness: :fresh | :stale
+          day_bucket: integer()
         }
 end

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -35,7 +35,6 @@ defmodule Logflare.LogEvent do
     field :event_type, Ecto.Enum, values: [:log, :metric, :trace], default: :log
     field :source_id, :integer, default: nil
     field :day_bucket, :integer
-    field :ingest_freshness, Ecto.Enum, values: [:fresh, :stale]
     # Indicates if the event was removed from ets during ingest
     field :is_popped, :boolean, virtual: true, default: false
 
@@ -67,7 +66,6 @@ defmodule Logflare.LogEvent do
       when is_integer(ingested_at_us) do
     ingested_at_dt = DateTime.from_unix!(ingested_at_us, :microsecond)
     day_bucket = body["timestamp"] && DayBucket.from_microseconds(body["timestamp"])
-    ingest_freshness = day_bucket && DayBucket.classify_freshness(day_bucket)
 
     %__MODULE__{
       id: id,
@@ -80,7 +78,6 @@ defmodule Logflare.LogEvent do
       valid: true,
       drop: false,
       day_bucket: day_bucket,
-      ingest_freshness: ingest_freshness,
       via_rule_id: Map.get(record, :via_rule_id)
     }
   end
@@ -96,7 +93,6 @@ defmodule Logflare.LogEvent do
       ) do
     {:ok, ingested_at_dt, _} = DateTime.from_iso8601(ingested_at)
     day_bucket = body["timestamp"] && DayBucket.from_microseconds(body["timestamp"])
-    ingest_freshness = day_bucket && DayBucket.classify_freshness(day_bucket)
 
     %__MODULE__{
       id: id,
@@ -109,7 +105,6 @@ defmodule Logflare.LogEvent do
       valid: true,
       drop: false,
       day_bucket: day_bucket,
-      ingest_freshness: ingest_freshness,
       via_rule_id: Map.get(record, "via_rule_id")
     }
   end
@@ -154,7 +149,6 @@ defmodule Logflare.LogEvent do
 
     body = changeset.changes.body
     day_bucket = DayBucket.from_microseconds(body["timestamp"])
-    ingest_freshness = DayBucket.classify_freshness(day_bucket)
 
     le_map =
       Map.merge(changeset.changes, %{
@@ -167,8 +161,7 @@ defmodule Logflare.LogEvent do
         id: body["id"],
         event_type: event_type,
         timestamp_inferred: mapped["timestamp_inferred"],
-        day_bucket: day_bucket,
-        ingest_freshness: ingest_freshness
+        day_bucket: day_bucket
       })
 
     Logflare.LogEvent

--- a/lib/logflare/logs/log_event/day_bucket.ex
+++ b/lib/logflare/logs/log_event/day_bucket.ex
@@ -59,18 +59,6 @@ defmodule Logflare.LogEvent.DayBucket do
     div(ts, @microseconds_per_day)
   end
 
-  @doc """
-  Classifies a day bucket against the current UTC day bucket.
-
-  Returns `:fresh` when the bucket is within one day of the current day
-  bucket (a ±1-day window absorbs clock skew and timezone-edge events),
-  and `:stale` otherwise.
-  """
-  @spec classify_freshness(integer()) :: :fresh | :stale
-  def classify_freshness(bucket) when is_integer(bucket) do
-    if abs(bucket - current()) <= 1, do: :fresh, else: :stale
-  end
-
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -209,18 +209,17 @@ defmodule Logflare.Telemetry do
       distribution("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
         event_name: [:logflare, :backends, :pipeline, :handle_batch],
         measurement: :batch_size,
-        tags: [:event_type, :freshness, :batch_trigger],
+        tags: [:event_type, :batch_trigger],
         keep: &clickhouse_batch?/1,
         reporter_options: batch_size_reporter_opts(),
-        description:
-          "Distribution of ClickHouse batch sizes by event type, freshness, and trigger"
+        description: "Distribution of ClickHouse batch sizes by event type and trigger"
       ),
       sum("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
         event_name: [:logflare, :backends, :pipeline, :handle_batch],
         measurement: :batch_size,
-        tags: [:event_type, :freshness, :batch_trigger],
+        tags: [:event_type, :batch_trigger],
         keep: &clickhouse_batch?/1,
-        description: "Sum of ClickHouse batch sizes by event type, freshness, and trigger"
+        description: "Sum of ClickHouse batch sizes by event type and trigger"
       ),
       counter("logflare.cache_buster.to_bust.count", tags: []),
       sum("logflare.logs.ingest_logs.drop_lql",

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -73,8 +73,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       size: :erlang.external_size(event.body),
       retries: event.retries || 0,
       event_type: event.event_type,
-      day_bucket: event.day_bucket,
-      ingest_freshness: event.ingest_freshness
+      day_bucket: event.day_bucket
     }
   end
 
@@ -136,7 +135,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   end
 
   describe "handle_message/3" do
-    test "routes fresh log events to :ch_fresh batcher keyed by {event_type, day_bucket}", %{
+    test "routes log events to :ch batcher keyed by {event_type, day_bucket}", %{
       context: context,
       backend: backend
     } do
@@ -151,7 +150,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_message(:default, message, context)
 
-      assert %Message{batcher: :ch_fresh, batch_key: {:log, day_bucket}} = result
+      assert %Message{batcher: :ch, batch_key: {:log, day_bucket}} = result
       assert result.data == pointer
       assert day_bucket == event.day_bucket
     end
@@ -168,7 +167,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_message(:default, message, context)
 
-      assert %Message{batcher: :ch_fresh, batch_key: {:metric, _}} = result
+      assert %Message{batcher: :ch, batch_key: {:metric, _}} = result
     end
 
     test "keys trace events by `{:trace, day_bucket}`", %{context: context, backend: backend} do
@@ -183,22 +182,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_message(:default, message, context)
 
-      assert %Message{batcher: :ch_fresh, batch_key: {:trace, _}} = result
-    end
-
-    test "routes stale events to :ch_stale batcher", %{context: context, backend: backend} do
-      event = build(:log_event) |> Map.put(:ingest_freshness, :stale)
-      gen_tid = setup_generation_events([event])
-      pointer = pointer_for(event, gen_tid)
-
-      message = %Message{
-        data: pointer,
-        acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
-      }
-
-      result = Pipeline.handle_message(:default, message, context)
-
-      assert %Message{batcher: :ch_stale, batch_key: {:log, _}} = result
+      assert %Message{batcher: :ch, batch_key: {:trace, _}} = result
     end
 
     test "fails message when event_type is nil", %{context: context, backend: backend} do
@@ -233,7 +217,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       ]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 2,
         trigger: :size
@@ -242,7 +226,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       telemetry_event = [:logflare, :backends, :pipeline, :handle_batch]
       TestUtils.attach_forwarder(telemetry_event)
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_same_messages(result, messages)
 
@@ -251,8 +235,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                         backend_type: :clickhouse,
                         backend_id: backend_id,
                         event_type: :log,
-                        batcher: :ch_fresh,
-                        freshness: :fresh,
                         batch_trigger: :size,
                         day_bucket: @day_bucket
                       }}
@@ -272,13 +254,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
     test "handles empty messages list", %{context: context} do
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 0,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, [], batch_info, context)
+      result = Pipeline.handle_batch(:ch, [], batch_info, context)
       assert result == []
     end
 
@@ -302,15 +284,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       ]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 2,
         trigger: :flush
       }
 
-      Mimic.reject(ClickHouseAdaptor, :insert_log_events_compressed, 4)
+      Mimic.reject(ClickHouseAdaptor, :insert_log_events_compressed, 3)
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert length(result) == 2
       assert Enum.all?(result, &match?(%Message{status: {:failed, :not_found}}, &1))
@@ -353,13 +335,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       ]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 2,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
       Process.sleep(200)
@@ -403,13 +385,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       ]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 3,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_same_messages(result, messages)
 
@@ -437,13 +419,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:metric, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_same_messages(result, messages)
 
@@ -470,13 +452,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:trace, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_same_messages(result, messages)
 
@@ -507,13 +489,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
       Process.sleep(200)
@@ -572,13 +554,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:metric, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
       Process.sleep(200)
@@ -629,13 +611,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:trace, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
       Process.sleep(200)
@@ -901,102 +883,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
-                                                                        _compressed,
-                                                                        _opts ->
+                                                                        _compressed ->
         {:error, "Connection timeout"}
       end)
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
-      result = Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+      result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert [%Message{status: {:failed, "Connection timeout"}}] = result
-    end
-  end
-
-  describe "handle_batch/4 async routing" do
-    setup %{source: source, backend: backend} do
-      log_event = build(:log_event, source: source, message: "Test message")
-      gen_tid = setup_generation_events([log_event])
-      messages = [batch_message(log_event, gen_tid, backend.id)]
-      [messages: messages]
-    end
-
-    test "routes stale batches through async inserts", %{
-      context: context,
-      messages: messages,
-      backend: backend
-    } do
-      test_pid = self()
-
-      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
-                                                                        _event_type,
-                                                                        _compressed,
-                                                                        opts ->
-        send(test_pid, {:insert_opts, opts})
-        :ok
-      end)
-
-      batch_info = %Broadway.BatchInfo{
-        batcher: :ch_stale,
-        batch_key: {:log, @day_bucket},
-        size: 1,
-        trigger: :timeout
-      }
-
-      telemetry_event = [:logflare, :backends, :pipeline, :handle_batch]
-      TestUtils.attach_forwarder(telemetry_event)
-
-      Pipeline.handle_batch(:ch_stale, messages, batch_info, context)
-
-      assert_receive {:insert_opts, opts}
-      assert Keyword.get(opts, :async) == true
-
-      assert_receive {:telemetry_event, ^telemetry_event,
-                      %{batch_size: 1, batch_trigger: :timeout},
-                      %{
-                        backend_type: :clickhouse,
-                        backend_id: backend_id,
-                        event_type: :log,
-                        batcher: :ch_stale,
-                        freshness: :stale,
-                        batch_trigger: :timeout,
-                        day_bucket: @day_bucket
-                      }}
-
-      assert backend_id == backend.id
-    end
-
-    test "routes fresh batches through synchronous inserts", %{
-      context: context,
-      messages: messages
-    } do
-      test_pid = self()
-
-      Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
-                                                                        _event_type,
-                                                                        _compressed,
-                                                                        opts ->
-        send(test_pid, {:insert_opts, opts})
-        :ok
-      end)
-
-      batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
-        batch_key: {:log, @day_bucket},
-        size: 1,
-        trigger: :flush
-      }
-
-      Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
-
-      assert_receive {:insert_opts, opts}
-      assert Keyword.get(opts, :async) == false
     end
   end
 
@@ -1012,8 +912,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
-                                                                        _compressed,
-                                                                        _opts ->
+                                                                        _compressed ->
         send(test_pid, :inserted)
         :ok
       end)
@@ -1023,14 +922,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(log_event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
       assert [%Message{status: :ok}] =
-               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+               Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_received :inserted
     end
@@ -1045,8 +944,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
-                                                                        _compressed,
-                                                                        _opts ->
+                                                                        _compressed ->
         {:error, "boom"}
       end)
 
@@ -1060,14 +958,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(log_event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
       assert [%Message{status: {:failed, "boom"}}] =
-               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+               Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_received {:recorded_failure, ^expected_backend_id}
     end
@@ -1085,8 +983,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
-                                                                        _compressed,
-                                                                        _opts ->
+                                                                        _compressed ->
         {:error, too_many_parts_error}
       end)
 
@@ -1103,14 +1000,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(log_event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
       assert [%Message{status: {:failed, ^too_many_parts_error}}] =
-               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+               Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       assert_received {:tripped, ^expected_backend_id}
     end
@@ -1126,8 +1023,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
-                                                                        _compressed,
-                                                                        _opts ->
+                                                                        _compressed ->
         {:error, too_many_parts_error}
       end)
 
@@ -1139,14 +1035,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       messages = [batch_message(event, gen_tid, backend.id)]
 
       batch_info = %Broadway.BatchInfo{
-        batcher: :ch_fresh,
+        batcher: :ch,
         batch_key: {:log, @day_bucket},
         size: 1,
         trigger: :flush
       }
 
       assert [failed_message = %Message{status: {:failed, ^too_many_parts_error}}] =
-               Pipeline.handle_batch(:ch_fresh, messages, batch_info, context)
+               Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       log = capture_log(fn -> Pipeline.ack(:ack_ref, [], [failed_message]) end)
 

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -309,14 +309,12 @@ defmodule Logflare.Backends.BufferProducerTest do
           build(:log_event, source: source)
           |> Map.put(:event_type, :log)
           |> Map.put(:day_bucket, 12_345)
-          |> Map.put(:ingest_freshness, :fresh)
         end
 
       partial =
         build(:log_event, source: source)
         |> Map.put(:event_type, :metric)
         |> Map.put(:day_bucket, 12_345)
-        |> Map.put(:ingest_freshness, :fresh)
 
       :ok = IngestEventQueue.add_to_table(startup_key, complete_group ++ [partial])
 
@@ -334,11 +332,11 @@ defmodule Logflare.Backends.BufferProducerTest do
       own_key = {:consolidated, backend.id, producer}
 
       assert IngestEventQueue.pending_batch_key_counts(own_key) == %{
-               {:fresh, :log, 12_345} => 2
+               {:log, 12_345} => 2
              }
 
       assert IngestEventQueue.pending_batch_key_counts(startup_key) == %{
-               {:fresh, :metric, 12_345} => 1
+               {:metric, 12_345} => 1
              }
     end
 
@@ -354,7 +352,6 @@ defmodule Logflare.Backends.BufferProducerTest do
           build(:log_event, source: source)
           |> Map.put(:event_type, event_type)
           |> Map.put(:day_bucket, 12_345)
-          |> Map.put(:ingest_freshness, :fresh)
         end
 
       :ok = IngestEventQueue.add_to_table(startup_key, events)
@@ -380,7 +377,7 @@ defmodule Logflare.Backends.BufferProducerTest do
       backend: backend
     } do
       startup_key = {:consolidated, backend.id, nil}
-      batch_key = {:fresh, :log, 12_345}
+      batch_key = {:log, 12_345}
       IngestEventQueue.upsert_tid(startup_key)
 
       events =
@@ -388,7 +385,6 @@ defmodule Logflare.Backends.BufferProducerTest do
           build(:log_event, source: source)
           |> Map.put(:event_type, :log)
           |> Map.put(:day_bucket, 12_345)
-          |> Map.put(:ingest_freshness, :fresh)
         end
 
       :ok = IngestEventQueue.add_to_table(startup_key, events)
@@ -510,7 +506,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         build(:log_event, source: source)
         |> Map.put(:event_type, :trace)
         |> Map.put(:day_bucket, 123_456)
-        |> Map.put(:ingest_freshness, :stale)
 
       :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
 
@@ -523,7 +518,6 @@ defmodule Logflare.Backends.BufferProducerTest do
                size: size,
                event_type: :trace,
                day_bucket: 123_456,
-               ingest_freshness: :stale,
                retries: 0
              } = pointer
 

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -430,7 +430,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       rows_before = pointer_tid |> :ets.tab2list()
 
       gen_event_id_by_id =
-        Map.new(rows_before, fn {id, _gen_tid, gen_event_id, _, _, _, _, _} ->
+        Map.new(rows_before, fn {id, _gen_tid, gen_event_id, _, _, _, _} ->
           {id, gen_event_id}
         end)
 
@@ -575,38 +575,34 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
     test "pointers carry routing metadata and can resolve the full event via lookup_event/2",
          %{source: source, sbp: sbp} do
-      fresh =
+      log_ev =
         build(:log_event, source: source)
         |> Map.put(:event_type, :log)
         |> Map.put(:day_bucket, 12_345)
-        |> Map.put(:ingest_freshness, :fresh)
 
-      stale =
+      trace_ev =
         build(:log_event, source: source)
         |> Map.put(:event_type, :trace)
         |> Map.put(:day_bucket, 54_321)
-        |> Map.put(:ingest_freshness, :stale)
 
-      assert :ok = IngestEventQueue.add_to_table(sbp, [fresh, stale])
+      assert :ok = IngestEventQueue.add_to_table(sbp, [log_ev, trace_ev])
 
       assert {:ok, pointers, tid} = IngestEventQueue.pop_pending_pointers(sbp, 2)
       assert tid != nil
 
       by_id = Map.new(pointers, &{&1.id, &1})
 
-      fresh_pointer = Map.fetch!(by_id, fresh.id)
-      assert fresh_pointer.event_type == :log
-      assert fresh_pointer.day_bucket == 12_345
-      assert fresh_pointer.ingest_freshness == :fresh
-      assert fresh_pointer.size == :erlang.external_size(fresh.body)
+      log_pointer = Map.fetch!(by_id, log_ev.id)
+      assert log_pointer.event_type == :log
+      assert log_pointer.day_bucket == 12_345
+      assert log_pointer.size == :erlang.external_size(log_ev.body)
 
-      assert IngestEventQueue.lookup_event(fresh_pointer.tid, fresh_pointer.gen_event_id).id ==
-               fresh.id
+      assert IngestEventQueue.lookup_event(log_pointer.tid, log_pointer.gen_event_id).id ==
+               log_ev.id
 
-      stale_pointer = Map.fetch!(by_id, stale.id)
-      assert stale_pointer.event_type == :trace
-      assert stale_pointer.day_bucket == 54_321
-      assert stale_pointer.ingest_freshness == :stale
+      trace_pointer = Map.fetch!(by_id, trace_ev.id)
+      assert trace_pointer.event_type == :trace
+      assert trace_pointer.day_bucket == 54_321
 
       assert IngestEventQueue.total_pending(sbp) == 0
     end
@@ -616,42 +612,40 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       sbp: sbp
     } do
       events =
-        for {event_type, day_bucket, freshness, count} <- [
-              {:log, 12_345, :fresh, 3},
-              {:metric, 12_345, :fresh, 2},
-              {:log, 54_321, :stale, 1}
+        for {event_type, day_bucket, count} <- [
+              {:log, 12_345, 3},
+              {:metric, 12_345, 2},
+              {:log, 54_321, 1}
             ],
             _ <- 1..count do
           build(:log_event, source: source)
           |> Map.put(:event_type, event_type)
           |> Map.put(:day_bucket, day_bucket)
-          |> Map.put(:ingest_freshness, freshness)
         end
 
       assert :ok = IngestEventQueue.add_to_table(sbp, events)
 
       assert IngestEventQueue.pending_batch_key_counts(sbp) == %{
-               {:fresh, :log, 12_345} => 3,
-               {:fresh, :metric, 12_345} => 2,
-               {:stale, :log, 54_321} => 1
+               {:log, 12_345} => 3,
+               {:metric, 12_345} => 2,
+               {:log, 54_321} => 1
              }
 
       assert {:ok, pointers, _tid} =
                IngestEventQueue.pop_pending_pointers_by_batch_key(
                  sbp,
-                 {:fresh, :log, 12_345},
+                 {:log, 12_345},
                  2
                )
 
       assert length(pointers) == 2
       assert Enum.all?(pointers, &match?(%{event_type: :log, day_bucket: 12_345}, &1))
-      assert Enum.all?(pointers, &(&1.ingest_freshness == :fresh))
       assert IngestEventQueue.total_pending(sbp) == 4
 
       assert IngestEventQueue.pending_batch_key_counts(sbp) == %{
-               {:fresh, :log, 12_345} => 1,
-               {:fresh, :metric, 12_345} => 2,
-               {:stale, :log, 54_321} => 1
+               {:log, 12_345} => 1,
+               {:metric, 12_345} => 2,
+               {:log, 54_321} => 1
              }
     end
 
@@ -665,7 +659,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
           build(:log_event, source: source)
           |> Map.put(:event_type, :log)
           |> Map.put(:day_bucket, 12_345)
-          |> Map.put(:ingest_freshness, :fresh)
         end
 
       assert :ok = IngestEventQueue.add_to_table(sbp, events)
@@ -676,7 +669,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
             {:ok, pointers, _tid} =
               IngestEventQueue.pop_pending_pointers_by_batch_key(
                 sbp,
-                {:fresh, :log, 12_345},
+                {:log, 12_345},
                 500
               )
 
@@ -714,7 +707,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         build(:log_event, source: source)
         |> Map.put(:event_type, nil)
         |> Map.put(:day_bucket, nil)
-        |> Map.put(:ingest_freshness, nil)
 
       assert :ok = IngestEventQueue.add_to_table(sbp, [event])
 
@@ -724,7 +716,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert pointer.size == :erlang.external_size(event.body)
       assert pointer.event_type == nil
       assert pointer.day_bucket == nil
-      assert pointer.ingest_freshness == nil
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
@@ -848,8 +839,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         size: 0,
         retries: 0,
         event_type: :log,
-        day_bucket: 0,
-        ingest_freshness: :fresh
+        day_bucket: 0
       }
 
       assert :ok = IngestEventQueue.reinsert_pointer(pointer)

--- a/test/logflare/backends/spool/producer_pipeline_test.exs
+++ b/test/logflare/backends/spool/producer_pipeline_test.exs
@@ -42,8 +42,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
         size: size,
         retries: 0,
         event_type: :log,
-        day_bucket: 0,
-        ingest_freshness: :fresh
+        day_bucket: 0
       }
     }
   end

--- a/test/logflare/log_event/day_bucket_test.exs
+++ b/test/logflare/log_event/day_bucket_test.exs
@@ -37,41 +37,6 @@ defmodule Logflare.LogEvent.DayBucketTest do
     end
   end
 
-  describe "classify_freshness/1" do
-    setup do
-      [current: DayBucket.current()]
-    end
-
-    test "current day is :fresh", %{current: current} do
-      assert DayBucket.classify_freshness(current) == :fresh
-    end
-
-    test "one day in the past is :fresh", %{current: current} do
-      assert DayBucket.classify_freshness(current - 1) == :fresh
-    end
-
-    test "one day in the future is :fresh", %{current: current} do
-      assert DayBucket.classify_freshness(current + 1) == :fresh
-    end
-
-    test "two days in the past is :stale", %{current: current} do
-      assert DayBucket.classify_freshness(current - 2) == :stale
-    end
-
-    test "two days in the future is :stale", %{current: current} do
-      assert DayBucket.classify_freshness(current + 2) == :stale
-    end
-
-    test "pre-epoch (negative) bucket is :stale" do
-      assert DayBucket.classify_freshness(-1) == :stale
-      assert DayBucket.classify_freshness(-1000) == :stale
-    end
-
-    test "far-future bucket is :stale", %{current: current} do
-      assert DayBucket.classify_freshness(current + 365) == :stale
-    end
-  end
-
   describe "current/0" do
     test "returns today's bucket from the persistent_term cache" do
       expected = div(System.system_time(:microsecond), @microseconds_per_day)

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -69,13 +69,13 @@ defmodule Logflare.TelemetryTest do
       for metric <- metrics do
         assert metric.event_name == [:logflare, :backends, :pipeline, :handle_batch]
         assert metric.measurement == :batch_size
-        assert metric.tags == [:event_type, :freshness, :batch_trigger]
+        assert metric.tags == [:event_type, :batch_trigger]
         assert metric.keep.(%{backend_type: :clickhouse})
         refute metric.keep.(%{backend_type: :bigquery})
       end
     end
 
-    test "aggregates ClickHouse batches by event type, freshness, and trigger" do
+    test "aggregates ClickHouse batches by event type and trigger" do
       start_supervised!(
         {OtelMetricExporter,
          name: @clickhouse_batch_exporter,
@@ -88,9 +88,9 @@ defmodule Logflare.TelemetryTest do
       )
 
       event = [:logflare, :backends, :pipeline, :handle_batch]
-      log_tags = %{event_type: :log, freshness: :fresh, batch_trigger: :size}
-      metric_tags = %{event_type: :metric, freshness: :fresh, batch_trigger: :timeout}
-      trace_tags = %{event_type: :trace, freshness: :stale, batch_trigger: :timeout}
+      log_tags = %{event_type: :log, batch_trigger: :size}
+      metric_tags = %{event_type: :metric, batch_trigger: :timeout}
+      trace_tags = %{event_type: :trace, batch_trigger: :timeout}
 
       :telemetry.execute(
         event,


### PR DESCRIPTION
Now that we are not allowing data older than 24h in, the stale lane in the ClickHouse pipeline is just bloat.

Note that this also removes the `freshness` tag from the telemetry so any grafana charts will need to be updated when this rolls.