### PR TITLE
test: speed up backend adaptor integration tests

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/pipeline.ex
+++ b/lib/logflare/backends/adaptor/http_based/pipeline.ex
@@ -13,6 +13,9 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
   alias Logflare.Sources.Source
   alias Logflare.Utils
 
+  @batch_timeout if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+  @producer_interval if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+
   @spec start_link(Source.t(), Backend.t(), module()) :: Broadway.on_start()
   def start_link(source, backend, client) do
     Broadway.start_link(__MODULE__,
@@ -26,7 +29,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
           {BufferProducer,
            [
              backend_id: backend.id,
-             source_id: source.id
+             source_id: source.id,
+             interval: @producer_interval
            ]},
         transformer: {__MODULE__, :transform, []},
         concurrency: 1
@@ -35,7 +39,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Pipeline do
         default: [concurrency: 3, min_demand: 1]
       ],
       batchers: [
-        http: [concurrency: 6, batch_size: 250]
+        http: [concurrency: 6, batch_size: 250, batch_timeout: @batch_timeout]
       ],
       context: %{
         source_id: source.id,

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -303,6 +303,9 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     alias Logflare.Backends.BufferProducer
     alias Logflare.Backends.Adaptor.WebhookAdaptor.Client
 
+    @batch_timeout if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+    @producer_interval if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
+
     def start_link(args) do
       Broadway.start_link(__MODULE__,
         name: Backends.via_source(args.source, __MODULE__, args.backend),
@@ -315,7 +318,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
             {BufferProducer,
              [
                backend_id: Map.get(args.backend || %{}, :id),
-               source_id: args.source.id
+               source_id: args.source.id,
+               interval: @producer_interval
              ]},
           transformer: {__MODULE__, :transform, []},
           concurrency: 1
@@ -324,7 +328,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
           default: [concurrency: 3, min_demand: 1]
         ],
         batchers: [
-          http: [concurrency: 6, batch_size: 250]
+          http: [concurrency: 6, batch_size: 250, batch_timeout: @batch_timeout]
         ],
         context: %{
           startup_config: args.config,

--- a/test/logflare/backends/adaptor/axiom_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/axiom_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
@@ -111,7 +110,6 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -141,7 +139,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert {:ok, _} = enqueue_backend_logs([log_event], source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [log] = Jason.decode!(json)
@@ -165,7 +163,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [_, _, _] = Jason.decode!(json)

--- a/test/logflare/backends/adaptor/axiom_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/axiom_adaptor_test.exs
@@ -1,9 +1,10 @@
 defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Tesla.MockAdapter
 
@@ -108,8 +109,8 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
   describe "logs ingestion" do
     setup :backend_data
 
-    setup %{source: source, backend: backend} do
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+    setup %{source: source} do
+      start_supervised!({SourceSup, source})
       :ok
     end
 
@@ -139,7 +140,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = enqueue_backend_logs([log_event], source)
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [log] = Jason.decode!(json)
@@ -163,7 +164,7 @@ defmodule Logflare.Backends.Adaptor.AxiomAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, gzipped}, 5000
       assert json = :zlib.gunzip(gzipped)
       assert [_, _, _] = Jason.decode!(json)

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -28,9 +28,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       end
     end)
 
-    Process.sleep(200)
-
-    assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+    TestUtils.retry_assert(fn ->
+      assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+    end)
 
     context = %{backend_id: backend.id}
 
@@ -241,15 +241,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert backend_id == backend.id
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      assert {:ok, {[%{"count" => 2}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 2}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "handles empty messages list", %{context: context} do
@@ -344,17 +344,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      {:ok, {query_result, _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          "SELECT event_message, timestamp FROM #{table_name} ORDER BY timestamp DESC"
-        )
+      query_result =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {query_result, _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     "SELECT event_message, timestamp FROM #{table_name} ORDER BY timestamp DESC"
+                   )
 
-      assert length(query_result) == 2
+          assert length(query_result) == 2
+          query_result
+        end)
 
       [first_row, second_row] = query_result
 
@@ -395,15 +397,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      assert {:ok, {[%{"count" => 3}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 3}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "routes metric events to metrics table", %{
@@ -429,15 +431,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
-      assert {:ok, {[%{"count" => 1}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 1}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "routes trace events to traces table", %{
@@ -462,15 +464,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
-      assert {:ok, {[%{"count" => 1}], _bytes}} =
-               ClickHouseAdaptor.execute_ch_query(
-                 backend,
-                 "SELECT count(*) as count FROM #{table_name}"
-               )
+      TestUtils.retry_assert(fn ->
+        assert {:ok, {[%{"count" => 1}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) as count FROM #{table_name}"
+                 )
+      end)
     end
 
     test "inserts logs with all scalar fields readable via SELECT", %{
@@ -498,23 +500,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, trace_id, span_id, trace_flags,
-            severity_text, severity_number, service_name, event_message,
-            scope_name, scope_version, scope_schema_url, resource_schema_url,
-            resource_attributes, scope_attributes, log_attributes, timestamp
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, trace_id, span_id, trace_flags,
+                       severity_text, severity_number, service_name, event_message,
+                       scope_name, scope_version, scope_schema_url, resource_schema_url,
+                       resource_attributes, scope_attributes, log_attributes, timestamp
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])
@@ -563,28 +568,31 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, time_unix, start_time_unix,
-            metric_name, metric_description, metric_unit, metric_type,
-            service_name, event_message, scope_name, scope_version,
-            scope_schema_url, resource_schema_url,
-            resource_attributes, scope_attributes, attributes,
-            aggregation_temporality, is_monotonic, flags,
-            value, count, sum, min, max,
-            scale, zero_count, positive_offset, negative_offset,
-            timestamp
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, time_unix, start_time_unix,
+                       metric_name, metric_description, metric_unit, metric_type,
+                       service_name, event_message, scope_name, scope_version,
+                       scope_schema_url, resource_schema_url,
+                       resource_attributes, scope_attributes, attributes,
+                       aggregation_temporality, is_monotonic, flags,
+                       value, count, sum, min, max,
+                       scale, zero_count, positive_offset, negative_offset,
+                       timestamp
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])
@@ -620,25 +628,28 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
       assert_same_messages(result, messages)
 
-      Process.sleep(200)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
-      {:ok, {[row], _bytes}} =
-        ClickHouseAdaptor.execute_ch_query(
-          backend,
-          """
-          SELECT
-            id, source_uuid, source_name, project, timestamp,
-            trace_id, span_id, parent_span_id, trace_state,
-            span_name, span_kind, service_name, event_message,
-            duration, status_code, status_message,
-            scope_name, scope_version,
-            resource_attributes, span_attributes
-          FROM #{table_name}
-          LIMIT 1
-          """
-        )
+      row =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, {[row], _bytes}} =
+                   ClickHouseAdaptor.execute_ch_query(
+                     backend,
+                     """
+                     SELECT
+                       id, source_uuid, source_name, project, timestamp,
+                       trace_id, span_id, parent_span_id, trace_state,
+                       span_name, span_kind, service_name, event_message,
+                       duration, status_code, status_message,
+                       scope_name, scope_version,
+                       resource_attributes, span_attributes
+                     FROM #{table_name}
+                     LIMIT 1
+                     """
+                   )
+
+          row
+        end)
 
       assert row["id"] != nil
       assert is_binary(row["source_uuid"])

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
@@ -67,23 +67,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ProvisionerTest do
 
   describe "connection test failure handling" do
     @tag capture_log: true
-    test "fails initialization when ClickHouse is unavailable" do
-      {_source, invalid_backend} =
-        setup_clickhouse_test(
-          config: %{
-            url: "http://localhost",
-            username: "invalid_user",
-            password: "invalid_pass",
-            port: 19_999
-          }
-        )
+    test "fails initialization when ClickHouse is unavailable", %{backend: backend} do
+      expect(ClickHouseAdaptor, :test_connection, fn ^backend ->
+        {:error, :grant_check_unknown_failure}
+      end)
 
-      pid = start_supervised!({Provisioner, invalid_backend}, restart: :transient)
+      pid = start_supervised!({Provisioner, backend}, restart: :transient)
       ref = Process.monitor(pid)
 
       assert_receive {:DOWN, ^ref, :process, ^pid,
                       {:shutdown, {:error, :grant_check_unknown_failure}}},
-                     5_000
+                     1_000
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/provisioner_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ProvisionerTest do
 
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Provisioner
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates
 
   import Logflare.ClickHouseMappedEvents
 
@@ -67,9 +68,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ProvisionerTest do
 
   describe "connection test failure handling" do
     @tag capture_log: true
-    test "fails initialization when ClickHouse is unavailable", %{backend: backend} do
-      expect(ClickHouseAdaptor, :test_connection, fn ^backend ->
-        {:error, :grant_check_unknown_failure}
+    test "stops when the ingest grant check encounters a connection error", %{
+      backend: backend
+    } do
+      grant_check_statement = QueryTemplates.grant_check_statement()
+
+      stub(Ch, :query, fn
+        _pool, ^grant_check_statement, _params, _opts ->
+          {:error, %DBConnection.ConnectionError{message: "unreachable"}}
+
+        pool, statement, params, opts ->
+          Mimic.call_original(Ch, :query, [pool, statement, params, opts])
       end)
 
       pid = start_supervised!({Provisioner, backend}, restart: :transient)

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -10,6 +10,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryConnectionSup
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates
   alias Logflare.Backends.Backend
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.Adaptor.QueryResult
@@ -373,20 +374,35 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert :ok = ClickHouseAdaptor.test_connection(backend)
     end
 
-    test "fails when ingest URL is unreachable" do
-      {_source, backend} =
-        setup_clickhouse_test(config: %{url: "http://localhost:19999"})
+    test "fails when the ingest cluster returns a connection error" do
+      {_source, backend} = setup_clickhouse_test(cleanup?: false)
 
-      start_supervised!({ClickHouseAdaptor, backend})
-      assert {:error, _} = ClickHouseAdaptor.test_connection(backend)
+      stub(Ch, :query, fn _pool, _statement, _params, _opts ->
+        {:error, %DBConnection.ConnectionError{message: "unreachable"}}
+      end)
+
+      assert {:error, :grant_check_unknown_failure} = ClickHouseAdaptor.test_connection(backend)
     end
 
-    test "fails when read_only_url is unreachable" do
+    test "fails when the read cluster returns a connection error" do
       {_source, backend} =
-        setup_clickhouse_test(config: %{read_only_url: "http://localhost:19999"})
+        setup_clickhouse_test(
+          config: %{read_only_url: "http://localhost:8123"},
+          cleanup?: false
+        )
 
-      start_supervised!({ClickHouseAdaptor, backend})
-      assert {:error, _} = ClickHouseAdaptor.test_connection(backend)
+      read_grant_statement = QueryTemplates.read_grant_check_statement()
+
+      stub(Ch, :query, fn pool, statement, params, opts ->
+        if statement == read_grant_statement do
+          {:error, %DBConnection.ConnectionError{message: "unreachable"}}
+        else
+          Mimic.call_original(Ch, :query, [pool, statement, params, opts])
+        end
+      end)
+
+      assert {:error, :grant_check_unknown_failure} = ClickHouseAdaptor.test_connection(backend)
+      QueryConnectionSup.terminate_backend_local(backend.id)
     end
 
     test "passes when async is enabled and async_insert_cluster_url points to a valid cluster" do
@@ -485,8 +501,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       result = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log, async: true)
       assert :ok = result
 
-      Process.sleep(500)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
       query_result =
@@ -518,8 +532,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       result = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
       assert :ok = result
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -587,8 +599,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log)
 
-      Process.sleep(100)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
       {:ok, {[row], _bytes}} =
@@ -618,8 +628,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [metric_event], :metric)
 
-      Process.sleep(100)
-
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :metric)
 
       {:ok, {[row], _bytes}} =
@@ -646,8 +654,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         )
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, [trace_event], :trace)
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :trace)
 
