### PR TITLE
test: build and synchronize queue fixtures efficiently

### DIFF
--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -24,7 +24,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     [%LogEvent{id: id}] =
@@ -51,7 +50,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     PubSubRatesCache.cache_rates(source.token, %{
@@ -87,11 +85,9 @@ defmodule Logflare.Backends.BufferProducerTest do
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
     startup_table_key = {source.id, nil, nil}
     IngestEventQueue.upsert_tid(startup_table_key)
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
-    Process.exit(buffer_producer_pid, :normal)
-    :timer.sleep(200)
+    signal_exit_and_wait(buffer_producer_pid)
 
     assert IngestEventQueue.total_pending(startup_table_key) == 1
     assert IngestEventQueue.total_pending(sid_bid_pid) == 0
@@ -107,7 +103,6 @@ defmodule Logflare.Backends.BufferProducerTest do
       start_supervised!({BufferProducer, backend_id: nil, source_id: source.id, id_passing: true})
 
     sid_bid_pid = {source.id, nil, buffer_producer_pid}
-    :timer.sleep(100)
     :ok = IngestEventQueue.add_to_table(sid_bid_pid, [le])
 
     tid = IngestEventQueue.get_tid(sid_bid_pid)
@@ -159,9 +154,9 @@ defmodule Logflare.Backends.BufferProducerTest do
     captured =
       capture_log(fn ->
         send(pid, {:add_to_buffer, items})
-        :timer.sleep(100)
+        :sys.get_state(pid)
         send(pid, {:add_to_buffer, items})
-        :timer.sleep(100)
+        :sys.get_state(pid)
       end)
 
     assert captured =~ source.name
@@ -192,7 +187,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
       sid_bid_pid = {source.id, nil, buffer_producer_pid}
-      :timer.sleep(100)
 
       own_event = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(sid_bid_pid, [own_event])
@@ -222,7 +216,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, backend_id: nil, source_id: source.id})
 
       sid_bid_pid = {source.id, nil, buffer_producer_pid}
-      :timer.sleep(100)
 
       own_event = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(sid_bid_pid, [own_event])
@@ -262,8 +255,6 @@ defmodule Logflare.Backends.BufferProducerTest do
           {BufferProducer, backend_id: nil, source_id: source.id, id_passing: true},
           id: :producer_b
         )
-
-      :timer.sleep(100)
 
       events = [build(:log_event, source: source), build(:log_event, source: source)]
       :ok = IngestEventQueue.add_to_table(startup_key, events)
@@ -428,7 +419,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
@@ -473,13 +463,11 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event, source: source)
       :ok = IngestEventQueue.add_to_table(consolidated_key, [le])
 
-      Process.exit(buffer_producer_pid, :normal)
-      :timer.sleep(200)
+      signal_exit_and_wait(buffer_producer_pid)
 
       assert IngestEventQueue.total_pending(startup_key) == 1
       assert IngestEventQueue.total_pending(consolidated_key) == 0
@@ -500,7 +488,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         )
 
       consolidated_key = {:consolidated, backend.id, buffer_producer_pid}
-      :timer.sleep(150)
 
       le =
         build(:log_event, source: source)
@@ -547,9 +534,9 @@ defmodule Logflare.Backends.BufferProducerTest do
       captured =
         capture_log(fn ->
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
         end)
 
       assert captured =~ "Consolidated GenStage producer has discarded"
@@ -573,7 +560,6 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, spool_producer: true, interval: 100})
 
       spool_key = {:spool_producer, nil, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event)
       :ok = IngestEventQueue.add_to_table(spool_key, [le])
@@ -621,16 +607,14 @@ defmodule Logflare.Backends.BufferProducerTest do
         start_supervised!({BufferProducer, spool_producer: true, interval: 100})
 
       spool_key = {:spool_producer, nil, buffer_producer_pid}
-      :timer.sleep(150)
 
       le = build(:log_event)
       :ok = IngestEventQueue.add_to_table(spool_key, [le])
 
-      Process.exit(buffer_producer_pid, :normal)
-      :timer.sleep(200)
+      stop_and_wait(buffer_producer_pid)
 
       assert IngestEventQueue.total_pending(startup_key) == 1
-      assert IngestEventQueue.total_pending(spool_key) == 0
+      assert IngestEventQueue.total_pending(spool_key) == {:error, :not_initialized}
     end
 
     test "format_discarded logs a spool-specific message" do
@@ -646,9 +630,9 @@ defmodule Logflare.Backends.BufferProducerTest do
       captured =
         capture_log(fn ->
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
           send(pid, {:add_to_buffer, items})
-          :timer.sleep(100)
+          :sys.get_state(pid)
         end)
 
       assert captured =~ "Spool producer GenStage has discarded"
