### PR TITLE
fix(otlp): decode trace/span IDs and dedupe content-type header

### DIFF
--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
 
     response =
       env
-      |> Tesla.put_header("content-type", @protobuf_content_type)
+      |> put_content_type_header()
       |> Tesla.put_body(transform_batch(env.body, source))
       |> Tesla.run(next)
 
@@ -35,6 +35,15 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
         response
       end
     end
+  end
+
+  # Strips any pre-existing content-type header case-insensitively before setting ours,
+  # since Tesla.put_header/3 matches keys case-sensitively and would otherwise leave a
+  # user-configured "Content-Type" header alongside this one, sending two content-type
+  # header lines that some receivers (e.g. Envoy-fronted ingests) reject outright.
+  defp put_content_type_header(env) do
+    headers = Enum.reject(env.headers, fn {k, _v} -> String.downcase(k) == "content-type" end)
+    Tesla.put_header(%{env | headers: headers}, "content-type", @protobuf_content_type)
   end
 
   defp transform_batch(events, source) do
@@ -112,9 +121,25 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp build_log_record_fields({"severity_text", msg}) when is_binary(msg),
     do: [severity_text: msg]
 
-  defp build_log_record_fields({"trace_id", id}) when is_binary(id), do: [trace_id: id]
-  defp build_log_record_fields({"span_id", id}) when is_binary(id), do: [span_id: id]
+  defp build_log_record_fields({"trace_id", id}) when is_binary(id),
+    do: build_id_field(:trace_id, id)
+
+  defp build_log_record_fields({"span_id", id}) when is_binary(id),
+    do: build_id_field(:span_id, id)
+
   defp build_log_record_fields(_unmatched), do: []
+
+  # trace_id/span_id arrive as hex-encoded strings (the standard OTel textual
+  # representation); the protobuf fields require raw bytes, so this must decode
+  # them first or the receiver sees a hex-length-instead-of-byte-length value.
+  # Falls back to sending the raw value as-is if it isn't valid hex, matching
+  # prior behavior rather than dropping the field outright.
+  defp build_id_field(field, hex_id) do
+    case Base.decode16(hex_id, case: :mixed) do
+      {:ok, decoded} -> [{field, decoded}]
+      :error -> [{field, hex_id}]
+    end
+  end
 
   defp make_value(v) when is_binary(v), do: %AnyValue{value: {:string_value, v}}
   defp make_value(v) when is_boolean(v), do: %AnyValue{value: {:bool_value, v}}

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -182,6 +182,104 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request
     end
+
+    test "hex-decodes trace_id and span_id into raw protobuf bytes", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      mock_adapter(fn env ->
+        send(this, {ref, IO.iodata_to_binary(env.body)})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      trace_id = "0102030405060708090a0b0c0d0e0f10"
+      span_id = "0102030405060708"
+
+      log_event =
+        build(:log_event,
+          source: source,
+          trace_id: trace_id,
+          span_id: span_id,
+          timestamp: System.system_time(:microsecond)
+        )
+
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert_receive {^ref, body}, 5000
+
+      assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+               Protobuf.decode(body, ExportLogsServiceRequest)
+
+      assert log_record.trace_id == Base.decode16!(trace_id, case: :mixed)
+      assert byte_size(log_record.trace_id) == 16
+      assert log_record.span_id == Base.decode16!(span_id, case: :mixed)
+      assert byte_size(log_record.span_id) == 8
+    end
+
+    test "falls back to the raw value rather than raising when not valid hex", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      mock_adapter(fn env ->
+        send(this, {ref, IO.iodata_to_binary(env.body)})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      log_event =
+        build(:log_event,
+          source: source,
+          trace_id: "not-valid-hex",
+          timestamp: System.system_time(:microsecond)
+        )
+
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert_receive {^ref, body}, 5000
+
+      assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+               Protobuf.decode(body, ExportLogsServiceRequest)
+
+      assert log_record.trace_id == "not-valid-hex"
+    end
+  end
+
+  describe "content-type header handling" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :otlp,
+          sources: [source],
+          config: %{@valid_config | headers: %{"Content-Type" => "application/x-protobuf"}}
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+      :timer.sleep(250)
+
+      [source: source]
+    end
+
+    test "does not duplicate content-type header when one is already configured", %{
+      source: source
+    } do
+      this = self()
+      ref = make_ref()
+
+      mock_adapter(fn env ->
+        send(this, {ref, env.headers})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      log_event = build(:log_event, source: source, timestamp: System.system_time(:microsecond))
+
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert_receive {^ref, headers}, 5000
+
+      content_type_headers =
+        Enum.filter(headers, fn {k, _v} -> String.downcase(k) == "content-type" end)
+
+      assert content_type_headers == [{"content-type", "application/x-protobuf"}]
+    end
   end
 
   describe "redact_config/1" do


### PR DESCRIPTION
This fixes two independent bugs in the OTLP backend adaptor's ProtobufFormatter, both discovered while debugging a customer's Dash0 log drain that was silently receiving zero traffic. First, trace_id/span_id values from the log event body are hex-encoded strings (the standard OTel textual representation), but the formatter was passing them straight through as the protobuf bytes field value instead of decoding them — sending a 32-byte ASCII string where a 16-byte TraceID is expected, which strict OTLP receivers (Dash0's included) reject outright with an unmarshal error. Second, the formatter unconditionally force-sets a lowercase content-type header via Tesla.put_header/3, which does a case-sensitive key match — so a backend with a user-configured Content-Type header (differing only in casing) ends up sending two separate content-type header lines, which some receivers reject as an unsupported/ambiguous media type. Both were confirmed against the real destination by capturing live Tesla egress traffic and replaying the actual failing request with each fix applied in isolation. The trace/span ID fix falls back to sending the raw value unchanged if it isn't valid hex, matching prior behavior rather than dropping the field, and the header fix strips any pre-existing content-type header case-insensitively before setting the correct one. Tests were added covering correct decoding, the invalid-hex fallback, and de-duplication of the content-type header.