### PR TITLE
test: synchronize lifecycle and side-effect assertions

### DIFF
--- a/lib/logflare/utils.ex
+++ b/lib/logflare/utils.ex
@@ -316,13 +316,13 @@ defmodule Logflare.Utils do
   iex> ip_version("127.0.0.1:8222")
   :nxdomain
 
-  iex> ip_version("1467:f4e1:7a77:756a:896c:dff5:ca48:cf3c")
-  :inet6
-
-  iex> ip_version("supabase.com")
+  iex> ip_version("localhost")
   :inet
 
-  iex> ip_version("ipv6.google.com")
+  iex> ip_version("::1")
+  :inet6
+
+  iex> ip_version("1467:f4e1:7a77:756a:896c:dff5:ca48:cf3c")
   :inet6
 
   iex> ip_version("not_an_address")

--- a/test/logflare/backends/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/bigquery_adaptor_test.exs
@@ -36,7 +36,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :streamed, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "does not use LF managed BQ if legacy user BQ config is set" do
@@ -64,7 +64,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :ok, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "can query with parameters" do
@@ -78,10 +78,6 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
         {:ok, TestUtils.gen_bq_response([%{"test" => value}])}
       end)
-
-      user = insert(:user)
-      source = insert(:source, user: user)
-      start_supervised!({SourceSup, source})
 
       assert {:ok, %QueryResult{rows: [%{"test" => "input_data"}]}} =
                BigQueryAdaptor.execute_query(
@@ -102,10 +98,6 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
         {:ok, TestUtils.gen_bq_response([%{"test" => "1"}])}
       end)
-
-      user = insert(:user)
-      source = insert(:source, user: user)
-      start_supervised!({SourceSup, source})
 
       assert {:ok, %QueryResult{rows: [%{"test" => "1"}]}} =
                BigQueryAdaptor.execute_query(backend, "SELECT 1", [])
@@ -146,7 +138,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert {:ok, _} = Backends.ingest_logs([log_event], source)
 
       assert_receive :streamed, 2500
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "update table", %{source: source} do
@@ -174,7 +166,7 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
       assert {:ok, _} = Backends.ingest_logs([log_event], source)
 
       assert_receive :patched, 2500
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
 
     test "bug: invalid json encode update table", %{
@@ -209,25 +201,12 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
 
       assert {:ok, %{len: 1}} = Backends.cache_local_buffer_lens(source_id, nil)
       assert {:ok, %{len: 1}} = Backends.cache_local_buffer_lens(source_id, backend_id)
-      :timer.sleep(2000)
 
       TestUtils.retry_assert(fn ->
         assert_receive ^ref
       end)
 
-      {:ok, %{queues: queues}} = Backends.cache_local_buffer_lens(source_id, nil)
-
-      assert Enum.find_value(queues, fn
-               {{^source_id, nil, nil}, count} -> count
-               _ -> nil
-             end) == 0
-
-      {:ok, %{queues: queues}} = Backends.cache_local_buffer_lens(source_id, backend_id)
-
-      assert Enum.find_value(queues, fn
-               {{^source_id, ^backend_id, nil}, count} -> count
-               _ -> nil
-             end) == 0
+      assert_buffers_empty(source_id, backend_id)
     end
   end
 
@@ -330,8 +309,18 @@ defmodule Logflare.Backends.BigQueryAdaptorTest do
         assert_receive :ok, 2500
       end)
 
-      :timer.sleep(1000)
+      assert_buffers_empty(source.id)
     end
+  end
+
+  defp assert_buffers_empty(source_id, backend_id \\ nil) do
+    TestUtils.retry_assert(fn ->
+      assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source_id)
+
+      if backend_id do
+        assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source_id, backend_id)
+      end
+    end)
   end
 
   describe "bq storage api benchmark" do

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -11,7 +11,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
   alias Logflare.Backends.QueryError
   alias Logflare.Backends.SourceSup
   alias Logflare.Backends.UserMonitoring