@@ -873,5 +857,17 @@ defmodule Logflare.Backends.BufferProducerTest do
       assert_receive :scheduled_resolve, 400
       refute_receive :scheduled_resolve, 400
     end
+  end
+
+  defp signal_exit_and_wait(pid) do
+    Process.exit(pid, :normal)
+    :sys.get_state(pid)
+    assert Process.alive?(pid)
+  end
+
+  defp stop_and_wait(pid) do
+    monitor_ref = Process.monitor(pid)
+    :ok = GenServer.stop(pid, :normal, 1_000)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 1_000
   end
 end

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -153,10 +153,8 @@ defmodule Logflare.Backends.BufferProducerTest do
 
     captured =
       capture_log(fn ->
-        send(pid, {:add_to_buffer, items})
-        :sys.get_state(pid)
-        send(pid, {:add_to_buffer, items})
-        :sys.get_state(pid)
+        TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
+        TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
       end)
 
     assert captured =~ source.name
@@ -533,10 +531,8 @@ defmodule Logflare.Backends.BufferProducerTest do
 
       captured =
         capture_log(fn ->
-          send(pid, {:add_to_buffer, items})
-          :sys.get_state(pid)
-          send(pid, {:add_to_buffer, items})
-          :sys.get_state(pid)
+          TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
+          TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
         end)
 
       assert captured =~ "Consolidated GenStage producer has discarded"
@@ -629,10 +625,8 @@ defmodule Logflare.Backends.BufferProducerTest do
 
       captured =
         capture_log(fn ->
-          send(pid, {:add_to_buffer, items})
-          :sys.get_state(pid)
-          send(pid, {:add_to_buffer, items})
-          :sys.get_state(pid)
+          TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
+          TestUtils.send_and_wait_for_handling(pid, {:add_to_buffer, items})
         end)
 
       assert captured =~ "Spool producer GenStage has discarded"

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -29,6 +29,12 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     ]
   end
 
+  defp wait_for_stop do
+    receive do
+      :stop -> :ok
+    end
+  end
+
   test "add_pipeline/1 can scale up pipelines", %{name: name, pipeline_args: pipeline_args} do
     start_supervised!(
       {DynamicPipeline,
@@ -84,10 +90,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
 
   test ":resolve_count and :resolve_interval option will determine number of pipelines to start periodically",
        %{name: name, pipeline_args: pipeline_args} do
-    pid =
-      spawn(fn ->
-        :timer.sleep(400)
-      end)
+    pid = spawn(&wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,
@@ -116,6 +119,10 @@ defmodule Logflare.Backends.DynamicPipelineTest do
       assert DynamicPipeline.pipeline_count(name) == 5
     end)
 
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 10
     end)
@@ -136,7 +143,9 @@ defmodule Logflare.Backends.DynamicPipelineTest do
                   resolve_interval: 100}
                )
 
-             :timer.sleep(300)
+             coordinator = DynamicPipeline.find_coordinator_name(name)
+             send(coordinator, :check)
+             :sys.get_state(coordinator)
              assert Process.alive?(pid)
            end) =~ "some error"
   end
@@ -190,10 +199,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
         [:logflare, :backends, :dynamic_pipeline, :decrement]
       ])
 
-    pid =
-      spawn(fn ->
-        :timer.sleep(400)
-      end)
+    pid = spawn(&wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,
@@ -221,6 +227,10 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 10
     end)
+
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
 
     TestUtils.retry_assert(fn ->
       assert DynamicPipeline.pipeline_count(name) == 5

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -144,8 +144,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
                )
 
              coordinator = DynamicPipeline.find_coordinator_name(name)
-             send(coordinator, :check)
-             :sys.get_state(coordinator)
+             TestUtils.send_and_wait_for_handling(coordinator, :check)
              assert Process.alive?(pid)
            end) =~ "some error"
   end

--- a/test/logflare/backends/dynamic_pipeline_test.exs
+++ b/test/logflare/backends/dynamic_pipeline_test.exs
@@ -29,12 +29,6 @@ defmodule Logflare.Backends.DynamicPipelineTest do
     ]
   end
 