@@ -677,8 +683,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
         :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], event_type)
 
-        Process.sleep(100)
-
         table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, event_type)
 
         {:ok, {query_result, _bytes}} =
@@ -707,8 +711,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     test "executes a query with query-level SETTINGS", %{source: source, backend: backend} do
       log_event = build_mapped_log_event(source: source, message: "settings exec test")
       assert :ok = ClickHouseAdaptor.insert_log_events(backend, [log_event], :log)
-
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -786,7 +788,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       ]
 
       :ok = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
-      Process.sleep(100)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -863,7 +864,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         end
 
       assert :ok = ClickHouseAdaptor.insert_log_events(backend, log_events, :log)
-      Process.sleep(200)
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 
@@ -1032,7 +1032,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       {source, backend} = setup_clickhouse_test()
 
       start_supervised!({ClickHouseAdaptor, backend})
-      Process.sleep(100)
       [source: source, backend: backend]
     end
 
@@ -1100,7 +1099,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       {source, backend} = setup_clickhouse_test()
 
       start_supervised!({ClickHouseAdaptor, backend})
-      Process.sleep(100)
       [source: source, backend: backend]
     end
 

--- a/test/logflare/backends/adaptor/datadog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/datadog_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Backends.Adaptor.DatadogAdaptor
@@ -106,7 +105,6 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       start_supervised!({AdaptorSupervisor, {source, backend}}, id: :source1)
       start_supervised!({AdaptorSupervisor, {source_with_service_name, backend}}, id: :source2)