-  alias Logflare.Backends.UserMonitoring.IngestPipeline
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.LogEvent
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
@@ -32,7 +31,9 @@ defmodule Logflare.Backends.UserMonitoringTest do
     [source: source, source_b: source_b, user: user]
   end
 
-  def start_otel_exporter(_context) do
+  def start_user_monitoring_pipeline(_context) do
+    start_supervised!(AllLogsLogged)
+
     UserMonitoring.get_otel_exporter()
     |> Enum.each(&start_supervised!/1)
 
@@ -180,10 +181,9 @@ defmodule Logflare.Backends.UserMonitoringTest do
   defp invalid_query_error_log_event?(_event), do: false
 
   describe "system monitoring labels" do
-    setup :start_otel_exporter
+    setup :start_user_monitoring_pipeline
 
     setup do
-      start_supervised!(AllLogsLogged)
       insert(:plan)
       :ok
     end
@@ -253,8 +253,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
                  )
                )
       end)
-
-      stop_supervised!(IngestPipeline)
     end
 
     test "other users metrics" do
@@ -333,18 +331,15 @@ defmodule Logflare.Backends.UserMonitoringTest do
         refute attr["source_id"] in [source_id, metrics_source_id]
         refute attr["my_label"] == "test"
       end
-
-      stop_supervised!(IngestPipeline)
     end
   end
 
   describe "egress" do
-    setup :start_otel_exporter
+    setup :start_user_monitoring_pipeline
     setup :set_mimic_global
 
     setup do
       Mimic.stub(Logflare.Utils.SSRF, :safe_resolve, fn _ -> {:ok, {127, 0, 0, 1}} end)
-      start_supervised!(AllLogsLogged)
       insert(:plan)
       :ok
     end
@@ -399,16 +394,13 @@ defmodule Logflare.Backends.UserMonitoringTest do
       assert attributes["backend_id"] == webhook_backend.id
       assert attributes["_backend_environment"] == "test"
       assert attributes["_backend_region"] == "us-west"
-
-      stop_supervised!(IngestPipeline)
     end
   end
 
   describe "endpoints" do
-    setup :start_otel_exporter
+    setup :start_user_monitoring_pipeline
 
     setup do
-      start_supervised!(AllLogsLogged)
       insert(:plan)
       :ok
     end
@@ -462,8 +454,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
-
-      stop_supervised!(IngestPipeline)
     end
 
     test "endpoints.query emits backend_id and backend_type in attributes" do
@@ -516,8 +506,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
-
-      stop_supervised!(IngestPipeline)
     end
   end
 

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -11,6 +11,7 @@ defmodule Logflare.Backends.UserMonitoringTest do
   alias Logflare.Backends.QueryError
   alias Logflare.Backends.SourceSup
   alias Logflare.Backends.UserMonitoring
+  alias Logflare.Backends.UserMonitoring.IngestPipeline
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.LogEvent
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
@@ -28,7 +29,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
     start_supervised!({SourceSup, source}, id: :source)
     start_supervised!({SourceSup, source_b}, id: :source_b)
 
-    :timer.sleep(250)
     [source: source, source_b: source_b, user: user]
   end
 
@@ -206,8 +206,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
       start_supervised!({SourceSup, metrics_source}, id: :metrics_source)
       start_supervised!({SourceSup, source}, id: :source)
 
-      :timer.sleep(1000)
-
       assert {:ok, _} = Backends.ingest_logs([%{"metadata" => %{"value" => "test"}}], source)
 
       TestUtils.retry_assert(fn ->
@@ -255,6 +253,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                  )
                )
       end)
+
+      stop_supervised!(IngestPipeline)
     end
 
     test "other users metrics" do
@@ -333,6 +333,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
         refute attr["source_id"] in [source_id, metrics_source_id]
         refute attr["my_label"] == "test"
       end
+
+      stop_supervised!(IngestPipeline)
     end
   end
 
@@ -375,8 +377,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
       {:ok, _} = Backends.update_source_backends(source, [webhook_backend])
       Backends.Cache.get_backend(webhook_backend.id)
 
-      :timer.sleep(1000)
-
       assert {:ok, _} = Backends.ingest_logs([%{"message" => "test webhook egress"}], source)
 
       assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 15_000