-  defp wait_for_stop do
-    receive do
-      :stop -> :ok
-    end
-  end
-
   test "add_pipeline/1 can scale up pipelines", %{name: name, pipeline_args: pipeline_args} do
     start_supervised!(
       {DynamicPipeline,
@@ -90,7 +84,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
 
   test ":resolve_count and :resolve_interval option will determine number of pipelines to start periodically",
        %{name: name, pipeline_args: pipeline_args} do
-    pid = spawn(&wait_for_stop/0)
+    pid = spawn(&TestUtils.wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,
@@ -198,7 +192,7 @@ defmodule Logflare.Backends.DynamicPipelineTest do
         [:logflare, :backends, :dynamic_pipeline, :decrement]
       ])
 
-    pid = spawn(&wait_for_stop/0)
+    pid = spawn(&TestUtils.wait_for_stop/0)
 
     start_supervised!(
       {DynamicPipeline,

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -1206,6 +1206,8 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     end
   end
 
+  # These tests only exercise queue cardinality. For performance, clone one factory-built
+  # event with unique IDs instead of rerunning the full log-event factory for every item.
   defp build_queue_events(count, attrs \\ []) do
     event = build(:log_event, attrs)
     for id <- 1..count, do: %{event | id: {event.id, id}}

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -924,7 +924,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_queue_size()
-      full_batch = build_list(max_size, :log_event, source: source)
+      full_batch = build_queue_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1019,13 +1019,13 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {source.id, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_list(max_size, :log_event))
+          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
           queue
         end
 
       # every existing queue is at the hard cap — nothing eligible remains, so the
       # whole new batch falls through to the startup queue instead
-      new_events = build_list(10_000, :log_event)
+      new_events = build_queue_events(10_000)
       :ok = IngestEventQueue.add_to_table({source.id, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
@@ -1124,7 +1124,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_consolidated_queue_size()
-      full_batch = build_list(max_size, :log_event, source: source)
+      full_batch = build_queue_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1168,10 +1168,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(queue1)
       IngestEventQueue.upsert_tid(queue2)
 
-      :ok = IngestEventQueue.add_to_table(queue1, build_list(1_000, :log_event))
-      :ok = IngestEventQueue.add_to_table(queue2, build_list(1_010, :log_event))
+      :ok = IngestEventQueue.add_to_table(queue1, build_queue_events(1_000))
+      :ok = IngestEventQueue.add_to_table(queue2, build_queue_events(1_010))
 
-      new_events = build_list(200, :log_event)
+      new_events = build_queue_events(200)
 
       :ok =
         IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events, chunk_size: 50)
@@ -1194,16 +1194,21 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_list(max_size, :log_event))
+          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
           queue
         end
 
-      new_events = build_list(10_000, :log_event)
+      new_events = build_queue_events(10_000)
       :ok = IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
       for queue <- queues, do: assert(IngestEventQueue.get_table_size(queue) == max_size)
     end
+  end
+
+  defp build_queue_events(count, attrs \\ []) do
+    event = build(:log_event, attrs)
+    for id <- 1..count, do: %{event | id: {event.id, id}}
   end
 
   describe "pop_pending/2" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -924,7 +924,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_queue_size()
-      full_batch = build_queue_events(max_size, source: source)
+      full_batch = build_queue_saturation_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1019,13 +1019,13 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {source.id, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
+          :ok = IngestEventQueue.add_to_table(queue, build_queue_saturation_events(max_size))
           queue
         end
 
       # every existing queue is at the hard cap — nothing eligible remains, so the
       # whole new batch falls through to the startup queue instead
-      new_events = build_queue_events(10_000)
+      new_events = build_queue_saturation_events(10_000)
       :ok = IngestEventQueue.add_to_table({source.id, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
@@ -1124,7 +1124,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(available_queue)
 
       max_size = IngestEventQueue.max_consolidated_queue_size()
-      full_batch = build_queue_events(max_size, source: source)
+      full_batch = build_queue_saturation_events(max_size, source: source)
       :ok = IngestEventQueue.add_to_table(full_queue, full_batch)
 
       assert IngestEventQueue.get_table_size(full_queue) == max_size
@@ -1168,10 +1168,10 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       IngestEventQueue.upsert_tid(queue1)
       IngestEventQueue.upsert_tid(queue2)
 
-      :ok = IngestEventQueue.add_to_table(queue1, build_queue_events(1_000))
-      :ok = IngestEventQueue.add_to_table(queue2, build_queue_events(1_010))
+      :ok = IngestEventQueue.add_to_table(queue1, build_queue_saturation_events(1_000))
+      :ok = IngestEventQueue.add_to_table(queue2, build_queue_saturation_events(1_010))
 
-      new_events = build_queue_events(200)
+      new_events = build_queue_saturation_events(200)
 
       :ok =
         IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events, chunk_size: 50)
@@ -1194,23 +1194,19 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         for n <- 1..3 do
           queue = {:consolidated, backend.id, :erlang.list_to_pid(~c"<0.200.#{n}>")}
           IngestEventQueue.upsert_tid(queue)
-          :ok = IngestEventQueue.add_to_table(queue, build_queue_events(max_size))
+
+          :ok =
+            IngestEventQueue.add_to_table(queue, build_queue_saturation_events(max_size))
+
           queue
         end
 
-      new_events = build_queue_events(10_000)
+      new_events = build_queue_saturation_events(10_000)
       :ok = IngestEventQueue.add_to_table({:consolidated, backend.id}, new_events)
 
       assert IngestEventQueue.get_table_size(startup_key) == 10_000
       for queue <- queues, do: assert(IngestEventQueue.get_table_size(queue) == max_size)
     end
-  end
-
-  # These tests only exercise queue cardinality. For performance, clone one factory-built
-  # event with unique IDs instead of rerunning the full log-event factory for every item.
-  defp build_queue_events(count, attrs \\ []) do
-    event = build(:log_event, attrs)
-    for id <- 1..count, do: %{event | id: {event.id, id}}
   end
 
   describe "pop_pending/2" do

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -1343,11 +1343,12 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     le = build(:log_event, source: source)
     IngestEventQueue.add_to_table(table, [le])
     IngestEventQueue.add_to_table(other_table, [le])
-    :timer.sleep(300)
 
     # Verify worker cached the values automatically (without manual cache calls)
-    assert PubSubRates.Cache.get_cluster_buffers(source.id, backend.id) == 1
-    assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 1
+    TestUtils.retry_assert(fn ->
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, backend.id) == 1
+      assert PubSubRates.Cache.get_cluster_buffers(source.id, nil) == 1
+    end)
   end
 
   test "QueueJanitor purges if exceeds max" do
@@ -1364,7 +1365,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       {QueueJanitor, source: source, backend: backend, interval: 50, max: 100, purge_ratio: 1.0}
     )
 
-    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == 0
   end
 
@@ -1382,7 +1382,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       {QueueJanitor, source: source, backend: backend, interval: 50, max: 90, purge_ratio: 0.5}
     )
 
-    :timer.sleep(550)
     assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == 50
   end
 
@@ -1421,7 +1420,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
          consolidated_key: queues_key}
       )
 
