### PR TITLE
perf(logs): reduce LogEvent.make allocations

### DIFF
--- a/lib/logflare/logs/ingest_transformers.ex
+++ b/lib/logflare/logs/ingest_transformers.ex
@@ -22,7 +22,11 @@ defmodule Logflare.Logs.IngestTransformers do
 
   @spec transform(map(), direct_transform() | [transform_rule()]) :: map()
   def transform(log_params, :clean_to_bigquery_column_spec) when is_map(log_params) do
-    clean_and_to_bigquery_column_spec(log_params)
+    if clean_and_bq_safe?(log_params) do
+      log_params
+    else
+      clean_and_to_bigquery_column_spec(log_params)
+    end
   catch
     :throw, :normalized_bigquery_column_collision ->
       log_params
@@ -37,6 +41,46 @@ defmodule Logflare.Logs.IngestTransformers do
   def transform(log_params, rules) when is_map(log_params) and is_list(rules) do
     Enum.reduce(rules, log_params, &do_transform(&2, &1))
   end
+
+  defp clean_and_bq_safe?(%_{}), do: false
+
+  defp clean_and_bq_safe?(data) when is_map(data) do
+    :maps.fold(
+      fn
+        _k, _v, false ->
+          false
+
+        _k, v, true when is_nil_or_empty(v) ->
+          false
+
+        k, v, true when is_map(v) or is_list(v) ->
+          bq_safe_key?(k) and clean_and_bq_safe?(v)
+
+        k, _v, true ->
+          bq_safe_key?(k)
+      end,
+      true,
+      data
+    )
+  end
+
+  defp clean_and_bq_safe?([head | tail]) do
+    clean_list_is_unchanged?(head) and clean_and_bq_safe_list_tail?(tail)
+  end
+
+  defp clean_list_is_unchanged?(value) when is_nil_or_empty(value), do: false
+
+  defp clean_list_is_unchanged?(value) when is_map(value) or is_list(value),
+    do: clean_and_bq_safe?(value)
+
+  defp clean_list_is_unchanged?(_value), do: true
+
+  defp clean_and_bq_safe_list_tail?([]), do: true
+
+  defp clean_and_bq_safe_list_tail?([head | tail]),
+    do: clean_list_is_unchanged?(head) and clean_and_bq_safe_list_tail?(tail)
+
+  defp clean_and_bq_safe_list_tail?(_improper_tail), do: false
 
   defp clean_and_to_bigquery_column_spec(data) when is_map(data) do
     :maps.fold(
@@ -140,6 +184,7 @@ defmodule Logflare.Logs.IngestTransformers do
   defp bq_reserved_prefix?("_CHANGE_TIMESTAMP" <> _), do: true
   defp bq_reserved_prefix?(_), do: false
 
+  defp bq_safe_key?(key) when not is_binary(key), do: true
   defp bq_safe_key?(key) when byte_size(key) > @max_field_length, do: false
   defp bq_safe_key?(<<>>), do: true
   defp bq_safe_key?(<<b, _rest::binary>>) when b in ?0..?9, do: false

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -16,8 +16,6 @@ defmodule Logflare.LogEvent do
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
-  @validators [BigQuerySchemaChange]
-
   @primary_key {:id, :binary_id, []}
   typed_embedded_schema do
     field :body, :map, default: %{}
@@ -135,12 +133,12 @@ defmodule Logflare.LogEvent do
       ) do
     event_type = TypeDetection.detect(params)
 
-    %{
-      "body" => %{"id" => id, "timestamp" => timestamp} = body,
-      "timestamp_inferred" => timestamp_inferred
-    } = mapper_for_ingest(params, event_type)
+    {%{"id" => id, "timestamp" => timestamp} = body, timestamp_inferred} =
+      mapper_for_ingest(params, event_type)
 
     day_bucket = DayBucket.from_microseconds(timestamp)
+    ingested_at = DateTime.utc_now()
+    body = transform_body(body, source)
 
     %__MODULE__{
       body: body,
@@ -148,55 +146,25 @@ defmodule Logflare.LogEvent do
       source_uuid: source_uuid,
       source_name: source_name,
       valid: true,
-      ingested_at: DateTime.utc_now(),
+      ingested_at: ingested_at,
       id: id,
       event_type: event_type,
       timestamp_inferred: timestamp_inferred,
       day_bucket: day_bucket
     }
-    |> transform(source)
     |> validate(source)
   end
 
   @spec mapper_from_db(map(), TypeDetection.event_type()) :: %{String.t() => term}
-  defp mapper_from_db(params, event_type),
-    do: mapper(params, event_type, &MetadataCleaner.deep_reject_nil_and_empty/1)
-
-  @spec mapper_for_ingest(map(), TypeDetection.event_type()) :: %{String.t() => term}
-  defp mapper_for_ingest(params, event_type),
-    do: mapper(params, event_type, &clean_ingest_body/1)
-
-  @spec mapper(map(), TypeDetection.event_type(), (map() -> map())) :: %{String.t() => term}
-  defp mapper(params, event_type, clean_body) do
-    # TODO: deprecate and remove `message`
-    event_message = params["message"] || params["event_message"]
+  defp mapper_from_db(params, event_type) do
+    event_message = event_message(params)
     id = id(params)