@@ -399,6 +399,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
       assert attributes["backend_id"] == webhook_backend.id
       assert attributes["_backend_environment"] == "test"
       assert attributes["_backend_region"] == "us-west"
+
+      stop_supervised!(IngestPipeline)
     end
   end
 
@@ -441,7 +443,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
         )
 
       assert {:ok, _} = Endpoints.run_query(endpoint)
-      :timer.sleep(1000)
       endpoint_id = endpoint.id
 
       assert_receive {:insert_all,
@@ -461,6 +462,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
+
+      stop_supervised!(IngestPipeline)
     end
 
     test "endpoints.query emits backend_id and backend_type in attributes" do
@@ -495,7 +498,6 @@ defmodule Logflare.Backends.UserMonitoringTest do
         )
 
       assert {:ok, _} = Endpoints.run_query(endpoint)
-      :timer.sleep(1000)
 
       backend_id = backend.id
 
@@ -514,6 +516,8 @@ defmodule Logflare.Backends.UserMonitoringTest do
                         | _
                       ]},
                      5_000
+
+      stop_supervised!(IngestPipeline)
     end
   end
 

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -23,9 +23,11 @@ defmodule Logflare.BackendsTest do
   alias Logflare.Repo
   alias Logflare.Rules
   alias Logflare.Sources
+  alias Logflare.Sources.Counters
   alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.Pipeline
   alias Logflare.Sources.Source.Data
+  alias Logflare.Sources.Source.RateCounterServer
   alias Logflare.Sources.SourceRouter
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Logflare.User
@@ -585,8 +587,6 @@ defmodule Logflare.BackendsTest do
 
       # unchanged
       assert %Backend{config: %{url: "http" <> _}} = Backends.get_backend(backend.id)
-
-      :timer.sleep(1000)
     end
 
     test "partial config update preserves existing fields", %{user: user} do
@@ -754,25 +754,25 @@ defmodule Logflare.BackendsTest do
 
       # start an out-of-tree SourceSupWorker
       start_supervised({SourceSupWorker, [source: source, interval: 100]})
-      :timer.sleep(200)
-      new_length = Supervisor.which_children(via) |> length()
-      assert new_length > prev_length
-      assert new_length - prev_length == 3
+
+      TestUtils.retry_assert(fn ->
+        new_length = Supervisor.which_children(via) |> length()
+        assert new_length - prev_length == 3
+      end)
 
       Logflare.Repo.delete_all(Logflare.Rules.Rule)
       Logflare.Repo.delete_all(Logflare.Backends.SourcesBackend)
       Logflare.Repo.delete_all(Logflare.Backends.Backend)
 
-      :timer.sleep(200)
       # removal
-      new_length = Supervisor.which_children(via) |> length()
-      assert new_length == prev_length
+      TestUtils.retry_assert(fn ->
+        assert Supervisor.which_children(via) |> length() == prev_length
+      end)
     end
 
     test "source_sup_started?/1, lookup/2", %{source: source} do
       assert false == Backends.source_sup_started?(source)
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
       assert true == Backends.source_sup_started?(source)
     end
 
@@ -824,7 +824,6 @@ defmodule Logflare.BackendsTest do
       Backends.clear_list_backends_cache(source.id)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       via = Backends.via_source(source, SourceSup)
 
@@ -858,7 +857,6 @@ defmodule Logflare.BackendsTest do
       assert backend.consolidated_ingest? == true
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       assert :noop = SourceSup.start_backend_child(source, backend)
     end
@@ -870,7 +868,10 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user_id: user.id)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
+
+      rate_counter = GenServer.whereis(Backends.via_source(source, RateCounterServer))
+      assert source.token == :sys.get_state(rate_counter)
+
       {:ok, source: source}
     end
 
@@ -905,6 +906,7 @@ defmodule Logflare.BackendsTest do
       assert Backends.fetch_latest_timestamp(source) == 0
       le = build(:log_event, source: source, some: "event")
       assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert {:ok, 1} = Counters.get_inserts(source.token)
 
       # RecentInsertsCacher bridges Counters.increment/2 (called by ingest_logs)
       # → Counters.increment_source_changed_at_unix_ts/2 (read by