-      :timer.sleep(550)
       assert IngestEventQueue.get_table_size(consolidated_key) == 0
       assert IngestEventQueue.list_recent_events(queues_key, 10) == []
     end
@@ -1453,7 +1451,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
          consolidated_key: {:consolidated, backend.id}}
       )
 
-      :timer.sleep(550)
       # Events should remain because 150 < 1000 (consolidated max = 100 * 10)
       assert IngestEventQueue.get_table_size(consolidated_key) == 150
     end
@@ -1517,9 +1514,11 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     tid = IngestEventQueue.get_tid({source.id, backend.id, pid})
     :ets.delete(tid)
     start_supervised!({MapperJanitor, interval: 100})
-    :timer.sleep(500)
-    assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == nil
-    assert :ets.info(:ingest_event_queue_mapping, :size) == 0
+
+    TestUtils.retry_assert(fn ->
+      assert IngestEventQueue.get_table_size({source.id, backend.id, pid}) == nil
+      assert :ets.info(:ingest_event_queue_mapping, :size) == 0
+    end)
   end
 
   describe "recent-events cache" do

--- a/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
+++ b/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
@@ -35,7 +35,7 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     :ok
   end
@@ -117,7 +117,8 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 0.0
     )
 
-    Process.sleep(1_100)
+    send(MemoryMonitor, :refresh)
+    :sys.get_state(MemoryMonitor)
     assert MemoryMonitor.throttled?() == true
   end
 
@@ -127,7 +128,8 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 1.0
     )
 
-    Process.sleep(1_100)
+    send(MemoryMonitor, :refresh)
+    :sys.get_state(MemoryMonitor)
     assert MemoryMonitor.throttled?() == false
   end
 
@@ -190,12 +192,11 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       pid = start_producer()
       Task.async(fn -> GenStage.stream([{pid, max_demand: 1}]) |> Enum.take(1) end)
 
-      Process.sleep(50)
-
-      poll_timer = :sys.get_state(pid).state.poll_timer
-
-      refute is_nil(poll_timer)
-      assert Process.read_timer(poll_timer)
+      TestUtils.retry_assert(fn ->
+        poll_timer = :sys.get_state(pid).state.poll_timer
+        refute is_nil(poll_timer)
+        assert Process.read_timer(poll_timer)
+      end)
     end
 
     test "recovers automatically once memory pressure drops, without any new demand arriving" do
@@ -229,12 +230,11 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       pid = start_producer()
       Task.async(fn -> GenStage.stream([{pid, max_demand: 1}]) |> Enum.take(1) end)
 
