### PR TITLE
perf(ingest): reduce pointer claim and lookup overhead

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -278,7 +278,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   Looks up a single event directly in a generation table.
 
   `tid` here is a generation's tid (e.g. a claimed `LogEventPointer.tid`) — a direct
-  `:ets.lookup/2`, no separate id-to-table resolution needed. Returns `nil` on a miss,
+  `:ets.lookup_element/4`, no separate id-to-table resolution needed. Returns `nil` on a miss,
   including when the generation has already been dropped by rotation (see
   `drop_generation/2`) — callers should treat that the same as any other lookup miss,
   not as an error.

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -285,10 +285,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec lookup_event(:ets.tid(), term()) :: LogEvent.t() | nil
   def lookup_event(tid, id) do
-    case :ets.lookup(tid, id) do
-      [{^id, event}] -> event
-      [] -> nil
-    end
+    :ets.lookup_element(tid, id, 2, nil)
   rescue
     ArgumentError ->
       emit_stale_ets_table_telemetry()
@@ -909,8 +906,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   def pop_pending_pointers(sid_bid_pid, n) when is_integer(n) do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [],
-       [{{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}}]}
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [], [:"$1"]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
@@ -966,8 +962,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       when event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
              is_integer(n) and n > 0 do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}, [],
-       [{{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}}]}
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}, [], [:"$1"]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
@@ -975,35 +970,34 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   defp pop_selected_pointers(sid_bid_pid, n, ms) do
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         {selected, _cont} <- :ets.select(tid, ms, n) do
-      confirmed =
-        Enum.flat_map(selected, fn {id, _, _, _, _, _, _} -> take_pointer(tid, id) end)
-
-      {:ok, confirmed, tid}
+         {selected_ids, _cont} <- :ets.select(tid, ms, n) do
+      {:ok, take_selected_pointers(selected_ids, tid, []), tid}
     else
       nil -> {:error, :not_initialized}
       :"$end_of_table" -> {:ok, [], nil}
     end
   end
 
-  defp take_pointer(tid, id) do
+  defp take_selected_pointers([], _tid, pointers), do: :lists.reverse(pointers)
+
+  defp take_selected_pointers([id | selected_ids], tid, pointers) do
     case :ets.take(tid, id) do
       [{^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket}] ->
-        [
-          %LogEventPointer{
-            id: id,
-            tid: gen_tid,
-            gen_event_id: gen_event_id,
-            queue_tid: tid,
-            size: size,
-            retries: retries,
-            event_type: event_type,
-            day_bucket: day_bucket
-          }
-        ]
+        pointer = %LogEventPointer{
+          id: id,
+          tid: gen_tid,
+          gen_event_id: gen_event_id,
+          queue_tid: tid,
+          size: size,
+          retries: retries,
+          event_type: event_type,
+          day_bucket: day_bucket
+        }
+
+        take_selected_pointers(selected_ids, tid, [pointer | pointers])
 
       [] ->