@@ -913,6 +915,7 @@ defmodule Logflare.BackendsTest do
       cacher = GenServer.whereis(Backends.via_source(source, RecentInsertsCacher))
       TestUtils.send_and_wait_for_handling(cacher, :do_cache)
 
+      assert Counters.get_inserts_since_boot(source.token) == 1
       assert Backends.fetch_latest_timestamp(source) != 0
     end
 
@@ -1020,7 +1023,6 @@ defmodule Logflare.BackendsTest do
         insert(:source, user: user, drop_lql_string: "testing", drop_lql_filters: lql_filters)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
 
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_lql])
 
@@ -1034,8 +1036,6 @@ defmodule Logflare.BackendsTest do
 
       assert_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_lql], %{count: 1},
                       %{source_id: ^source_id, source_token: ^source_token}}
-
-      :timer.sleep(1000)
     end
 
     test "emits rejected telemetry for events with pipeline_error", %{user: user} do
@@ -1071,7 +1071,6 @@ defmodule Logflare.BackendsTest do
         insert(:source, user: user, drop_lql_string: "testing", drop_lql_filters: lql_filters)
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(1000)
 
       TestUtils.attach_forwarder([:logflare, :logs, :ingest_logs, :drop_lql])
 
@@ -1087,8 +1086,6 @@ defmodule Logflare.BackendsTest do
                       %{source_id: ^source_id, source_token: ^source_token}}
 
       refute_receive {:telemetry_event, [:logflare, :logs, :ingest_logs, :drop_lql], _, _}
-
-      :timer.sleep(1000)
     end
 
     test "route to source with lql", %{user: user} do
@@ -1097,7 +1094,6 @@ defmodule Logflare.BackendsTest do
       source = Logflare.Repo.preload(source, :rules, force: true)
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
-      :timer.sleep(500)
 
       assert {:ok, 2} =
                Backends.ingest_logs(
@@ -1125,7 +1121,6 @@ defmodule Logflare.BackendsTest do
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
       start_supervised!({SourceSup, other_target}, id: :other_target)
-      :timer.sleep(500)
 
       assert {:ok, 1} = Backends.ingest_logs([%{"event_message" => "testing 123"}], source)
 
@@ -1145,7 +1140,6 @@ defmodule Logflare.BackendsTest do
       start_supervised!({SourceSup, source}, id: :source)
       start_supervised!({SourceSup, target}, id: :target)
       start_supervised!({SourceSup, other_target}, id: :other_target)
-      :timer.sleep(500)
 
       assert {:ok, 1} = Backends.ingest_logs([%{"event_message" => "testing 123"}], source)
 
@@ -1295,8 +1289,6 @@ defmodule Logflare.BackendsTest do
       TestUtils.retry_assert(fn ->
         assert_received ^ref
       end)
-
-      :timer.sleep(1000)
     end
 
     test "cascade delete for rules on backend deletion", %{user: user} do
@@ -1480,7 +1472,6 @@ defmodule Logflare.BackendsTest do
       )
 
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
       {:ok, source: source}
     end
 
@@ -1500,8 +1491,6 @@ defmodule Logflare.BackendsTest do
       TestUtils.retry_assert(fn ->
         assert_received {^ref, %{"event_message" => "some event"}}
       end)
-
-      :timer.sleep(1000)
     end
   end
 
@@ -1655,7 +1644,6 @@ defmodule Logflare.BackendsTest do
     } do
       # Start actual SourceSup process
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       via = Backends.via_source(source, SourceSup)
 
@@ -1730,7 +1718,9 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user: user)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
+
+      rate_counter = GenServer.whereis(Backends.via_source(source, RateCounterServer))
+      assert source.token == :sys.get_state(rate_counter)
 
       {:ok, source: source}
     end
@@ -1895,7 +1885,6 @@ defmodule Logflare.BackendsTest do
       user = insert(:user)
       source = insert(:source, user: user, enable_spooling: false)
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       prev_spool_config = Application.get_env(:logflare, :spool)
 

