### PR TITLE
feat: label ClickHouse batch metrics by backend

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -209,17 +209,17 @@ defmodule Logflare.Telemetry do
       distribution("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
         event_name: [:logflare, :backends, :pipeline, :handle_batch],
         measurement: :batch_size,
-        tags: [:event_type, :batch_trigger],
+        tags: [:backend_id, :event_type, :batch_trigger],
         keep: &clickhouse_batch?/1,
         reporter_options: batch_size_reporter_opts(),
-        description: "Distribution of ClickHouse batch sizes by event type and trigger"
+        description: "Distribution of ClickHouse batch sizes by backend, event type, and trigger"
       ),
       sum("logflare.backends.clickhouse.pipeline.handle_batch.batch_size",
         event_name: [:logflare, :backends, :pipeline, :handle_batch],
         measurement: :batch_size,
-        tags: [:event_type, :batch_trigger],
+        tags: [:backend_id, :event_type, :batch_trigger],
         keep: &clickhouse_batch?/1,
-        description: "Sum of ClickHouse batch sizes by event type and trigger"
+        description: "Sum of ClickHouse batch sizes by backend, event type, and trigger"
       ),
       counter("logflare.cache_buster.to_bust.count", tags: []),
       sum("logflare.logs.ingest_logs.drop_lql",

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -69,13 +69,13 @@ defmodule Logflare.TelemetryTest do
       for metric <- metrics do
         assert metric.event_name == [:logflare, :backends, :pipeline, :handle_batch]
         assert metric.measurement == :batch_size
-        assert metric.tags == [:event_type, :batch_trigger]
+        assert metric.tags == [:backend_id, :event_type, :batch_trigger]
         assert metric.keep.(%{backend_type: :clickhouse})
         refute metric.keep.(%{backend_type: :bigquery})
       end
     end
 
-    test "aggregates ClickHouse batches by event type and trigger" do
+    test "aggregates ClickHouse batches by backend, event type, and trigger" do
       start_supervised!(
         {OtelMetricExporter,
          name: @clickhouse_batch_exporter,
@@ -88,14 +88,21 @@ defmodule Logflare.TelemetryTest do
       )
 
       event = [:logflare, :backends, :pipeline, :handle_batch]
-      log_tags = %{event_type: :log, batch_trigger: :size}
-      metric_tags = %{event_type: :metric, batch_trigger: :timeout}
-      trace_tags = %{event_type: :trace, batch_trigger: :timeout}
+      log_tags = %{backend_id: 1, event_type: :log, batch_trigger: :size}
+      other_log_tags = %{backend_id: 2, event_type: :log, batch_trigger: :size}
+      metric_tags = %{backend_id: 1, event_type: :metric, batch_trigger: :timeout}
+      trace_tags = %{backend_id: 2, event_type: :trace, batch_trigger: :timeout}
 
       :telemetry.execute(
         event,
         %{batch_size: 20_000},
         Map.put(log_tags, :backend_type, :clickhouse)
+      )
+
+      :telemetry.execute(
+        event,
+        %{batch_size: 10_000},
+        Map.put(other_log_tags, :backend_type, :clickhouse)
       )
 
       :telemetry.execute(
@@ -117,8 +124,18 @@ defmodule Logflare.TelemetryTest do
                {:sum, @clickhouse_batch_metric_string} => sums
              } = MetricStore.get_metrics(@clickhouse_batch_exporter)
 
-      assert sums == %{log_tags => 20_000, metric_tags => 500, trace_tags => 125}
+      assert sums == %{
+               log_tags => 20_000,
+               other_log_tags => 10_000,
+               metric_tags => 500,
+               trace_tags => 125
+             }
+
       assert [{_bucket, {1, 20_000}}] = distributions |> Map.fetch!(log_tags) |> Map.to_list()
+
+      assert [{_bucket, {1, 10_000}}] =
+               distributions |> Map.fetch!(other_log_tags) |> Map.to_list()
+
       assert [{_bucket, {1, 500}}] = distributions |> Map.fetch!(metric_tags) |> Map.to_list()
       assert [{_bucket, {1, 125}}] = distributions |> Map.fetch!(trace_tags) |> Map.to_list()
     end


### PR DESCRIPTION
## Summary
- add `backend_id` to ClickHouse batch-size distribution and sum metric labels
- cover separate aggregation for batches from different backends