-      Process.sleep(50)
-
-      poll_timer = :sys.get_state(pid).state.poll_timer
-
-      refute is_nil(poll_timer)
-      assert Process.read_timer(poll_timer)
+      TestUtils.retry_assert(fn ->
+        poll_timer = :sys.get_state(pid).state.poll_timer
+        refute is_nil(poll_timer)
+        assert Process.read_timer(poll_timer)
+      end)
     end
 
     test "recovers automatically once consumer backlog clears, without any new demand arriving" do

--- a/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
+++ b/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
@@ -117,8 +117,7 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 0.0
     )
 
-    send(MemoryMonitor, :refresh)
-    :sys.get_state(MemoryMonitor)
+    TestUtils.send_and_wait_for_handling(MemoryMonitor, :refresh)
     assert MemoryMonitor.throttled?() == true
   end
 
@@ -128,8 +127,7 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       spool_max_ets_percent: 1.0
     )
 
-    send(MemoryMonitor, :refresh)
-    :sys.get_state(MemoryMonitor)
+    TestUtils.send_and_wait_for_handling(MemoryMonitor, :refresh)
     assert MemoryMonitor.throttled?() == false
   end
 

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -92,6 +92,17 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       :sys.get_state(pid)
     end
 
+    defp fill_queue(table_key) do
+      event = build(:log_event)
+
+      events =
+        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
+          %{event | id: {event.id, id}}
+        end
+
+      IngestEventQueue.add_to_table(table_key, events)
+    end
+
     test "is true once a registered source's destination buffer is full", %{
       source: source,
       table_key: table_key,
@@ -99,10 +110,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     } do
       assert MemoryMonitor.consumer_throttled?() == false
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)
@@ -115,10 +123,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       table_key: table_key,
       pid: pid
     } do
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)
@@ -134,10 +139,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       table_key: table_key,
       pid: pid
     } do
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       # never registered
       force_refresh(pid)
@@ -164,10 +166,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       MemoryMonitor.register_source(source.id)
       MemoryMonitor.register_source(source.id)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key)
 
       force_refresh(pid)
 
@@ -189,10 +188,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       backend_table_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(backend_table_key, [le])
-      end
+      fill_queue(backend_table_key)
 
       MemoryMonitor.register_source(source.id)
       force_refresh(pid)

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -111,16 +111,8 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       TestUtils.send_and_wait_for_handling(pid, :refresh)
     end
 
-    # These assertions only exercise queue cardinality. For performance, clone one
-    # factory-built event with unique IDs instead of rebuilding every queued event.
     defp fill_queue(table_key) do
-      event = build(:log_event)
-
-      events =
-        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
-          %{event | id: {event.id, id}}
-        end
-
+      events = build_queue_saturation_events(Backends.max_buffer_queue_len() + 500)
       IngestEventQueue.add_to_table(table_key, events)
     end
 

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -27,7 +27,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     assert MemoryMonitor.throttled?() == true
   end
@@ -39,9 +39,29 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
 
     assert MemoryMonitor.throttled?() == false
+  end
+
+  test "periodically refreshes cached memory pressure without an explicit message" do
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 1.0,
+      spool_max_ets_percent: 1.0
+    )
+
+    start_supervised!(MemoryMonitor)
+    :sys.get_state(MemoryMonitor)
+    assert MemoryMonitor.throttled?() == false
+
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 0.0,
+      spool_max_ets_percent: 0.0
+    )
+
+    TestUtils.retry_assert([duration: 1_500, sleep: 25], fn ->
+      assert MemoryMonitor.throttled?() == true
+    end)
   end
 
   test "refresh/0 emits a [:logflare, :backends, :spool, :throttled] telemetry event on every refresh" do
@@ -82,7 +102,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       )
 
       pid = start_supervised!(MemoryMonitor)
-      Process.sleep(50)
+      :sys.get_state(pid)
 
       {:ok, user: user, source: source, table_key: table_key, pid: pid}
     end

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -112,6 +112,8 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
       :sys.get_state(pid)
     end
 
+    # These assertions only exercise queue cardinality. For performance, clone one
+    # factory-built event with unique IDs instead of rebuilding every queued event.
     defp fill_queue(table_key) do
       event = build(:log_event)
 

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -108,8 +108,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     end
 
     defp force_refresh(pid) do
-      send(pid, :refresh)
-      :sys.get_state(pid)
+      TestUtils.send_and_wait_for_handling(pid, :refresh)
     end
 
     # These assertions only exercise queue cardinality. For performance, clone one

--- a/test/logflare/backends/spool/producer_pipeline_test.exs
+++ b/test/logflare/backends/spool/producer_pipeline_test.exs
@@ -161,8 +161,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
         spool_max_ets_percent: 1.0
       )
 