--- a/test/logflare/endpoints/cache_test.exs
+++ b/test/logflare/endpoints/cache_test.exs
@@ -13,7 +13,7 @@ defmodule Logflare.Endpoints.CacheTest do
           user: user,
           query: "select current_datetime() as testing",
           proactive_requerying_seconds: 1,
-          cache_duration_seconds: 3
+          cache_duration_seconds: 2
         )
 
       endpoint_2 =
@@ -69,6 +69,7 @@ defmodule Logflare.Endpoints.CacheTest do
     end
 
     test "cache dies on timeout from query task", %{endpoint: endpoint} do
+      endpoint = %{endpoint | proactive_requerying_seconds: 3}
       test_response = [%{"testing" => "123"}]
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -88,10 +89,9 @@ defmodule Logflare.Endpoints.CacheTest do
         {:error, :timeout}
       end)
 
-      # should be larger than :proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
-
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+      send(cache_pid, :refresh)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal}, 1_500
     end
 
     test "cache handles BigQuery error response bodies", %{endpoint: endpoint} do
@@ -124,22 +124,23 @@ defmodule Logflare.Endpoints.CacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
+      started_at = System.monotonic_time(:millisecond)
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
+      monitor_ref = Process.monitor(cache_pid)
       assert Process.alive?(cache_pid)
 
       # First query should succeed
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
-      # Cache should still be alive before cache_duration_seconds
-      Process.sleep(endpoint.cache_duration_seconds * 1000 - 100)
-      assert Process.alive?(cache_pid)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1_000 + 500
 
-      # Cache should die after cache_duration_seconds
-      Process.sleep(endpoint.cache_duration_seconds * 1000 + 100)
-      refute Process.alive?(cache_pid)
+      elapsed = System.monotonic_time(:millisecond) - started_at
+      assert elapsed >= endpoint.cache_duration_seconds * 1_000
     end
 
     test "cache dies after cache_duration_seconds gets set to 0", %{endpoint: endpoint} do
+      endpoint = %{endpoint | proactive_requerying_seconds: 3}
       test_response = [%{"testing" => "123"}]
 
       GoogleApi.BigQuery.V2.Api.Jobs
@@ -159,9 +160,9 @@ defmodule Logflare.Endpoints.CacheTest do
 
       assert Logflare.ContextCache.bust_keys([{Logflare.Endpoints, endpoint.id}]) == {:ok, 1}
 
-      # Cache should still be alive before cache_duration_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 * 2)
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+      send(cache_pid, :refresh)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal}, 1_500
     end
 
     test "cache updates cached results after proactive_requerying_seconds", %{endpoint: endpoint} do
@@ -172,6 +173,7 @@ defmodule Logflare.Endpoints.CacheTest do
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
+      started_at = System.monotonic_time(:millisecond)
       {:ok, cache_pid} = start_supervised({Logflare.Endpoints.ResultsCache, {endpoint, %{}, []}})
       assert Process.alive?(cache_pid)
 
@@ -179,22 +181,27 @@ defmodule Logflare.Endpoints.CacheTest do
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       # Cache should still return first response before proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 500)
       assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
 
       test_response = [%{"testing" => "456"}]
+      test_pid = self()
+      refresh_ref = make_ref()
 
       GoogleApi.BigQuery.V2.Api.Jobs
       |> stub(:bigquery_jobs_query, fn _conn, _proj_id, _opts ->
+        send(test_pid, {refresh_ref, System.monotonic_time(:millisecond)})
         {:ok, TestUtils.gen_bq_response(test_response)}
       end)
 
