### PR TITLE
fix: preserve serialized string values in logflare mapper NIF

### DIFF
--- a/bench/mapper_elevate_metadata.exs
+++ b/bench/mapper_elevate_metadata.exs
@@ -1,0 +1,76 @@
+# Usage: mix run bench/mapper_elevate_metadata.exs
+#
+# Validates that preserving a non-map `metadata` value as a literal key in the
+# `Logflare.Mapper` NIF does not regress the hot path. `log_attributes` is
+# mapped for every ingested ClickHouse event (~2M/s in prod), so the elevate
+# step must stay tight.
+#
+# Three input shapes exercise the elevate branch:
+#   * metadata_map    — `metadata` is a nested map, children elevated (unchanged path)
+#   * metadata_string — `metadata` is a serialized string, now preserved (fixed path)
+#   * no_metadata     — no `metadata` key, elevate is a no-op (baseline)
+
+alias Logflare.Mapper
+alias Logflare.Mapper.MappingConfig
+alias Logflare.Mapper.MappingConfig.FieldConfig, as: Field
+
+config =
+  MappingConfig.new([
+    Field.flat_map("log_attributes",
+      path: "$",
+      exclude_keys: ["id", "event_message", "timestamp"],
+      elevate_keys: ["metadata"]
+    )
+  ])
+
+compiled = Mapper.compile!(config)
+
+base_attrs = fn ->
+  for i <- 1..12, into: %{}, do: {"attribute_key_#{i}", "some attribute value #{i}"}
+end
+
+metadata_map =
+  base_attrs.()
+  |> Map.merge(%{
+    "id" => "uuid-1",
+    "event_message" => "User logged in",
+    "timestamp" => 1_769_018_088_144_506_000,
+    "metadata" => %{"region" => "us-east-1", "host" => "web-01", "reason" => "abuse"}
+  })
+
+metadata_string =
+  base_attrs.()
+  |> Map.merge(%{
+    "id" => "uuid-1",
+    "event_message" => "User logged in",
+    "timestamp" => 1_769_018_088_144_506_000,
+    "metadata" => ~s({"region":"us-east-1","host":"web-01","reason":"abuse","actor":"admin"})
+  })
+
+no_metadata =
+  base_attrs.()
+  |> Map.merge(%{
+    "id" => "uuid-1",
+    "event_message" => "User logged in",
+    "timestamp" => 1_769_018_088_144_506_000
+  })
+
+# Sanity: confirm the metadata string is preserved and the map is elevated.
+string_attrs = Mapper.map(metadata_string, compiled)["log_attributes"]
+map_attrs = Mapper.map(metadata_map, compiled)["log_attributes"]
+
+IO.puts("metadata_string preserved: #{Map.get(string_attrs, "metadata") != nil}")
+IO.puts("metadata_map elevated (region): #{Map.get(map_attrs, "region") != nil}")
+IO.puts("metadata_map key dropped: #{not Map.has_key?(map_attrs, "metadata")}\n")
+
+Benchee.run(
+  %{
+    "metadata_map (elevated)" => fn -> Mapper.map(metadata_map, compiled) end,
+    "metadata_string (preserved)" => fn -> Mapper.map(metadata_string, compiled) end,
+    "no_metadata (baseline)" => fn -> Mapper.map(no_metadata, compiled) end
+  },
+  time: 3,
+  warmup: 1,
+  memory_time: 1,
+  print: [configuration: false]
+)

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -403,8 +403,13 @@ fn apply_elevate_keys<'a>(env: Env<'a>, map: Term<'a>, elevate: &[Vec<u8>]) -> T
                         elevated_keys.push(ck);
                         elevated_values.push(cv);
                     }
+                    continue; // Don't include the elevated key itself
                 }
-                continue; // Don't include the elevated key itself
+                // Non-map value (e.g. a stringified `metadata`): there are no
+                // children to elevate, so preserve it as a literal top-level
+                // key instead of dropping it.
+                top_entries.push((k, v));
+                continue;
             }
         }
         top_entries.push((k, v));