-      send(MemoryMonitor, :refresh)
-      :sys.get_state(MemoryMonitor)
+      TestUtils.send_and_wait_for_handling(MemoryMonitor, :refresh)
       assert MemoryMonitor.throttled?() == false
 
       # 5MB + 8MB = 13MB, over the locked-in 12MB budget (would NOT emit under

--- a/test/logflare/backends/spool/producer_pipeline_test.exs
+++ b/test/logflare/backends/spool/producer_pipeline_test.exs
@@ -99,7 +99,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
   end
 
   defp throttled! do
@@ -109,7 +109,7 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
     )
 
     start_supervised!(MemoryMonitor)
-    Process.sleep(50)
+    :sys.get_state(MemoryMonitor)
   end
 
   describe "spool_batch_size_splitter/0 when not throttled" do
@@ -161,7 +161,8 @@ defmodule Logflare.Backends.Spool.ProducerPipelineTest do
         spool_max_ets_percent: 1.0
       )
 
-      Process.sleep(1_100)
+      send(MemoryMonitor, :refresh)
+      :sys.get_state(MemoryMonitor)
       assert MemoryMonitor.throttled?() == false
 
       # 5MB + 8MB = 13MB, over the locked-in 12MB budget (would NOT emit under

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -917,6 +917,8 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
+    # These assertions only exercise queue cardinality. For performance, clone one
+    # factory-built event with unique IDs instead of rebuilding every queued event.
     defp fill_queue_over_limit(table_key) do
       event = build(:log_event)
 

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -917,6 +917,17 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
+    defp fill_queue_over_limit(table_key) do
+      event = build(:log_event)
+
+      events =
+        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
+          %{event | id: {event.id, id}}
+        end
+
+      IngestEventQueue.add_to_table(table_key, events)
+    end
+
     test "any_ingest_queue_over_limit?/1 is false when no queues exist for the source", %{
       source: source
     } do
@@ -928,10 +939,7 @@ defmodule Logflare.BackendsTest do
       table_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue_over_limit(table_key)
 
       assert Backends.any_ingest_queue_over_limit?(source.id)
     end
@@ -945,10 +953,7 @@ defmodule Logflare.BackendsTest do
       table_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue_over_limit(table_key)
 
       assert Backends.any_ingest_queue_over_limit?(source.id)
     end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -908,11 +908,10 @@ defmodule Logflare.BackendsTest do
 
       # RecentInsertsCacher bridges Counters.increment/2 (called by ingest_logs)
       # → Counters.increment_source_changed_at_unix_ts/2 (read by
-      # fetch_latest_timestamp/1). Trigger it explicitly and use :sys.get_state/1
-      # as a sync fence so the test doesn't depend on the cacher's timer.
+      # fetch_latest_timestamp/1). Trigger it synchronously so the test doesn't
+      # depend on the cacher's timer.
       cacher = GenServer.whereis(Backends.via_source(source, RecentInsertsCacher))
-      send(cacher, :do_cache)
-      :sys.get_state(cacher)
+      TestUtils.send_and_wait_for_handling(cacher, :do_cache)
 
       assert Backends.fetch_latest_timestamp(source) != 0
     end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -916,16 +916,8 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
-    # These assertions only exercise queue cardinality. For performance, clone one
-    # factory-built event with unique IDs instead of rebuilding every queued event.
     defp fill_queue_over_limit(table_key) do
-      event = build(:log_event)
-
-      events =
-        for id <- 1..(Backends.max_buffer_queue_len() + 500) do
-          %{event | id: {event.id, id}}
-        end
-
+      events = build_queue_saturation_events(Backends.max_buffer_queue_len() + 500)
       IngestEventQueue.add_to_table(table_key, events)
     end
 

--- a/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
@@ -15,6 +15,16 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     {:ok, conn: conn, source: source, table_key: table_key}
   end
 
+  defp queue_events(source, count) do
+    event = build(:log_event, source: source)
+    for id <- 1..count, do: %{event | id: {event.id, id}}
+  end
+
+  defp fill_queue(table_key, source) do
+    events = queue_events(source, Backends.max_buffer_queue_len() + 500)
+    IngestEventQueue.add_to_table(table_key, events)
+  end
+
   test "returns 429 when memory utilization is at or over 85%", %{conn: conn, source: source} do
     SystemCache
     |> stub(:memory_utilization, fn -> 0.85 end)
@@ -46,10 +56,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     source: source,
     table_key: table_key
   } do
-    for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-    end
+    fill_queue(table_key, source)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -72,11 +79,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     other_table_key = {source.id, nil, self()}
     IngestEventQueue.upsert_tid(other_table_key)
 
