### PR TITLE
perf(logs): normalize integer timestamps without digit lists

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -479,7 +479,7 @@ defmodule Logflare.LogEvent do
   end
 
   defp determine_timestamp(%{"timestamp" => x}) when is_non_negative_integer(x) do
-    {Utils.to_microseconds(x), false}
+    {timestamp_to_microseconds(x), false}
   end
 
   defp determine_timestamp(%{"timestamp" => x}) when is_float(x) do
@@ -504,18 +504,41 @@ defmodule Logflare.LogEvent do
 
   @spec extract_trace_start_time(params :: map()) :: pos_integer() | nil
   defp extract_trace_start_time(%{"start_time" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"startTime" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"start_time_unix_nano" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(%{"startTimeUnixNano" => n}) when is_pos_integer(n),
-    do: Utils.to_microseconds(n)
+    do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(_params), do: nil
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000_000_000 and
+              raw < 10_000_000_000_000_000_000,
+       do: div(raw, 1_000)
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000_000 and
+              raw < 10_000_000_000_000_000,
+       do: raw
+
+  defp timestamp_to_microseconds(raw)
+       when raw >= 1_000_000_000_000 and
+              raw < 10_000_000_000_000,
+       do: raw * 1_000
+
+  defp timestamp_to_microseconds(raw) when raw >= 1_000_000_000 and raw < 10_000_000_000,
+    do: raw * 1_000_000
+
+  defp timestamp_to_microseconds(raw) when raw >= 1_000_000 and raw < 10_000_000,
+    do: raw * 1_000_000_000
+
+  defp timestamp_to_microseconds(raw), do: raw
 
   @spec default_timestamp() :: integer()
   defp default_timestamp do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -4,6 +4,7 @@ defmodule Logflare.LogEventTest do
   use ExUnitProperties
 
   alias Logflare.LogEvent
+  alias Logflare.LogEvent.DayBucket
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
@@ -783,6 +784,58 @@ defmodule Logflare.LogEventTest do
       assert le.timestamp_inferred == false
     end
 
+    test "preserves integer timestamp unit conversion", %{source: source} do
+      for timestamp <- [
+            0,
+            999_999,
+            1_000_000,
+            9_999_999,
+            10_000_000,
+            100_000_000,
+            1_000_000_000,
+            9_999_999_999,
+            10_000_000_000,
+            100_000_000_000,
+            1_000_000_000_000,
+            9_999_999_999_999,
+            10_000_000_000_000,
+            100_000_000_000_000,
+            1_000_000_000_000_000,
+            9_999_999_999_999_999,
+            10_000_000_000_000_000,
+            100_000_000_000_000_000,
+            1_000_000_000_000_000_000,
+            9_999_999_999_999_999_999,
+            10_000_000_000_000_000_000
+          ] do
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+        assert le.body["timestamp"] == Utils.to_microseconds(timestamp)
+      end
+    end
+
+    property "generated integer and float timestamps match the reference conversion" do
+      source = build(:source, user: build(:user), validate_schema: false)
+
+      check all timestamp <-
+                  one_of([
+                    integer(1_713_268_565_764_892..1_713_268_565_764_999),
+                    integer(1_713_268_565_764..1_713_268_565_999),
+                    integer(1_713_268_565..1_713_268_999),
+                    float(min: 1_713_268_565.1, max: 1_713_268_999.9),
+                    float(min: 1_713_268_000_000.1, max: 1_713_268_000_999.9),
+                    float(min: 1_713_268_565_000_000.1, max: 1_713_268_565_000_999.9)
+                  ]) do
+        rounded = if is_float(timestamp), do: round(timestamp), else: timestamp
+        expected = Utils.to_microseconds(rounded)
+        params = Map.put(@vallog_event_ids, "timestamp", timestamp)
+        le = LogEvent.make(params, %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
+    end
+
     test "is false when a valid float timestamp is provided", %{source: source} do
       params = Map.put(@vallog_event_ids, "timestamp", 1_713_268_565.5)
       le = LogEvent.make(params, %{source: source})
@@ -827,17 +880,36 @@ defmodule Logflare.LogEventTest do
       assert le.body["timestamp"] == start_time_us
     end
 
-    test "honors `start_time_unix_nano` (OTEL processor key)", %{source: source} do
+    test "honors every supported trace start-time key", %{source: source} do
+      start_time_ns = System.system_time(:nanosecond) - 1_000_000_000
+
+      for key <- ~w(start_time startTime start_time_unix_nano startTimeUnixNano) do
+        params = %{
+          "event_message" => "trace from otel processor",
+          "metadata" => %{"type" => "span"},
+          key => start_time_ns
+        }
+
+        le = LogEvent.make(params, %{source: source})
+
+        assert le.timestamp_inferred
+        assert le.body["timestamp"] == Utils.to_microseconds(start_time_ns)
+      end
+    end
+
+    test "uses trace start time when an explicit timestamp is invalid", %{source: source} do
       start_time_ns = System.system_time(:nanosecond) - 1_000_000_000
 
       params = %{
-        "event_message" => "trace from otel processor",
+        "event_message" => "trace with invalid timestamp",
         "metadata" => %{"type" => "span"},
+        "timestamp" => "not-a-timestamp",
         "start_time_unix_nano" => start_time_ns
       }
 
       le = LogEvent.make(params, %{source: source})
 
+      assert le.timestamp_inferred
       assert le.body["timestamp"] == Utils.to_microseconds(start_time_ns)
     end
 
@@ -952,23 +1024,6 @@ defmodule Logflare.LogEventTest do
         le = event_with_message("#{first}.#{second}", metadata)
 
         assert Jason.encode!(metadata[first][second]) == le.body["event_message"]
-      end
-    end
-
-    property "timestamp unix conversions" do
-      source = build(:source, user: build(:user))
-
-      check all ts <-
-                  one_of([
-                    integer(1_713_268_565_764_892..1_713_268_565_764_999),
-                    integer(1_713_268_565_764..1_713_268_565_999),
-                    integer(1_713_268_565..1_713_268_999),
-                    float(min: 1_713_268_565.1, max: 1_713_268_999.9),
-                    float(min: 1_713_268_000_000.1, max: 1_713_268_000_999.9),
-                    float(min: 1_713_268_565_000_000.1, max: 1_713_268_565_000_999.9)
-                  ]) do
-        params = Map.put(@vallog_event_ids, "timestamp", ts)
-        LogEvent.make(params, %{source: source})
       end
     end
 


### PR DESCRIPTION
## Summary

- Replace `Integer.digits/1 |> Enum.count/1` timestamp-unit detection with numeric range guards.
- Preserve the existing 7-, 10-, 13-, 16-, and 19-digit conversion behavior.
- Use the same allocation-free helper for explicit event timestamps and all supported trace start-time aliases.
- Add conversion-boundary, generated parity, day-bucket, trace-alias, and invalid-explicit-timestamp coverage.

## Stack

1. #3765 — Reuse clean BigQuery-safe payloads
2. #3767 — Transform bodies before constructing LogEvent
3. **#3768 — Normalize integer timestamps without digit lists**
4. #3769 — Fast-path common UTC ISO 8601 timestamps