### PR TITLE
fix: share one OTel timestamp predicate between BQ schema typing and value conversion

### DIFF
--- a/lib/logflare/google/bigquery/event_utils.ex
+++ b/lib/logflare/google/bigquery/event_utils.ex
@@ -3,7 +3,8 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   Event utils for BigQuery.
   """
 
-  alias Logflare.LogEvent.TypeDetection
+  @ns_threshold 1_000_000_000_000_000_000
+  @us_threshold 1_000_000_000_000
 
   @doc """
   Converts LogEvent's body into a valid dataframe struct for Explorer
@@ -23,34 +24,20 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   @doc """
   Converts nanosecond/microsecond timestamps to seconds.
   https://docs.cloud.google.com/bigquery/docs/streaming-data-into-bigquery#send_date_and_time_data
-
-  `timestamp` is always converted. `start_time`/`end_time` are only converted
-  when the event carries OTel timestamps, mirroring the `TIMESTAMP` column
-  typing in `SchemaBuilder`. The flag is detected at ingest and stored on
-  `Logflare.LogEvent` as `otel_timestamps` — pass it via `convert_to_seconds/2`;
-  `convert_to_seconds/1` falls back to detecting it from `data`.
   """
-  @spec convert_to_seconds(map()) :: map()
-  def convert_to_seconds(data) do
-    convert_to_seconds(data, TypeDetection.otel_timestamps?(data))
-  end
-
   @spec convert_to_seconds(map(), boolean()) :: map()
-  def convert_to_seconds(data, otel_timestamps?) do
-    data = timestamp_to_seconds(data)
+  def convert_to_seconds(data, false), do: timestamp_to_seconds(data)
 
-    if otel_timestamps? do
-      data
-      |> ns_to_seconds("start_time")
-      |> ns_to_seconds("end_time")
-    else
-      data
-    end
+  def convert_to_seconds(data, true) do
+    data
+    |> timestamp_to_seconds()
+    |> ns_to_seconds("start_time")
+    |> ns_to_seconds("end_time")
   end
 
   defp ns_to_seconds(data, field) do
     case data do
-      %{^field => ts} when is_integer(ts) and ts > 1_000_000_000_000_000_000 ->
+      %{^field => ts} when is_integer(ts) and ts > @ns_threshold ->
         %{data | field => ts / :math.pow(1000, 3)}
 
       _ ->
@@ -58,13 +45,13 @@ defmodule Logflare.Google.BigQuery.EventUtils do
     end
   end
 
-  defp timestamp_to_seconds(%{"timestamp" => ts} = data)
-       when is_integer(ts) and ts > 1_000_000_000_000_000_000,
-       do: %{data | "timestamp" => ts / :math.pow(1000, 3)}
-
-  defp timestamp_to_seconds(%{"timestamp" => ts} = data)
-       when is_integer(ts) and ts > 1_000_000_000_000,
-       do: %{data | "timestamp" => ts / :math.pow(1000, 2)}
+  defp timestamp_to_seconds(%{"timestamp" => ts} = data) when is_integer(ts) do
+    cond do
+      ts > @ns_threshold -> %{data | "timestamp" => ts / :math.pow(1000, 3)}
+      ts > @us_threshold -> %{data | "timestamp" => ts / :math.pow(1000, 2)}
+      true -> data
+    end
+  end
 
   defp timestamp_to_seconds(data), do: data
 

--- a/lib/logflare/google/bigquery/event_utils.ex
+++ b/lib/logflare/google/bigquery/event_utils.ex
@@ -8,9 +8,7 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   @doc """
   Converts LogEvent's body into a valid dataframe struct for Explorer
   """
-  def log_event_to_df_struct(%Logflare.LogEvent{body: body}) do
-    otel_timestamps? = TypeDetection.otel_timestamps?(body)
-
+  def log_event_to_df_struct(%Logflare.LogEvent{body: body, otel_timestamps: otel_timestamps?}) do
     for {k, v} <- body, into: %{} do
       if is_map(v) do
         {k, prepare_for_ingest(v)}
@@ -27,10 +25,10 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   https://docs.cloud.google.com/bigquery/docs/streaming-data-into-bigquery#send_date_and_time_data
 
   `timestamp` is always converted. `start_time`/`end_time` are only converted