@@ -519,8 +524,13 @@ fn apply_elevate_keys_flat<'a>(env: Env<'a>, map: Term<'a>, elevate: &[Vec<u8>])
             let mut matched = false;
             for ek in elevate {
                 if key_bytes == ek.as_slice() {
-                    // Exact match — drop the key entirely
-                    matched = true;
+                    // Exact match. A map value is a leftover parent placeholder
+                    // whose children were elevated — drop it. A non-map value
+                    // (e.g. a stringified `metadata`) has no children, so leave
+                    // it unmatched and preserve it as a literal top-level key.
+                    if v.is_map() {
+                        matched = true;
+                    }
                     break;
                 }
                 if key_bytes.len() > ek.len()

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -478,6 +478,46 @@ defmodule Logflare.MapperTest do
 
       assert result["attrs"] == %{"region" => "us-east"}
     end
+
+    test "elevate_keys: non-map value is preserved as a literal key" do
+      doc = %{
+        "level" => "info",
+        "metadata" => "{\"reason\":\"abuse\",\"actor\":\"admin\"}"
+      }
+
+      result =
+        compile_and_map(
+          [Field.json("attrs", path: "$", elevate_keys: ["metadata"])],
+          doc
+        )
+
+      assert result["attrs"]["level"] == "info"
+      assert result["attrs"]["metadata"] == "{\"reason\":\"abuse\",\"actor\":\"admin\"}"
+    end
+
+    test "elevate_keys: preserves stringified metadata alongside excluded keys" do
+      doc = %{
+        "id" => "uuid",
+        "event_message" => "hello",
+        "timestamp" => 123,
+        "region" => "us-east",
+        "metadata" => "serialized-string"
+      }
+
+      result =
+        compile_and_map(
+          [
+            Field.json("attrs",
+              path: "$",
+              exclude_keys: ["id", "event_message", "timestamp"],
+              elevate_keys: ["metadata"]
+            )
+          ],
+          doc
+        )
+
+      assert result["attrs"] == %{"region" => "us-east", "metadata" => "serialized-string"}
+    end
   end
 
   # ── Pick ──────────────────────────────────────────────────────────────
@@ -2104,6 +2144,30 @@ defmodule Logflare.MapperTest do
       assert attrs["extra"] == "val"
     end
 
+    test "elevate_keys: non-map metadata is preserved as a literal string key" do
+      result =
+        compile_and_map(
+          [
+            Field.flat_map("attrs",
+              path: "$",
+              exclude_keys: ["id"],
+              elevate_keys: ["metadata"]
+            )
+          ],
+          %{
+            "id" => "123",
+            "metadata" => ~s({"reason":"abuse","actor":"admin"}),
+            "extra" => "val"
+          }
+        )
+
+      attrs = result["attrs"]
+      refute Map.has_key?(attrs, "id")
+      assert attrs["extra"] == "val"
+      # stringified metadata survives elevate and stringify: attrs["metadata"] == raw string
+      assert attrs["metadata"] == ~s({"reason":"abuse","actor":"admin"})
+    end
+
     test "JSON-encodes list of mixed types" do
       result =
         compile_and_map(
@@ -2231,6 +2295,29 @@ defmodule Logflare.MapperTest do
         )
 
       assert result["body"] == doc
+    end
+
+    test "elevate_keys strips prefixes but preserves a non-map leaf at the elevate key" do
+      result =
+        compile_and_map_flat(
+          [
+            Field.json("attrs",
+              path: "$",
+              elevate_keys: ["metadata"]
+            )
+          ],
+          %{
+            "level" => "info",
+            "metadata" => "serialized-string",
+            "metadata.region" => "us-east"
+          }
+        )
+
+      # dotted child is elevated (prefix stripped)
+      assert result["attrs"]["region"] == "us-east"
+      # bare `metadata` leaf survives instead of being dropped
+      assert result["attrs"]["metadata"] == "serialized-string"
+      assert result["attrs"]["level"] == "info"
     end
   end
 


### PR DESCRIPTION
The `Logflare.Mapper` NIF is used to handle ClickHouse data and does conversions between `metadata` JSON objects to `map(string, string)` fields. Some data sources come in with `metadata` as a serialized string value and that prevented data from being populated in the attribute map fields.

This change simply _elevates_ a serialized value like this and uses the field name as the key and does NOT parse the stringified JSON by design.

Benchmarks show no measurable perf hit on this as it's a single `Vec::push` of the existing term into an already allocated buffer.