-      # After proactive_requerying_seconds, should return updated response
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
-      assert {:ok, %{rows: [%{"testing" => "456"}]}} = Endpoints.run_cached_query(endpoint)
+      assert {:ok, %{rows: [%{"testing" => "123"}]}} = Endpoints.run_cached_query(endpoint)
+
+      assert_receive {^refresh_ref, refreshed_at},
+                     endpoint.proactive_requerying_seconds * 1_000 + 500
+
+      assert refreshed_at - started_at >= endpoint.proactive_requerying_seconds * 1_000
 
       TestUtils.retry_assert(fn ->
-        refute Process.alive?(cache_pid)
+        assert {:ok, %{rows: [%{"testing" => "456"}]}} = Endpoints.run_cached_query(endpoint)
       end)
     end
 
@@ -207,7 +214,7 @@ defmodule Logflare.Endpoints.CacheTest do
           cache_duration_seconds: 3
         )
 
-      # perform at most 2 queries before dying
+      # The initial query and two proactive refreshes must run before expiry.
       GoogleApi.BigQuery.V2.Api.Jobs
       |> expect(:bigquery_jobs_query, 3, fn _conn, _proj_id, _opts ->
         {:ok, TestUtils.gen_bq_response()}
@@ -221,8 +228,10 @@ defmodule Logflare.Endpoints.CacheTest do
       assert {:ok, %{rows: [_]}} = Endpoints.run_cached_query(endpoint)
 
       # should terminate after cache_duration_seconds
-      Process.sleep(2500)
-      refute Process.alive?(cache_pid)
+      monitor_ref = Process.monitor(cache_pid)
+
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1000
     end
 
     test "endpoint 2: cache dies before proactive query", %{endpoint_2: endpoint} do
@@ -241,10 +250,10 @@ defmodule Logflare.Endpoints.CacheTest do
 
       reject(GoogleApi.BigQuery.V2.Api.Jobs, :bigquery_jobs_query, 4)
 
-      # should be larger than :proactive_requerying_seconds
-      Process.sleep(endpoint.proactive_requerying_seconds * 1000 + 100)
+      monitor_ref = Process.monitor(cache_pid)
 
-      refute Process.alive?(cache_pid)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^cache_pid, :normal},
+                     endpoint.cache_duration_seconds * 1000 + 500
     end
   end
 end

--- a/test/logflare/slack_hook_server_test.exs
+++ b/test/logflare/slack_hook_server_test.exs
@@ -48,10 +48,8 @@ defmodule Logflare.SlackHookServerTest do
 
       start_supervised!({SlackHookServer, source: source})
 
-      :timer.sleep(500)
       Counters.increment(source.token)
       Counters.increment(source.token)
-      :timer.sleep(500)
 
       assert_receive {^ref, %{blocks: [_section, rtf]}}, 2_000
       assert inspect(rtf) =~ "new event"

--- a/test/logflare/sources_test.exs
+++ b/test/logflare/sources_test.exs
@@ -355,12 +355,12 @@ defmodule Logflare.SourcesTest do
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
-      :timer.sleep(500)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, token)
-      :timer.sleep(1_000)
+      TestUtils.retry_assert(fn -> assert {:ok, _pid} = Backends.lookup(SourceSup, token) end)
       assert {:ok, ^token} = Source.Supervisor.delete_source(token)
-      :timer.sleep(1000)
-      assert {:error, :not_started} = Backends.lookup(SourceSup, token)
+
+      TestUtils.retry_assert(fn ->
+        assert {:error, :not_started} = Backends.lookup(SourceSup, token)
+      end)
     end
 
     test "reset_source/1", %{user: user} do
@@ -368,12 +368,19 @@ defmodule Logflare.SourcesTest do
       start_supervised!(Source.Supervisor)
       # TODO: cast should return :ok
       assert {:ok, ^token} = Source.Supervisor.start_source(token)
-      :timer.sleep(500)
-      assert {:ok, pid} = Backends.lookup(SourceSup, token)
+
+      pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, pid} = Backends.lookup(SourceSup, token)
+          pid
+        end)
+
       assert {:ok, ^token} = Source.Supervisor.reset_source(token)
-      :timer.sleep(1500)
-      assert {:ok, new_pid} = Backends.lookup(SourceSup, token)
-      assert new_pid != pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, new_pid} = Backends.lookup(SourceSup, token)
+        assert new_pid != pid
+      end)
     end
 
     test "able to start supervision tree", %{user: user} do
