### PR TITLE
feat: quick filter appends same-path LQL filters

### DIFF
--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -181,7 +181,7 @@ defmodule LogflareWeb.QueryComponents do
         updated_lql =
           lql
           |> Lql.decode!(lql_schema)
-          |> upsert_filter_rule(resolved_path, value, list_includes?, action)
+          |> put_quick_filter_rule(resolved_path, value, list_includes?, action)
           |> Lql.encode!()
 
         params =
@@ -197,7 +197,7 @@ defmodule LogflareWeb.QueryComponents do
     end
   end
 
-  defp upsert_filter_rule(rules, "timestamp", value, _list_includes?, action) do
+  defp put_quick_filter_rule(rules, "timestamp", value, _list_includes?, action) do
     chart_period = Lql.Rules.get_chart_period(rules, :minute)
 
     ts_rule =
@@ -208,7 +208,7 @@ defmodule LogflareWeb.QueryComponents do
     Lql.Rules.upsert_filter_rule_by_path(rules, ts_rule)
   end
 
-  defp upsert_filter_rule(rules, path, value, list_includes?, action) do
+  defp put_quick_filter_rule(rules, path, value, list_includes?, action) do
     filter_rule =
       FilterRule.build(
         path: path,
@@ -218,7 +218,7 @@ defmodule LogflareWeb.QueryComponents do
       )
       |> maybe_negate_filter_rule(action)
 
-    Lql.Rules.upsert_filter_rule_by_path(rules, filter_rule)
+    rules ++ [filter_rule]
   end
 
   defp maybe_negate_filter_rule(%FilterRule{} = rule, :exclude) do

--- a/test/logflare_web/components/query_components_test.exs
+++ b/test/logflare_web/components/query_components_test.exs
@@ -238,6 +238,57 @@ defmodule LogflareWeb.QueryComponentsTest do
                URI.decode_query(query)
     end
 
+    test "appends a filter when path is already filtered", %{
+      source: source,
+      schema: schema,
+      source_schema_flat_map: flat_map
+    } do
+      html =
+        render_component(&QueryComponents.quick_filter/1, %{
+          lql: ~s|m.status:~"o"|,
+          node: %{key: "status", path: ["metadata", "status"], value: "ok"},
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: schema
+        })
+
+      %URI{query: query} = html |> quick_filter_href("Append to query") |> URI.parse()
+      %{"querystring" => querystring} = URI.decode_query(query)
+
+      assert [
+               %FilterRule{path: "metadata.status", operator: :"~", value: "o"},
+               %FilterRule{path: "metadata.status", operator: :=, value: "ok"}
+             ] = Lql.decode!(querystring, schema)
+    end
+
+    test "appends an exclude filter when the path is already filtered", %{
+      source: source,
+      schema: schema,
+      source_schema_flat_map: flat_map
+    } do
+      html =
+        render_component(&QueryComponents.quick_filter/1, %{
+          lql: ~s|m.user_id:~"12"|,
+          node: %{key: "user_id", path: ["metadata", "user_id"], value: "123"},
+          source: source,
+          source_schema_flat_map: flat_map,
+          lql_schema: schema
+        })
+
+      %URI{query: query} = html |> quick_filter_href("Exclude from query") |> URI.parse()
+      %{"querystring" => querystring} = URI.decode_query(query)
+
+      assert [
+               %FilterRule{path: "metadata.user_id", operator: :"~", value: "12"},
+               %FilterRule{
+                 path: "metadata.user_id",
+                 operator: :=,
+                 value: "123",
+                 modifiers: %{negate: true}
+               }
+             ] = Lql.decode!(querystring, schema)
+    end
+
     test "renders a metadata array quick filter link", %{
       source: source,
       schema: schema,

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -1271,7 +1271,7 @@ defmodule LogflareWeb.Source.SearchLVTest do
       {:ok, view, _html} =
         live_with_redirect(
           conn,
-          ~p"/sources/#{source.id}/search?#{%{querystring: ~s|user_id:\"abc-123\"|, tz: "Africa/Lagos"}}"
+          ~p"/sources/#{source.id}/search?#{%{querystring: ~s|user_id:~\"abc\"|, tz: "Africa/Lagos"}}"
         )
 
       %{executor_pid: search_executor_pid} = get_view_assigns(view)
@@ -1295,7 +1295,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       |> render_click()
 
       to = assert_patch(view)
-      assert find_querystring(render(view)) =~ ~s|user_id:"abc-123"|
+      querystring = find_querystring(render(view))
+
+      assert querystring =~ ~s|user_id:~"abc"|
+      assert querystring =~ ~s|user_id:"abc-123"|
 
       %URI{query: query} = URI.parse(to)
 


### PR DESCRIPTION
Quick filter links will append a path if is already in the query. Previously the exiting filter rule would be overwritten.

Fixes O11Y-2229

## Demo
https://github.com/user-attachments/assets/07cd71db-9df6-43d5-bacf-ed367979af13

