### PR TITLE
chore: adds 60s timeout for endpoint queries when BQ reservation is provided

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -44,6 +44,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @service_account_prefix "logflare-managed"
   @reservation_error_regex ~r/reservation/i
   @search_query_timeout_ms 60_000
+  @endpoint_query_timeout_ms 60_000
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = source_backend) do
@@ -584,7 +585,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       dryRun: Keyword.get(opts, :dry_run, false),
       query_type: query_type,
       reservation: reservation
-    ] ++ query_timeout_opts(query_type)
+    ] ++ query_timeout_opts(query_type, reservation)
   end
 
   @spec resolve_reservation(
@@ -601,15 +602,23 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   defp resolve_reservation(%User{}, _query_type, nil), do: nil
   defp resolve_reservation(%User{}, _query_type, override), do: override
 
-  @spec query_timeout_opts(query_type :: atom() | nil) :: Keyword.t()
-  defp query_timeout_opts(:search) do
+  @spec query_timeout_opts(query_type :: atom() | nil, reservation :: String.t() | nil) ::
+          Keyword.t()
+  defp query_timeout_opts(:search, _reservation) do
     [
       jobTimeoutMs: @search_query_timeout_ms,
       timeoutMs: @search_query_timeout_ms
     ]
   end
 
-  defp query_timeout_opts(_query_type), do: []
+  defp query_timeout_opts(:endpoint, reservation) when is_non_empty_binary(reservation) do
+    [
+      jobTimeoutMs: @endpoint_query_timeout_ms,
+      timeoutMs: @endpoint_query_timeout_ms
+    ]
+  end
+
+  defp query_timeout_opts(_query_type, _reservation), do: []
 
   @spec execute_query_with_context(
           user_id :: integer(),

--- a/lib/logflare/endpoints.ex
+++ b/lib/logflare/endpoints.ex
@@ -740,8 +740,9 @@ defmodule Logflare.Endpoints do
         end
 
       redact_pii = Keyword.get(opts, :redact_pii, endpoint_query.redact_pii)
+      query_opts = Keyword.put(opts, :query_type, :endpoint)
 
-      case adaptor.execute_query(backend, query_args, opts) do
+      case adaptor.execute_query(backend, query_args, query_opts) do
         {:ok, %QueryResult{rows: rows} = result} ->
           redacted_rows = PiiRedactor.redact_query_result(rows, redact_pii)
           {:ok, result |> Map.put(:rows, redacted_rows) |> Map.from_struct()}

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -440,6 +440,31 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
 
       assert_received {:timeouts, 60_000, 60_000}
     end
+
+    test "uses a 60s timeout for :endpoint queries with a custom reservation" do
+      user = insert(:user, bigquery_dataset_id: "test_dataset")
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user.bigquery_dataset_id, user.id},
+        {"select 1", []},
+        query_type: :endpoint,
+        reservation: "projects/p/locations/l/reservations/endpoint"
+      )
+
+      assert_received {:timeouts, 60_000, 60_000}
+    end
+
+    test "keeps the default timeout for :endpoint queries without a reservation" do
+      user = insert(:user, bigquery_dataset_id: "test_dataset")
+
+      BigQueryAdaptor.execute_query(
+        {"test-project", user.bigquery_dataset_id, user.id},
+        {"select 1", []},
+        query_type: :endpoint
+      )
+
+      assert_received {:timeouts, 25_000, 25_000}
+    end
   end
 
   describe "reservation error logging" do

--- a/test/logflare/endpoints_test.exs
+++ b/test/logflare/endpoints_test.exs
@@ -525,6 +525,41 @@ defmodule Logflare.EndpointsTest do
       }
     end
 
+    test "run_query/3 uses a 60s timeout when a custom reservation is provided" do
+      pid = self()
+
+      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
+        send(pid, {:timeouts, opts[:body].jobTimeoutMs, opts[:body].timeoutMs})
+        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      end)
+
+      user = insert(:user)
+      endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
+
+      assert {:ok, %{rows: [%{"testing" => _}]}} =
+               Endpoints.run_query(endpoint, %{},
+                 reservation: "projects/p/locations/l/reservations/endpoint"
+               )
+
+      assert_received {:timeouts, 60_000, 60_000}
+    end
+
+    test "run_query/3 keeps the default timeout when no reservation is provided" do
+      pid = self()
+
+      expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
+        send(pid, {:timeouts, opts[:body].jobTimeoutMs, opts[:body].timeoutMs})
+        {:ok, TestUtils.gen_bq_response([%{"testing" => "123"}])}
+      end)
+
+      user = insert(:user)
+      endpoint = insert(:endpoint, user: user, query: "select current_datetime() as testing")
+
+      assert {:ok, %{rows: [%{"testing" => _}]}} = Endpoints.run_query(endpoint)
+
+      assert_received {:timeouts, 25_000, 25_000}
+    end
+
     test "run an endpoint query with query composition" do
       expect(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 1, fn _conn, _proj_id, opts ->
         assert opts[:body].query =~ "current_datetime"


### PR DESCRIPTION
60s timeout added for BigQuery-based endpoint queries that include a custom reservation