@@ -381,9 +388,11 @@ defmodule Logflare.SourcesTest do
 
       start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(1000)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "able to reset supervision tree", %{user: user} do
@@ -391,14 +400,21 @@ defmodule Logflare.SourcesTest do
 
       start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+
+      pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+          pid
+        end)
+
       assert {:ok, _} = Source.Supervisor.reset_source(source.token)
       assert {:ok, _} = Source.Supervisor.reset_source(source.token)
-      :timer.sleep(3000)
-      assert {:ok, new_pid} = Backends.lookup(SourceSup, source.token)
-      assert pid != new_pid
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, new_pid} = Backends.lookup(SourceSup, source.token)
+        assert pid != new_pid
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "concurrent start attempts", %{user: user} do
@@ -410,31 +426,49 @@ defmodule Logflare.SourcesTest do
       assert :ok = Source.Supervisor.ensure_started(source)
       assert :ok = Source.Supervisor.ensure_started(source)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
-      assert Backends.cached_pending_buffer_len(source) == 0
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, _pid} = Backends.lookup(SourceSup, source.token)
+        assert Backends.cached_pending_buffer_len(source) == 0
+      end)
     end
 
     test "terminating Source.Supervisor does not bring everything down", %{user: user} do
       source = insert(:source, user_id: user.id)
       pid = start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+
+      prev_pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+          prev_pid
+        end)
+
       Process.exit(pid, :kill)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
-      assert prev_pid == pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+        assert prev_pid == pid
+      end)
     end
 
     test "should start broadcasting metrics on ingest", %{user: user} do
       source = insert(:source, user_id: user.id)
       pid = start_supervised!(Source.Supervisor)
       assert :ok = Source.Supervisor.ensure_started(source)
-      :timer.sleep(3000)
-      assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+
+      prev_pid =
+        TestUtils.retry_assert(fn ->
+          assert {:ok, prev_pid} = Backends.lookup(SourceSup, source.token)
+          prev_pid
+        end)
+
       Process.exit(pid, :kill)
-      assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
-      assert prev_pid == pid
+
+      TestUtils.retry_assert(fn ->
+        assert {:ok, pid} = Backends.lookup(SourceSup, source.token)
+        assert prev_pid == pid
+      end)
     end
   end
 
@@ -721,7 +755,6 @@ defmodule Logflare.SourcesTest do
       source = insert(:source, user_id: user.id, log_events_updated_at: timestamp)
       Sources.Cache.get_by_id(source.id)
       start_supervised!({SourceSup, source})
-      :timer.sleep(800)
       timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
       assert {:ok, 1} = Sources.recent_events_touch(timestamp)
       updated = Sources.get_by(id: source.id)
@@ -729,8 +762,7 @@ defmodule Logflare.SourcesTest do
 
       # does not update again if recently updated
       Sources.Cache.get_by_id(source.id)
-      :timer.sleep(1_000)
-      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      timestamp = NaiveDateTime.add(timestamp, 1, :second)
       assert {:ok, 0} = Sources.recent_events_touch(timestamp)
 
       updated = Sources.get_by(id: source.id)

--- a/test/logflare/utils_test.exs
+++ b/test/logflare/utils_test.exs
@@ -14,6 +14,8 @@ defmodule Logflare.Utils.FlagTest do
   alias Logflare.User
   alias Logflare.Utils
 
+  setup :set_mimic_global
+
   setup do
     start_supervised!(ConfigCatCache)
 
@@ -338,7 +340,7 @@ defmodule Logflare.UtilsSyncTest do
 
           ref = Process.monitor(pid)
           assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1000
-          Process.sleep(500)
+          Logger.flush()
         end)
 
       refute log =~ "secret_bearer_token_789"
@@ -361,7 +363,7 @@ defmodule Logflare.UtilsSyncTest do
 
           ref = Process.monitor(pid)
           assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1000
-          Process.sleep(500)
+          Logger.flush()
         end)
 
       assert log =~ "UndefinedError"

