### PR TITLE
feat(helm): replace reloader toggle with generic deploymentAnnotations

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -160,7 +160,7 @@ You can list multiple Secret names in `secretRefs` (e.g. one per `ExternalSecret
 | `logflare.secretRefs` | see [Loading secrets](#loading-secrets) | |
 | `logflare.certFilesSecret` | — | Name of a Secret whose keys are cert filenames; mounted as files. See [Certificate files](#certificate-files) |
 | `logflare.certFilesMountPath` | `DB_SSL_*_PATH`, `LOGFLARE_TLS_*_PATH` | Mount path for `certFilesSecret`; the chart points the cert path env vars here |
-| `logflare.reloader` | — | When `true`, adds the Stakater Reloader annotation so the Deployment rolls on ConfigMap/Secret changes |
+| `deploymentAnnotations` | — | Annotations on the Deployment object. Set `reloader.stakater.com/auto: "true"` to roll pods on ConfigMap/Secret changes (requires Stakater Reloader) |
 | `logflare.extraConfig` | (any) | Map of non-secret env vars rendered verbatim into the ConfigMap |
 
 See `values.yaml` for the full set of generic chart values (image, service, ingress, resources, autoscaling, etc.).

--- a/helm/deployment_test.yaml
+++ b/helm/deployment_test.yaml
@@ -134,15 +134,16 @@ tests:
             value: /etc/logflare/certs/cert.pem
         template: deployment.yaml
 
-  - it: should add the Reloader annotation only when enabled
+  - it: should set no Deployment annotations by default
     asserts:
       - notExists:
-          path: metadata.annotations["reloader.stakater.com/auto"]
+          path: metadata.annotations
         template: deployment.yaml
 
-  - it: should add the Reloader annotation when reloader is true
+  - it: should render deploymentAnnotations on the Deployment when set
     set:
-      logflare.reloader: true
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"
     asserts:
       - equal:
           path: metadata.annotations["reloader.stakater.com/auto"]

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.vmArgs }}
+        checksum/vm-args: {{ include (print $.Template.BasePath "/vm-args-configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -75,6 +78,10 @@ spec:
             - name: LOGFLARE_TLS_KEY_PATH
               value: {{ printf "%s/cert.key" $mount | quote }}
             {{- end }}
+            {{- if .Values.vmArgs }}
+            - name: RELEASE_VM_ARGS
+              value: /etc/logflare/vm.args
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "logflare.fullname" . }}
@@ -98,8 +105,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.logflare.certFilesSecret .Values.volumeMounts }}
+          {{- if or .Values.vmArgs .Values.logflare.certFilesSecret .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.vmArgs }}
+            - name: vm-args
+              mountPath: /etc/logflare/vm.args
+              subPath: vm.args
+              readOnly: true
+            {{- end }}
             {{- if .Values.logflare.certFilesSecret }}
             - name: cert-files
               mountPath: {{ .Values.logflare.certFilesMountPath }}
@@ -109,8 +122,13 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.logflare.certFilesSecret .Values.volumes }}
+      {{- if or .Values.vmArgs .Values.logflare.certFilesSecret .Values.volumes }}
       volumes:
+        {{- if .Values.vmArgs }}
+        - name: vm-args
+          configMap:
+            name: {{ include "logflare.fullname" . }}-vm-args
+        {{- end }}
         {{- if .Values.logflare.certFilesSecret }}
         - name: cert-files
           secret:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,9 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "logflare.fullname" . }}
-  {{- if .Values.logflare.reloader }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    reloader.stakater.com/auto: "true"
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "logflare.labels" . | nindent 4 }}

--- a/helm/templates/vm-args-configmap.yaml
+++ b/helm/templates/vm-args-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.vmArgs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logflare.fullname" . }}-vm-args
+  labels:
+    {{- include "logflare.labels" . | nindent 4 }}
+data:
+  vm.args: |
+    {{- .Values.vmArgs | nindent 4 }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -88,6 +88,23 @@ logflare:
     postgres:
       schema: "public" # POSTGRES_BACKEND_SCHEMA; url (POSTGRES_BACKEND_URL) comes from a Secret in logflare.secretRefs
 
+# Erlang VM flags. When set, rendered into a ConfigMap, mounted at
+# /etc/logflare/vm.args, and pointed at via RELEASE_VM_ARGS (overriding the
+# image's baked-in vm.args). Set to "" to use the image default instead.
+#
+# `+Q` caps the BEAM's preallocated port table and is effectively REQUIRED on
+# Kubernetes: containerd commonly runs pods with nofile=infinity, and without
+# +Q the VM sizes the table from that limit — ~2GB RSS at boot. Keep +Q set.
+vmArgs: |
+  +Q 1048576
+  +sbwt none
+  +sbwtdcpu none
+  +sbwtdio none
+  +swt very_low
+  +P 8000000
+  -kernel prevent_overlapping_partitions false
+  -kernel net_ticktime 45
+
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,9 +56,6 @@ logflare:
   certFilesSecret: ""
   certFilesMountPath: /etc/logflare/certs
 
-  # Roll the Deployment automatically when its ConfigMap or referenced Secrets
-  # change. Requires the Stakater Reloader controller to be installed.
-  reloader: false
 
   # Free-form non-secret environment variables rendered verbatim into the
   # ConfigMap. Use this for configuration not modeled as first-class values
@@ -122,6 +119,13 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
+
+# Annotations for the Deployment object itself (not the pods). Use this to
+# drive controllers that watch the Deployment — e.g. Stakater Reloader, to roll
+# pods when a referenced ConfigMap/Secret changes:
+#   deploymentAnnotations:
+#     reloader.stakater.com/auto: "true"
+deploymentAnnotations: {}
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/helm/vmargs_test.yaml
+++ b/helm/vmargs_test.yaml
@@ -1,0 +1,54 @@
+suite: test vm.args wiring
+templates:
+  - vm-args-configmap.yaml
+  - deployment.yaml
+tests:
+  - it: renders the vm.args ConfigMap with +Q by default
+    template: vm-args-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["vm.args"]
+          pattern: "\\+Q 1048576"
+
+  - it: sets RELEASE_VM_ARGS and mounts vm-args by default
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_VM_ARGS
+            value: /etc/logflare/vm.args
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: vm-args
+            mountPath: /etc/logflare/vm.args
+            subPath: vm.args
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: vm-args
+            configMap:
+              name: RELEASE-NAME-logflare-vm-args
+
+  - it: renders no ConfigMap when vmArgs is empty
+    set:
+      vmArgs: ""
+    template: vm-args-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits RELEASE_VM_ARGS when vmArgs is empty
+    set:
+      vmArgs: ""
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_VM_ARGS
+            value: /etc/logflare/vm.args


### PR DESCRIPTION
Stacked on #3735 (which is stacked on `feat/helm`). Addresses Ziinc's review comment on #3728: the `logflare.reloader` boolean hard-coded a Stakater-specific annotation, too opinionated for a public/community chart.

## Change

Replaces the `reloader` toggle with a generic top-level **`deploymentAnnotations`** map (mirroring `podAnnotations`) rendered onto the Deployment's own `metadata.annotations`.

- Chart stays neutral about the reload mechanism — opt into Reloader with:
  ```yaml
  deploymentAnnotations:
    reloader.stakater.com/auto: "true"
  ```