-      :timer.sleep(500)
 
       [
         backend: backend,
@@ -128,7 +126,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -144,7 +142,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source, message: nil, event_message: nil)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -160,7 +158,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.service_name
     end
@@ -177,7 +175,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.name
     end
@@ -194,7 +192,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["data"] == le.body
     end

--- a/test/logflare/backends/adaptor/datadog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/datadog_adaptor_test.exs
@@ -1,10 +1,11 @@
 defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends.AdaptorSupervisor
-  alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Backends.Adaptor.DatadogAdaptor
+  alias Logflare.Backends.SourceSup
+  alias Logflare.SystemMetrics.AllLogsLogged
 
   @subject DatadogAdaptor
   @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
@@ -103,8 +104,8 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
           config: %{api_key: "foo-bar", region: "US1"}
         )
 
-      start_supervised!({AdaptorSupervisor, {source, backend}}, id: :source1)
-      start_supervised!({AdaptorSupervisor, {source_with_service_name, backend}}, id: :source2)
+      start_supervised!({SourceSup, source}, id: :source1)
+      start_supervised!({SourceSup, source_with_service_name}, id: :source2)
 
       [
         backend: backend,
@@ -126,7 +127,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -142,7 +143,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source, message: nil, event_message: nil)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -158,7 +159,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.service_name
     end