-    for _ <- 1..round(Backends.max_buffer_queue_len() / 2) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.add_to_table(other_table_key, [le])
-    end
+    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2))
+    IngestEventQueue.add_to_table(table_key, events)
+    IngestEventQueue.add_to_table(other_table_key, events)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -88,11 +93,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     assert conn.halted == false
 
-    for _ <- 1..(round(Backends.max_buffer_queue_len() / 2) + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.add_to_table(other_table_key, [le])
-    end
+    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2) + 500)
+    IngestEventQueue.add_to_table(table_key, events)
+    IngestEventQueue.add_to_table(other_table_key, events)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -108,11 +111,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   end
 
   test "200 if most events are ingested", %{conn: conn, source: source, table_key: table_key} do
-    for _ <- 1..(Backends.max_buffer_queue_len() - 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-      IngestEventQueue.pop_pending(table_key, 1)
-    end
+    count = Backends.max_buffer_queue_len() - 500
+    IngestEventQueue.add_to_table(table_key, queue_events(source, count))
+    IngestEventQueue.pop_pending(table_key, count)
 
     # get and cache the value
     Backends.cache_local_buffer_lens(source.id, nil)
@@ -162,10 +163,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     refute_receive {:telemetry_event, [:logflare, :ingest, :requests, :buffer_full], _, _}
 
-    for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-      le = build(:log_event, source: source)
-      IngestEventQueue.add_to_table(table_key, [le])
-    end
+    fill_queue(table_key, source)
 
     Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -220,10 +218,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       table_key_webhook = {source.id, backend2.id, self()}
       IngestEventQueue.upsert_tid(table_key_webhook)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key_webhook, [le])
-      end
+      fill_queue(table_key_webhook, source)
 
       table_key_bigquery = {source.id, backend1.id, self()}
       IngestEventQueue.upsert_tid(table_key_bigquery)
