### PR TITLE
feat(helm): add optional ESO ExternalSecret templates

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/README.md
+++ b/helm/README.md
@@ -129,6 +129,67 @@ logflare:
 
 You can list multiple Secret names in `secretRefs` (e.g. one per `ExternalSecret`/upstream secret-store path) — all of their keys are injected together.
 
+#### Letting the chart render the ExternalSecrets (optional)
+
+If you already run ESO, the chart can render the `ExternalSecret` objects for you instead of you hand-writing them, so all of the deployment configuration lives in one place. This is opt-in via `externalSecrets.enabled` and requires ESO (and its CRDs) to be installed in the cluster. When it is disabled (the default) the chart renders no `ExternalSecret` and the manual flow above still applies.
+
+Point it at an existing `(Cluster)SecretStore` and list the secrets to sync. Each entry produces one `ExternalSecret`, and therefore one Kubernetes `Secret`, whose name you then reference in `logflare.secretRefs` (for env vars) or mount as files (for certificates):
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStore:
+    name: my-secret-store        # an existing ClusterSecretStore / SecretStore
+    kind: ClusterSecretStore
+  secrets:
+    - name: logflare-secrets           # env-var secrets, injected via secretRefs below
+      remotePrefix: secret/logflare
+      keys:
+        - PHX_SECRET_KEY_BASE
+        - PHX_LIVE_VIEW_SIGNING_SALT
+        - LOGFLARE_DB_ENCRYPTION_KEY
+        - DB_PASSWORD
+        - GOOGLE_SERVICE_ACCOUNT
+    - name: logflare-cert-files        # cert/key files, mounted as a volume
+      remotePrefix: secret/logflare
+      keys:
+        - db-server-ca.pem
+        - db-client-cert.pem
+        - db-client-key.pem
+
+logflare:
+  secretRefs:
+    - logflare-secrets
+
+# Mount the cert-file Secret with the chart's generic volume hooks:
+volumes:
+  - name: logflare-cert-files
+    secret:
+      secretName: logflare-cert-files
+volumeMounts:
+  - name: logflare-cert-files
+    mountPath: /etc/logflare/certs
+    readOnly: true
+```
+
+`remotePrefix` is prepended to each key, so a key of `DB_PASSWORD` reads from `secret/logflare/DB_PASSWORD` and lands in the Secret under the identical key name `DB_PASSWORD`. Omit `remotePrefix` to use each key as the remote reference verbatim.
+
+When the backend paths do not map one-to-one to key names, drop to the verbatim `data` and `dataFrom` passthroughs on an entry (they map straight onto the `ExternalSecret` spec), for example to extract a whole bundle:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStore:
+    name: my-secret-store
+  secrets:
+    - name: logflare-secrets
+      dataFrom:
+        - extract:
+            key: secret/logflare/all
+```
+
+Per-entry `refreshInterval` and `creationPolicy` overrides are also supported; see `values.yaml` for the full set of fields. This block is ESO-specific by design, so support for other providers (for example a HashiCorp Vault Agent integration) can be added as a sibling block without disturbing it.
+
 ## Configurable values
 
 | `values.yaml` key | Env var | Notes |