@@ -175,7 +176,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["service"] == source.name
     end
@@ -192,7 +193,7 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, [log_entry]}, 2000
       assert log_entry["data"] == le.body
     end

--- a/test/logflare/backends/adaptor/elastic_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/elastic_adaptor_test.exs
@@ -3,7 +3,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
   alias Logflare.Backends.Adaptor
   alias Logflare.SystemMetrics.AllLogsLogged
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
 
   @subject Logflare.Backends.Adaptor.ElasticAdaptor
@@ -65,7 +64,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -81,7 +79,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -97,7 +95,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end
@@ -120,7 +118,6 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
         )
 
       pid = start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [pid: pid, backend: backend, source: source]
     end
 
@@ -137,7 +134,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end

--- a/test/logflare/backends/adaptor/elastic_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/elastic_adaptor_test.exs
@@ -1,9 +1,10 @@
 defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
-  alias Logflare.Backends.AdaptorSupervisor
 
   @subject Logflare.Backends.Adaptor.ElasticAdaptor
   @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
@@ -63,7 +64,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
           config: %{url: "http://localhost:1234"}
         )
 
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+      start_supervised!({SourceSup, source})
       [backend: backend, source: source]
     end
 
@@ -79,7 +80,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -95,7 +96,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end
@@ -117,7 +118,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
           }
         )
 
-      pid = start_supervised!({AdaptorSupervisor, {source, backend}})
+      pid = start_supervised!({SourceSup, source})
       [pid: pid, backend: backend, source: source]
     end
 
