### PR TITLE
perf(logs): fast-path common UTC ISO 8601 timestamps

### DIFF
--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -469,12 +469,9 @@ defmodule Logflare.LogEvent do
     do: {default_timestamp(), true}
 
   defp determine_timestamp(%{"timestamp" => x}) when is_non_empty_binary(x) do
-    case DateTime.from_iso8601(x) do
-      {:ok, udt, _} ->
-        {DateTime.to_unix(udt, :microsecond), false}
-
-      {:error, _} ->
-        {default_timestamp(), true}
+    case iso8601_to_microseconds(x) do
+      {:ok, timestamp} -> {timestamp, false}
+      {:error, _} -> {default_timestamp(), true}
     end
   end
 
@@ -516,6 +513,75 @@ defmodule Logflare.LogEvent do
     do: timestamp_to_microseconds(n)
 
   defp extract_trace_start_time(_params), do: nil
+
+  defp iso8601_to_microseconds(
+         <<y1, y2, y3, y4, ?-, mo1, mo2, ?-, d1, d2, ?T, h1, h2, ?:, mi1, mi2, ?:, s1, s2, ?., u1,
+           u2, u3, u4, u5, u6, ?Z>> = timestamp
+       )
+       when y1 in ?0..?9 and y2 in ?0..?9 and y3 in ?0..?9 and y4 in ?0..?9 and
+              mo1 in ?0..?9 and mo2 in ?0..?9 and d1 in ?0..?9 and d2 in ?0..?9 and
+              h1 in ?0..?9 and h2 in ?0..?9 and mi1 in ?0..?9 and mi2 in ?0..?9 and
+              s1 in ?0..?9 and s2 in ?0..?9 and u1 in ?0..?9 and u2 in ?0..?9 and
+              u3 in ?0..?9 and u4 in ?0..?9 and u5 in ?0..?9 and u6 in ?0..?9 do
+    year = decimal4(y1, y2, y3, y4)
+    month = decimal2(mo1, mo2)
+    day = decimal2(d1, d2)
+    hour = decimal2(h1, h2)
+    minute = decimal2(mi1, mi2)
+    second = decimal2(s1, s2)
+
+    days_before_month =
+      if year in 1970..2099 do
+        days_before_month(year, month, day)
+      end
+
+    if is_integer(days_before_month) and hour < 24 and minute < 60 and second < 60 do
+      microsecond = decimal6(u1, u2, u3, u4, u5, u6)
+
+      days =
+        (year - 1970) * 365 + div(year - 1969, 4) + days_before_month + day - 1
+
+      {:ok, (((days * 24 + hour) * 60 + minute) * 60 + second) * 1_000_000 + microsecond}
+    else
+      parse_iso8601(timestamp)
+    end
+  end
+
+  defp iso8601_to_microseconds(timestamp), do: parse_iso8601(timestamp)
+
+  defp parse_iso8601(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.to_unix(datetime, :microsecond)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp days_before_month(_year, 1, day) when day in 1..31, do: 0
+  defp days_before_month(_year, 2, day) when day in 1..28, do: 31
+  defp days_before_month(year, 2, 29) when rem(year, 4) == 0, do: 31
+  defp days_before_month(year, 3, day) when day in 1..31, do: 59 + leap_day(year)
+  defp days_before_month(year, 4, day) when day in 1..30, do: 90 + leap_day(year)
+  defp days_before_month(year, 5, day) when day in 1..31, do: 120 + leap_day(year)
+  defp days_before_month(year, 6, day) when day in 1..30, do: 151 + leap_day(year)
+  defp days_before_month(year, 7, day) when day in 1..31, do: 181 + leap_day(year)
+  defp days_before_month(year, 8, day) when day in 1..31, do: 212 + leap_day(year)
+  defp days_before_month(year, 9, day) when day in 1..30, do: 243 + leap_day(year)
+  defp days_before_month(year, 10, day) when day in 1..31, do: 273 + leap_day(year)
+  defp days_before_month(year, 11, day) when day in 1..30, do: 304 + leap_day(year)
+  defp days_before_month(year, 12, day) when day in 1..31, do: 334 + leap_day(year)
+  defp days_before_month(_year, _month, _day), do: nil
+
+  defp leap_day(year) when rem(year, 4) == 0, do: 1
+  defp leap_day(_year), do: 0
+
+  @compile {:inline, decimal2: 2, decimal4: 4, decimal6: 6}
+  defp decimal2(a, b), do: (a - ?0) * 10 + b - ?0
+  defp decimal4(a, b, c, d), do: (a - ?0) * 1_000 + (b - ?0) * 100 + decimal2(c, d)
+
+  defp decimal6(a, b, c, d, e, f),
+    do:
+      (a - ?0) * 100_000 + (b - ?0) * 10_000 + (c - ?0) * 1_000 + (d - ?0) * 100 +
+        (e - ?0) * 10 + f - ?0
 
   defp timestamp_to_microseconds(raw)
        when raw >= 1_000_000_000_000_000_000 and

--- a/test/logflare/google/bigquery/event_utils_test.exs
+++ b/test/logflare/google/bigquery/event_utils_test.exs
@@ -2,8 +2,41 @@ defmodule Logflare.Google.BigQuery.EventUtilsTest do
   use ExUnit.Case, async: true
 
   alias Logflare.Google.BigQuery.EventUtils
+  alias Logflare.LogEvent
+  alias Logflare.Sources.Source
 
   doctest EventUtils
+
+  describe "log_event_to_df_struct/1" do
+    test "preserves the timestamp type required by BigQuery Storage API encoding" do
+      source = %Source{id: 1, name: "storage-contract-test", validate_schema: false}
+      timestamp = "2024-02-29T12:34:56.123456Z"
+      {:ok, expected, _offset} = DateTime.from_iso8601(timestamp)
+
+      log_event =
+        LogEvent.make(
+          %{
+            "id" => "00000000-0000-0000-0000-000000000000",
+            "event_message" => "storage contract",
+            "timestamp" => timestamp
+          },
+          %{source: source}
+        )
+
+      assert log_event.body["timestamp"] == DateTime.to_unix(expected, :microsecond)
+
+      row = EventUtils.log_event_to_df_struct(log_event)
+      assert row["timestamp"] == expected
+
+      dataframe = Explorer.DataFrame.new([row])
+
+      assert Explorer.DataFrame.dtypes(dataframe)["timestamp"] ==
+               {:datetime, :microsecond, "Etc/UTC"}
+
+      assert {:ok, _schema} = Explorer.DataFrame.dump_ipc_schema(dataframe)
+      assert {:ok, [_batch | _]} = Explorer.DataFrame.dump_ipc_record_batch(dataframe)
+    end
+  end
 
   describe "prepare_for_ingest/1" do
     test "wraps event in list and nested maps in lists" do

--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -772,6 +772,84 @@ defmodule Logflare.LogEventTest do
       assert le.timestamp_inferred == false
     end
 
+    test "preserves microseconds for common UTC ISO 8601 timestamps", %{source: source} do
+      for timestamp <- [
+            "1970-01-01T00:00:00.000001Z",
+            "1972-02-29T12:34:56.654321Z",
+            "2000-02-29T23:59:59.123456Z",
+            "2024-12-31T12:34:56.999999Z",
+            "2096-02-29T00:00:00.000000Z",
+            "2099-12-31T23:59:59.000001Z"
+          ] do
+        {:ok, datetime, _offset} = DateTime.from_iso8601(timestamp)
+        expected = DateTime.to_unix(datetime, :microsecond)
+
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        assert le.timestamp_inferred == false
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
+    end
+
+    property "common UTC ISO 8601 fast path matches DateTime", %{source: source} do
+      max_date_offset = Date.diff(~D[2099-12-31], ~D[1970-01-01])
+
+      check all date_offset <- integer(0..max_date_offset),
+                hour <- integer(0..23),
+                minute <- integer(0..59),
+                second <- integer(0..59),
+                microsecond <- integer(0..999_999) do
+        datetime =
+          ~D[1970-01-01]
+          |> Date.add(date_offset)
+          |> DateTime.new!(Time.new!(hour, minute, second, {microsecond, 6}), "Etc/UTC")
+
+        timestamp = DateTime.to_iso8601(datetime)
+        expected = DateTime.to_unix(datetime, :microsecond)
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+        assert le.day_bucket == DayBucket.from_microseconds(expected)
+      end
+    end
+
+    test "standard parser fallback preserves other valid ISO 8601 forms", %{source: source} do
+      for timestamp <- [
+            "1969-12-31T23:59:59.123456Z",
+            "2100-03-01T00:00:00.123456Z",
+            "2024-01-01T12:34:56.123Z",
+            "2024-01-01T12:34:56Z",
+            "2024-01-01T12:34:56.123456+05:30"
+          ] do
+        {:ok, datetime, _offset} = DateTime.from_iso8601(timestamp)
+        expected = DateTime.to_unix(datetime, :microsecond)
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+
+        refute le.timestamp_inferred
+        assert le.body["timestamp"] == expected
+      end
+    end
+
+    test "rejects invalid common-shape ISO 8601 timestamps", %{source: source} do
+      for timestamp <- [
+            "2025-02-29T12:34:56.123456Z",
+            "2100-02-29T12:34:56.123456Z",
+            "2024-00-01T12:34:56.123456Z",
+            "2024-13-01T12:34:56.123456Z",
+            "2024-01-00T12:34:56.123456Z",
+            "2024-04-31T12:34:56.123456Z",
+            "2024-01-01T24:00:00.123456Z",
+            "2024-01-01T12:60:00.123456Z",
+            "2024-01-01T12:34:60.123456Z",
+            "2024-01-01T12:34:56.12345xZ"
+          ] do
+        le = LogEvent.make(Map.put(@vallog_event_ids, "timestamp", timestamp), %{source: source})
+        assert le.timestamp_inferred == true
+      end
+    end
+
     test "is true when an unparsable string timestamp is provided", %{source: source} do
       params = Map.put(@vallog_event_ids, "timestamp", "not-a-timestamp")
       le = LogEvent.make(params, %{source: source})


### PR DESCRIPTION
## Summary

- Parse the common production form `YYYY-MM-DDTHH:MM:SS.ffffffZ` directly for years 1970 through 2099.
- Validate calendar days, leap days, hours, minutes, and seconds before computing Unix microseconds.
- Retain `DateTime.from_iso8601/1` as the compatibility fallback for offsets, other precision, out-of-range years, and invalid common-shape values.
- Add generated parity, boundary, invalid-date, and fallback coverage.
- Assert that BigQuery Storage API conversion still produces UTC `DateTime` values and Arrow timestamp data.

## Stack

1. #3765 — Reuse clean BigQuery-safe payloads
2. #3767 — Transform bodies before constructing LogEvent
3. #3768 — Normalize integer timestamps without digit lists
4. **#3769 — Fast-path common UTC ISO 8601 timestamps**