-  when the event carries OTel timestamps (`TypeDetection.otel_timestamps?/1`),
-  mirroring the `TIMESTAMP` column typing in `SchemaBuilder`. The predicate must
-  be computed on the raw event body — pass it explicitly via
-  `convert_to_seconds/2` when `data` has already been transformed for ingest.
+  when the event carries OTel timestamps, mirroring the `TIMESTAMP` column
+  typing in `SchemaBuilder`. The flag is detected at ingest and stored on
+  `Logflare.LogEvent` as `otel_timestamps` — pass it via `convert_to_seconds/2`;
+  `convert_to_seconds/1` falls back to detecting it from `data`.
   """
   @spec convert_to_seconds(map()) :: map()
   def convert_to_seconds(data) do
@@ -53,7 +51,7 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   defp ns_to_seconds(data, field) do
     case data do
       %{^field => ts} when is_integer(ts) and ts > 1_000_000_000_000_000_000 ->
-        %{data | field => ts / 1_000_000_000}
+        %{data | field => ts / :math.pow(1000, 3)}
 
       _ ->
         data
@@ -62,11 +60,11 @@ defmodule Logflare.Google.BigQuery.EventUtils do
 
   defp timestamp_to_seconds(%{"timestamp" => ts} = data)
        when is_integer(ts) and ts > 1_000_000_000_000_000_000,
-       do: %{data | "timestamp" => ts / 1_000_000_000}
+       do: %{data | "timestamp" => ts / :math.pow(1000, 3)}
 
   defp timestamp_to_seconds(%{"timestamp" => ts} = data)
        when is_integer(ts) and ts > 1_000_000_000_000,
-       do: %{data | "timestamp" => ts / 1_000_000}
+       do: %{data | "timestamp" => ts / :math.pow(1000, 2)}
 
   defp timestamp_to_seconds(data), do: data
 

--- a/lib/logflare/google/bigquery/event_utils.ex
+++ b/lib/logflare/google/bigquery/event_utils.ex
@@ -3,10 +3,14 @@ defmodule Logflare.Google.BigQuery.EventUtils do
   Event utils for BigQuery.
   """
 
+  alias Logflare.LogEvent.TypeDetection
+
   @doc """
   Converts LogEvent's body into a valid dataframe struct for Explorer
   """
   def log_event_to_df_struct(%Logflare.LogEvent{body: body}) do
+    otel_timestamps? = TypeDetection.otel_timestamps?(body)
+
     for {k, v} <- body, into: %{} do
       if is_map(v) do
         {k, prepare_for_ingest(v)}
@@ -15,34 +19,56 @@ defmodule Logflare.Google.BigQuery.EventUtils do
       end
     end
     |> Map.put("event_message", body["event_message"])
-    |> convert_to_seconds()
+    |> convert_to_seconds(otel_timestamps?)
   end
 
   @doc """
-  Recursively converts nanosecond/microsecond timestamps to seconds
+  Converts nanosecond/microsecond timestamps to seconds.
   https://docs.cloud.google.com/bigquery/docs/streaming-data-into-bigquery#send_date_and_time_data
+
+  `timestamp` is always converted. `start_time`/`end_time` are only converted
+  when the event carries OTel timestamps (`TypeDetection.otel_timestamps?/1`),
+  mirroring the `TIMESTAMP` column typing in `SchemaBuilder`. The predicate must
+  be computed on the raw event body — pass it explicitly via
+  `convert_to_seconds/2` when `data` has already been transformed for ingest.
   """
   @spec convert_to_seconds(map()) :: map()
-
   def convert_to_seconds(data) do
-    data
-    |> convert_to_seconds("timestamp")
-    |> convert_to_seconds("start_time")
-    |> convert_to_seconds("end_time")
+    convert_to_seconds(data, TypeDetection.otel_timestamps?(data))
   end
 
-  defp convert_to_seconds(data, field) do
-    case data do
-      %{^field => ts} when ts > 1_000_000_000_000_000_000 ->
-        %{data | field => ts / :math.pow(1000, 3)}
+  @spec convert_to_seconds(map(), boolean()) :: map()
+  def convert_to_seconds(data, otel_timestamps?) do
+    data = timestamp_to_seconds(data)
 
-      %{"timestamp" => ts} when ts > 1_000_000_000_000 ->
-        %{data | field => ts / :math.pow(1000, 2)}
+    if otel_timestamps? do
+      data
+      |> ns_to_seconds("start_time")
+      |> ns_to_seconds("end_time")
+    else
+      data
+    end
+  end
+
+  defp ns_to_seconds(data, field) do
+    case data do
+      %{^field => ts} when is_integer(ts) and ts > 1_000_000_000_000_000_000 ->
+        %{data | field => ts / 1_000_000_000}
 
       _ ->
         data
     end
   end
