### PR TITLE
feat(config): make credential and cert paths configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -317,8 +317,18 @@ cond do
            )
 
   config_env() != :test ->
-    if File.exists?("gcloud.json") do
-      config :goth, json: File.read!("gcloud.json")
+    google_credentials =
+      case System.get_env("GOOGLE_APPLICATION_CREDENTIALS_JSON") do
+        json when is_binary(json) and json != "" ->
+          json
+
+        _ ->
+          credentials_path = System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "gcloud.json")
+          if File.exists?(credentials_path), do: File.read!(credentials_path)
+      end
+
+    if google_credentials do
+      config :goth, json: google_credentials
     end
 
   config_env() == :test ->
@@ -328,27 +338,34 @@ cond do
     raise "Missing Google or Backend credentials"
 end
 
+tls_cert_path = System.get_env("LOGFLARE_TLS_CERT_PATH", "cert.pem")
+tls_key_path = System.get_env("LOGFLARE_TLS_KEY_PATH", "cert.key")
+
 if(
   Env.get_boolean("LOGFLARE_ENABLE_GRPC_SSL") &&
-    File.exists?("cert.pem") && File.exists?("cert.key")
+    File.exists?(tls_cert_path) && File.exists?(tls_key_path)
 ) do
   config :logflare,
     ssl: [
-      certfile: "cert.pem",
-      keyfile: "cert.key"
+      certfile: tls_cert_path,
+      keyfile: tls_key_path
     ]
 end
 
+db_ssl_ca_cert_path = System.get_env("DB_SSL_CA_CERT_PATH", "db-server-ca.pem")
+db_ssl_client_cert_path = System.get_env("DB_SSL_CLIENT_CERT_PATH", "db-client-cert.pem")
+db_ssl_client_key_path = System.get_env("DB_SSL_CLIENT_KEY_PATH", "db-client-key.pem")
+
 if(
-  Env.get_boolean("DB_SSL") && File.exists?("db-server-ca.pem") &&
-    File.exists?("db-client-cert.pem") && File.exists?("db-client-key.pem")
+  Env.get_boolean("DB_SSL") && File.exists?(db_ssl_ca_cert_path) &&
+    File.exists?(db_ssl_client_cert_path) && File.exists?(db_ssl_client_key_path)
 ) do
   base_db_ssl_opts = [
     # ssl opts follow recs here: https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
     verify: :verify_peer,
-    cacertfile: Path.absname("db-server-ca.pem"),
-    certfile: Path.absname("db-client-cert.pem"),
-    keyfile: Path.absname("db-client-key.pem"),
+    cacertfile: Path.absname(db_ssl_ca_cert_path),
+    certfile: Path.absname(db_ssl_client_cert_path),
+    keyfile: Path.absname(db_ssl_client_key_path),
     depth: 3,
     versions: [:"tlsv1.2", :"tlsv1.3"],
     customize_hostname_check: [

--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -143,6 +143,14 @@ To enable SSL for the internal Logflare database:
 
 All three files must be present for SSL to be enabled.
 
+The default filenames above are resolved relative to the working directory. To
+load them from another location (for example a mounted secret volume), override
+the paths with environment variables:
+
+- `DB_SSL_CA_CERT_PATH` - defaults to `db-server-ca.pem`
+- `DB_SSL_CLIENT_CERT_PATH` - defaults to `db-client-cert.pem`
+- `DB_SSL_CLIENT_KEY_PATH` - defaults to `db-client-key.pem`
+
 ### Configuration Details
 
 The SSL connection is configured with:
@@ -211,6 +219,20 @@ Thereafter, click on "Add Key" to create a new key. The key will be in a JSON fo
 ![Add Key Button](add-key.png)
 
 You can also obtain the key via the `gcloud` CLI by following the [official documentation](https://cloud.google.com/iam/docs/keys-create-delete).
+
+#### Providing the Service Account Key
+
+By default Logflare reads the service account key from a `gcloud.json` file in
+the working directory on server startup. You can supply the key in two other
+ways instead:
+
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to the service account key file.
+  Defaults to `gcloud.json`. Use this to load the key from a different location,
+  such as a mounted secret volume.
+- `GOOGLE_APPLICATION_CREDENTIALS_JSON` - the service account key JSON provided
+  inline as an environment variable. When set (and non-empty), it takes
+  precedence over the file, so no file needs to be mounted. Useful for
+  environments where secrets are injected as environment variables.
 
 ## Deployment with Docker Compose
 


### PR DESCRIPTION
Part of [O11Y-2137](https://linear.app/supabase/issue/O11Y-2137).

## What

Makes Logflare's file-based credentials and certificates locatable via environment variables, and lets the BigQuery service account key be supplied inline as JSON.

New environment variables (all with backward-compatible defaults):

| Variable | Default | Purpose |
| --- | --- | --- |
| `GOOGLE_APPLICATION_CREDENTIALS` | `gcloud.json` | Path to the BigQuery service account key file |
| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | _(unset)_ | Service account key JSON provided inline; takes precedence over the file when set |
| `LOGFLARE_TLS_CERT_PATH` | `cert.pem` | gRPC TLS certificate path |
| `LOGFLARE_TLS_KEY_PATH` | `cert.key` | gRPC TLS key path |
| `DB_SSL_CA_CERT_PATH` | `db-server-ca.pem` | Internal DB SSL server CA cert path |
| `DB_SSL_CLIENT_CERT_PATH` | `db-client-cert.pem` | Internal DB SSL client cert path |
| `DB_SSL_CLIENT_KEY_PATH` | `db-client-key.pem` | Internal DB SSL client key path |

## Why

Today `config/runtime.exs` reads these secrets as fixed filenames in the working directory (`gcloud.json`, `cert.pem`, `db-*.pem`). That assumes secrets are baked into the image at a known path, which is how the current GCE deployment works but does not fit environments that inject secrets as environment variables or mounted secret volumes (e.g. Kubernetes / Helm).

These changes decouple credential loading from a fixed working directory:

- **Configurable paths** let a deployment mount a secret volume anywhere and point Logflare at it.
- **Inline JSON credentials** let the BigQuery key ride the same env-var/secret injection path as every other secret, with no file mount at all.

All defaults preserve the existing filenames, so current deployments are unaffected.

## Changes

- `config/runtime.exs`: resolve credential/cert locations from env vars with the existing filenames as defaults; support inline `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
- `docs/docs.logflare.com/docs/self-hosting/index.md`: document the new variables under the Database SSL and BigQuery setup sections.

## Notes

Backward compatible — no behavior change when the new variables are unset.

## Related PRs

Part of the Logflare-on-Kubernetes secrets migration:

- #3719 — initial Helm chart (base for the chart work)
- #3728 — Helm chart secret/config wiring
- supabase/k8s-observability#574 — encrypted secrets synced to SSM Parameter Store
- supabase/k8s-observability#573 — ExternalSecrets (helper + `LogflareSecretsChart`)