--- a/test/logflare/utils_test.exs
+++ b/test/logflare/utils_test.exs
@@ -14,8 +14,6 @@ defmodule Logflare.Utils.FlagTest do
   alias Logflare.User
   alias Logflare.Utils
 
-  setup :set_mimic_global
-
   setup do
     start_supervised!(ConfigCatCache)
 

--- a/test/logflare_web/controllers/endpoints_controller_test.exs
+++ b/test/logflare_web/controllers/endpoints_controller_test.exs
@@ -725,8 +725,6 @@ defmodule LogflareWeb.EndpointsControllerTest do
         )
       end
 
-      :timer.sleep(2_000)
-
       params = %{
         iso_timestamp_start:
           DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.to_iso8601(),
@@ -735,13 +733,18 @@ defmodule LogflareWeb.EndpointsControllerTest do
         sql: "select  timestamp,  event_message, metadata from edge_logs"
       }
 
-      conn =
-        initial_conn
-        |> put_req_header("x-api-key", user.api_key)
-        |> get(~p"/endpoints/query/logs.all?#{params}")
+      {conn, timestamp} =
+        TestUtils.retry_assert(fn ->
+          conn =
+            initial_conn
+            |> put_req_header("x-api-key", user.api_key)
+            |> get(~p"/endpoints/query/logs.all?#{params}")
 
-      assert [%{"event_message" => "some message", "timestamp" => timestamp}] =
-               json_response(conn, 200)["result"]
+          assert [%{"event_message" => "some message", "timestamp" => timestamp}] =
+                   json_response(conn, 200)["result"]
+
+          {conn, timestamp}
+        end)
 
       # render as unix microsecond
       assert inspect(timestamp) |> String.length() == 16

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -20,7 +20,6 @@ defmodule LogflareWeb.HealthCheckControllerTest do
 
   test "normal node health check", %{conn: conn} do
     start_supervised!(Source.Supervisor)
-    :timer.sleep(1000)
 
     conn = get(conn, "/health")
 

--- a/test/logflare_web/controllers/log_controller_test.exs
+++ b/test/logflare_web/controllers/log_controller_test.exs
@@ -6,6 +6,7 @@ defmodule LogflareWeb.LogControllerTest do
   alias Logflare.SingleTenant
   alias Logflare.Users
   alias Logflare.Sources
+  alias Logflare.Backends
   alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
 
@@ -633,7 +634,6 @@ defmodule LogflareWeb.LogControllerTest do
 
       # ingestion setup
       start_supervised!({SourceSup, source})
-      :timer.sleep(500)
 
       conn =
         conn
@@ -649,7 +649,10 @@ defmodule LogflareWeb.LogControllerTest do
 
       assert_logged_successfully(conn)
 
-      :timer.sleep(3000)
+      TestUtils.retry_assert(fn ->
+        assert [_event] = Backends.list_recent_logs_local(source)
+        assert {:ok, %{len: 0}} = Backends.cache_local_buffer_lens(source.id)
+      end)
     end
   end
 
@@ -658,7 +661,6 @@ defmodule LogflareWeb.LogControllerTest do
     user = insert(:user)
     source = insert(:source, user: user)
     start_supervised!({SourceSup, source})
-    :timer.sleep(500)
 
     {:ok, source: source, user: user, conn: conn}
   end


### PR DESCRIPTION
## Summary

- synchronize source and backend lifecycle assertions with process state and monitors
- await ingestion, telemetry, cache, and controller side effects instead of sleeping
- exercise endpoint cache timer behavior directly while retaining timer-delivery coverage
- remove external DNS dependencies and flush Logger synchronously in utility checks
- isolate user-monitoring log capture from unrelated asynchronous logs

## Stack

- [#3775](https://github.com/Logflare/logflare/pull/3775) — Backend adaptor integration tests
- [#3776](https://github.com/Logflare/logflare/pull/3776) — Queue fixtures and worker synchronization
- [#3777](https://github.com/Logflare/logflare/pull/3777) — Lifecycle and side-effect synchronization **(this PR)**
- [#3778](https://github.com/Logflare/logflare/pull/3778) — LiveView setup reuse