+
+  defp timestamp_to_seconds(%{"timestamp" => ts} = data)
+       when is_integer(ts) and ts > 1_000_000_000_000_000_000,
+       do: %{data | "timestamp" => ts / 1_000_000_000}
+
+  defp timestamp_to_seconds(%{"timestamp" => ts} = data)
+       when is_integer(ts) and ts > 1_000_000_000_000,
+       do: %{data | "timestamp" => ts / 1_000_000}
+
+  defp timestamp_to_seconds(data), do: data
 
   @doc """
   Checks for all maps fields from the dataframe list, then adds the missing fields to the

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -75,7 +75,7 @@ defmodule Logflare.LogEvent do
       source_name: source.name,
       body: body,
       event_type: event_type,
-      otel_timestamps: TypeDetection.otel_timestamps?(body, event_type),
+      otel_timestamps: TypeDetection.otel_timestamps?(event_type),
       ingested_at: ingested_at_dt,
       valid: true,
       drop: false,
@@ -104,7 +104,7 @@ defmodule Logflare.LogEvent do
       source_name: source.name,
       body: body,
       event_type: event_type,
-      otel_timestamps: TypeDetection.otel_timestamps?(body, event_type),
+      otel_timestamps: TypeDetection.otel_timestamps?(event_type),
       ingested_at: ingested_at_dt,
       valid: true,
       drop: false,
@@ -135,7 +135,6 @@ defmodule Logflare.LogEvent do
   @spec make(%{optional(String.t()) => term}, %{source: Source.t()}) :: LE.t()
   def make(params, %{source: source}, _opts \\ []) do
     event_type = TypeDetection.detect(params)
-    otel_timestamps = TypeDetection.otel_timestamps?(params, event_type)
     mapped = mapper(params, event_type)
 
     changeset =
@@ -165,7 +164,7 @@ defmodule Logflare.LogEvent do
         ingested_at: DateTime.utc_now(),
         id: body["id"],
         event_type: event_type,
-        otel_timestamps: otel_timestamps,
+        otel_timestamps: TypeDetection.otel_timestamps?(event_type),
         timestamp_inferred: mapped["timestamp_inferred"],
         day_bucket: day_bucket
       })

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -33,6 +33,7 @@ defmodule Logflare.LogEvent do
     field :via_rule_id, :id
     field :retries, :integer, default: 0
     field :event_type, Ecto.Enum, values: [:log, :metric, :trace], default: :log
+    field :otel_timestamps, :boolean, default: false
     field :source_id, :integer, default: nil
     field :day_bucket, :integer
     # Indicates if the event was removed from ets during ingest
@@ -74,6 +75,7 @@ defmodule Logflare.LogEvent do
       source_name: source.name,
       body: body,
       event_type: event_type,
+      otel_timestamps: TypeDetection.otel_timestamps?(body, event_type),
       ingested_at: ingested_at_dt,
       valid: true,
       drop: false,
@@ -93,6 +95,7 @@ defmodule Logflare.LogEvent do
       ) do
     {:ok, ingested_at_dt, _} = DateTime.from_iso8601(ingested_at)
     day_bucket = body["timestamp"] && DayBucket.from_microseconds(body["timestamp"])
+    event_type = String.to_existing_atom(event_type)
 
     %__MODULE__{
       id: id,
@@ -100,7 +103,8 @@ defmodule Logflare.LogEvent do
       source_uuid: source.token,
       source_name: source.name,
       body: body,
-      event_type: String.to_existing_atom(event_type),
+      event_type: event_type,
+      otel_timestamps: TypeDetection.otel_timestamps?(body, event_type),
       ingested_at: ingested_at_dt,
       valid: true,
       drop: false,
@@ -131,6 +135,7 @@ defmodule Logflare.LogEvent do
   @spec make(%{optional(String.t()) => term}, %{source: Source.t()}) :: LE.t()
   def make(params, %{source: source}, _opts \\ []) do
     event_type = TypeDetection.detect(params)
+    otel_timestamps = TypeDetection.otel_timestamps?(params, event_type)
     mapped = mapper(params, event_type)
 
     changeset =
@@ -160,6 +165,7 @@ defmodule Logflare.LogEvent do
         ingested_at: DateTime.utc_now(),
         id: body["id"],
         event_type: event_type,
+        otel_timestamps: otel_timestamps,
         timestamp_inferred: mapped["timestamp_inferred"],
         day_bucket: day_bucket
       })

--- a/lib/logflare/logs/log_event/type_detection.ex
+++ b/lib/logflare/logs/log_event/type_detection.ex
@@ -38,7 +38,16 @@ defmodule Logflare.LogEvent.TypeDetection do
   """
   @spec otel_timestamps?(map()) :: boolean()
   def otel_timestamps?(params) when is_map(params) do
-    detect(params) in [:metric, :trace] or otel_shaped?(params)
+    otel_timestamps?(params, detect(params))
+  end
+
+  @doc """
+  Same as `otel_timestamps?/1`, reusing an already-computed event type to
+  avoid running detection twice.
+  """
+  @spec otel_timestamps?(map(), event_type()) :: boolean()
+  def otel_timestamps?(params, event_type) when is_map(params) do
+    event_type in [:metric, :trace] or otel_shaped?(params)
   end
 
   defp otel_shaped?(params) do