@@ -251,10 +246,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       IngestEventQueue.upsert_tid(table_key)
 
       # Fill up the default ingest backend
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -275,10 +267,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       table_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(table_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(table_key, [le])
-      end
+      fill_queue(table_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -299,10 +288,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       system_queue_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(system_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(system_queue_key, [le])
-      end
+      fill_queue(system_queue_key, source)
 
       user_queue_key = {source.id, backend1.id, self()}
       IngestEventQueue.upsert_tid(user_queue_key)
@@ -341,10 +327,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       user_queue_key = {source.id, backend1.id, spawn(fn -> :ok end)}
       IngestEventQueue.upsert_tid(user_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(user_queue_key, [le])
-      end
+      fill_queue(user_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
       Backends.cache_local_buffer_lens(source.id, backend1.id)
@@ -407,10 +390,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       unlinked_queue_key = {source.id, unlinked_backend.id, self()}
       IngestEventQueue.upsert_tid(unlinked_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(unlinked_queue_key, [le])
-      end
+      fill_queue(unlinked_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, unlinked_backend.id)
 
@@ -441,20 +421,14 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       backend_queue_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(backend_queue_key, [le])
-      end
+      fill_queue(backend_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, backend.id)
 
       other_queue_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(other_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(other_queue_key, [le])
-      end
+      fill_queue(other_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, nil)
 
@@ -486,10 +460,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       backend_queue_key = {source.id, backend.id, self()}
       IngestEventQueue.upsert_tid(backend_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(backend_queue_key, [le])
-      end
+      fill_queue(backend_queue_key, source)
 
       Backends.cache_local_buffer_lens(source.id, backend.id)
 
@@ -534,10 +505,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       clickhouse_queue_key = {source.id, clickhouse_backend.id, self()}
       IngestEventQueue.upsert_tid(clickhouse_queue_key)
 
-      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
-        le = build(:log_event, source: source)
-        IngestEventQueue.add_to_table(clickhouse_queue_key, [le])
-      end
+      fill_queue(clickhouse_queue_key, source)
 
       # Cache buffer stats for both backends
       Backends.cache_local_buffer_lens(source.id, nil)

--- a/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
@@ -15,6 +15,8 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     {:ok, conn: conn, source: source, table_key: table_key}
   end
 
+  # Buffer limiting only depends on queue cardinality. For performance, clone one
+  # factory-built event with unique IDs instead of rebuilding every queued event.
   defp queue_events(source, count) do
     event = build(:log_event, source: source)
     for id <- 1..count, do: %{event | id: {event.id, id}}

--- a/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/controllers/plugs/buffer_limiter_test.exs
@@ -15,15 +15,10 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     {:ok, conn: conn, source: source, table_key: table_key}
   end
 
-  # Buffer limiting only depends on queue cardinality. For performance, clone one
-  # factory-built event with unique IDs instead of rebuilding every queued event.
-  defp queue_events(source, count) do
-    event = build(:log_event, source: source)
-    for id <- 1..count, do: %{event | id: {event.id, id}}
-  end
-
   defp fill_queue(table_key, source) do
-    events = queue_events(source, Backends.max_buffer_queue_len() + 500)
+    events =
+      build_queue_saturation_events(Backends.max_buffer_queue_len() + 500, source: source)
+
     IngestEventQueue.add_to_table(table_key, events)
   end
 
@@ -81,7 +76,9 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
     other_table_key = {source.id, nil, self()}
     IngestEventQueue.upsert_tid(other_table_key)
 
-    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2))
+    events =
+      build_queue_saturation_events(round(Backends.max_buffer_queue_len() / 2), source: source)
+
     IngestEventQueue.add_to_table(table_key, events)
     IngestEventQueue.add_to_table(other_table_key, events)
 
@@ -95,7 +92,12 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     assert conn.halted == false
 
-    events = queue_events(source, round(Backends.max_buffer_queue_len() / 2) + 500)
+    events =
+      build_queue_saturation_events(
+        round(Backends.max_buffer_queue_len() / 2) + 500,
+        source: source
+      )
+
     IngestEventQueue.add_to_table(table_key, events)
     IngestEventQueue.add_to_table(other_table_key, events)
 
@@ -114,7 +116,12 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
   test "200 if most events are ingested", %{conn: conn, source: source, table_key: table_key} do
     count = Backends.max_buffer_queue_len() - 500
-    IngestEventQueue.add_to_table(table_key, queue_events(source, count))
+
+    IngestEventQueue.add_to_table(
+      table_key,
+      build_queue_saturation_events(count, source: source)
+    )
+
     IngestEventQueue.pop_pending(table_key, count)
 
     # get and cache the value

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -170,6 +170,18 @@ defmodule Logflare.Factory do
     end)
   end
 
+  @doc """
+  Builds queue saturation events without rerunning the full log-event factory for every item.
+
+  Queue saturation tests only require unique queue keys, so this builds one event and clones it
+  with unique IDs.
+  """
+  @spec build_queue_saturation_events(pos_integer(), keyword()) :: [LogEvent.t()]
+  def build_queue_saturation_events(count, attrs \\ []) do
+    event = build(:log_event, attrs)
+    for id <- 1..count, do: %{event | id: {event.id, id}}
+  end
+
   def plan_factory do
     %Plan{
       stripe_id: "31415",

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -459,6 +459,19 @@ defmodule Logflare.TestUtils do
   def random_pos_integer(limit \\ 1000), do: :rand.uniform(limit)
 
   @doc """
+  Sends a message and waits until the receiver handles it.
+
+  Messages from this process are delivered in order, so the synchronous state request acts as a
+  barrier for the preceding message. This does not drain unrelated mailbox messages.
+  """
+  @spec send_and_wait_for_handling(pid() | atom(), term()) :: :ok
+  def send_and_wait_for_handling(server, message) do
+    send(server, message)
+    :sys.get_state(server)
+    :ok
+  end
+
+  @doc """
   Run function `times` times and will retry failed assertions
   """
   @spec retry_assert(opts :: keyword(), func :: (-> any())) :: any()

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -472,6 +472,18 @@ defmodule Logflare.TestUtils do
   end
 
   @doc """
+  Blocks the calling process until it receives `:stop`.
+
+  This provides a deterministic process body for tests that need to control process liveness.
+  """
+  @spec wait_for_stop() :: :ok
+  def wait_for_stop do
+    receive do
+      :stop -> :ok
+    end
+  end
+
+  @doc """
   Run function `times` times and will retry failed assertions
   """
   @spec retry_assert(opts :: keyword(), func :: (-> any())) :: any()


### PR DESCRIPTION
## Summary

- build one valid queue event and clone it with unique IDs for saturation fixtures
- enqueue large fixtures in batches instead of performing factory and ETS work per event
- replace worker sleeps with monitors, messages, state barriers, and retry assertions
- preserve queue-cap, spillover, memory-monitor, and buffer-limiter coverage

## Stack

- [#3775](https://github.com/Logflare/logflare/pull/3775) — Backend adaptor integration tests
- [#3776](https://github.com/Logflare/logflare/pull/3776) — Queue fixtures and worker synchronization **(this PR)**
- [#3777](https://github.com/Logflare/logflare/pull/3777) — Lifecycle and side-effect synchronization
- [#3778](https://github.com/Logflare/logflare/pull/3778) — LiveView setup reuse
