### PR TITLE
fix: scope event age filtering back to ClickHouse backend

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -33,7 +33,6 @@ defmodule Logflare.Backends do
 
   defdelegate child_spec(arg), to: __MODULE__.Supervisor
 
-  @max_event_age_us 24 * 3_600 * 1_000_000
   @max_future_event_us 1 * 3_600 * 1_000_000
   @max_pending_buffer_len_per_queue IngestEventQueue.max_queue_size()
 
@@ -46,16 +45,12 @@ defmodule Logflare.Backends do
   def max_buffer_queue_len, do: @max_pending_buffer_len_per_queue
 
   @doc """
-  Returns the maximum age, in microseconds, of an event that will be accepted at
-  ingestion. Events older than this are dropped as stale.
-  """
-  @spec max_event_age_us() :: non_neg_integer()
-  def max_event_age_us, do: @max_event_age_us
-
-  @doc """
   Returns the maximum time, in microseconds, that an event's timestamp may be in
   the future and still be accepted at ingestion. Events further ahead than this
   are dropped.
+
+  There is no equivalent global lower bound. Dropping events for being too old is
+  now a backend-specific concern (_see `Logflare.Backends.Adaptor.ClickHouseAdaptor.pre_ingest/3`_)
   """
   @spec max_future_event_us() :: non_neg_integer()
   def max_future_event_us, do: @max_future_event_us
@@ -664,9 +659,7 @@ defmodule Logflare.Backends do
   end
 
   defp split_valid_events(source, event_params) do
-    now_us = System.system_time(:microsecond)
-    min_allowed = now_us - @max_event_age_us
-    max_allowed = now_us + @max_future_event_us
+    max_allowed = System.system_time(:microsecond) + @max_future_event_us
 
     {events, errors, total, tally} =
       for param <- event_params, reduce: {[], [], 0, %{}} do
@@ -678,9 +671,6 @@ defmodule Logflare.Backends do
             %{pipeline_error: %_{message: message}, valid: false} ->
               {events, [message | errors], total + 1, bump(tally, :rejected)}
 
-            %{body: %{"timestamp" => timestamp}} when timestamp < min_allowed ->
-              {events, errors, total + 1, bump(tally, :drop_stale)}
-
             %{body: %{"timestamp" => timestamp}} when timestamp > max_allowed ->
               {events, errors, total + 1, bump(tally, :drop_future)}
 
@@ -691,15 +681,12 @@ defmodule Logflare.Backends do
 
     emit_ingest_telemetry(tally, source)
 
-    dropped_old = Map.get(tally, :drop_stale, 0)
     dropped_future = Map.get(tally, :drop_future, 0)
-    dropped_total = dropped_old + dropped_future
 
-    if dropped_total > 0 do
+    if dropped_future > 0 do
       Logger.warning(
-        "Dropping #{dropped_total} of #{total} event(s): timestamps outside [-24h, +1h] window",
+        "Dropping #{dropped_future} of #{total} event(s): timestamps more than 1h in the future",
         source_id: source.token,
-        old_events_dropped: dropped_old,
         future_events_dropped: dropped_future,
         total_event_count: total
       )

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -33,6 +33,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   alias Logflare.Backends.QueryError
   alias Logflare.LogEvent
   alias Logflare.LogEvent.TypeDetection
+  alias Logflare.Sources.Source
 
   @min_pipelines 1
   @resolve_interval 10_000
@@ -40,6 +41,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @async_insert_busy_timeout_max_ms 3_000
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
+  @us_per_hour 3_600 * 1_000_000
+  @default_max_event_age_hours 24
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
 
@@ -126,6 +129,87 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @impl Logflare.Backends.Adaptor
   def supports_default_ingest?, do: true
 