--- a/lib/logflare/logs/log_event/type_detection.ex
+++ b/lib/logflare/logs/log_event/type_detection.ex
@@ -28,31 +28,13 @@ defmodule Logflare.LogEvent.TypeDetection do
   end
 
   @doc """
-  Whether `start_time`/`end_time` fields in the params hold OpenTelemetry
-  unix-nanosecond timestamps.
-
-  Single definition shared by BigQuery schema typing
-  (`Logflare.Sources.Source.BigQuery.SchemaBuilder`) and value conversion
-  (`Logflare.Google.BigQuery.EventUtils.convert_to_seconds/1`) so the column
-  type and the ingested value always agree.
+  Whether the event's `start_time`/`end_time` fields hold OpenTelemetry
+  unix-nanosecond timestamps. Accepts raw params or an already-detected
+  event type.
   """
-  @spec otel_timestamps?(map()) :: boolean()
-  def otel_timestamps?(params) when is_map(params) do
-    otel_timestamps?(params, detect(params))
-  end
-
-  @doc """
-  Same as `otel_timestamps?/1`, reusing an already-computed event type to
-  avoid running detection twice.
-  """
-  @spec otel_timestamps?(map(), event_type()) :: boolean()
-  def otel_timestamps?(params, event_type) when is_map(params) do
-    event_type in [:metric, :trace] or otel_shaped?(params)
-  end
-
-  defp otel_shaped?(params) do
-    Map.has_key?(params, "resource") and Map.has_key?(params, "scope")
-  end
+  @spec otel_timestamps?(map() | event_type()) :: boolean()
+  def otel_timestamps?(event_type) when is_atom(event_type), do: event_type in [:metric, :trace]
+  def otel_timestamps?(params) when is_map(params), do: otel_timestamps?(detect(params))
 
   defp trace?(params) do
     has_trace_id?(params) and has_span_id?(params) and has_span_field?(params)

--- a/lib/logflare/logs/log_event/type_detection.ex
+++ b/lib/logflare/logs/log_event/type_detection.ex
@@ -27,6 +27,24 @@ defmodule Logflare.LogEvent.TypeDetection do
     end
   end
 
+  @doc """
+  Whether `start_time`/`end_time` fields in the params hold OpenTelemetry
+  unix-nanosecond timestamps.
+
+  Single definition shared by BigQuery schema typing
+  (`Logflare.Sources.Source.BigQuery.SchemaBuilder`) and value conversion
+  (`Logflare.Google.BigQuery.EventUtils.convert_to_seconds/1`) so the column
+  type and the ingested value always agree.
+  """
+  @spec otel_timestamps?(map()) :: boolean()
+  def otel_timestamps?(params) when is_map(params) do
+    detect(params) in [:metric, :trace] or otel_shaped?(params)
+  end
+
+  defp otel_shaped?(params) do
+    Map.has_key?(params, "resource") and Map.has_key?(params, "scope")
+  end
+
   defp trace?(params) do
     has_trace_id?(params) and has_span_id?(params) and has_span_field?(params)
   end

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -12,6 +12,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   alias Logflare.Google.BigQuery.EventUtils
   alias Logflare.Google.BigQuery.GenUtils
   alias Logflare.LogEvent, as: LE
+  alias Logflare.LogEvent.TypeDetection
   alias Logflare.Mailer
   alias Logflare.Sources
   alias Logflare.Backends.IngestEventQueue
@@ -339,6 +340,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   end
 
   def le_to_bq_row(%LE{body: body, id: id}) do
+    otel_timestamps? = TypeDetection.otel_timestamps?(body)
+
     body =
       for {k, v} <- body, into: %{} do
         if is_map(v) do
@@ -348,7 +351,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
         end
       end
       |> Map.put("event_message", body["event_message"])