@@ -134,7 +135,7 @@ defmodule Logflare.Backends.Adaptor.ElasticAdaptorTest do
 
       le = build(:log_event, source: source, some: "key")
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, [event]}, 2000
       assert event["some"] == "key"
     end

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Alerting
@@ -122,7 +121,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -137,7 +135,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
 
       %{body: %{"event_message" => message}} = le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive payload, 2000
 
       assert %{
@@ -170,7 +168,6 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source, user: user]
     end
 

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -1,10 +1,12 @@
 defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Alerting
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
-  alias Logflare.Alerting
 
   @subject Logflare.Backends.Adaptor.IncidentioAdaptor
   @client Logflare.Backends.Adaptor.WebhookAdaptor.Client
@@ -120,7 +122,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
           }
         )
 
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+      start_supervised!({SourceSup, source})
       [backend: backend, source: source]
     end
 
@@ -135,7 +137,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
 
       %{body: %{"event_message" => message}} = le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive payload, 2000
 
       assert %{

--- a/test/logflare/backends/adaptor/last9_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/last9_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
   alias Logflare.Backends.AdaptorSupervisor
@@ -110,7 +109,6 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -130,7 +128,7 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
 
       log_events = build_list(3, :log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/last9_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/last9_adaptor_test.exs
@@ -1,9 +1,10 @@
 defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
-  alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Tesla.MockAdapter
   alias Opentelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest
@@ -107,8 +108,8 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
   describe "logs ingestion" do
     setup :backend_data
 
-    setup %{source: source, backend: backend} do
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+    setup %{source: source} do
+      start_supervised!({SourceSup, source})
       :ok
     end
 
@@ -128,7 +129,7 @@ defmodule Logflare.Backends.Adaptor.Last9AdaptorTest do
 
       log_events = build_list(3, :log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/loki_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/loki_adaptor_test.exs
@@ -2,7 +2,6 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.SystemMetrics.AllLogsLogged
 
@@ -120,7 +119,6 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -136,7 +134,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -152,7 +150,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, log_entry}, 2000
 
       assert %{streams: [%{stream: %{source: "supabase", service: ^source_name}}]} = log_entry
@@ -170,7 +168,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive {^ref, payload}, 2000
 
       assert %{

--- a/test/logflare/backends/adaptor/loki_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/loki_adaptor_test.exs
@@ -1,8 +1,9 @@
 defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
 
   @subject Logflare.Backends.Adaptor.LokiAdaptor
@@ -118,7 +119,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
           config: %{url: "http://localhost:1234"}
         )
 
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+      start_supervised!({SourceSup, source})
       [backend: backend, source: source]
     end
 
@@ -134,7 +135,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive ^ref, 2000
     end
 
@@ -150,7 +151,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, log_entry}, 2000
 
       assert %{streams: [%{stream: %{source: "supabase", service: ^source_name}}]} = log_entry
@@ -168,7 +169,7 @@ defmodule Logflare.Backends.Adaptor.LokiAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive {^ref, payload}, 2000
 
       assert %{

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.HttpBased
   alias Logflare.Backends.AdaptorSupervisor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Tesla.MockAdapter
   alias Opentelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess
@@ -134,8 +135,8 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
   describe "logs ingestion" do
     setup :backend_data
 
-    setup %{source: source, backend: backend} do
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+    setup %{source: source} do
+      start_supervised!({SourceSup, source})
       :ok
     end
 
@@ -164,7 +165,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: ts_us
         )
 
-      assert {:ok, _} = enqueue_backend_logs([log_event], source)
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
@@ -189,7 +190,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -136,7 +136,6 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
     setup %{source: source, backend: backend} do
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(250)
       :ok
     end
 
@@ -165,7 +164,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: ts_us
         )
 
-      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert {:ok, _} = enqueue_backend_logs([log_event], source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
@@ -190,7 +189,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           timestamp: System.system_time(:microsecond)
         )
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, body}, 5000
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [_, _, _]}]}]} = request

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
   use Logflare.DataCase, async: false
 
-  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
@@ -91,7 +90,6 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}})
-      :timer.sleep(500)
       [backend: backend, source: source]
     end
 
