### PR TITLE
perf(bigquery): reduce acknowledgement allocations

### DIFF
--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -155,7 +155,11 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   @spec decrement_in_flight([Message.t()]) :: :ok
   defp decrement_in_flight(messages), do: decrement_in_flight(messages, nil, 0)
 
-  defp decrement_in_flight([], nil, 0), do: :ok
+  @spec decrement_in_flight(
+          [Message.t()],
+          :atomics.atomics_ref() | nil,
+          non_neg_integer()
+        ) :: :ok
 
   # Flush the final run after consuming all messages.
   defp decrement_in_flight([], ref, run_count),

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -134,7 +134,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   def ack({queue, config}, successful, failed) do
     {sid, bid, _pipeline_ref} = queue
 
-    decrement_in_flight(successful ++ failed)
+    decrement_in_flight(successful)
+    decrement_in_flight(failed)
     finalize_acked_events({sid, bid}, successful)
     maybe_requeue_failed({sid, bid}, failed, config)
 
@@ -148,16 +149,28 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   end
 
   @spec decrement_in_flight([Message.t()]) :: :ok
-  defp decrement_in_flight(messages) do
-    messages
-    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
-      Map.get(ack_data, :in_flight_ref)
-    end)
-    |> Enum.each(fn
-      {nil, _msgs} -> :ok
-      {ref, msgs} -> :atomics.sub(ref, 1, length(msgs))
-    end)
+  defp decrement_in_flight(messages), do: decrement_in_flight(messages, nil, 0)
+
+  defp decrement_in_flight([], nil, 0), do: :ok
+  defp decrement_in_flight([], ref, count), do: decrement_in_flight_ref(ref, count)
+
+  defp decrement_in_flight(
+         [%{acknowledger: {_, _, ack_data}} | messages],
+         current_ref,
+         count
+       ) do
+    ref = Map.get(ack_data, :in_flight_ref)
+
+    if ref == current_ref do
+      decrement_in_flight(messages, current_ref, count + 1)
+    else
+      decrement_in_flight_ref(current_ref, count)
+      decrement_in_flight(messages, ref, 1)
+    end
   end
+
+  defp decrement_in_flight_ref(nil, _count), do: :ok
+  defp decrement_in_flight_ref(ref, count), do: :atomics.sub(ref, 1, count)
 
   # Always deletes the generation-store row. If the source's ingest rate is low, also
   # keeps an independent copy in the recent-events cache first, so "recent logs" reads

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -148,29 +148,36 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     :ok
   end
 
+  # Scan messages as contiguous runs of the same in-flight reference.
+  # `current_ref` and `run_count` describe the run immediately preceding `messages`.
+  # When the reference changes, subtract the completed run and begin a new one.
+  # A reference appearing again later is handled as another run.
   @spec decrement_in_flight([Message.t()]) :: :ok
   defp decrement_in_flight(messages), do: decrement_in_flight(messages, nil, 0)
 
   defp decrement_in_flight([], nil, 0), do: :ok
-  defp decrement_in_flight([], ref, count), do: decrement_in_flight_ref(ref, count)
+
+  # Flush the final run after consuming all messages.
+  defp decrement_in_flight([], ref, run_count),
+    do: decrement_in_flight_ref(ref, run_count)
 
   defp decrement_in_flight(
          [%{acknowledger: {_, _, ack_data}} | messages],
          current_ref,
-         count
+         run_count
        ) do
     ref = Map.get(ack_data, :in_flight_ref)
 
     if ref == current_ref do
-      decrement_in_flight(messages, current_ref, count + 1)
+      decrement_in_flight(messages, current_ref, run_count + 1)
     else
-      decrement_in_flight_ref(current_ref, count)
+      decrement_in_flight_ref(current_ref, run_count)
       decrement_in_flight(messages, ref, 1)
     end
   end
 