-        []
+        take_selected_pointers(selected_ids, tid, pointers)
     end
   end
 

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -906,7 +906,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   def pop_pending_pointers(sid_bid_pid, n) when is_integer(n) do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [], [:"$1"]}
+      {{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$1"]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
@@ -962,7 +962,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       when event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
              is_integer(n) and n > 0 do
     ms = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", event_type, day_bucket}, [], [:"$1"]}
+      {{:"$1", :_, :_, :_, :_, event_type, day_bucket}, [], [:"$1"]}
     ]
 
     pop_selected_pointers(sid_bid_pid, n, ms)

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -607,6 +607,19 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert IngestEventQueue.total_pending(sbp) == 0
     end
 
+    test "lookup_event/2 distinguishes a missing key from a stale generation table" do
+      tid = :ets.new(:lookup_event_generation, [:set])
+      assert IngestEventQueue.lookup_event(tid, make_ref()) == nil
+
+      event = [:logflare, :ingest_event_queue, :stale_table]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+      on_exit(fn -> :telemetry.detach(ref) end)
+      :ets.delete(tid)
+
+      assert IngestEventQueue.lookup_event(tid, make_ref()) == nil
+      assert_receive {^event, ^ref, %{count: 1}, %{}}
+    end
+
     test "counts and claims pointers by exact ClickHouse batch key", %{
       source: source,
       sbp: sbp

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -609,13 +609,14 @@ defmodule Logflare.Backends.IngestEventQueueTest do
 
     test "lookup_event/2 distinguishes a missing key from a stale generation table" do
       tid = :ets.new(:lookup_event_generation, [:set])
-      assert IngestEventQueue.lookup_event(tid, make_ref()) == nil
-
       event = [:logflare, :ingest_event_queue, :stale_table]
       ref = :telemetry_test.attach_event_handlers(self(), [event])
       on_exit(fn -> :telemetry.detach(ref) end)
-      :ets.delete(tid)
 
+      assert IngestEventQueue.lookup_event(tid, make_ref()) == nil
+      refute_receive {^event, ^ref, _, _}
+
+      :ets.delete(tid)
       assert IngestEventQueue.lookup_event(tid, make_ref()) == nil
       assert_receive {^event, ^ref, %{count: 1}, %{}}
     end

--- a/test/profiling/ingest_event_queue_pointer_claim_bench.exs
+++ b/test/profiling/ingest_event_queue_pointer_claim_bench.exs
@@ -1,0 +1,57 @@
+# credo:disable-for-this-file Credo.Check.Refactor.IoPuts
+#
+# Usage:
+#   MIX_ENV=test mix run test/profiling/ingest_event_queue_pointer_claim_bench.exs
+#
+# Measures the two production queue hot paths changed by the pointer-claim optimization
+# with a full 500-event batch. The claim job restores the pointer rows inside each timed
+# invocation so every iteration can atomically claim the same batch. That shared restore
+# work makes the measured claim improvement conservative.
+#
+# Recorded in the same six-scheduler Linux container with BENCH_TIME=2, comparing
+# parent 825bd40d to the optimized implementation:
+#
+#   job                         median (old -> new)   memory (old -> new)    reductions
+#   claim + restore pointers     128.57 -> 99.05 us   200.78 -> 187.51 KB   6.12 -> 3.89 K
+#   resolve generation events     66.62 -> 61.63 us   486.17 -> 456.48 KB   5.61 -> 5.56 K
+
+alias Logflare.Backends.IngestEventQueue
+alias Logflare.Factory
+
+batch_size = 500
+bench_time = System.get_env("BENCH_TIME", "3") |> String.to_integer()
+
+user = Factory.insert(:user)
+source = Factory.insert(:source, user: user)
+queue = {source.id, nil, self()}
+IngestEventQueue.upsert_tid(queue)
+
+events = for _ <- 1..batch_size, do: Factory.build(:log_event, source: source)
+:ok = IngestEventQueue.add_to_table(queue, events)
+{:ok, pointers, queue_tid} = IngestEventQueue.pop_pending_pointers(queue, batch_size)
+
+pointer_rows =
+  Enum.map(pointers, fn pointer ->
+    {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
+     pointer.event_type, pointer.day_bucket}
+  end)
+
+Benchee.run(
+  %{
+    "production: claim + restore 500 pointers" => fn ->
+      true = :ets.insert(queue_tid, pointer_rows)
+      {:ok, claimed, ^queue_tid} = IngestEventQueue.pop_pending_pointers(queue, batch_size)
+      ^batch_size = length(claimed)
+    end,
+    "production: resolve 500 generation events" => fn ->
+      Enum.each(pointers, fn pointer ->
+        %Logflare.LogEvent{} =
+          IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id)
+      end)
+    end
+  },
+  time: bench_time,
+  warmup: bench_time,
+  memory_time: bench_time,
+  reduction_time: bench_time
+)


### PR DESCRIPTION
## Summary

- select only pointer IDs from the ETS queue before atomically claiming rows with `:ets.take/2`
- build claimed pointers with a tail-recursive accumulator instead of `Enum.flat_map/2` and per-pointer temporary lists
- read generation-store events directly with `:ets.lookup_element/4`
- preserve atomic claim behavior and stale-table telemetry
- include a reproducible 500-event benchmark for both optimized production paths

## Performance

Local 500-item benchmarks:

| Hot path | Median latency | Memory | BEAM reductions |
| --- | ---: | ---: | ---: |
| Pointer claim | 128.57 → 99.05 µs (**23% lower**) | 200.78 → 187.51 KB (**7% lower**) | 6.12K → 3.89K (**36% lower**) |
| Event lookup | 66.62 → 61.63 µs (**7.5% lower**) | 486.17 → 456.48 KB (**6% lower**) | 5.61K → 5.56K (**1% lower**) |

The pointer-claim benchmark includes restoring queue rows between iterations, so shared setup overhead dilutes the claim-only improvement.