-      |> EventUtils.convert_to_seconds()
+      |> EventUtils.convert_to_seconds(otel_timestamps?)
 
     %Model.TableDataInsertAllRequestRows{
       insertId: id,

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -12,7 +12,6 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   alias Logflare.Google.BigQuery.EventUtils
   alias Logflare.Google.BigQuery.GenUtils
   alias Logflare.LogEvent, as: LE
-  alias Logflare.LogEvent.TypeDetection
   alias Logflare.Mailer
   alias Logflare.Sources
   alias Logflare.Backends.IngestEventQueue
@@ -339,9 +338,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     collect_batch_events(rest, [le | log_events], count + 1, bytes + size)
   end
 
-  def le_to_bq_row(%LE{body: body, id: id}) do
-    otel_timestamps? = TypeDetection.otel_timestamps?(body)
-
+  def le_to_bq_row(%LE{body: body, id: id, otel_timestamps: otel_timestamps?}) do
     body =
       for {k, v} <- body, into: %{} do
         if is_map(v) do

--- a/lib/logflare/sources/source/bigquery/schema_builder.ex
+++ b/lib/logflare/sources/source/bigquery/schema_builder.ex
@@ -266,7 +266,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaBuilder do
   end
 
   defp otel_data?(params) do
-    TypeDetection.detect(params) in [:metric, :trace]
+    TypeDetection.otel_timestamps?(params)
   end
 
   defimpl DeepMerge.Resolver, for: Model.TableFieldSchema do

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -324,6 +324,7 @@ defmodule Logflare.BigQuery.PipelineTest do
     test "converts OTel timestamps from nanoseconds to microseconds", %{source: source} do
       json =
         make_le(source,
+          metadata: %{"type" => "span"},
           resource: %{"service.name" => "svc"},
           scope: %{"name" => "scope"},
           start_time: @start_ns,
@@ -338,6 +339,7 @@ defmodule Logflare.BigQuery.PipelineTest do
     test "converts only start_time when end_time is missing", %{source: source} do
       json =
         make_le(source,
+          metadata: %{"type" => "span"},
           resource: %{"service.name" => "svc"},
           scope: %{"name" => "scope"},
           start_time: @start_ns

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -11,9 +11,14 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       "event_message" => "test"
     }
 
-    test "converts start_time from nanoseconds to seconds (float)" do
+    @otel_body Map.merge(@base_body, %{
+                 "resource" => %{"service.name" => "svc"},
+                 "scope" => %{"name" => "scope"}
+               })
+
+    test "converts OTel start_time from nanoseconds to seconds (float)" do
       le = %Logflare.LogEvent{
-        body: Map.put(@base_body, "start_time", 1_779_436_330_890_427_000)
+        body: Map.put(@otel_body, "start_time", 1_779_436_330_890_427_000)
       }
 
       result = EventUtils.log_event_to_df_struct(le)
@@ -21,10 +26,10 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       assert_in_delta result["start_time"], 1_779_436_330.890_427, 1.0e-6
     end
 
-    test "converts both start_time and end_time from nanoseconds to seconds (float)" do
+    test "converts both OTel start_time and end_time from nanoseconds to seconds (float)" do
       le = %Logflare.LogEvent{
         body:
-          @base_body
+          @otel_body
           |> Map.put("start_time", 1_779_436_330_890_427_000)
           |> Map.put("end_time", 1_779_436_901_362_775_000)
       }
@@ -37,7 +42,7 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
 
     test "converts only end_time from nanoseconds to seconds (float)" do
       le = %Logflare.LogEvent{
-        body: Map.put(@base_body, "end_time", 1_779_436_901_362_775_000)
+        body: Map.put(@otel_body, "end_time", 1_779_436_901_362_775_000)
       }
 
       result = EventUtils.log_event_to_df_struct(le)
@@ -45,14 +50,27 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       assert result["end_time"] == 1_779_436_901.362_775
     end
 
-    test "converts start_time from nanoseconds to seconds (float) regardless of event type" do
+    test "converts start_time for events tagged as metric/span via metadata.type" do
+      le = %Logflare.LogEvent{
+        body:
+          @base_body
+          |> Map.put("metadata", %{"type" => "metric"})
+          |> Map.put("start_time", 1_779_436_330_890_427_000)
+      }
+
+      result = EventUtils.log_event_to_df_struct(le)
+
+      assert_in_delta result["start_time"], 1_779_436_330.890_427, 1.0e-6
+    end
+
+    test "leaves non-OTel start_time unchanged even in the nanosecond range" do
       le = %Logflare.LogEvent{
         body: Map.put(@base_body, "start_time", 1_779_436_330_890_427_000)
       }
 
       result = EventUtils.log_event_to_df_struct(le)
 
-      assert_in_delta result["start_time"], 1_779_436_330.890_427, 1.0e-6
+      assert result["start_time"] == 1_779_436_330_890_427_000
     end
 
     test "passes timestamp through as seconds (float)" do
@@ -67,9 +85,14 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
   describe "convert_to_seconds/1" do
     @ns 1_779_436_330_890_427_000
     @us 1_779_436_901_362_775
+    @otel_markers %{
+      "resource" => %{"service.name" => "svc"},
+      "scope" => %{"name" => "scope"}
+    }
 
-    test "converts nanosecond start_time and end_time to float seconds" do
-      body = %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000}
+    test "converts OTel nanosecond start_time and end_time to float seconds" do
+      body =
+        Map.merge(@otel_markers, %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000})
 
       result = EventUtils.convert_to_seconds(body)
 