@@ -117,7 +115,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -192,7 +190,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           )
         end)
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -237,7 +235,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -288,7 +286,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -340,7 +338,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -380,7 +378,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = Backends.ingest_logs(log_events, source)
+      assert {:ok, _} = enqueue_backend_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")

--- a/test/logflare/backends/adaptor/sentry_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/sentry_adaptor_test.exs
@@ -1,10 +1,11 @@
 defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor
-  alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.Adaptor.HttpBased
   alias Logflare.Backends.Adaptor.SentryAdaptor
+  alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.Tesla.MockAdapter
 
@@ -89,7 +90,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           config: %{dsn: "https://abc123@o123456.ingest.sentry.io/123456"}
         )
 
-      start_supervised!({AdaptorSupervisor, {source, backend}})
+      start_supervised!({SourceSup, source})
       [backend: backend, source: source]
     end
 
@@ -115,7 +116,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -190,7 +191,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
           )
         end)
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -235,7 +236,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -286,7 +287,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -338,7 +339,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")
@@ -378,7 +379,7 @@ defmodule Logflare.Backends.Adaptor.SentryAdaptorTest do
         )
       ]
 
-      assert {:ok, _} = enqueue_backend_logs(log_events, source)
+      assert {:ok, _} = Backends.ingest_logs(log_events, source)
       assert_receive {^ref, envelope_body}, 2000
 
       [_header_line, _item_header_line, item_payload_line] = String.split(envelope_body, "\n")

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -7,9 +7,8 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends
   alias Logflare.Backends.Backend
-  alias Logflare.SystemMetrics.AllLogsLogged
-  alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.SourceSup
+  alias Logflare.SystemMetrics.AllLogsLogged
   alias Tesla.Middleware.JSON
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
 
@@ -31,11 +30,11 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
           config: %{http: "http1", url: "https://example.com"}
         )
 
+      start_supervised!({SourceSup, source})
       [source: source, backend: backend]
     end
 
     test "ingest through the full source supervision tree", %{source: source} do
-      start_supervised!({SourceSup, source})
       this = self()
       ref = make_ref()
 
@@ -53,9 +52,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       assert_receive ^ref, 2000
     end
 
-    test "uses cache for config fetching", %{source: source, backend: backend} do
-      start_supervised!({AdaptorSupervisor, {source, backend}})
-
+    test "uses cache for config fetching", %{source: source} do
       Logflare.Repo.update_all(Backend,
         set: [config_encrypted: %{http: "http1", url: "https://other-email.com"}]
       )
@@ -74,7 +71,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = enqueue_backend_logs([le], source)
+      assert {:ok, _} = Backends.ingest_logs([le], source)
       assert_receive ^ref, 2000
     end
   end

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -8,6 +8,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends
   alias Logflare.Backends.Backend
   alias Logflare.SystemMetrics.AllLogsLogged
+  alias Logflare.Backends.AdaptorSupervisor
   alias Logflare.Backends.SourceSup
   alias Tesla.Middleware.JSON
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
@@ -30,12 +31,11 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
           config: %{http: "http1", url: "https://example.com"}
         )
 
-      start_supervised!({SourceSup, source})
-      :timer.sleep(500)
       [source: source, backend: backend]
     end
 
-    test "ingest", %{source: source} do
+    test "ingest through the full source supervision tree", %{source: source} do
+      start_supervised!({SourceSup, source})
       this = self()
       ref = make_ref()
 
@@ -53,7 +53,9 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       assert_receive ^ref, 2000
     end
 
-    test "uses cache for config fetching", %{source: source} do
+    test "uses cache for config fetching", %{source: source, backend: backend} do
+      start_supervised!({AdaptorSupervisor, {source, backend}})
+
       Logflare.Repo.update_all(Backend,
         set: [config_encrypted: %{http: "http1", url: "https://other-email.com"}]
       )
@@ -72,7 +74,7 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
 
       le = build(:log_event, source: source)
 
-      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, _} = enqueue_backend_logs([le], source)
       assert_receive ^ref, 2000
     end
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -128,6 +128,7 @@ defmodule Logflare.DataCase do
   - `:user` - Existing user to use (creates one if not provided)
   - `:source` - Existing source to use (creates one if not provided)
   - `:default_ingest_backend?` - Whether to set the backend as the default ingest backend (requires a source to be provided with the default ingest backend option set to true)
