### PR TITLE
fix(cloudbuild): log startup script phases for GCE diagnosability

### DIFF
--- a/cloudbuild/gce-startup.sh
+++ b/cloudbuild/gce-startup.sh
@@ -23,10 +23,14 @@ phase() {
 }
 
 report_failure() {
-  log "FAILED during phase: ${CURRENT_PHASE}" >&2
+  local status="$1"
+  local line="$2"
+  local command="$3"
+
+  log "FAILED during phase: ${CURRENT_PHASE} (line ${line}, exit ${status}): ${command}" >&2
 }
 
-trap report_failure ERR
+trap 'report_failure "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 metadata() {
   local key="$1"

--- a/cloudbuild/gce-startup.sh
+++ b/cloudbuild/gce-startup.sh
@@ -1,11 +1,32 @@
 #!/bin/bash
 
-set -euo pipefail
+set -Eeuo pipefail
 
 readonly METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
 readonly CONTAINER_NAME="logflare"
 readonly CONTAINER_ENV_FILE="${LOGFLARE_CONTAINER_ENV_FILE:-/run/logflare-container.env}"
 readonly DOCKER_HOME="${LOGFLARE_DOCKER_HOME:-/home/logflare}"
+
+# Tracks the current step so an unexpected failure reports where it happened.
+# Every phase is logged with elapsed seconds, which is what distinguishes a
+# script that never ran from one that stalled (e.g. on a metadata retry).
+CURRENT_PHASE="startup"
+
+log() {
+  echo "gce-startup[+${SECONDS}s] $*"
+}
+
+phase() {
+  CURRENT_PHASE="$1"
+
+  log "phase: ${CURRENT_PHASE}"
+}
+
+report_failure() {
+  log "FAILED during phase: ${CURRENT_PHASE}" >&2
+}
+
+trap report_failure ERR
 
 metadata() {
   local key="$1"
@@ -24,8 +45,11 @@ metadata() {
 }
 
 wait_for_docker() {
-  for _ in {1..30}; do
+  local attempt
+
+  for attempt in {1..30}; do
     if docker info >/dev/null 2>&1; then
+      log "docker ready after ${attempt} attempt(s)"
       return 0
     fi
 
@@ -56,29 +80,41 @@ main() {
 
   umask 077
 
+  log "begin"
+
+  phase "read container image metadata"
   image="$(metadata logflare-container-image)"
   if [[ -z "${image}" ]]; then
     echo "logflare-container-image metadata is empty" >&2
     return 1
   fi
+  log "container image: ${image}"
 
+  phase "write container env file"
   metadata logflare-container-env >"${CONTAINER_ENV_FILE}"
   if [[ ! -s "${CONTAINER_ENV_FILE}" ]]; then
     echo "logflare-container-env metadata is empty" >&2
     return 1
   fi
 
+  phase "configure docker credentials"
   export HOME="${DOCKER_HOME}"
   mkdir -p "${HOME}"
   chmod 0700 "${HOME}"
   docker-credential-gcr configure-docker --registries=gcr.io
 
+  phase "configure host firewall"
   configure_firewall
+
+  phase "wait for docker"
   wait_for_docker
 
   # Keep the existing container available if the registry is temporarily
   # unavailable during a manual startup-script rerun.
+  phase "pull container image"
   docker pull "${image}"
+
+  phase "start container"
   docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
 
   docker run \
@@ -92,6 +128,8 @@ main() {
     --log-opt max-file=3 \
     --env-file "${CONTAINER_ENV_FILE}" \
     "${image}"
+
+  phase "done"
 }
 
 main "$@"

--- a/test/cloudbuild/gce_scripts_test.sh
+++ b/test/cloudbuild/gce_scripts_test.sh
@@ -47,7 +47,9 @@ test_startup_script_contract() {
     "--log-driver=json-file" \
     "--log-opt max-size=500m" \
     "--log-opt max-file=3" \
-    "--env-file"; do
+    "--env-file" \
+    "gce-startup[+\${SECONDS}s]" \
+    "trap report_failure ERR"; do
     assert_contains "${STARTUP_SCRIPT}" "${required}"
   done
 }

--- a/test/cloudbuild/gce_scripts_test.sh
+++ b/test/cloudbuild/gce_scripts_test.sh
@@ -49,7 +49,7 @@ test_startup_script_contract() {
     "--log-opt max-file=3" \
     "--env-file" \
     "gce-startup[+\${SECONDS}s]" \
-    "trap report_failure ERR"; do
+    "trap 'report_failure \"\$?\" \"\$LINENO\" \"\$BASH_COMMAND\"' ERR"; do
     assert_contains "${STARTUP_SCRIPT}" "${required}"
   done
 }


### PR DESCRIPTION
## Context

During the staging rollout of #3722 (startup-script based instance templates), `instance-group-staging-main-saturated-p7kx` came up with **no Logflare container at all**. The MIG autohealer detected it and recreated the instance ~8 minutes later, so the rollout self-healed and the final state was correct — but the failure could not be root-caused.

The VM booted normally on the failed attempt. Comparing log streams for the failed boot (14:04) against the repaired boot (14:19) on the same instance:

| Log stream | Failed boot | Repaired boot |
|---|---|---|
| `GCEGuestAgent` | 14 | 14 |
| `konlet-startup.service` | 1 | 1 |
| `docker.service` | 10 | 7 |
| **`GCEMetadataScripts`** | **0** | **97** |
| `cos_containers` | 0 | 60 |

The guest agent logged identically on both boots and dockerd reached `Daemon has completed initialization`. Only the metadata-script runner is missing — it never even emitted its own `Starting startup scripts` line, so `gce-startup.sh` is not implicated. Why the unit didn't fire is undetermined; the failed boot's serial console was lost to the in-place restart.

## Problem

`gce-startup.sh` produced no output until `docker-credential-gcr` (line 74 of the original). Everything before it is silent:

- `metadata()` uses `--retry 10 --retry-delay 2 --max-time 30` and can block for minutes with zero output
- `wait_for_docker()` can spin for 60s silently

So "the script never ran", "the script stalled on a metadata retry", and "the script failed early" all look identical in Cloud Logging: nothing.

## Change

- Log every phase with elapsed seconds (`gce-startup[+12s] phase: pull container image`)
- Report the phase name on unexpected failure via an `ERR` trap
- Log the resolved container image and how many attempts `wait_for_docker` needed
- `set -E` (errtrace) so the `ERR` trap fires from inside `main`