@@ -85,10 +108,28 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       assert result["timestamp"] == 1_779_436_901.362_775
     end
 
-    test "leaves start_time unchanged when not nanoseconds" do
-      body = %{"start_time" => 1_234_567_890}
+    test "leaves OTel start_time unchanged when not nanoseconds" do
+      body = Map.put(@otel_markers, "start_time", 1_234_567_890)
 
       assert EventUtils.convert_to_seconds(body) == body
+    end
+
+    test "leaves non-OTel start_time and end_time unchanged even in the nanosecond range" do
+      body = %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000}
+
+      assert EventUtils.convert_to_seconds(body) == body
+    end
+  end
+
+  describe "convert_to_seconds/2" do
+    test "explicit flag overrides body-shape detection" do
+      body = %{"start_time" => 1_779_436_330_890_427_000}
+
+      assert EventUtils.convert_to_seconds(body, true) == %{
+               "start_time" => 1_779_436_330.8904269
+             }
+
+      assert EventUtils.convert_to_seconds(body, false) == body
     end
   end
 

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -11,14 +11,10 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       "event_message" => "test"
     }
 
-    @otel_body Map.merge(@base_body, %{
-                 "resource" => %{"service.name" => "svc"},
-                 "scope" => %{"name" => "scope"}
-               })
-
-    test "converts OTel start_time from nanoseconds to seconds (float)" do
+    test "converts start_time from nanoseconds to seconds (float) when otel_timestamps is set" do
       le = %Logflare.LogEvent{
-        body: Map.put(@otel_body, "start_time", 1_779_436_330_890_427_000)
+        body: Map.put(@base_body, "start_time", 1_779_436_330_890_427_000),
+        otel_timestamps: true
       }
 
       result = EventUtils.log_event_to_df_struct(le)
@@ -26,12 +22,13 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       assert_in_delta result["start_time"], 1_779_436_330.890_427, 1.0e-6
     end
 
-    test "converts both OTel start_time and end_time from nanoseconds to seconds (float)" do
+    test "converts both start_time and end_time from nanoseconds to seconds (float)" do
       le = %Logflare.LogEvent{
         body:
-          @otel_body
+          @base_body
           |> Map.put("start_time", 1_779_436_330_890_427_000)
-          |> Map.put("end_time", 1_779_436_901_362_775_000)
+          |> Map.put("end_time", 1_779_436_901_362_775_000),
+        otel_timestamps: true
       }
 
       result = EventUtils.log_event_to_df_struct(le)
@@ -42,7 +39,8 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
 
     test "converts only end_time from nanoseconds to seconds (float)" do
       le = %Logflare.LogEvent{
-        body: Map.put(@otel_body, "end_time", 1_779_436_901_362_775_000)
+        body: Map.put(@base_body, "end_time", 1_779_436_901_362_775_000),
+        otel_timestamps: true
       }
 
       result = EventUtils.log_event_to_df_struct(le)
@@ -50,20 +48,7 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
       assert result["end_time"] == 1_779_436_901.362_775
     end
 
-    test "converts start_time for events tagged as metric/span via metadata.type" do
-      le = %Logflare.LogEvent{
-        body:
-          @base_body
-          |> Map.put("metadata", %{"type" => "metric"})
-          |> Map.put("start_time", 1_779_436_330_890_427_000)
-      }
-
-      result = EventUtils.log_event_to_df_struct(le)
-
-      assert_in_delta result["start_time"], 1_779_436_330.890_427, 1.0e-6
-    end
-
-    test "leaves non-OTel start_time unchanged even in the nanosecond range" do
+    test "leaves start_time unchanged when otel_timestamps is not set" do
       le = %Logflare.LogEvent{
         body: Map.put(@base_body, "start_time", 1_779_436_330_890_427_000)
       }

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -67,52 +67,32 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
     end
   end
 
-  describe "convert_to_seconds/1" do
+  describe "convert_to_seconds/2" do
     @ns 1_779_436_330_890_427_000
     @us 1_779_436_901_362_775
-    @otel_markers %{
-      "resource" => %{"service.name" => "svc"},
-      "scope" => %{"name" => "scope"}
-    }
 
-    test "converts OTel nanosecond start_time and end_time to float seconds" do
-      body =
-        Map.merge(@otel_markers, %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000})
+    test "converts nanosecond start_time and end_time to float seconds for OTel events" do
+      body = %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000}
 
-      result = EventUtils.convert_to_seconds(body)
+      result = EventUtils.convert_to_seconds(body, true)
 
       assert result["start_time"] == 1_779_436_330.8904269
       assert result["end_time"] == 1_779_436_901.362_775
     end
 
     test "converts microsecond timestamp to float seconds" do
