### PR TITLE
fix: pause tailing when event modal is open

### DIFF
--- a/lib/logflare_web/live/search_live/log_event_components.ex
+++ b/lib/logflare_web/live/search_live/log_event_components.ex
@@ -40,6 +40,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
           <div class="group-has-[.log-event-selected-field]:tw-ml-[13rem] group-has-[.log-event-selected-field]:tw-pb-1.5 tw-inline-block">
             <.modal_link
                    component={LogEventViewerComponent}
+                   click={JS.push("open_log_event_modal")}
+                   close={JS.push("close_log_event_modal", target: "#source-logs-search-control") |> JS.push("close")}
                    class="tw-text-[0.65rem]"
                    modal_id={:log_event_viewer}
                    title="Log Event"
@@ -50,8 +52,8 @@ defmodule LogflareWeb.SearchLive.LogEventComponents do
                  </.modal_link>
                  <.modal_link
                    component={LogflareWeb.SearchLive.EventContextComponent}
-                   click={JS.push("open_event_context")}
-                   close={JS.push("close_event_context", target: "#source-logs-search-control") |> JS.push("close")}
+                   click={JS.push("open_log_event_modal")}
+                   close={JS.push("close_log_event_modal", target: "#source-logs-search-control") |> JS.push("close")}
                    class="tw-text-[0.65rem]"
                    modal_id={:log_event_context_viewer}
                    title="View Event Context"

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -92,7 +92,7 @@ defmodule LogflareWeb.Source.SearchLV do
       tailing_initial?: true,
       tailing_timer: nil,
       tailing?: tailing?,
-      resume_tailing_after_context?: false,
+      resume_tailing_after_modal?: false,
       # search states
       search_op: nil,
       search_op_error: nil,
@@ -412,26 +412,26 @@ defmodule LogflareWeb.Source.SearchLV do
     soft_pause(ev, socket)
   end
 
-  def handle_event("open_event_context", _, socket) do
+  def handle_event("open_log_event_modal", _, socket) do
     resume_tailing? = socket.assigns.tailing?
 
     socket =
       socket
-      |> assign(:resume_tailing_after_context?, resume_tailing?)
+      |> assign(:resume_tailing_after_modal?, resume_tailing?)
       |> pause_tailing()
 
     {:noreply, socket}
   end
 
-  def handle_event("close_event_context", _, socket) do
+  def handle_event("close_log_event_modal", _, socket) do
     socket =
-      if socket.assigns.resume_tailing_after_context? do
+      if socket.assigns.resume_tailing_after_modal? do
         resume_tailing(socket)
       else
         socket
       end
 
-    {:noreply, assign(socket, :resume_tailing_after_context?, false)}
+    {:noreply, assign(socket, :resume_tailing_after_modal?, false)}
   end
 
   def handle_event("hard_play" = ev, _, socket) do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1562,6 +1562,23 @@ defmodule LogflareWeb.Source.SearchLVTest do
       assert get_view_assigns(view).tailing?
     end
 
+    test "opening a log event pauses a live search", %{conn: conn, source: source} do
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/sources/#{source.id}/search")
+
+      view |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
+      assert get_view_assigns(view).tailing?
+
+      view
+      |> element("#logs-list li:first-of-type a", "view")
+      |> render_click()
+
+      refute get_view_assigns(view).tailing?
+
+      render_click(view, "close_log_event_modal", %{})
+
+      assert get_view_assigns(view).tailing?
+    end
+
     test "closing context does not resume a paused search", %{
       conn: conn,
       source: source
@@ -1574,9 +1591,9 @@ defmodule LogflareWeb.Source.SearchLVTest do
       render_click(view, "soft_pause", %{})
       refute get_view_assigns(view).tailing?
 
-      render_click(view, "open_event_context", %{})
+      render_click(view, "open_log_event_modal", %{})
 
-      render_click(view, "close_event_context", %{})
+      render_click(view, "close_log_event_modal", %{})
 
       refute get_view_assigns(view).tailing?
     end
@@ -1590,11 +1607,11 @@ defmodule LogflareWeb.Source.SearchLVTest do
       view |> TestUtils.wait_for_render("#logs-list li:first-of-type a")
       assert get_view_assigns(view).tailing?
 
-      render_click(view, "open_event_context", %{})
+      render_click(view, "open_log_event_modal", %{})
 
       refute get_view_assigns(view).tailing?
 
-      render_click(view, "close_event_context", %{})
+      render_click(view, "close_log_event_modal", %{})
 
       assert get_view_assigns(view).tailing?
     end


### PR DESCRIPTION
Follow up to #3720 

## Demo



https://github.com/user-attachments/assets/ba73a2ce-b77e-4589-af13-9aad45dbdf96

Hard to see but if you scrub through you can the tailing button switch state as the modal transitions in:


<img width="1436" height="1080" alt="image" src="https://github.com/user-attachments/assets/a923c960-2fd7-4f6e-9dd2-80721ebc55e5" />