-  defp decrement_in_flight_ref(nil, _count), do: :ok
-  defp decrement_in_flight_ref(ref, count), do: :atomics.sub(ref, 1, count)
+  defp decrement_in_flight_ref(nil, _run_count), do: :ok
+  defp decrement_in_flight_ref(ref, run_count), do: :atomics.sub(ref, 1, run_count)
 
   # Always deletes the generation-store row. If the source's ingest rate is low, also
   # keeps an independent copy in the recent-events cache first, so "recent logs" reads

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -199,6 +199,44 @@ defmodule Logflare.BigQuery.PipelineTest do
       assert IngestEventQueue.list_recent_events({source.id, nil}, 10) == []
     end
 
+    test "ack decrements each producer's in-flight count without requiring grouped messages", %{
+      source: source
+    } do
+      backend = insert(:backend, user_id: source.user_id, type: :bigquery)
+      ack_ref = {{source.id, backend.id, self()}, %{max_retries: 0}}
+      generation_tid = :ets.new(:bq_ack_in_flight, [:set])
+      first_ref = :atomics.new(1, signed: false)
+      second_ref = :atomics.new(1, signed: false)
+      :atomics.put(first_ref, 1, 2)
+      :atomics.put(second_ref, 1, 2)
+
+      messages =
+        [first_ref, first_ref, second_ref, nil, second_ref]
+        |> Enum.with_index()
+        |> Enum.map(fn {in_flight_ref, index} ->
+          pointer = %LogEventPointer{
+            id: index,
+            tid: generation_tid,
+            gen_event_id: make_ref(),
+            queue_tid: generation_tid,
+            size: 1,
+            retries: 0,
+            event_type: :log,
+            day_bucket: 0
+          }
+
+          %Message{
+            data: pointer,
+            acknowledger: {Pipeline, ack_ref, %{in_flight_ref: in_flight_ref}}
+          }
+        end)
+
+      Pipeline.ack(ack_ref, messages, [])
+
+      assert :atomics.get(first_ref, 1) == 0
+      assert :atomics.get(second_ref, 1) == 0
+    end
+
     test "handle_batch emits ingest telemetry with resolved labels when source has labels", %{
       source: source
     } do

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -211,30 +211,29 @@ defmodule Logflare.BigQuery.PipelineTest do
       :atomics.put(second_ref, 1, 2)
 
       messages =
-        [first_ref, first_ref, second_ref, nil, second_ref]
-        |> Enum.with_index()
-        |> Enum.map(fn {in_flight_ref, index} ->
-          pointer = %LogEventPointer{
-            id: index,
-            tid: generation_tid,
-            gen_event_id: make_ref(),
-            queue_tid: generation_tid,
-            size: 1,
-            retries: 0,
-            event_type: :log,
-            day_bucket: 0
-          }
-
-          %Message{
-            data: pointer,
-            acknowledger: {Pipeline, ack_ref, %{in_flight_ref: in_flight_ref}}
-          }
-        end)
+        build_ack_messages(
+          ack_ref,
+          generation_tid,
+          [first_ref, first_ref, second_ref, nil, second_ref]
+        )
 
       Pipeline.ack(ack_ref, messages, [])
 
       assert :atomics.get(first_ref, 1) == 0
       assert :atomics.get(second_ref, 1) == 0