-      body = %{"timestamp" => @us}
-
-      result = EventUtils.convert_to_seconds(body)
-
-      assert result["timestamp"] == 1_779_436_901.362_775
+      assert EventUtils.convert_to_seconds(%{"timestamp" => @us}, false) ==
+               %{"timestamp" => 1_779_436_901.362_775}
     end
 
-    test "leaves OTel start_time unchanged when not nanoseconds" do
-      body = Map.put(@otel_markers, "start_time", 1_234_567_890)
+    test "leaves start_time unchanged when not nanoseconds" do
+      body = %{"start_time" => 1_234_567_890}
 
-      assert EventUtils.convert_to_seconds(body) == body
+      assert EventUtils.convert_to_seconds(body, true) == body
     end
 
     test "leaves non-OTel start_time and end_time unchanged even in the nanosecond range" do
       body = %{"start_time" => @ns, "end_time" => 1_779_436_901_362_775_000}
-
-      assert EventUtils.convert_to_seconds(body) == body
-    end
-  end
-
-  describe "convert_to_seconds/2" do
-    test "explicit flag overrides body-shape detection" do
-      body = %{"start_time" => 1_779_436_330_890_427_000}
-
-      assert EventUtils.convert_to_seconds(body, true) == %{
-               "start_time" => 1_779_436_330.8904269
-             }
 
       assert EventUtils.convert_to_seconds(body, false) == body
     end