-
     {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
-
-    base_merge = %{
-      "timestamp" => timestamp,
-      "id" => id
-    }
-
-    base_merge =
-      if event_message != nil do
-        Map.put(base_merge, "event_message", event_message)
-      else
-        base_merge
-      end
 
     body =
       params
-      |> clean_body.()
-      |> Map.merge(base_merge)
-      |> case do
-        %{"message" => m, "event_message" => em} = map when m == em ->
-          Map.delete(map, "message")
-
-        other ->
-          other
-      end
+      |> MetadataCleaner.deep_reject_nil_and_empty()
+      |> put_mapper_fields(event_message, id, timestamp)
 
     %{
       "body" => body,
@@ -205,88 +173,126 @@ defmodule Logflare.LogEvent do
     }
   end
 
-  @spec validate(LE.t(), Source.t()) :: LE.t()
-  defp validate(%LE{valid: true} = le, source) do
-    @validators
-    |> Enum.reduce_while(true, fn validator, _acc ->
-      case validator.validate(le, source) do
-        :ok ->
-          {:cont, %{le | valid: true, pipeline_error: nil}}
+  @spec mapper_for_ingest(map(), TypeDetection.event_type()) :: {map(), boolean()}
+  defp mapper_for_ingest(params, event_type) do
+    event_message = event_message(params)
+    id = id(params)
+    {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
 
-        {:error, message} ->
-          {:halt,
-           %{
-             le
-             | valid: false,
-               pipeline_error: %LE.PipelineError{
-                 stage: "validators",
-                 type: "validate",
-                 message: message
-               }
-           }}
-      end
-    end)
+    body =
+      params
+      |> IngestTransformers.transform(:clean_to_bigquery_column_spec)
+      |> put_mapper_fields(event_message, id, timestamp)
+
+    {body, timestamp_inferred}
   end
 
-  @spec clean_ingest_body(map()) :: map()
-  defp clean_ingest_body(params),
-    do: IngestTransformers.transform(params, :clean_to_bigquery_column_spec)
+  @spec put_mapper_fields(map(), term(), String.t(), integer()) :: map()
+  defp put_mapper_fields(body, event_message, id, timestamp) do
+    mapped_fields = %{"id" => id, "timestamp" => timestamp}
 
-  @spec transform(LE.t(), Source.t()) :: LE.t()
-  defp transform(%LE{} = le, %Source{} = source) do
-    with {:ok, le} <- copy_fields(le, source),
-         {:ok, le} <- kv_enrich(le, source),
-         {:ok, le} <- drop_fields(le, source) do
-      le
+    mapped_fields =
+      if event_message != nil do
+        Map.put(mapped_fields, "event_message", event_message)
+      else
+        mapped_fields
+      end
+
+    body = Map.merge(body, mapped_fields)
+
+    case body do
+      %{"message" => m, "event_message" => em} = body when m == em ->
+        Map.delete(body, "message")
+
+      body ->
+        body
     end
   end
 
-  @spec copy_fields(LE.t(), Source.t()) :: {:ok, LE.t()}
-  defp copy_fields(%LE{} = le, %Source{
+  @spec validate(LE.t(), Source.t()) :: LE.t()
+  defp validate(%LE{} = le, source) do
+    case BigQuerySchemaChange.validate(le, source) do
+      :ok ->
+        le
+
+      {:error, message} ->
+        %{
+          le
+          | valid: false,
+            pipeline_error: %LE.PipelineError{
+              stage: "validators",
+              type: "validate",
+              message: message
+            }
+        }
+    end
+  end
+
+  @spec transform_body(map(), Source.t()) :: map()
+  defp transform_body(body, %Source{
+         transform_copy_fields: copy_config,
+         transform_copy_fields_parsed: copy_parsed,
+         transform_key_values: kv_config,
+         transform_key_values_parsed: kv_parsed,
+         transform_drop_fields: drop_config,
+         transform_drop_fields_parsed: drop_parsed
+       })
+       when (copy_parsed == [] or (is_nil(copy_parsed) and copy_config in [nil, ""])) and
+              (kv_parsed == [] or (is_nil(kv_parsed) and kv_config in [nil, ""])) and
+              (drop_parsed == [] or (is_nil(drop_parsed) and drop_config in [nil, ""])),
+       do: body
+
+  defp transform_body(body, %Source{} = source) do
+    body
+    |> copy_fields(source)
+    |> kv_enrich(source)
+    |> drop_fields(source)
+  end
+
+  @spec copy_fields(map(), Source.t()) :: map()
+  defp copy_fields(body, %Source{
          transform_copy_fields_parsed: nil,
          transform_copy_fields: blank
        })
        when blank in [nil, ""],
-       do: {:ok, le}
+       do: body
 
-  defp copy_fields(%LE{} = le, %Source{transform_copy_fields_parsed: []}), do: {:ok, le}
+  defp copy_fields(body, %Source{transform_copy_fields_parsed: []}), do: body
 
-  defp copy_fields(%LE{} = le, %Source{transform_copy_fields_parsed: parsed})
+  defp copy_fields(body, %Source{transform_copy_fields_parsed: parsed})
        when is_list(parsed) do
-    new_body =
-      Enum.reduce(parsed, le.body, fn %{from_path: from_path, to_path: to_path}, acc ->
-        case get_in(acc, from_path) do
-          nil -> acc
-          value -> put_at_path(acc, to_path, value)
-        end
-      end)
-
-    {:ok, %{le | body: new_body}}
+    Enum.reduce(parsed, body, fn %{from_path: from_path, to_path: to_path}, acc ->
+      case get_at_path(acc, from_path) do
+        nil -> acc
+        value -> put_at_path(acc, to_path, value)
+      end
+    end)
   end
 
-  defp copy_fields(%LE{} = le, %Source{} = source) do
-    copy_fields(le, Source.parse_copy_fields_config(source))
+  defp copy_fields(body, %Source{} = source) do
+    copy_fields(body, Source.parse_copy_fields_config(source))
   end
 
-  @spec kv_enrich(LE.t(), Source.t()) :: {:ok, LE.t()}
-  defp kv_enrich(%LE{} = le, %Source{transform_key_values: nil, transform_key_values_parsed: nil}),
-       do: {:ok, le}
+  @spec kv_enrich(map(), Source.t()) :: map()
+  defp kv_enrich(body, %Source{
+         transform_key_values: blank,
+         transform_key_values_parsed: nil
+       })
+       when blank in [nil, ""],
+       do: body
 
-  defp kv_enrich(%LE{} = le, %Source{transform_key_values_parsed: []}), do: {:ok, le}
+  defp kv_enrich(body, %Source{transform_key_values_parsed: []}), do: body
 
-  defp kv_enrich(%LE{} = le, %Source{transform_key_values_parsed: parsed, user_id: user_id})
+  defp kv_enrich(body, %Source{transform_key_values_parsed: parsed, user_id: user_id})
        when is_list(parsed) do
-    new_body =
-      Enum.reduce(parsed, le.body, fn instruction, acc ->
-        apply_kv_instruction(acc, instruction, user_id)
-      end)
-
-    {:ok, %{le | body: new_body}}
+    Enum.reduce(parsed, body, fn instruction, acc ->
+      apply_kv_instruction(acc, instruction, user_id)
+    end)
   end
 
   # Fallback: parse at ingestion time when parsed field is not populated
-  defp kv_enrich(%LE{} = le, %Source{} = source) do
-    kv_enrich(le, Source.parse_key_values_config(source))
+  defp kv_enrich(body, %Source{} = source) do
+    kv_enrich(body, Source.parse_key_values_config(source))
   end
 
   @spec apply_kv_instruction(map(), map(), integer()) :: map()
@@ -297,7 +303,7 @@ defmodule Logflare.LogEvent do
        ) do
     accessor_path = Map.get(instruction, :accessor_path)
 
-    with raw when not is_nil(raw) <- get_in(body, from_path),
+    with raw when not is_nil(raw) <- get_at_path(body, from_path),
          raw_string <- to_string(raw),
          true <- Utils.flag("key_values", raw_string),
          value when not is_nil(value) <-
@@ -308,6 +314,16 @@ defmodule Logflare.LogEvent do
     end
   end
 
+  defp get_at_path(nil, _path), do: nil
+
+  defp get_at_path(map, [key]) when is_map(map) and is_binary(key),
+    do: Map.get(map, key)
+
+  defp get_at_path(map, [head | tail]) when is_map(map) and is_binary(head),
+    do: get_at_path(Map.get(map, head), tail)
+
+  defp get_at_path(data, path), do: get_in(data, path)
+
   @spec put_at_path(map(), [String.t()], term()) :: map()
   defp put_at_path(map, [leaf], value) when is_map(map), do: Map.put(map, leaf, value)
 
@@ -316,24 +332,23 @@ defmodule Logflare.LogEvent do
     Map.put(map, head, put_at_path(child, rest, value))
   end
 
-  @spec drop_fields(LE.t(), Source.t()) :: {:ok, LE.t()}
-  defp drop_fields(%LE{} = le, %Source{
+  @spec drop_fields(map(), Source.t()) :: map()
+  defp drop_fields(body, %Source{
          transform_drop_fields_parsed: nil,
          transform_drop_fields: blank
        })
        when blank in [nil, ""],
-       do: {:ok, le}
+       do: body
 
-  defp drop_fields(%LE{} = le, %Source{transform_drop_fields_parsed: []}), do: {:ok, le}
+  defp drop_fields(body, %Source{transform_drop_fields_parsed: []}), do: body
 
-  defp drop_fields(%LE{} = le, %Source{transform_drop_fields_parsed: parsed})
+  defp drop_fields(body, %Source{transform_drop_fields_parsed: parsed})
        when is_list(parsed) do
-    new_body = Enum.reduce(parsed, le.body, fn keys, acc -> drop_field_at(acc, keys) end)
-    {:ok, %{le | body: new_body}}
+    Enum.reduce(parsed, body, fn keys, acc -> drop_field_at(acc, keys) end)
   end
 
-  defp drop_fields(%LE{} = le, %Source{} = source) do
-    drop_fields(le, Source.parse_drop_fields_config(source))
+  defp drop_fields(body, %Source{} = source) do
+    drop_fields(body, Source.parse_drop_fields_config(source))
   end
 
   @spec drop_field_at(term(), [String.t()]) :: term()
@@ -341,8 +356,14 @@ defmodule Logflare.LogEvent do
 
   defp drop_field_at(body, [head | rest]) when is_map(body) do
     case Map.fetch(body, head) do
-      {:ok, child} when is_map(child) -> Map.put(body, head, drop_field_at(child, rest))
-      _ -> body
+      {:ok, child} when is_map(child) ->
+        case drop_field_at(child, rest) do
+          ^child -> body
+          updated_child -> Map.put(body, head, updated_child)
+        end
+
+      _ ->
+        body
     end
   end
 
@@ -427,6 +448,10 @@ defmodule Logflare.LogEvent do
     end
   end
 
+  # TODO: deprecate and remove `message`
+  @compile {:inline, event_message: 1}
+  defp event_message(params), do: params["message"] || params["event_message"]
+
   @spec id(map()) :: String.t()
   defp id(params) do
     params["id"] || params[:id] || Ecto.UUID.generate()
@@ -444,17 +469,14 @@ defmodule Logflare.LogEvent do
     do: {default_timestamp(), true}
 
   defp determine_timestamp(%{"timestamp" => x}) when is_non_empty_binary(x) do
-    case DateTime.from_iso8601(x) do
-      {:ok, udt, _} ->
-        {DateTime.to_unix(udt, :microsecond), false}
-
-      {:error, _} ->
-        {default_timestamp(), true}
+    case iso8601_to_microseconds(x) do
+      {:ok, timestamp} -> {timestamp, false}
+      {:error, _} -> {default_timestamp(), true}
     end
   end
 
   defp determine_timestamp(%{"timestamp" => x}) when is_non_negative_integer(x) do
-    {Utils.to_microseconds(x), false}
+    {timestamp_to_microseconds(x), false}
   end
 
   defp determine_timestamp(%{"timestamp" => x}) when is_float(x) do
@@ -479,18 +501,110 @@ defmodule Logflare.LogEvent do
 
   @spec extract_trace_start_time(params :: map()) :: pos_integer() | nil
   defp extract_trace_start_time(%{"start_time" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"startTime" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"start_time_unix_nano" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"startTimeUnixNano" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(_params), do: nil
+
+  defp iso8601_to_microseconds(
+         <<y1, y2, y3, y4, ?-, mo1, mo2, ?-, d1, d2, ?T, h1, h2, ?:, mi1, mi2, ?:, s1, s2, ?., u1,
+           u2, u3, u4, u5, u6, ?Z>> = timestamp
+       )
+       when y1 in ?0..?9 and y2 in ?0..?9 and y3 in ?0..?9 and y4 in ?0..?9 and
+              mo1 in ?0..?9 and mo2 in ?0..?9 and d1 in ?0..?9 and d2 in ?0..?9 and
+              h1 in ?0..?9 and h2 in ?0..?9 and mi1 in ?0..?9 and mi2 in ?0..?9 and
+              s1 in ?0..?9 and s2 in ?0..?9 and u1 in ?0..?9 and u2 in ?0..?9 and
+              u3 in ?0..?9 and u4 in ?0..?9 and u5 in ?0..?9 and u6 in ?0..?9 do
+    year = decimal4(y1, y2, y3, y4)
+    month = decimal2(mo1, mo2)
+    day = decimal2(d1, d2)
+    hour = decimal2(h1, h2)
+    minute = decimal2(mi1, mi2)
+    second = decimal2(s1, s2)
+
+    days_before_month =
+      if year in 1970..2099 do
+        days_before_month(year, month, day)
+      end
+
+    if is_integer(days_before_month) and hour < 24 and minute < 60 and second < 60 do
+      microsecond = decimal6(u1, u2, u3, u4, u5, u6)
+
+      days =
+        (year - 1970) * 365 + div(year - 1969, 4) + days_before_month + day - 1
+
+      {:ok, (((days * 24 + hour) * 60 + minute) * 60 + second) * 1_000_000 + microsecond}
+    else
+      parse_iso8601(timestamp)
+    end
+  end
+
+  defp iso8601_to_microseconds(timestamp), do: parse_iso8601(timestamp)
+
+  defp parse_iso8601(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.to_unix(datetime, :microsecond)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp days_before_month(_year, 1, day) when day in 1..31, do: 0
+  defp days_before_month(_year, 2, day) when day in 1..28, do: 31
+  defp days_before_month(year, 2, 29) when rem(year, 4) == 0, do: 31
+  defp days_before_month(year, 3, day) when day in 1..31, do: 59 + leap_day(year)
+  defp days_before_month(year, 4, day) when day in 1..30, do: 90 + leap_day(year)
+  defp days_before_month(year, 5, day) when day in 1..31, do: 120 + leap_day(year)
+  defp days_before_month(year, 6, day) when day in 1..30, do: 151 + leap_day(year)
+  defp days_before_month(year, 7, day) when day in 1..31, do: 181 + leap_day(year)
+  defp days_before_month(year, 8, day) when day in 1..31, do: 212 + leap_day(year)
+  defp days_before_month(year, 9, day) when day in 1..30, do: 243 + leap_day(year)
+  defp days_before_month(year, 10, day) when day in 1..31, do: 273 + leap_day(year)
+  defp days_before_month(year, 11, day) when day in 1..30, do: 304 + leap_day(year)
+  defp days_before_month(year, 12, day) when day in 1..31, do: 334 + leap_day(year)
+  defp days_before_month(_year, _month, _day), do: nil
+
+  defp leap_day(year) when rem(year, 4) == 0, do: 1
+  defp leap_day(_year), do: 0
+
+  @compile {:inline, decimal2: 2, decimal4: 4, decimal6: 6}
+  defp decimal2(a, b), do: (a - ?0) * 10 + b - ?0
+  defp decimal4(a, b, c, d), do: (a - ?0) * 1_000 + (b - ?0) * 100 + decimal2(c, d)
+
+  defp decimal6(a, b, c, d, e, f),
+    do:
+      (a - ?0) * 100_000 + (b - ?0) * 10_000 + (c - ?0) * 1_000 + (d - ?0) * 100 +
+        (e - ?0) * 10 + f - ?0
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000_000_000 and
+              raw < 10_000_000_000_000_000_000,
+       do: div(raw, 1_000)
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000_000 and
+              raw < 10_000_000_000_000_000,
+       do: raw
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000 and
+              raw < 10_000_000_000_000,
+       do: raw * 1_000
+
+  defp timestamp_to_microseconds(raw) when raw >= 1_000_000_000 and raw < 10_000_000_000,
+    do: raw * 1_000_000
+
+  defp timestamp_to_microseconds(raw) when raw >= 1_000_000 and raw < 10_000_000,
+    do: raw * 1_000_000_000
+
+  defp timestamp_to_microseconds(raw), do: raw
 
   @spec default_timestamp() :: integer()
   defp default_timestamp do

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -2,8 +2,41 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
   use ExUnit.Case, async: true
 
   alias Logflare.Google.BigQuery.EventUtils
+  alias Logflare.LogEvent
+  alias Logflare.Sources.Source
 
   doctest EventUtils
+
+  describe "log_event_to_df_struct/1" do
+    test "preserves the timestamp type required by BigQuery Storage API encoding" do
+      source = %Source{id: 1, name: "storage-contract-test", validate_schema: false}
+      timestamp = "2024-02-29T12:34:56.123456Z"
+      {:ok, expected, _offset} = DateTime.from_iso8601(timestamp)
+
+      log_event =
+        LogEvent.make(
+          %{
+            "id" => "00000000-0000-0000-0000-000000000000",
+            "event_message" => "storage contract",
+            "timestamp" => timestamp
+          },
+          %{source: source}
+        )
+
+      assert log_event.body["timestamp"] == DateTime.to_unix(expected, :microsecond)
+
+      row = EventUtils.log_event_to_df_struct(log_event)
+      assert row["timestamp"] == expected
+
+      dataframe = Explorer.DataFrame.new([row])
+
+      assert Explorer.DataFrame.dtypes(dataframe)["timestamp"] ==
+               {:datetime, :microsecond, "Etc/UTC"}
+
+      assert {:ok, _schema} = Explorer.DataFrame.dump_ipc_schema(dataframe)
+      assert {:ok, [_batch | _]} = Explorer.DataFrame.dump_ipc_record_batch(dataframe)
+    end
+  end
 
   describe "prepare_for_ingest/1" do
     test "wraps event in list and nested maps in lists" do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -4,6 +4,7 @@ defmodule Logflare.LogEventTest do
   use ExUnitProperties
 
   alias Logflare.LogEvent
+  alias Logflare.LogEvent.DayBucket
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
@@ -32,6 +33,28 @@ defmodule Logflare.LogEventTest do
     assert id == body["id"]
     assert body["metadata"]["my"] == "key"
     assert source_id == source.id
+  end
+
+  describe "mapper fields" do
+    test "preserves explicit IDs and normalizes legacy message fields", %{source: source} do
+      id = Ecto.UUID.generate()
+      timestamp = "2024-01-01T00:00:00.123456Z"
+
+      for {message_fields, expected_message} <- [
+            {%{"message" => "legacy"}, "legacy"},
+            {%{"event_message" => "current"}, "current"},
+            {%{"message" => "same", "event_message" => "same"}, "same"},
+            {%{"message" => "legacy wins", "event_message" => "current"}, "legacy wins"}
+          ] do
+        params = Map.merge(message_fields, %{"id" => id, "timestamp" => timestamp})
+        le = LogEvent.make(params, %{source: source})
+
+        assert le.id == id
+        assert le.body["id"] == id
+        assert le.body["event_message"] == expected_message
+        refute Map.has_key?(le.body, "message")
+      end
+    end
   end
 
   describe "bigquery_spec" do
@@ -702,6 +725,23 @@ defmodule Logflare.LogEventTest do
     assert body["metadata"] == "some string"
   end
 
+  test "make_from_db/2 preserves mapper fields and normalizes legacy messages", %{source: source} do
+    id = Ecto.UUID.generate()
+    timestamp = 1_713_268_565_764_892
+
+    le =
+      LogEvent.make_from_db(
+        %{"id" => id, "message" => "legacy", "timestamp" => timestamp},
+        %{source: source}
+      )
+
+    assert le.id == id
+    assert le.body["id"] == id
+    assert le.body["timestamp"] == timestamp
+    assert le.body["event_message"] == "legacy"
+    refute Map.has_key?(le.body, "message")
+  end
+
   test "apply_custom_event_message/1 generates custom event message from source setting", %{
     source: source
   } do
@@ -732,6 +772,84 @@ defmodule Logflare.LogEventTest do
       assert le.timestamp_inferred == false
     end
 
+    test "preserves microseconds for common UTC ISO 8601 timestamps", %{source: source} do
+      for timestamp <- [
+            "1970-01-01T00:00:00.000001Z",
+            "1972-02-29T12:34:56.654321Z",
+            "2000-02-29T23:59:59.123456Z",
+            "2024-12-31T12:34:56.999999Z",
+            "2096-02-29T00:00:00.000000Z",
+            "2099-12-31T23:59:59.000001Z"
+          ] do
+        {:ok, datetime, _offset} = DateTime.from_iso8601(timestamp)
+        expected = DateTime.to_unix(datetime, :microsecond)
+
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        assert le.timestamp_inferred == false
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
+    end
+
+    property "common UTC ISO 8601 fast path matches DateTime", %{source: source} do
+      max_date_offset = Date.diff(~D[2099-12-31], ~D[1970-01-01])
+
+      check all date_offset <- integer(0..max_date_offset),
+                hour <- integer(0..23),
+                minute <- integer(0..59),
+                second <- integer(0..59),
+                microsecond <- integer(0..999_999) do
+        datetime =
+          ~D[1970-01-01]
+          |> Date.add(date_offset)
+          |> DateTime.new!(Time.new!(hour, minute, second, {microsecond, 6}), "Etc/UTC")
+
+        timestamp = DateTime.to_iso8601(datetime)
+        expected = DateTime.to_unix(datetime, :microsecond)
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
+    end
+
+    test "standard parser fallback preserves other valid ISO 8601 forms", %{source: source} do
+      for timestamp <- [
+            "1969-12-31T23:59:59.123456Z",
+            "2100-03-01T00:00:00.123456Z",
+            "2024-01-01T12:34:56.123Z",
+            "2024-01-01T12:34:56Z",
+            "2024-01-01T12:34:56.123456+05:30"
+          ] do
+        {:ok, datetime, _offset} = DateTime.from_iso8601(timestamp)
+        expected = DateTime.to_unix(datetime, :microsecond)
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+      end
+    end
+
+    test "rejects invalid common-shape ISO 8601 timestamps", %{source: source} do
+      for timestamp <- [
+            "2025-02-29T12:34:56.123456Z",
+            "2100-02-29T12:34:56.123456Z",
+            "2024-00-01T12:34:56.123456Z",
+            "2024-13-01T12:34:56.123456Z",
+            "2024-01-00T12:34:56.123456Z",
+            "2024-04-31T12:34:56.123456Z",
+            "2024-01-01T24:00:00.123456Z",
+            "2024-01-01T12:60:00.123456Z",
+            "2024-01-01T12:34:60.123456Z",
+            "2024-01-01T12:34:56.12345xZ"
+          ] do
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+        assert le.timestamp_inferred == true
+      end
+    end
+
     test "is true when an unparsable string timestamp is provided", %{source: source} do
       params = Map.put(@vallog_event_ids, "timestamp", "not-a-timestamp")
       le = LogEvent.make(params, %{source: source})
@@ -742,6 +860,58 @@ defmodule Logflare.LogEventTest do
       params = Map.put(@vallog_event_ids, "timestamp", 1_713_268_565_764_892)
       le = LogEvent.make(params, %{source: source})
       assert le.timestamp_inferred == false
+    end
+
+    test "preserves integer timestamp unit conversion", %{source: source} do
+      for timestamp <- [
+            0,
+            999_999,
+            1_000_000,
+            9_999_999,
+            10_000_000,
+            100_000_000,
+            1_000_000_000,
+            9_999_999_999,
+            10_000_000_000,
+            100_000_000_000,
+            1_000_000_000_000,
+            9_999_999_999_999,
+            10_000_000_000_000,
+            100_000_000_000_000,
+            1_000_000_000_000_000,
+            9_999_999_999_999_999,
+            10_000_000_000_000_000,
+            100_000_000_000_000_000,
+            1_000_000_000_000_000_000,
+            9_999_999_999_999_999_999,
+            10_000_000_000_000_000_000
+          ] do
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+        assert le.body["timestamp"] == Utils.to_microseconds(timestamp)
+      end
+    end
+
+    property "generated integer and float timestamps match the reference conversion" do
+      source = build(:source, user: build(:user), validate_schema: false)
+
+      check all timestamp <-
+                  one_of([
+                    integer(1_713_268_565_764_892..1_713_268_565_764_999),
+                    integer(1_713_268_565_764..1_713_268_565_999),
+                    integer(1_713_268_565..1_713_268_999),
+                    float(min: 1_713_268_565.1, max: 1_713_268_999.9),
+                    float(min: 1_713_268_000_000.1, max: 1_713_268_000_999.9),
+                    float(min: 1_713_268_565_000_000.1, max: 1_713_268_565_000_999.9)
+                  ]) do
+        rounded = if is_float(timestamp), do: round(timestamp), else: timestamp
+        expected = Utils.to_microseconds(rounded)
+        params = Map.put(@vallog_event_ids, "timestamp", timestamp)
+        le = LogEvent.make(params, %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
     end
 
     test "is false when a valid float timestamp is provided", %{source: source} do
@@ -788,17 +958,36 @@ defmodule Logflare.LogEventTest do
       assert le.body["timestamp"] == start_time_us
     end
 
-    test "honors `start_time_unix_nano` (OTEL processor key)", %{source: source} do
+    test "honors every supported trace start-time key", %{source: source} do
+      start_time_ns = System.system_time(:nanosecond) - 1_000_000_000
+
+      for key <- ~w(start_time startTime start_time_unix_nano startTimeUnixNano) do
+        params = %{
+          "event_message" => "trace from otel processor",
+          "metadata" => %{"type" => "span"},
+          key => start_time_ns
+        }
+
+        le = LogEvent.make(params, %{source: source})
+
+        assert le.timestamp_inferred
+        assert le.body["timestamp"] == Utils.to_microseconds(start_time_ns)
+      end
+    end
+
+    test "uses trace start time when an explicit timestamp is invalid", %{source: source} do
       start_time_ns = System.system_time(:nanosecond) - 1_000_000_000
 
       params = %{
-        "event_message" => "trace from otel processor",
+        "event_message" => "trace with invalid timestamp",
         "metadata" => %{"type" => "span"},
+        "timestamp" => "not-a-timestamp",
         "start_time_unix_nano" => start_time_ns
       }
 
       le = LogEvent.make(params, %{source: source})
 
+      assert le.timestamp_inferred
       assert le.body["timestamp"] == Utils.to_microseconds(start_time_ns)
     end
 
@@ -913,23 +1102,6 @@ defmodule Logflare.LogEventTest do
         le = event_with_message("#{first}.#{second}", metadata)
 
         assert Jason.encode!(metadata[first][second]) == le.body["event_message"]
-      end
-    end
-
-    property "timestamp unix conversions" do
-      source = build(:source, user: build(:user))
-
-      check all ts <-
-                  one_of([
-                    integer(1_713_268_565_764_892..1_713_268_565_764_999),
-                    integer(1_713_268_565_764..1_713_268_565_999),
-                    integer(1_713_268_565..1_713_268_999),
-                    float(min: 1_713_268_565.1, max: 1_713_268_999.9),
-                    float(min: 1_713_268_000_000.1, max: 1_713_268_000_999.9),
-                    float(min: 1_713_268_565_000_000.1, max: 1_713_268_565_000_999.9)
-                  ]) do
-        params = Map.put(@vallog_event_ids, "timestamp", ts)
-        LogEvent.make(params, %{source: source})
       end
     end
 

--- a/test/logflare/logs/ingest/ingest_transformer_test.exs
+++ b/test/logflare/logs/ingest/ingest_transformer_test.exs
@@ -418,6 +418,33 @@ defmodule Logflare.Logs.IngestTransformerTest do
   end
 
   describe ":clean_to_bigquery_column_spec fused pipeline" do
+    test "preserves a fully clean and BigQuery-safe nested payload" do
+      input = %{
+        "safe_key" => "value",
+        "nested_map" => %{"child_1" => 1, "child_2" => false},
+        "nested_list" => [%{"item_1" => "one"}, [1, 2, 3]],
+        :non_binary_key => 42
+      }
+
+      assert transform(input, :clean_to_bigquery_column_spec) == input
+    end
+
+    test "detects cleaning and normalization needs inside nested maps and lists" do
+      for input <- [
+            %{"safe" => %{"empty" => nil, "kept" => 1}},
+            %{"safe" => [%{"bad-key" => 1}]},
+            %{"safe" => [%{"_TABLE_value" => 1}]},
+            %{"safe" => [[[], %{}, "", "kept"]]}
+          ] do
+        expected =
+          input
+          |> MetadataCleaner.deep_reject_nil_and_empty()
+          |> transform(:to_bigquery_column_spec)
+
+        assert transform(input, :clean_to_bigquery_column_spec) == expected
+      end
+    end
+
     property "matches sequential cleaning and key normalization" do
       check all input <- log_params_generator() do
         assert transform(input, :clean_to_bigquery_column_spec) ==

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -60,6 +60,8 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
           %{source: source}
         )
 
+      assert le.valid
+      assert le.pipeline_error == nil
       assert validate(le, source) === :ok
     end
 
@@ -81,6 +83,12 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
         |> put_in(~w[user address city], 1000)
 
       le = LE.make(%{"metadata" => conflicting_metadata}, %{source: source})
+
+      refute le.valid
+      assert le.pipeline_error.stage == "validators"
+      assert le.pipeline_error.type == "validate"
+      assert le.pipeline_error.message =~ "Type error"
+      assert le.pipeline_error.message =~ "metadata.user.address.city"
 
       assert {:error, message} = validate(le, source)
       assert message =~ "Type error"


### PR DESCRIPTION
> [!NOTE]
> Superseded by the five-PR stack #3765 → #3766 → #3767 → #3768 → #3769 (GitHub stack #3770).

## Summary

This is a follow-up to #3741 that further reduces allocations and hot-path work in `LogEvent.make/2`:

1. **Reuse already-clean payloads** instead of rebuilding every nested map and list.
2. **Return the ingest mapper result directly** instead of allocating an intermediate envelope map.
3. **Transform event bodies directly** instead of constructing intermediate `LogEvent` structs and `{:ok, value}` tuples.
4. **Skip and specialize transform work** for sources without transforms and for common string-key map paths.
5. **Call the active validator directly** instead of reducing over a single-element validator list.
6. **Fast-path common UTC ISO 8601 timestamps** while retaining the standard parser as a compatibility fallback.
7. **Convert integer timestamp units with range guards** instead of allocating a digit list and counting it.

## Detailed improvements

### 1. Reuse already-clean payloads

The fused ingestion cleaner previously rebuilt the payload even when every value was already retained and every key already satisfied the BigQuery column specification.

`IngestTransformers.transform/2` now first scans nested maps and lists for empty values and unsafe keys. If the payload is already clean and BigQuery-safe, it returns the original payload unchanged. Payloads that require work still use the existing fused clean-and-normalize traversal, including the collision fallback that preserves sequential-cleaner behavior.

### 2. Remove the ingest mapper envelope

The ingest mapper previously returned a map containing `body`, `id`, and `timestamp_inferred`, only for `make/2` to destructure it immediately.

The ingest path now returns `{body, timestamp_inferred}` directly and reads the ID from the mapped body. The database reconstruction path retains the map shape required by its Ecto changeset. Shared mapper-field insertion keeps ID, timestamp, and legacy `message` normalization behavior consistent across both paths.

### 3. Transform body maps directly

Copy-field, key-value enrichment, and drop-field transforms previously accepted a full `LogEvent`, returned `{:ok, LogEvent.t()}`, and allocated a new event struct at each configured stage.

The transform pipeline now operates on the body map and constructs the final `LogEvent` once. Transform order remains:

1. copy fields
2. key-value enrichment
3. drop fields

A guard returns the body immediately when all three transform configurations are absent or pre-parsed to empty lists.

### 4. Reduce transform-path allocations

Common binary-key map lookups now use a small recursive `Map.get/2` path walker instead of generic `get_in/2` dispatch. The generic fallback remains for uncommon path shapes.

Nested drop operations also reuse the parent map when the requested descendant does not exist, avoiding a chain of equivalent `Map.put/3` results. The legacy message lookup is inlined on the mapper hot path.

### 5. Simplify validation

`LogEvent.make/2` currently has one validator: `BigQuerySchemaChange`. The code now calls it directly instead of invoking `Enum.reduce_while/3` over a single-element module list and allocating reducer tuples. Validation failures still produce the same `valid: false` event and `PipelineError` fields.

### 6. Fast-path common ISO 8601 timestamps

The common production form `YYYY-MM-DDTHH:MM:SS.ffffffZ` is parsed directly for years 1970 through 2099. The parser validates calendar days, leap days, hours, minutes, and seconds, then computes Unix microseconds without allocating a `DateTime` struct.

All other forms—including timezone offsets, other fractional precision, dates outside the fast-path range, and invalid common-shape values—fall back to `DateTime.from_iso8601/1`. This changes only incoming timestamp parsing; the BigQuery Storage API output remains a UTC `DateTime`/Arrow timestamp.

### 7. Avoid digit-list allocation for integer timestamps

Integer timestamp normalization previously used `Integer.digits/1 |> Enum.count/1` to distinguish seconds, milliseconds, microseconds, and nanoseconds.

The replacement uses numeric range guards matching the existing 7-, 10-, 13-, 16-, and 19-digit behavior. The same helper is used for explicit event timestamps and supported trace start-time fields.

## Test coverage

Coverage added in this PR includes:

- generated parity checks between the ISO fast path and `DateTime` across 1970–2099
- leap-year, month-boundary, invalid-date, timezone-offset, precision, and fallback cases
- integer and float timestamp conversion boundaries plus day-bucket assertions
- all supported trace start-time aliases and invalid-explicit-timestamp fallback
- mapper precedence and `make_from_db/2` behavior
- fully clean and nested slow-path cleaner cases
- validator success and failure integration through `LogEvent.make/2`
- a BigQuery Storage API regression contract asserting UTC `DateTime` output, Arrow timestamp dtype, and IPC encoding

## Benchmarks

These results measure the incremental improvement from `main@origin` at `825bd40d`—which already includes #3741—to this PR at `82750c78`.

Methodology:

- Three alternating baseline/candidate runs on the same Linux host
- 6 available cores and 11 GiB memory
- Elixir 1.19.5, Erlang/OTP 27.3.4.6, JIT enabled
- Benchee: 2 s warmup, 5 s runtime, 3 s memory time, 3 s reduction time, parallelism 1
- Production-shaped OTEL trace (~15 leaf values) and edge log (~80 leaf values) fixtures
- Transform variants exercise copy, key-value enrichment, drop, and combined configurations
- Each cell is the median of the three runs

Across all 12 scenarios, this follow-up delivers:

- **1.35–2.65x throughput** (**1.83x geometric mean**)
- **29.7–63.5% lower median latency**
- **35.3–55.7% less memory per operation**
- **18.1–24.7% fewer BEAM reductions**

| Scenario | Throughput, baseline → PR | Speedup | Median latency, baseline → PR | Memory change | Reduction change |
|---|---:|---:|---:|---:|---:|
| OTEL trace | 269.7K → 451.3K ops/s | 1.67x | 3.50 → 2.04 µs | -45.4% | -24.1% |
| OTEL trace + copy | 249.9K → 407.2K ops/s | 1.63x | 3.79 → 2.29 µs | -45.0% | -23.0% |
| OTEL trace + drop | 250.4K → 393.1K ops/s | 1.57x | 3.79 → 2.38 µs | -42.8% | -23.6% |
| OTEL trace + KV | 186.6K → 270.5K ops/s | 1.45x | 4.92 → 3.38 µs | -42.5% | -22.9% |
| OTEL trace + copy + KV | 165.6K → 236.3K ops/s | 1.43x | 5.21 → 3.58 µs | -36.6% | -21.8% |
| OTEL trace + all | 161.3K → 218.4K ops/s | 1.35x | 5.46 → 3.84 µs | -35.3% | -18.1% |
| Edge log | 157.2K → 416.4K ops/s | 2.65x | 6.05 → 2.21 µs | -54.8% | -24.7% |
| Edge log + copy | 145.2K → 354.9K ops/s | 2.44x | 6.46 → 2.58 µs | -55.7% | -21.6% |
| Edge log + drop | 141.6K → 335.8K ops/s | 2.37x | 6.59 → 2.75 µs | -50.2% | -20.6% |
| Edge log + KV | 127.4K → 272.4K ops/s | 2.14x | 7.38 → 3.38 µs | -51.8% | -22.9% |
| Edge log + copy + KV | 121.2K → 243.7K ops/s | 2.01x | 7.92 → 3.79 µs | -52.3% | -20.2% |
| Edge log + all | 106.5K → 186.3K ops/s | 1.75x | 8.64 → 4.46 µs | -46.0% | -22.0% |

These measurements isolate `LogEvent.make/2`; they do not represent end-to-end ingestion throughput.