+    end
+
+    test "ack decrements in-flight counts for failed messages", %{source: source} do
+      backend = insert(:backend, user_id: source.user_id, type: :bigquery)
+      ack_ref = {{source.id, backend.id, self()}, %{max_retries: 0}}
+      generation_tid = :ets.new(:bq_failed_ack_in_flight, [:set])
+      in_flight_ref = :atomics.new(1, signed: false)
+      :atomics.put(in_flight_ref, 1, 2)
+      messages = build_ack_messages(ack_ref, generation_tid, [in_flight_ref, in_flight_ref])
+
+      capture_log(fn -> Pipeline.ack(ack_ref, [], messages) end)
+
+      assert :atomics.get(in_flight_ref, 1) == 0
     end
 
     test "handle_batch emits ingest telemetry with resolved labels when source has labels", %{
@@ -822,6 +821,28 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       assert ^le = Pipeline.process_data(le, context, nil)
     end
+  end
+
+  defp build_ack_messages(ack_ref, generation_tid, in_flight_refs) do
+    in_flight_refs
+    |> Enum.with_index()
+    |> Enum.map(fn {in_flight_ref, index} ->
+      pointer = %LogEventPointer{
+        id: index,
+        tid: generation_tid,
+        gen_event_id: make_ref(),
+        queue_tid: generation_tid,
+        size: 1,
+        retries: 0,
+        event_type: :log,
+        day_bucket: 0
+      }
+
+      %Message{
+        data: pointer,
+        acknowledger: {Pipeline, ack_ref, %{in_flight_ref: in_flight_ref}}
+      }
+    end)
   end
 
   defp run_pipeline_benchmark(name, batch) do

--- a/test/profiling/bq_pipeline_ack_counting_bench.exs
+++ b/test/profiling/bq_pipeline_ack_counting_bench.exs
@@ -5,13 +5,17 @@
 # Isolates the in-flight reference accounting performed by BigQuery acknowledgement.
 # Both jobs operate on the same 500 messages: the old implementation concatenates and
 # groups them, while the new implementation counts contiguous reference runs. The
-# alternating input verifies the cost when each reference appears in multiple runs.
+# single-reference input represents steady state. The restart-handoff input models two
+# producer lifetimes arriving in processor-demand-sized runs; fully alternating refs
+# remain an adversarial comparison.
 #
-# Recorded in the same six-scheduler Linux container with BENCH_TIME=2:
+# Median of three runs in the same six-scheduler Linux container with BENCH_TIME=2:
 #
 #   input              median (old -> new)   memory (old -> new)   reductions
-#   contiguous refs       9.71 -> 4.13 us      44.61 -> 0.00 KB    6.31 -> 2.03 K
-#   alternating refs     13.58 -> 7.08 us      50.26 -> 0.00 KB    5.45 -> 4.01 K
+#   single producer        8.79 -> 4.00 us      38.47 -> 0.00 KB    6.28 -> 2.02 K
+#   restart handoff       10.04 -> 4.04 us      41.68 -> 0.00 KB    6.29 -> 2.03 K
+#   contiguous refs        9.79 -> 4.04 us      44.61 -> 0.00 KB    6.31 -> 2.03 K
+#   alternating refs      14.00 -> 7.17 us      50.26 -> 0.00 KB    5.45 -> 4.01 K
 
 batch_size = 500
 bench_time = System.get_env("BENCH_TIME", "3") |> String.to_integer()
@@ -28,7 +32,18 @@ build_input = fn ref_index ->
   Enum.split(messages, 450)
 end
 
+restart_handoff_ref = fn index ->
+  cond do
+    index < 200 -> 0
+    index < 300 -> 1
+    index < 400 -> 0
+    true -> 1
+  end
+end
+
 inputs = %{
+  "single producer ref" => build_input.(fn _index -> 0 end),
+  "producer restart handoff" => build_input.(restart_handoff_ref),
   "contiguous producer refs" => build_input.(fn index -> div(index, 125) end),
   "alternating producer refs" => build_input.(fn index -> rem(index, 4) end)
 }

--- a/test/profiling/bq_pipeline_ack_counting_bench.exs
+++ b/test/profiling/bq_pipeline_ack_counting_bench.exs
@@ -1,0 +1,86 @@
+# credo:disable-for-this-file Credo.Check.Refactor.IoPuts
+#
+# Usage: MIX_ENV=test mix run test/profiling/bq_pipeline_ack_counting_bench.exs
+#
+# Isolates the in-flight reference accounting performed by BigQuery acknowledgement.
+# Both jobs operate on the same 500 messages: the old implementation concatenates and
+# groups them, while the new implementation counts contiguous reference runs. The
+# alternating input verifies the cost when each reference appears in multiple runs.
+#
+# Recorded in the same six-scheduler Linux container with BENCH_TIME=2:
+#
+#   input              median (old -> new)   memory (old -> new)   reductions
+#   contiguous refs       9.71 -> 4.13 us      44.61 -> 0.00 KB    6.31 -> 2.03 K
+#   alternating refs     13.58 -> 7.08 us      50.26 -> 0.00 KB    5.45 -> 4.01 K
+
+batch_size = 500
+bench_time = System.get_env("BENCH_TIME", "3") |> String.to_integer()
+
+build_input = fn ref_index ->
+  refs = for _ <- 1..4, do: :atomics.new(1, signed: true)
+
+  messages =
+    for index <- 0..(batch_size - 1) do
+      ref = Enum.at(refs, ref_index.(index))
+      %{acknowledger: {nil, nil, %{in_flight_ref: ref}}}
+    end
+
+  Enum.split(messages, 450)
+end
+
+inputs = %{
+  "contiguous producer refs" => build_input.(fn index -> div(index, 125) end),
+  "alternating producer refs" => build_input.(fn index -> rem(index, 4) end)
+}
+
+defmodule BigQueryAckCountingBench do
+  def old_decrement({successful, failed}) do
+    (successful ++ failed)
+    |> Enum.group_by(fn %{acknowledger: {_, _, ack_data}} ->
+      Map.get(ack_data, :in_flight_ref)
+    end)
+    |> Enum.each(fn
+      {nil, _messages} -> :ok
+      {ref, messages} -> :atomics.sub(ref, 1, length(messages))
+    end)
+  end
+
+  def new_decrement({successful, failed}) do
+    decrement_runs(successful)
+    decrement_runs(failed)
+  end
+
+  defp decrement_runs(messages), do: decrement_runs(messages, nil, 0)
+  defp decrement_runs([], nil, 0), do: :ok
+  defp decrement_runs([], ref, run_count), do: decrement(ref, run_count)
+
+  defp decrement_runs(
+         [%{acknowledger: {_, _, ack_data}} | messages],
+         current_ref,
+         run_count
+       ) do
+    ref = Map.get(ack_data, :in_flight_ref)
+
+    if ref == current_ref do
+      decrement_runs(messages, current_ref, run_count + 1)
+    else
+      decrement(current_ref, run_count)
+      decrement_runs(messages, ref, 1)
+    end
+  end
+
+  defp decrement(nil, _run_count), do: :ok
+  defp decrement(ref, run_count), do: :atomics.sub(ref, 1, run_count)
+end
+
+Benchee.run(
+  %{
+    "old: concatenate and group messages" => &BigQueryAckCountingBench.old_decrement/1,
+    "new: count contiguous reference runs" => &BigQueryAckCountingBench.new_decrement/1
+  },
+  inputs: inputs,
+  time: bench_time,
+  warmup: bench_time,
+  memory_time: bench_time,
+  reduction_time: bench_time
+)


### PR DESCRIPTION
## Summary

- avoid concatenating successful and failed Broadway messages during acknowledgement
- replace `Enum.group_by/2` and per-reference message lists with tail-recursive contiguous-reference counting
- preserve correct in-flight accounting for interleaved producers and messages without an in-flight reference
- benchmark steady-state, producer-restart handoff, contiguous, and adversarial alternating reference layouts over the same 500 messages

Each contiguous run performs one atomic subtraction. A producer reference may appear in multiple runs or in both acknowledgement lists; those runs are subtracted independently and produce the same total count.

## Performance

Median of three local runs in the same six-scheduler Linux environment with `BENCH_TIME=2`. Every input contains 500 messages split into 450 successful and 50 failed messages.

| Producer-reference layout | Median latency | Memory | BEAM reductions |
| --- | ---: | ---: | ---: |
| Single producer (steady state) | 8.79 → 4.00 µs (**55% lower**) | 38.47 → 0.00 KB | 6.28K → 2.02K (**68% lower**) |
| Producer restart handoff | 10.04 → 4.04 µs (**60% lower**) | 41.68 → 0.00 KB | 6.29K → 2.03K (**68% lower**) |
| Four contiguous references | 9.79 → 4.04 µs (**59% lower**) | 44.61 → 0.00 KB | 6.31K → 2.03K (**68% lower**) |
| Four alternating references (adversarial) | 14.00 → 7.17 µs (**49% lower**) | 50.26 → 0.00 KB | 5.45K → 4.01K (**26% lower**) |

The single-reference input represents normal operation. The restart-handoff input uses two producer lifetimes in processor-demand-sized runs (`200 old, 100 new, 100 old, 100 new`). Fully alternating references remain an adversarial comparison rather than an expected steady-state layout.