+  - `:cleanup?` - Whether to drop the backend's ClickHouse tables on exit (defaults to true)
   """
   def setup_clickhouse_test(opts \\ []) do
     config = Keyword.get(opts, :config, %{})
@@ -163,7 +164,9 @@ defmodule Logflare.DataCase do
         sources: [source]
       )
 
-    on_exit(fn -> cleanup_clickhouse_tables(backend) end)
+    if Keyword.get(opts, :cleanup?, true) do
+      on_exit(fn -> cleanup_clickhouse_tables(backend) end)
+    end
 
     {source, backend}
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,11 +15,8 @@ defmodule Logflare.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL
-  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
-  alias Logflare.Backends.Cache, as: BackendsCache
   alias Logflare.Backends.ConsolidatedSup
-  alias Logflare.Backends.IngestEventQueue
 
   using do
     quote do
@@ -119,32 +116,6 @@ defmodule Logflare.DataCase do
         String.replace(acc, "%{#{key}}", to_string(value))
       end)
     end)
-  end
-
-  @doc """
-  Enqueues already-built log events directly into a source's configured backend pipeline.
-
-  Adaptor tests use this to exercise the adaptor without starting the unrelated full
-  source supervision tree through `Backends.ingest_logs/2`.
-  """
-  def enqueue_backend_logs(events, source) do
-    [backend | _] = BackendsCache.list_backends(source_id: source.id)
-    adaptor = Adaptor.get_adaptor(backend)
-
-    events =
-      if function_exported?(adaptor, :pre_ingest, 3) do
-        adaptor.pre_ingest(source, backend, events)
-      else
-        events
-      end
-
-    queue_key =
-      if backend.consolidated_ingest?,
-        do: {:consolidated, backend.id},
-        else: {source.id, backend.id}
-
-    :ok = IngestEventQueue.add_to_table(queue_key, events)
-    {:ok, length(events)}
   end
 
   @doc """

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,8 +15,11 @@ defmodule Logflare.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL
+  alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+  alias Logflare.Backends.Cache, as: BackendsCache
   alias Logflare.Backends.ConsolidatedSup
+  alias Logflare.Backends.IngestEventQueue
 
   using do
     quote do
@@ -116,6 +119,32 @@ defmodule Logflare.DataCase do
         String.replace(acc, "%{#{key}}", to_string(value))
       end)
     end)
+  end
+
+  @doc """
+  Enqueues already-built log events directly into a source's configured backend pipeline.
+
+  Adaptor tests use this to exercise the adaptor without starting the unrelated full
+  source supervision tree through `Backends.ingest_logs/2`.
+  """
+  def enqueue_backend_logs(events, source) do
+    [backend | _] = BackendsCache.list_backends(source_id: source.id)
+    adaptor = Adaptor.get_adaptor(backend)
+
+    events =
+      if function_exported?(adaptor, :pre_ingest, 3) do
+        adaptor.pre_ingest(source, backend, events)
+      else
+        events
+      end
+
+    queue_key =
+      if backend.consolidated_ingest?,
+        do: {:consolidated, backend.id},
+        else: {source.id, backend.id}
+
+    :ok = IngestEventQueue.add_to_table(queue_key, events)
+    {:ok, length(events)}
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- replace fixed ClickHouse waits with observable retry assertions
- inject deterministic ClickHouse connection failures instead of waiting on unreachable ports
- shorten HTTP adaptor producer and batch intervals only in the test environment
- exercise HTTP adaptor pipelines through the full `Backends.ingest_logs/2` path
- start source supervision synchronously instead of waiting for adaptor startup

## Stack

- [#3775](https://github.com/Logflare/logflare/pull/3775) — Backend adaptor integration tests **(this PR)**
- [#3776](https://github.com/Logflare/logflare/pull/3776) — Queue fixtures and worker synchronization
- [#3777](https://github.com/Logflare/logflare/pull/3777) — Lifecycle and side-effect synchronization
- [#3778](https://github.com/Logflare/logflare/pull/3778) — LiveView setup reuse