+  @doc """
+  Default max event age in hours.
+  """
+  @spec default_max_event_age_hours() :: pos_integer()
+  def default_max_event_age_hours, do: @default_max_event_age_hours
+
+  @doc """
+  Drops events older than the configured max age before they are
+  queued for the consolidated pipeline.
+
+  Late-arriving events land in older partitions, which increases the parts written
+  per insert.
+
+  To disable the check, set the `max_event_age_
+  Set the backend's `max_event_age_hours`
+  config to `0` to disable the check.
+  """
+  @impl Logflare.Backends.Adaptor
+  @spec pre_ingest(Source.t(), Backend.t(), [LogEvent.t()]) :: [LogEvent.t()]
+  def pre_ingest(_source, _backend, []), do: []
+
+  def pre_ingest(%Source{} = source, %Backend{} = backend, log_events) do
+    case max_event_age_hours(backend) do
+      0 -> log_events
+      hours -> reject_stale_events(source, backend, log_events, hours)
+    end
+  end
+
+  @spec max_event_age_hours(Backend.t()) :: non_neg_integer()
+  defp max_event_age_hours(%Backend{config: %{max_event_age_hours: hours}})
+       when is_integer(hours) and hours >= 0,
+       do: hours
+
+  defp max_event_age_hours(_backend), do: @default_max_event_age_hours
+
+  @spec reject_stale_events(Source.t(), Backend.t(), [LogEvent.t()], pos_integer()) :: [
+          LogEvent.t()
+        ]
+  defp reject_stale_events(source, backend, log_events, max_age_hours) do
+    min_allowed = System.system_time(:microsecond) - max_age_hours * @us_per_hour
+
+    case Enum.count(log_events, &stale?(&1, min_allowed)) do
+      0 ->
+        log_events
+
+      dropped ->
+        log_stale_drop(source, backend, dropped, length(log_events), max_age_hours)
+        Enum.reject(log_events, &stale?(&1, min_allowed))
+    end
+  end
+
+  @spec stale?(LogEvent.t(), integer()) :: boolean()
+  defp stale?(%LogEvent{body: %{"timestamp" => timestamp}}, min_allowed)
+       when is_integer(timestamp),
+       do: timestamp < min_allowed
+
+  defp stale?(_log_event, _min_allowed), do: false
+
+  @spec log_stale_drop(Source.t(), Backend.t(), pos_integer(), pos_integer(), pos_integer()) ::
+          :ok
+  defp log_stale_drop(source, backend, dropped, total, max_age_hours) do
+    Logger.warning(
+      "Dropping #{dropped} of #{total} ClickHouse event(s): timestamps older than #{max_age_hours}h",
+      source_id: source.token,
+      backend_id: backend.id,
+      old_events_dropped: dropped,
+      total_event_count: total
+    )
+
+    :telemetry.execute(
+      [:logflare, :logs, :ingest_logs, :drop_stale],
+      %{count: dropped},
+      %{
+        source_id: source.id,
+        source_token: source.token,
+        backend_id: backend.id,
+        backend_type: :clickhouse
+      }
+    )
+  end
+
   @doc false
   @impl Logflare.Backends.Adaptor
   def cast_config(%{} = params, existing_config \\ %{}) do
@@ -140,7 +224,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
        read_only_url: :string,
        use_async_inserts_for_small_batches: :boolean,
        async_insert_cluster_url: :string,
-       async_insert_max_rows: :integer
+       async_insert_max_rows: :integer,
+       max_event_age_hours: :integer
      }}
     |> Changeset.cast(params, [
       :url,
@@ -152,10 +237,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       :read_only_url,
       :use_async_inserts_for_small_batches,
       :async_insert_cluster_url,
-      :async_insert_max_rows
+      :async_insert_max_rows,
+      :max_event_age_hours
     ])
     |> Logflare.Utils.default_field_value(:use_async_inserts_for_small_batches, false)
     |> Logflare.Utils.default_field_value(:async_insert_max_rows, 1_000)
+    |> Logflare.Utils.default_field_value(
+      :max_event_age_hours,
+      @default_max_event_age_hours
+    )
   end
 
   @doc false
@@ -168,6 +258,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     |> Changeset.validate_format(:url, ~r/https?\:\/\/.+/)
     |> Changeset.validate_format(:async_insert_cluster_url, ~r/https?\:\/\/.+/)
     |> validate_number(:async_insert_max_rows, greater_than: 0)
