### PR TITLE
perf(logs): remove LogEvent ingest wrapper allocations

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -156,25 +156,21 @@ defmodule Logflare.LogEvent do
 
   @spec mapper_from_db(map(), TypeDetection.event_type()) :: %{String.t() => term}
   defp mapper_from_db(params, event_type) do
-    event_message = event_message(params)
+    event_message = event_message_from_params(params)
     id = id(params)
-    {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
+    {timestamp, _timestamp_inferred} = determine_timestamp(params, event_type)
 
     body =
       params
       |> MetadataCleaner.deep_reject_nil_and_empty()
       |> put_mapper_fields(event_message, id, timestamp)
 
-    %{
-      "body" => body,
-      "id" => id,
-      "timestamp_inferred" => timestamp_inferred
-    }
+    %{"body" => body, "id" => id}
   end
 
   @spec mapper_for_ingest(map(), TypeDetection.event_type()) :: {map(), boolean()}
   defp mapper_for_ingest(params, event_type) do
-    event_message = event_message(params)
+    event_message = event_message_from_params(params)
     id = id(params)
     {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
 
@@ -209,7 +205,7 @@ defmodule Logflare.LogEvent do
   end
 
   @spec validate(LE.t(), Source.t()) :: LE.t()
-  defp validate(%LE{} = le, source) do
+  defp validate(%LE{valid: true} = le, source) do
     case BigQuerySchemaChange.validate(le, source) do
       :ok ->
         le
@@ -423,8 +419,9 @@ defmodule Logflare.LogEvent do
   end
 
   # TODO: deprecate and remove `message`
-  @compile {:inline, event_message: 1}
-  defp event_message(params), do: params["message"] || params["event_message"]
+  @spec event_message_from_params(map()) :: term()
+  @compile {:inline, event_message_from_params: 1}
+  defp event_message_from_params(params), do: params["message"] || params["event_message"]
 
   @spec id(map()) :: String.t()
   defp id(params) do

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -16,8 +16,6 @@ defmodule Logflare.LogEvent do
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
-  @validators [BigQuerySchemaChange]
-
   @primary_key {:id, :binary_id, []}
   typed_embedded_schema do
     field :body, :map, default: %{}
@@ -135,10 +133,8 @@ defmodule Logflare.LogEvent do
       ) do
     event_type = TypeDetection.detect(params)
 
-    %{
-      "body" => %{"id" => id, "timestamp" => timestamp} = body,
-      "timestamp_inferred" => timestamp_inferred
-    } = mapper_for_ingest(params, event_type)
+    {%{"id" => id, "timestamp" => timestamp} = body, timestamp_inferred} =
+      mapper_for_ingest(params, event_type)
 
     day_bucket = DayBucket.from_microseconds(timestamp)
 
@@ -159,44 +155,15 @@ defmodule Logflare.LogEvent do
   end
 
   @spec mapper_from_db(map(), TypeDetection.event_type()) :: %{String.t() => term}
-  defp mapper_from_db(params, event_type),
-    do: mapper(params, event_type, &MetadataCleaner.deep_reject_nil_and_empty/1)
-
-  @spec mapper_for_ingest(map(), TypeDetection.event_type()) :: %{String.t() => term}
-  defp mapper_for_ingest(params, event_type),
-    do: mapper(params, event_type, &clean_ingest_body/1)
-
-  @spec mapper(map(), TypeDetection.event_type(), (map() -> map())) :: %{String.t() => term}
-  defp mapper(params, event_type, clean_body) do
-    # TODO: deprecate and remove `message`
-    event_message = params["message"] || params["event_message"]
+  defp mapper_from_db(params, event_type) do
+    event_message = event_message(params)
     id = id(params)
-
     {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
-
-    base_merge = %{
-      "timestamp" => timestamp,
-      "id" => id
-    }
-
-    base_merge =
-      if event_message != nil do
-        Map.put(base_merge, "event_message", event_message)
-      else
-        base_merge
-      end
 
     body =
       params
-      |> clean_body.()
-      |> Map.merge(base_merge)
-      |> case do
-        %{"message" => m, "event_message" => em} = map when m == em ->
-          Map.delete(map, "message")
-
-        other ->
-          other
-      end
+      |> MetadataCleaner.deep_reject_nil_and_empty()
+      |> put_mapper_fields(event_message, id, timestamp)
 
     %{
       "body" => body,
@@ -205,32 +172,60 @@ defmodule Logflare.LogEvent do
     }
   end
 
-  @spec validate(LE.t(), Source.t()) :: LE.t()
-  defp validate(%LE{valid: true} = le, source) do
-    @validators
-    |> Enum.reduce_while(true, fn validator, _acc ->
-      case validator.validate(le, source) do
-        :ok ->
-          {:cont, %{le | valid: true, pipeline_error: nil}}
+  @spec mapper_for_ingest(map(), TypeDetection.event_type()) :: {map(), boolean()}
+  defp mapper_for_ingest(params, event_type) do
+    event_message = event_message(params)
+    id = id(params)
+    {timestamp, timestamp_inferred} = determine_timestamp(params, event_type)
 
-        {:error, message} ->
-          {:halt,
-           %{
-             le
-             | valid: false,
-               pipeline_error: %LE.PipelineError{
-                 stage: "validators",
-                 type: "validate",
-                 message: message
-               }
-           }}
-      end
-    end)
+    body =
+      params
+      |> IngestTransformers.transform(:clean_to_bigquery_column_spec)
+      |> put_mapper_fields(event_message, id, timestamp)
+
+    {body, timestamp_inferred}
   end
 
-  @spec clean_ingest_body(map()) :: map()
-  defp clean_ingest_body(params),
-    do: IngestTransformers.transform(params, :clean_to_bigquery_column_spec)
+  @spec put_mapper_fields(map(), term(), String.t(), integer()) :: map()
+  defp put_mapper_fields(body, event_message, id, timestamp) do
+    mapped_fields = %{"id" => id, "timestamp" => timestamp}
+
+    mapped_fields =
+      if event_message != nil do
+        Map.put(mapped_fields, "event_message", event_message)
+      else
+        mapped_fields
+      end
+
+    body = Map.merge(body, mapped_fields)
+
+    case body do
+      %{"message" => m, "event_message" => em} = body when m == em ->
+        Map.delete(body, "message")
+
+      body ->
+        body
+    end
+  end
+
+  @spec validate(LE.t(), Source.t()) :: LE.t()
+  defp validate(%LE{} = le, source) do
+    case BigQuerySchemaChange.validate(le, source) do
+      :ok ->
+        le
+
+      {:error, message} ->
+        %{
+          le
+          | valid: false,
+            pipeline_error: %LE.PipelineError{
+              stage: "validators",
+              type: "validate",
+              message: message
+            }
+        }
+    end
+  end
 
   @spec transform(LE.t(), Source.t()) :: LE.t()
   defp transform(%LE{} = le, %Source{} = source) do
@@ -426,6 +421,10 @@ defmodule Logflare.LogEvent do
         "json_path_query_error"
     end
   end
+
+  # TODO: deprecate and remove `message`
+  @compile {:inline, event_message: 1}
+  defp event_message(params), do: params["message"] || params["event_message"]
 
   @spec id(map()) :: String.t()
   defp id(params) do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -735,6 +735,7 @@ defmodule Logflare.LogEventTest do
       )
 
     assert le.id == id
+    refute le.timestamp_inferred
     assert le.body["id"] == id
     assert le.body["timestamp"] == timestamp
     assert le.body["event_message"] == "legacy"

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -34,6 +34,28 @@ defmodule Logflare.LogEventTest do
     assert source_id == source.id
   end
 
+  describe "mapper fields" do
+    test "preserves explicit IDs and normalizes legacy message fields", %{source: source} do
+      id = Ecto.UUID.generate()
+      timestamp = "2024-01-01T00:00:00.123456Z"
+
+      for {message_fields, expected_message} <- [
+            {%{"message" => "legacy"}, "legacy"},
+            {%{"event_message" => "current"}, "current"},
+            {%{"message" => "same", "event_message" => "same"}, "same"},
+            {%{"message" => "legacy wins", "event_message" => "current"}, "legacy wins"}
+          ] do
+        params = Map.merge(message_fields, %{"id" => id, "timestamp" => timestamp})
+        le = LogEvent.make(params, %{source: source})
+
+        assert le.id == id
+        assert le.body["id"] == id
+        assert le.body["event_message"] == expected_message
+        refute Map.has_key?(le.body, "message")
+      end
+    end
+  end
+
   describe "bigquery_spec" do
     test "dashes to underscores", %{source: source} do
       assert %LogEvent{
@@ -700,6 +722,23 @@ defmodule Logflare.LogEventTest do
     params = %{"metadata" => "some string"}
     assert %{body: body} = LogEvent.make_from_db(params, %{source: source})
     assert body["metadata"] == "some string"
+  end
+
+  test "make_from_db/2 preserves mapper fields and normalizes legacy messages", %{source: source} do
+    id = Ecto.UUID.generate()
+    timestamp = 1_713_268_565_764_892
+
+    le =
+      LogEvent.make_from_db(
+        %{"id" => id, "message" => "legacy", "timestamp" => timestamp},
+        %{source: source}
+      )
+
+    assert le.id == id
+    assert le.body["id"] == id
+    assert le.body["timestamp"] == timestamp
+    assert le.body["event_message"] == "legacy"
+    refute Map.has_key?(le.body, "message")
   end
 
   test "apply_custom_event_message/1 generates custom event message from source setting", %{

--- a/test/logflare/validator/bq_schema_change_validator_test.exs
+++ b/test/logflare/validator/bq_schema_change_validator_test.exs
@@ -60,6 +60,8 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
           %{source: source}
         )
 
+      assert le.valid
+      assert le.pipeline_error == nil
       assert validate(le, source) === :ok
     end
 
@@ -81,6 +83,12 @@ defmodule Logflare.Validator.BigQuerySchemaChangeTest do
         |> put_in(~w[user address city], 1000)
 
       le = LE.make(%{"metadata" => conflicting_metadata}, %{source: source})
+
+      refute le.valid
+      assert le.pipeline_error.stage == "validators"
+      assert le.pipeline_error.type == "validate"
+      assert le.pipeline_error.message =~ "Type error"
+      assert le.pipeline_error.message =~ "metadata.user.address.city"
 
       assert {:error, message} = validate(le, source)
       assert message =~ "Type error"


### PR DESCRIPTION
> [!NOTE]
> Removed from the stack: the isolated benchmark showed only a noisy 2.4% geometric-mean throughput change with approximately neutral memory, which did not justify carrying this additional mapper/validator refactor. The remaining stack continues with #3765 → #3767 → #3768 → #3769.

## Summary

- Return `{body, timestamp_inferred}` directly from the ingest mapper instead of allocating an intermediate envelope map.
- Share mapper-field insertion between ingest and database reconstruction while retaining the map shape required by the Ecto changeset path.
- Omit the unused `timestamp_inferred` key from the database mapper result.
- Inline and clearly name legacy message lookup while preserving ID, timestamp, and message precedence behavior.
- Call the sole active validator directly while preserving its valid-event contract and error fields.
- Add mapper and validator integration coverage.

This is part 2 of 5 in the stack replacing #3760.

## Rationale

The ingest mapper previously returned a three-key envelope containing `body`, `id`, and `timestamp_inferred`. `LogEvent.make/2` immediately destructured that envelope, even though the ID was already present in the mapped body. Returning `{body, timestamp_inferred}` removes that short-lived map from every ingest operation.

The database reconstruction path still returns the map required by its Ecto changeset, but both paths now share mapper-field insertion and message normalization. Its unused top-level `timestamp_inferred` key is omitted. Validation also calls the sole active validator directly instead of traversing a one-element module list and creating reducer control tuples. The valid-event function contract and validation error shape remain unchanged.

## Incremental benchmark

This comparison isolates this PR from its stack parent, #3765:

- Baseline: `f60b8258` (`perf/logevent-clean-payload-reuse`)
- Candidate: `9422950b` (`perf/logevent-ingest-wrappers`)
- Three alternating baseline/candidate runs; each cell is the median of three runs
- Linux arm64 host, 6 schedulers, 11 GiB memory
- Elixir 1.19.5, Erlang/OTP 27.3.4.6 / ERTS 15.2.7.4, JIT enabled
- Benchee: 2 s warmup, 5 s runtime, 3 s memory time, 3 s reduction time, parallelism 1
- Production-shaped OTEL trace and edge-log payloads across no-transform, copy, drop, key-value, and combined transform configurations

Across all 12 scenarios, geometric-mean throughput improved **2.4%**. Individual throughput results ranged from **3.0% lower to 14.5% higher**; median latency was unchanged to **5.5% lower**. Per-operation memory was approximately neutral (**-2.4% to +2.6%**) and reductions were unchanged to **1.3% lower**. These incremental effects are modest and some throughput results are within run-to-run noise; the main value is removing unnecessary hot-path data structures while simplifying the mapper and validator flow.

| Scenario | Throughput, base → PR | Speedup | Median latency, base → PR | Memory | Reductions |
|---|---:|---:|---:|---:|---:|
| OTEL trace | 397.2K → 415.2K ops/s | 1.05x | 2.38 → 2.25 µs | +1.6% | +0.0% |
| OTEL trace + copy | 357.9K → 365.7K ops/s | 1.02x | 2.63 → 2.54 µs | -1.8% | -1.3% |
| OTEL trace + drop | 358.1K → 369.6K ops/s | 1.03x | 2.63 → 2.56 µs | -1.8% | -1.3% |
| OTEL trace + KV | 225.7K → 258.4K ops/s | 1.14x | 3.63 → 3.63 µs | -1.5% | +0.0% |
| OTEL trace + copy + KV | 223.6K → 218.3K ops/s | 0.98x | 3.92 → 3.84 µs | -1.6% | -1.1% |
| OTEL trace + all | 219.1K → 212.9K ops/s | 0.97x | 4.25 → 4.17 µs | -1.4% | -1.1% |
| Edge log | 380.8K → 375.9K ops/s | 0.99x | 2.46 → 2.46 µs | -1.2% | +0.0% |
| Edge log + copy | 327.1K → 333.3K ops/s | 1.02x | 2.87 → 2.83 µs | -1.7% | -0.7% |
| Edge log + drop | 304.5K → 311.6K ops/s | 1.02x | 3.04 → 3.00 µs | +2.0% | -0.7% |
| Edge log + KV | 238.3K → 250.7K ops/s | 1.05x | 3.68 → 3.63 µs | +2.6% | -0.7% |
| Edge log + copy + KV | 212.0K → 205.7K ops/s | 0.97x | 4.12 → 4.08 µs | -2.4% | -0.7% |
| Edge log + all | 166.6K → 175.5K ops/s | 1.05x | 4.84 → 4.79 µs | +0.7% | -0.6% |

These measurements isolate `LogEvent.make/2`; they do not represent end-to-end ingestion throughput.

## Stack

1. #3765 — Reuse clean BigQuery-safe payloads
2. **#3766 — Remove LogEvent ingest wrapper allocations**
3. #3767 — Transform bodies before constructing LogEvent
4. #3768 — Normalize integer timestamps without digit lists
5. #3769 — Fast-path common UTC ISO 8601 timestamps

## Validation

- `../bin/test test/logflare/log_event_test.exs test/logflare/validator/bq_schema_change_validator_test.exs`
- `MIX_ENV=test ../bin/x mix format --check-formatted`
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `MIX_ENV=test ../bin/x mix lint.all`