--- a/helm/externalsecret_test.yaml
+++ b/helm/externalsecret_test.yaml
@@ -1,0 +1,163 @@
+suite: test external secrets
+templates:
+  - externalsecret.yaml
+tests:
+  - it: should render no ExternalSecret by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render one ExternalSecret per entry when enabled
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+          kind: ClusterSecretStore
+        refreshInterval: 1h
+        secrets:
+          - name: logflare-secrets
+            remotePrefix: secret/logflare
+            keys:
+              - PHX_SECRET_KEY_BASE
+              - DB_PASSWORD
+          - name: logflare-cert-files
+            remotePrefix: secret/logflare
+            keys:
+              - db-server-ca.pem
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: ExternalSecret
+          apiVersion: external-secrets.io/v1
+          name: logflare-secrets
+        documentIndex: 0
+      - equal:
+          path: spec.secretStoreRef.name
+          value: my-store
+        documentIndex: 0
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: logflare-secrets
+        documentIndex: 0
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+        documentIndex: 0
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+        documentIndex: 0
+      - equal:
+          path: spec.data[0].secretKey
+          value: PHX_SECRET_KEY_BASE
+        documentIndex: 0
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: secret/logflare/PHX_SECRET_KEY_BASE
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: logflare-cert-files
+        documentIndex: 1
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: secret/logflare/db-server-ca.pem
+        documentIndex: 1
+
+  - it: should use the raw key when remotePrefix is unset
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+        secrets:
+          - name: logflare-secrets
+            keys:
+              - DB_PASSWORD
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: DB_PASSWORD
+        documentIndex: 0
+
+  - it: should default the store kind to ClusterSecretStore
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+        secrets:
+          - name: logflare-secrets
+            keys:
+              - DB_PASSWORD
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+        documentIndex: 0
+
+  - it: should support a SecretStore kind override
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+          kind: SecretStore
+        secrets:
+          - name: logflare-secrets
+            keys:
+              - DB_PASSWORD
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+        documentIndex: 0
+
+  - it: should pass dataFrom through verbatim
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+        secrets:
+          - name: logflare-bundle
+            dataFrom:
+              - extract:
+                  key: prod/logflare/bundle
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: prod/logflare/bundle
+        documentIndex: 0
+
+  - it: should fail when enabled but the store name is empty
+    set:
+      externalSecrets:
+        enabled: true
+        secrets:
+          - name: logflare-secrets
+            keys:
+              - DB_PASSWORD
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled is true but externalSecrets.secretStore.name is empty; set externalSecrets.secretStore.name to your (Cluster)SecretStore name"
+
+  - it: should fail when an entry has no keys, data, or dataFrom
+    set:
+      externalSecrets:
+        enabled: true
+        secretStore:
+          name: my-store
+        secrets:
+          - name: logflare-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: 'externalSecrets.secrets entry "logflare-secrets" must set at least one of keys, data, or dataFrom'

--- a/helm/templates/externalsecret.yaml
+++ b/helm/templates/externalsecret.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.externalSecrets.enabled }}
+{{- $top := . }}
+{{- $store := .Values.externalSecrets.secretStore }}
+{{- if not $store.name }}
+{{- fail "externalSecrets.enabled is true but externalSecrets.secretStore.name is empty; set externalSecrets.secretStore.name to your (Cluster)SecretStore name" }}
+{{- end }}
+{{- range $secret := .Values.externalSecrets.secrets }}
+{{- if not $secret.name }}
+{{- fail "each externalSecrets.secrets entry must set a name" }}
+{{- end }}
+{{- if not (or $secret.keys $secret.data $secret.dataFrom) }}
+{{- fail (printf "externalSecrets.secrets entry %q must set at least one of keys, data, or dataFrom" $secret.name) }}
+{{- end }}
+{{- $prefix := $secret.remotePrefix | default "" | trimSuffix "/" }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $secret.name }}
+  labels:
+    {{- include "logflare.labels" $top | nindent 4 }}
+spec:
+  refreshInterval: {{ $secret.refreshInterval | default $top.Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $store.kind | default "ClusterSecretStore" }}
+    name: {{ $store.name | quote }}
+  target:
+    name: {{ $secret.name }}
+    creationPolicy: {{ $secret.creationPolicy | default "Owner" }}
+  {{- if or $secret.keys $secret.data }}
+  data:
+    {{- range $key := ($secret.keys | default (list)) }}
+    - secretKey: {{ $key | quote }}
+      remoteRef:
+        key: {{ if $prefix }}{{ printf "%s/%s" $prefix $key | quote }}{{ else }}{{ $key | quote }}{{ end }}
+    {{- end }}
+    {{- with $secret.data }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with $secret.dataFrom }}
+  dataFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -102,6 +102,60 @@ vmArgs: |
   -kernel prevent_overlapping_partitions false
   -kernel net_ticktime 45
 