+    |> validate_number(:max_event_age_hours, greater_than_or_equal_to: 0)
     |> validate_read_only_url()
     |> validate_user_pass()
     |> validate_number(:pool_size,

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -241,6 +241,16 @@
             </small>
           </div>
           <div class="form-group">
+            {label(f_config, :max_event_age_hours, "Max Event Age (Hours)")}
+            {text_input(f_config, :max_event_age_hours,
+              class: "form-control",
+              value: input_value(f_config, "max_event_age_hours") || 24
+            )}
+            <small class="form-text text-muted">
+              Events with a timestamp older than this are not sent to ClickHouse. Set to <code>0</code> to disable the check.
+            </small>
+          </div>
+          <div class="form-group">
             {label(f_config, :port, "HTTP Port")}
             {text_input(f_config, :port, class: "form-control", value: input_value(f_config, "port") || 8443)}
             <small class="form-text text-muted">

--- a/lib/logflare_web/live/display_helpers.ex
+++ b/lib/logflare_web/live/display_helpers.ex
@@ -15,7 +15,7 @@ defmodule LogflareWeb.Live.DisplayHelpers do
   """
   def sanitize_backend_config(config) when is_map(config) do
     allowed_keys =
-      ~w(batch_timeout database hostname host max_message_bytes pool_size port project_id read_only_url region s3_bucket schema storage_region table url use_async_inserts_for_small_batches async_insert_cluster_url async_insert_max_rows)a
+      ~w(batch_timeout database hostname host max_event_age_hours max_message_bytes pool_size port project_id read_only_url region s3_bucket schema storage_region table url use_async_inserts_for_small_batches async_insert_cluster_url async_insert_max_rows)a
 
     config
     |> Enum.map(fn {key, value} ->

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -384,7 +384,8 @@ defmodule LogflareWeb.OpenApiSchemas do
       read_only_url: %Schema{type: :string, nullable: true},
       use_async_inserts_for_small_batches: %Schema{type: :boolean, nullable: true},
       async_insert_cluster_url: %Schema{type: :string, nullable: true},
-      async_insert_max_rows: %Schema{type: :integer, nullable: true}
+      async_insert_max_rows: %Schema{type: :integer, nullable: true},
+      max_event_age_hours: %Schema{type: :integer, nullable: true}
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:url, :database, :port]

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -230,7 +230,10 @@ defmodule Logflare.Telemetry do
       sum("logflare.logs.ingest_logs.drop_stale",
         event_name: [:logflare, :logs, :ingest_logs, :drop_stale],
         measurement: :count,
-        description: "Sum of events dropped (timestamp older than 24h)"
+        tags: [:backend_id, :backend_type],
+        keep: &backend_scoped_drop?/1,
+        description:
+          "Sum of events dropped by a backend (timestamp older than its configured max event age)"
       ),
       sum("logflare.logs.ingest_logs.drop_future",
         event_name: [:logflare, :logs, :ingest_logs, :drop_future],
@@ -602,6 +605,9 @@ defmodule Logflare.Telemetry do
 
   defp clickhouse_batch?(%{backend_type: :clickhouse}), do: true
   defp clickhouse_batch?(_metadata), do: false
+
+  defp backend_scoped_drop?(%{backend_id: _, backend_type: _}), do: true
+  defp backend_scoped_drop?(_metadata), do: false
 
   defp batch_size_reporter_opts do
     [buckets: [0, 1, 50, 100, 250, 500, 1_000, 5_000, 10_000, 20_000, 50_000]]

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -14,6 +14,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.QueryError
+  alias Logflare.LogEvent
   alias Logflare.Lql.BackendTransformer.ClickHouse, as: ClickHouseLQLTransformer
   alias Logflare.Lql.Rules.FilterRule
 
@@ -308,6 +309,138 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       refute changeset.valid?
       assert Keyword.has_key?(changeset.errors, :async_insert_cluster_url)
     end
+
+    test "max_event_age_hours defaults to 24 when not provided" do
+      changeset = cast_and_validate_config()
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :max_event_age_hours) == 24
+    end
+
+    test "casts a custom max_event_age_hours" do
+      changeset = cast_and_validate_config(max_event_age_hours: 72)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :max_event_age_hours) == 72
+    end
+
+    test "accepts a max_event_age_hours of zero to disable age filtering" do
+      changeset = cast_and_validate_config(max_event_age_hours: 0)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :max_event_age_hours) == 0
+    end
+
+    test "rejects a negative max_event_age_hours" do
+      changeset = cast_and_validate_config(max_event_age_hours: -1)
+
+      refute changeset.valid?
+      assert Keyword.has_key?(changeset.errors, :max_event_age_hours)
+    end
+  end
+
+  describe "pre_ingest/3 event age filtering" do
+    setup do
+      [source: build(:source)]
+    end
+
+    test "drops events older than the default max event age", %{source: source} do
+      backend = clickhouse_backend()
+      recent = log_event_aged_hours(source, 1)
+      stale = log_event_aged_hours(source, 25)
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, [recent, stale]) == [recent]
+    end
+
+    test "keeps every event when all are within the default max event age", %{source: source} do
+      backend = clickhouse_backend()
+      events = [log_event_aged_hours(source, 0), log_event_aged_hours(source, 23)]
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, events) == events
+    end
+
+    test "honors a custom max_event_age_hours", %{source: source} do
+      backend = clickhouse_backend(max_event_age_hours: 72)
+      within = log_event_aged_hours(source, 48)
+      stale = log_event_aged_hours(source, 96)
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, [within, stale]) == [within]
+    end
+
+    test "does no filtering when max_event_age_hours is zero", %{source: source} do
+      backend = clickhouse_backend(max_event_age_hours: 0)
+      events = [log_event_aged_hours(source, 1), log_event_aged_hours(source, 5_000)]
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, events) == events
+    end
+
+    test "falls back to the default when max_event_age_hours is absent", %{source: source} do
+      backend = build(:backend, type: :clickhouse, config: %{url: "http://localhost"})
+      recent = log_event_aged_hours(source, 1)
+      stale = log_event_aged_hours(source, 25)
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, [recent, stale]) == [recent]
+    end
+
+    test "emits drop_stale telemetry tagged with the backend", %{source: source} do
+      TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_stale])
+
+      backend = clickhouse_backend()
+      events = [log_event_aged_hours(source, 25), log_event_aged_hours(source, 30)]
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, events) == []
+
+      source_id = source.id
+      source_token = source.token
+      backend_id = backend.id
+
+      assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale],
+                      %{count: 2},
+                      %{
+                        source_id: ^source_id,
+                        source_token: ^source_token,
+                        backend_id: ^backend_id,
+                        backend_type: :clickhouse
+                      }}
+    end
+
+    test "does not emit drop_stale telemetry when nothing is dropped", %{source: source} do
+      TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_stale])
+
+      backend = clickhouse_backend()
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, [log_event_aged_hours(source, 2)]) !=
+               []
+
+      refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale], _, _}
+    end
+
+    test "keeps events without an integer timestamp", %{source: source} do
+      backend = clickhouse_backend()
+      event = %LogEvent{body: %{"timestamp" => nil}}
+
+      assert ClickHouseAdaptor.pre_ingest(source, backend, [event]) == [event]
+    end
+
+    test "handles an empty event list", %{source: source} do
+      assert ClickHouseAdaptor.pre_ingest(source, clickhouse_backend(), []) == []
+    end
+  end
+
+  defp clickhouse_backend(config_overrides \\ []) do
+    config =
+      Enum.into(config_overrides, %{
+        url: "http://localhost",
+        database: "test",
+        port: 8123
+      })
+
+    build(:backend, type: :clickhouse, config: config)
+  end
+
+  defp log_event_aged_hours(source, hours) do
+    timestamp = System.system_time(:microsecond) - hours * 3_600 * 1_000_000
+    build(:log_event, source: source, timestamp: timestamp)
   end
 
   defp cast_and_validate_config(attrs \\ []) do

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -25,6 +25,7 @@ defmodule Logflare.BackendsTest do
   alias Logflare.Sources
   alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.Pipeline
+  alias Logflare.Sources.Source.Data
   alias Logflare.Sources.SourceRouter
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.User
@@ -1725,7 +1726,7 @@ defmodule Logflare.BackendsTest do
     end
   end
 
-  describe "ingest_logs/2 event age filtering" do
+  describe "ingest_logs/2 event timestamp filtering" do
     setup do
       insert(:plan)
       user = insert(:user)
@@ -1736,21 +1737,32 @@ defmodule Logflare.BackendsTest do
       {:ok, source: source}
     end
 
-    test "drops events older than 24 hours", %{source: source} do
+    test "accepts events older than 24 hours", %{source: source} do
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_stale])
 
       now_us = System.system_time(:microsecond)
-      old_timestamp = now_us - 25 * 3_600 * 1_000_000
 
-      params = [%{"message" => "old event", "timestamp" => old_timestamp}]
+      params = [
+        %{"message" => "old event", "timestamp" => now_us - 25 * 3_600 * 1_000_000},
+        %{"message" => "very old event", "timestamp" => now_us - 500 * 3_600 * 1_000_000}
+      ]
 
-      assert {:ok, 0} = Backends.ingest_logs(params, source)
+      assert {:ok, 2} = Backends.ingest_logs(params, source)
 
-      source_id = source.id
-      source_token = source.token
+      refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale], _, _}
+    end
 
-      assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale],
-                      %{count: 1}, %{source_id: ^source_id, source_token: ^source_token}}
+    test "counts events older than 24 hours toward the source insert count", %{source: source} do
+      old_timestamp = System.system_time(:microsecond) - 25 * 3_600 * 1_000_000
+      before_count = Data.get_node_inserts(source.token)
+
+      params = [
+        %{"message" => "old event 1", "timestamp" => old_timestamp},
+        %{"message" => "old event 2", "timestamp" => old_timestamp}
+      ]
+
+      assert {:ok, 2} = Backends.ingest_logs(params, source)
+      assert Data.get_node_inserts(source.token) == before_count + 2
     end
 
     test "drops events more than 1 hour in the future", %{source: source} do
@@ -1782,56 +1794,43 @@ defmodule Logflare.BackendsTest do
       assert {:ok, 3} = Backends.ingest_logs(params, source)
     end
 
-    test "filters mixed batch of valid and invalid timestamps", %{source: source} do
+    test "drops only future timestamps from a mixed batch", %{source: source} do
       now_us = System.system_time(:microsecond)
 
       params = [
         %{"message" => "valid now", "timestamp" => now_us},
-        %{"message" => "too old", "timestamp" => now_us - 25 * 3_600 * 1_000_000},
+        %{"message" => "old", "timestamp" => now_us - 25 * 3_600 * 1_000_000},
         %{"message" => "too future", "timestamp" => now_us + 2 * 3_600 * 1_000_000},
         %{"message" => "valid past", "timestamp" => now_us - 15 * 3_600 * 1_000_000}
       ]
 
-      assert {:ok, 2} = Backends.ingest_logs(params, source)
+      assert {:ok, 3} = Backends.ingest_logs(params, source)
     end
 
-    test "tallies each drop reason separately within a single batch", %{source: source} do
+    test "tallies future drops within a single batch", %{source: source} do
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_stale])
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_future])
 
       now_us = System.system_time(:microsecond)
-      old_timestamp = now_us - 73 * 3_600 * 1_000_000
       future_timestamp = now_us + 2 * 3_600 * 1_000_000
 
       params = [
         %{"message" => "valid now", "timestamp" => now_us},
-        %{"message" => "too old 1", "timestamp" => old_timestamp},
-        %{"message" => "too old 2", "timestamp" => old_timestamp},
-        %{"message" => "too future", "timestamp" => future_timestamp}
+        %{"message" => "old", "timestamp" => now_us - 73 * 3_600 * 1_000_000},
+        %{"message" => "too future 1", "timestamp" => future_timestamp},
+        %{"message" => "too future 2", "timestamp" => future_timestamp}
       ]
 
-      assert {:ok, 1} = Backends.ingest_logs(params, source)
+      assert {:ok, 2} = Backends.ingest_logs(params, source)
 
       source_id = source.id
       source_token = source.token
 
-      assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale],
+      assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_future],
                       %{count: 2}, %{source_id: ^source_id, source_token: ^source_token}}
 
-      assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_future],
-                      %{count: 1}, %{source_id: ^source_id, source_token: ^source_token}}
-
-      refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale], _, _}
       refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_future], _, _}
-    end
-
-    test "accepts events at exact boundary (24 hours ago)", %{source: source} do
-      now_us = System.system_time(:microsecond)
-      boundary_timestamp = now_us - (23 * 3_600 + 59 * 60) * 1_000_000
-
-      params = [%{"message" => "boundary event", "timestamp" => boundary_timestamp}]
-
-      assert {:ok, 1} = Backends.ingest_logs(params, source)
+      refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_stale], _, _}
     end
 
     test "accepts events at exact boundary (1 hour in future)", %{source: source} do
@@ -1847,9 +1846,8 @@ defmodule Logflare.BackendsTest do
       now_us = System.system_time(:microsecond)
 
       params = [
-        %{"message" => "old event 1", "timestamp" => now_us - 73 * 3_600 * 1_000_000},
-        %{"message" => "old event 2", "timestamp" => now_us - 100 * 3_600 * 1_000_000},
-        %{"message" => "future event", "timestamp" => now_us + 2 * 3_600 * 1_000_000}
+        %{"message" => "future event 1", "timestamp" => now_us + 2 * 3_600 * 1_000_000},
+        %{"message" => "future event 2", "timestamp" => now_us + 100 * 3_600 * 1_000_000}
       ]
 
       assert {:ok, 0} = Backends.ingest_logs(params, source)
@@ -1862,9 +1860,8 @@ defmodule Logflare.BackendsTest do
 
       params = [
         %{"message" => "valid event", "timestamp" => now_us},
-        %{"message" => "old event 1", "timestamp" => now_us - 25 * 3_600 * 1_000_000},
-        %{"message" => "old event 2", "timestamp" => now_us - 100 * 3_600 * 1_000_000},
-        %{"message" => "future event", "timestamp" => now_us + 2 * 3_600 * 1_000_000}
+        %{"message" => "future event 1", "timestamp" => now_us + 2 * 3_600 * 1_000_000},
+        %{"message" => "future event 2", "timestamp" => now_us + 100 * 3_600 * 1_000_000}
       ]
 
       log =
@@ -1872,7 +1869,7 @@ defmodule Logflare.BackendsTest do
           assert {:ok, 1} = Backends.ingest_logs(params, source)
         end)
 
-      assert log =~ "Dropping 3 of 4 event(s): timestamps outside [-24h, +1h] window"
+      assert log =~ "Dropping 2 of 3 event(s): timestamps more than 1h in the future"
     end
 
     test "does not log when no events are filtered", %{source: source} do
@@ -1880,16 +1877,17 @@ defmodule Logflare.BackendsTest do
 
       params = [
         %{"message" => "valid event 1", "timestamp" => now_us},
-        %{"message" => "valid event 2", "timestamp" => now_us - 1 * 3_600 * 1_000_000}
+        %{"message" => "valid event 2", "timestamp" => now_us - 1 * 3_600 * 1_000_000},
+        %{"message" => "old event", "timestamp" => now_us - 500 * 3_600 * 1_000_000}
       ]
 
       log =
         capture_log(fn ->
-          assert {:ok, 2} = Backends.ingest_logs(params, source)
+          assert {:ok, 3} = Backends.ingest_logs(params, source)
         end)
 
       refute log =~ "Dropping"
-      refute log =~ "timestamps outside"
+      refute log =~ "timestamps more than"
     end
   end
 

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -18,6 +18,10 @@ defmodule Logflare.TelemetryTest do
   ]
   @clickhouse_batch_metric_string "logflare.backends.clickhouse.pipeline.handle_batch.batch_size"
 
+  @drop_stale_exporter :logflare_drop_stale_metrics_test
+  @drop_stale_metric_name [:logflare, :logs, :ingest_logs, :drop_stale]
+  @drop_stale_metric_string "logflare.logs.ingest_logs.drop_stale"
+
   describe "metrics/0" do
     test "returns only well-formed Telemetry.Metrics definitions" do
       metrics = Telemetry.metrics()
@@ -138,6 +142,59 @@ defmodule Logflare.TelemetryTest do
 
       assert [{_bucket, {1, 500}}] = distributions |> Map.fetch!(metric_tags) |> Map.to_list()
       assert [{_bucket, {1, 125}}] = distributions |> Map.fetch!(trace_tags) |> Map.to_list()
+    end
+
+    test "tags stale event drops by backend" do
+      [metric] = drop_stale_metrics()
+
+      assert metric.event_name == @drop_stale_metric_name
+      assert metric.measurement == :count
+      assert metric.tags == [:backend_id, :backend_type]
+    end
+
+    test "keeps only stale event drops carrying backend metadata" do
+      [metric] = drop_stale_metrics()
+
+      assert metric.keep.(%{backend_id: 1, backend_type: :clickhouse})
+      refute metric.keep.(%{source_id: 1, source_token: "abc"})
+      refute metric.keep.(%{backend_id: 1})
+      refute metric.keep.(%{backend_type: :clickhouse})
+    end
+
+    test "aggregates stale event drops per backend without source-level cardinality" do
+      start_supervised!(
+        {OtelMetricExporter,
+         name: @drop_stale_exporter,
+         metrics: drop_stale_metrics(),
+         export_period: :timer.minutes(5),
+         otlp_protocol: :http_protobuf,
+         otlp_endpoint: "http://localhost:4318",
+         otlp_headers: %{},
+         otlp_compression: nil}
+      )
+
+      backend_one = %{backend_id: 1, backend_type: :clickhouse}
+      backend_two = %{backend_id: 2, backend_type: :clickhouse}
+
+      for {backend_tags, source_id, count} <- [
+            {backend_one, 100, 5},
+            {backend_one, 200, 7},
+            {backend_two, 100, 3}
+          ] do
+        metadata =
+          backend_tags
+          |> Map.put(:source_id, source_id)
+          |> Map.put(:source_token, "source-#{source_id}")
+
+        :telemetry.execute(@drop_stale_metric_name, %{count: count}, metadata)
+      end
+
+      :telemetry.execute(@drop_stale_metric_name, %{count: 99}, %{source_id: 300})
+
+      assert %{{:sum, @drop_stale_metric_string} => sums} =
+               MetricStore.get_metrics(@drop_stale_exporter)
+
+      assert sums == %{backend_one => 12, backend_two => 3}
     end
   end
 
@@ -361,5 +418,9 @@ defmodule Logflare.TelemetryTest do
 
   defp clickhouse_batch_metrics do
     Enum.filter(Telemetry.metrics(), &(&1.name == @clickhouse_batch_metric_name))
+  end
+
+  defp drop_stale_metrics do
+    Enum.filter(Telemetry.metrics(), &(&1.name == @drop_stale_metric_name))
   end
 end


### PR DESCRIPTION
## Why?

Event age filtering currently runs in `Backends.split_valid_events/2`, which drops old events before _any_ backend sees them. That bound generally exists for ClickHouse as late-arriving events land in old partitions and increase parts written per insert, but applying it globally has implications for other backends. The filtering did originally live in the ClickHouse pipeline up until #3030. The big difference between then and now is that we also support the ability to adjust that threshold (_or disable_) per ClickHouse backend.

## Key Changes

- Removed the stale-age bound from `split_valid_events/2`. The `+1h` future guard stays global, since a future timestamp is bad data for every backend.
- ClickHouse now implements the existing optional `Adaptor.pre_ingest/3` callback, which fires at each dispatch site immediately before `IngestEventQueue.add_to_table`. Stale events are never queued into the consolidated pipeline with this approach.
- New `max_event_age_hours` config for ClickHouse backends (_defaults to `24`, `0` disables the check_)
- `drop_stale` keeps its telemetry event name for dashboard continuity, and gains `backend_id`/`backend_type` metadata plus matching metric tags. A `keep:` guard discards emissions missing either key, and `source_id`/`source_token` are deliberately left untagged to avoid per-source cardinality.
- Events in the newly-accepted age range now count toward `Sources.Counters`, so recorded usage for sources sending old events will rise. This is the accurate number.

## Callout For Grafana Dashboards

- Any dashboards querying the bare `logflare.logs.ingest_logs.drop_stale` series will need `sum()` across the new labels as adding tags changes series identity.