--- a/test/logflare/google/bigquery/schema_builder_test.exs
+++ b/test/logflare/google/bigquery/schema_builder_test.exs
@@ -153,6 +153,7 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
   describe "OpenTelemetry schema generation" do
     test "OTel: start_time and end_time are TIMESTAMP" do
       otel_trace_params = %{
+        "metadata" => %{"type" => "span"},
         "resource" => %{"service.name" => "my-service"},
         "scope" => %{"name" => "my-scope", "version" => "1.0"},
         "attributes" => %{"http.status" => 200},
@@ -190,6 +191,7 @@ defmodule Logflare.Google.BigQuery.SourceSchemaBuilderTest do
 
       # OTel: start_time becomes TIMESTAMP, other integer fields stay INTEGER
       otel_params = %{
+        "metadata" => %{"type" => "metric"},
         "resource" => %{"service.name" => "my-service"},
         "scope" => %{"name" => "my-scope", "version" => "1.0"},
         "attributes" => %{"request_id" => "abc"},

--- a/test/logflare/log_event/type_detection_test.exs
+++ b/test/logflare/log_event/type_detection_test.exs
@@ -213,16 +213,6 @@ defmodule Logflare.LogEvent.TypeDetectionTest do
       assert TypeDetection.otel_timestamps?(params)
     end
 
-    test "true for OTel-shaped payloads with resource and scope" do
-      params = %{
-        "resource" => %{"service.name" => "svc"},
-        "scope" => %{"name" => "scope"},
-        "start_time" => 1_779_436_330_890_427_000
-      }
-
-      assert TypeDetection.otel_timestamps?(params)
-    end
-
     test "false for plain logs with integer start_time" do
       params = %{
         "event_message" => "Hello world",
@@ -232,19 +222,20 @@ defmodule Logflare.LogEvent.TypeDetectionTest do
       refute TypeDetection.otel_timestamps?(params)
     end
 
-    test "false for resource without scope" do
-      params = %{"resource" => %{"service.name" => "svc"}}
+    test "false for OTel-shaped payloads without a metric/trace signal" do
+      params = %{
+        "resource" => %{"service.name" => "svc"},
+        "scope" => %{"name" => "scope"},
+        "start_time" => 1_779_436_330_890_427_000
+      }
+
       refute TypeDetection.otel_timestamps?(params)
     end
 
-    test "false for empty map" do
-      refute TypeDetection.otel_timestamps?(%{})
-    end
-
-    test "otel_timestamps?/2 reuses a precomputed event type" do
-      assert TypeDetection.otel_timestamps?(%{}, :metric)
-      assert TypeDetection.otel_timestamps?(%{}, :trace)
-      refute TypeDetection.otel_timestamps?(%{}, :log)
+    test "accepts a precomputed event type" do
+      assert TypeDetection.otel_timestamps?(:metric)
+      assert TypeDetection.otel_timestamps?(:trace)
+      refute TypeDetection.otel_timestamps?(:log)
     end
   end
 end

--- a/test/logflare/log_event/type_detection_test.exs
+++ b/test/logflare/log_event/type_detection_test.exs
@@ -240,5 +240,11 @@ defmodule Logflare.LogEvent.TypeDetectionTest do
     test "false for empty map" do
       refute TypeDetection.otel_timestamps?(%{})
     end
+
+    test "otel_timestamps?/2 reuses a precomputed event type" do
+      assert TypeDetection.otel_timestamps?(%{}, :metric)
+      assert TypeDetection.otel_timestamps?(%{}, :trace)
+      refute TypeDetection.otel_timestamps?(%{}, :log)
+    end
   end
 end

--- a/test/logflare/log_event/type_detection_test.exs
+++ b/test/logflare/log_event/type_detection_test.exs
@@ -201,4 +201,44 @@ defmodule Logflare.LogEvent.TypeDetectionTest do
       assert TypeDetection.detect(params) == :log
     end
   end
+
+  describe "otel_timestamps?/1" do
+    test "true for events detected as metric" do
+      params = %{"metadata" => %{"type" => "metric"}}
+      assert TypeDetection.otel_timestamps?(params)
+    end
+
+    test "true for events detected as trace" do
+      params = %{"metadata" => %{"type" => "span"}}
+      assert TypeDetection.otel_timestamps?(params)
+    end
+
+    test "true for OTel-shaped payloads with resource and scope" do
+      params = %{
+        "resource" => %{"service.name" => "svc"},
+        "scope" => %{"name" => "scope"},
+        "start_time" => 1_779_436_330_890_427_000
+      }
+
+      assert TypeDetection.otel_timestamps?(params)
+    end
+
+    test "false for plain logs with integer start_time" do
+      params = %{
+        "event_message" => "Hello world",
+        "start_time" => 1_779_436_330_890_427_000
+      }
+
+      refute TypeDetection.otel_timestamps?(params)
+    end
+
+    test "false for resource without scope" do
+      params = %{"resource" => %{"service.name" => "svc"}}
+      refute TypeDetection.otel_timestamps?(params)
+    end
+
+    test "false for empty map" do
+      refute TypeDetection.otel_timestamps?(%{})
+    end
+  end
 end

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -834,6 +834,38 @@ defmodule Logflare.LogEventTest do
     end
   end
 
+  describe "otel_timestamps detection" do
+    test "make/2 sets otel_timestamps for OTel metric/trace events", %{source: source} do
+      le =
+        LogEvent.make(
+          %{"event_message" => "span", "metadata" => %{"type" => "span"}},
+          %{source: source}
+        )
+
+      assert le.otel_timestamps
+    end
+
+    test "make/2 sets otel_timestamps for OTel-shaped payloads", %{source: source} do
+      le =
+        LogEvent.make(
+          %{
+            "event_message" => "otel shaped",
+            "resource" => %{"service.name" => "svc"},
+            "scope" => %{"name" => "scope"}
+          },
+          %{source: source}
+        )
+
+      assert le.otel_timestamps
+    end
+
+    test "make/2 leaves otel_timestamps unset for plain logs", %{source: source} do
+      le = LogEvent.make(%{"event_message" => "plain"}, %{source: source})
+
+      refute le.otel_timestamps
+    end
+  end
+
   describe "make_message/2" do
     property "if pattern is `nil` then the message is left as is" do
       check all message <- string(:printable) do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -845,7 +845,8 @@ defmodule Logflare.LogEventTest do
       assert le.otel_timestamps
     end
 
-    test "make/2 sets otel_timestamps for OTel-shaped payloads", %{source: source} do
+    test "make/2 leaves otel_timestamps unset for OTel-shaped payloads without a metric/trace signal",
+         %{source: source} do
       le =
         LogEvent.make(
           %{
@@ -856,7 +857,7 @@ defmodule Logflare.LogEventTest do
           %{source: source}
         )
 
-      assert le.otel_timestamps
+      refute le.otel_timestamps
     end
 
     test "make/2 leaves otel_timestamps unset for plain logs", %{source: source} do


### PR DESCRIPTION
Fixes the CI failures on #3557 ([run 30248438564](https://github.com/Logflare/logflare/actions/runs/30248438564/job/89920722303)) and implements [this review suggestion](https://github.com/Logflare/logflare/pull/3557#discussion_r3365573538): schema typing and value conversion used two different definitions of "`start_time`/`end_time` is a timestamp", so plain logs with ns-range values could ingest a float into an `INTEGER` column.

- Add `TypeDetection.otel_timestamps?/1` (true only for detected `:metric`/`:trace` events) as the single shared predicate for both `SchemaBuilder` `TIMESTAMP` typing and `convert_to_seconds` value conversion.
- Detect the flag once at ingest and store it on `LogEvent` as `otel_timestamps`, so the BQ hot path (`le_to_bq_row/1`, `log_event_to_df_struct/1`) reads it off the struct instead of recomputing.
- Fix the `convert_to_seconds/2` microsecond clause writing the `timestamp` value into the field under conversion, and update tests: OTel payloads now carry `metadata.type` (as set by the OTEL processors), which also fixes the failing `schema_builder_test` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMSGUCrc8hTP6XUDvXWorF