+# External Secrets Operator (ESO) integration. When enabled, the chart renders
+# ExternalSecret resources so ESO syncs secrets from your backend (AWS SSM,
+# Vault, GCP Secret Manager, etc., resolved via the referenced SecretStore) into
+# the Kubernetes Secrets this chart consumes. Requires ESO and its CRDs to be
+# installed in the cluster. Off by default: when disabled the chart renders no
+# ExternalSecret and you provision the Secrets in logflare.secretRefs yourself.
+#
+# This is one secret-provider integration. Others (e.g. a HashiCorp Vault Agent
+# block) can be added alongside it without changing this one.
+externalSecrets:
+  enabled: false
+
+  # The (Cluster)SecretStore every generated ExternalSecret references. ESO
+  # resolves the actual backend (SSM, Vault, ...) from this store, so the store
+  # must already exist in the cluster.
+  secretStore:
+    # Name of the store. Required when externalSecrets.enabled is true.
+    name: ""
+    # ClusterSecretStore (cluster-scoped) or SecretStore (namespaced).
+    kind: ClusterSecretStore
+
+  # Default re-sync interval for every generated ExternalSecret. Override per
+  # entry with secrets[].refreshInterval.
+  refreshInterval: 1h
+
+  # ExternalSecrets to generate. Each entry produces one ExternalSecret and, via
+  # ESO, one Kubernetes Secret named `name`. Add env-var Secrets to
+  # logflare.secretRefs; mount file Secrets via volumes / volumeMounts.
+  secrets: []
+    # - name: logflare-secrets
+    #   # Prepended to each key's remoteRef.key below. Omit for raw keys.
+    #   remotePrefix: secret/logflare
+    #   # Each key becomes a Secret entry whose key name IS the key, pulled from
+    #   # <remotePrefix>/<key>. For env-var Secrets these must match the env vars
+    #   # Logflare reads.
+    #   keys:
+    #     - PHX_SECRET_KEY_BASE
+    #     - DB_PASSWORD
+    # - name: logflare-cert-files
+    #   remotePrefix: secret/logflare
+    #   keys:
+    #     - db-server-ca.pem
+    #     - cert.pem
+    #   # Optional per-entry overrides:
+    #   # refreshInterval: 30m
+    #   # creationPolicy: Owner
+    #   # Advanced verbatim passthrough, merged after `keys` (use for bundle
+    #   # extraction or custom remoteRef options):
+    #   # data:
+    #   #   - secretKey: FOO
+    #   #     remoteRef: { key: path/to/foo }
+    #   # dataFrom:
+    #   #   - extract: { key: prod/logflare/bundle }
+
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.


### PR DESCRIPTION
Users who run the External Secrets Operator (ESO) currently have to hand-write the `ExternalSecret` objects separately from this chart. This adds an opt-in way for the chart to render them itself, so a deployment's workload and its ESO wiring can live in one place. It is off by default and the chart takes no dependency on ESO when disabled, so nothing changes for anyone who manages Secrets another way.

- New top-level `externalSecrets` block in `values.yaml`, off by default. When `externalSecrets.enabled` is true, the chart renders one `ExternalSecret` per entry in `externalSecrets.secrets`.
- Everything is parameterized under that one block: the `(Cluster)SecretStore` name and kind, the refresh interval, and per-entry `remotePrefix` + `keys`. Each key becomes a `data[]` entry where `secretKey` is the key verbatim and `remoteRef.key` is `remotePrefix/key`. Verbatim `data` / `dataFrom` passthrough covers cases that `keys` cannot express (e.g. extracting a whole bundle).
- Guardrails: templating fails with a clear message if enabled without a store name, or if an entry declares no `keys`, `data`, or `dataFrom`.
- The block is ESO-specific by design, leaving room to add sibling provider blocks (e.g. a HashiCorp Vault Agent block) later without disturbing it.

When disabled (the default) the chart renders no `ExternalSecret` and you keep managing Secrets yourself via `logflare.secretRefs`, exactly as before.

## Tests and validation

- `helm lint`, `helm template`, and 8 new helm-unittest cases (disabled renders nothing; multi-entry render; prefixed and raw keys; store-kind default and override; `dataFrom` passthrough; both failure paths). Full suite is 20/20.
- Chart version bumped 0.1.0 to 0.2.0 (required by the chart CI gate).
