### PR TITLE
test: reduce repeated LiveView setup

### DIFF
--- a/test/logflare_web/conn_case_test.exs
+++ b/test/logflare_web/conn_case_test.exs
@@ -24,6 +24,20 @@ defmodule LogflareWeb.ConnCaseTest do
     assert ConnCase.put_default_team_param(conn, path) == path
   end
 
+  test "prepare_live_with_redirect/3 can bypass the default team parameter" do
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:logflare_test_team_id, "team-123")
+
+    path = "/search?tailing=false"
+
+    assert {^path, [on_error: :warn]} =
+             ConnCase.prepare_live_with_redirect(conn, path,
+               bypass_team_param: true,
+               on_error: :warn
+             )
+  end
+
   test "redirected_to_different_team?/2 only follows a different selected team" do
     assert ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-456")
     refute ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-123")

--- a/test/logflare_web/conn_case_test.exs
+++ b/test/logflare_web/conn_case_test.exs
@@ -1,0 +1,32 @@
+defmodule LogflareWeb.ConnCaseTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.ConnCase
+
+  test "put_default_team_param/2 adds the selected team without losing query parameters" do
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:logflare_test_team_id, "team-123")
+
+    result = ConnCase.put_default_team_param(conn, "/search?tailing=false")
+    uri = URI.parse(result)
+
+    assert uri.path == "/search"
+    assert URI.decode_query(uri.query) == %{"t" => "team-123", "tailing" => "false"}
+  end
+
+  test "put_default_team_param/2 preserves an explicitly selected team" do
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:logflare_test_team_id, "team-123")
+
+    path = "/search?t=team-456&tailing=false"
+    assert ConnCase.put_default_team_param(conn, path) == path
+  end
+
+  test "redirected_to_different_team?/2 only follows a different selected team" do
+    assert ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-456")
+    refute ConnCase.redirected_to_different_team?("/search?t=team-123", "/search?t=team-123")
+    refute ConnCase.redirected_to_different_team?("/search?t=team-123", "/search")
+  end
+end

--- a/test/logflare_web/live/alerts/alerts_live_test.exs
+++ b/test/logflare_web/live/alerts/alerts_live_test.exs
@@ -721,7 +721,7 @@ defmodule LogflareWeb.AlertsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/alerts")
+        |> live_with_redirect(~p"/alerts", bypass_team_param: true)
 
       assert html =~ alert_query.name
     end
@@ -735,7 +735,7 @@ defmodule LogflareWeb.AlertsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/alerts/#{alert_query.id}")
+        |> live_with_redirect(~p"/alerts/#{alert_query.id}", bypass_team_param: true)
 
       assert html =~ alert_query.name
     end
@@ -747,7 +747,9 @@ defmodule LogflareWeb.AlertsLiveTest do
       alert_query: alert_query
     } do
       {:ok, _view, html} =
-        conn |> login_user(user, team_user) |> live_with_redirect(~p"/alerts")
+        conn
+        |> login_user(user, team_user)
+        |> live_with_redirect(~p"/alerts", bypass_team_param: true)
 
       assert html =~ ~r/alerts\/#{alert_query.id}[^"<]*t=#{team_user.team_id}/
     end
@@ -761,7 +763,7 @@ defmodule LogflareWeb.AlertsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/alerts/#{alert_query}")
+        |> live_with_redirect(~p"/alerts/#{alert_query}", bypass_team_param: true)
 
       assert html =~ ~r/alerts\/#{alert_query.id}\/edit[^"<]*t=#{team_user.team_id}/
     end

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -1280,7 +1280,7 @@ defmodule LogflareWeb.BackendsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/backends/#{backend.id}")
+        |> live_with_redirect(~p"/backends/#{backend.id}", bypass_team_param: true)
 
       assert html =~ backend.name
     end

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -2206,6 +2206,16 @@ defmodule LogflareWeb.Source.SearchLVTest do
       included_for_today = Enum.max([one_second_ago, today_start], DateTime)
       seconds_since_today_start = DateTime.diff(now, today_start, :second)
 
+      yesterday_start = DateTime.add(today_start, -1, :day)
+      yesterday_end = DateTime.add(today_start, -1, :second)
+
+      included_for_yesterday =
+        DateTime.add(
+          yesterday_start,
+          div(DateTime.diff(yesterday_end, yesterday_start, :second), 2),
+          :second
+        )
+
       today_chart_period =
         cond do
           seconds_since_today_start <= 1_000 -> :second
@@ -2214,40 +2224,49 @@ defmodule LogflareWeb.Source.SearchLVTest do
         end
 
       cases = [
+        {"t:last@5m", :second, {DateTime.add(now, -1, :minute), DateTime.add(now, 30, :second)}},
         {"t:this@day", today_chart_period,
-         {included_for_today, DateTime.add(today_start, -1, :minute)}}
+         {included_for_today, DateTime.add(today_start, -1, :minute)}},
+        {"t:yesterday", :hour, {included_for_yesterday, now}}
       ]
 
-      Enum.each(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->
-        matching_message = "included-#{System.unique_integer([:positive])}"
-        non_matching_message = "excluded-#{System.unique_integer([:positive])}"
+      cases =
+        Enum.map(cases, fn {querystring, chart_period, {included_timestamp, excluded_timestamp}} ->
+          matching_message = "included-#{System.unique_integer([:positive])}"
+          non_matching_message = "excluded-#{System.unique_integer([:positive])}"
 
-        {:ok, 2} =
-          [
-            %{
-              "event_message" => matching_message,
-              "timestamp" => included_timestamp |> DateTime.to_iso8601()
-            },
-            %{
-              "event_message" => non_matching_message,
-              "timestamp" => excluded_timestamp |> DateTime.to_iso8601()
-            }
-          ]
-          |> Backends.ingest_logs(source)
+          assert {:ok, 2} =
+                   Backends.ingest_logs(
+                     [
+                       %{
+                         "event_message" => matching_message,
+                         "timestamp" => DateTime.to_iso8601(included_timestamp)
+                       },
+                       %{
+                         "event_message" => non_matching_message,
+                         "timestamp" => DateTime.to_iso8601(excluded_timestamp)
+                       }
+                     ],
+                     source
+                   )
 
-        Enum.each(["UTC", "Singapore"], fn timezone ->
-          {:ok, view, _html} =
-            live_with_redirect(
-              conn,
-              Routes.live_path(conn, SearchLV, source.id,
-                tailing?: false,
-                tz: timezone
-              )
+          {querystring, chart_period, matching_message, non_matching_message}
+        end)
+
+      Enum.each(["UTC", "Singapore"], fn timezone ->
+        {:ok, view, _html} =
+          live_with_redirect(
+            conn,
+            Routes.live_path(conn, SearchLV, source.id,
+              tailing?: false,
+              tz: timezone
             )
+          )
 
-          %{executor_pid: search_executor_pid} = get_view_assigns(view)
-          allow_sandbox(search_executor_pid)
+        %{executor_pid: search_executor_pid} = get_view_assigns(view)
+        allow_sandbox(search_executor_pid)
 
+        Enum.each(cases, fn {querystring, chart_period, matching_message, non_matching_message} ->
           TestUtils.retry_assert(fn ->
             prev_completed_at = get_view_assigns(view)[:last_query_completed_at]
 

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -1351,7 +1351,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/endpoints")
+        |> live_with_redirect(~p"/endpoints", bypass_team_param: true)
 
       assert html =~ endpoint.name
     end
@@ -1365,7 +1365,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/endpoints/#{endpoint.id}")
+        |> live_with_redirect(~p"/endpoints/#{endpoint.id}", bypass_team_param: true)
 
       assert html =~ endpoint.name
     end
@@ -1379,7 +1379,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
       {:ok, view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/endpoints/#{endpoint.id}")
+        |> live_with_redirect(~p"/endpoints/#{endpoint.id}", bypass_team_param: true)
 
       assert html =~ endpoint.name
       assert view |> has_element?(~s|a[href="/access-tokens?t=#{team_user.team.id}"]|)
@@ -1395,7 +1395,9 @@ defmodule LogflareWeb.EndpointsLiveTest do
       insert(:endpoint, user: user, backend: backend)
 
       {:ok, view, _html} =
-        conn |> login_user(user, team_user) |> live_with_redirect(~p"/endpoints")
+        conn
+        |> login_user(user, team_user)
+        |> live_with_redirect(~p"/endpoints", bypass_team_param: true)
 
       html = render(view)
 
@@ -1413,7 +1415,7 @@ defmodule LogflareWeb.EndpointsLiveTest do
       {:ok, _view, html} =
         conn
         |> login_user(user, team_user)
-        |> live_with_redirect(~p"/endpoints/#{endpoint}")
+        |> live_with_redirect(~p"/endpoints/#{endpoint}", bypass_team_param: true)
 
       for path <- ["endpoints/#{endpoint.id}/edit", "access-tokens"] do
         assert html =~ ~r/#{path}[^"<]*t=#{team_user.team_id}/

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -215,11 +215,12 @@ defmodule LogflareWeb.ConnCase do
   application redirect when the resource belongs to another team.
 
   Supplying the common `t=` parameter up front avoids mounting the LiveView
-  twice solely to discover the default team.
+  twice solely to discover the default team. Set `bypass_team_param: true` when
+  the first mount must exercise team selection or authorization without it.
   """
   defmacro live_with_redirect(conn, path \\ nil, opts \\ []) do
     quote bind_quoted: [conn: conn, path: path, opts: opts] do
-      path = LogflareWeb.ConnCase.put_default_team_param(conn, path)
+      {path, opts} = LogflareWeb.ConnCase.prepare_live_with_redirect(conn, path, opts)
       result = Phoenix.LiveViewTest.live(conn, path, opts)
 
       case result do
@@ -240,6 +241,14 @@ defmodule LogflareWeb.ConnCase do
           result
       end
     end
+  end
+
+  @doc false
+  def prepare_live_with_redirect(conn, path, opts) do
+    {bypass_team_param?, opts} = Keyword.pop(opts, :bypass_team_param, false)
+    path = if bypass_team_param?, do: path, else: put_default_team_param(conn, path)
+
+    {path, opts}
   end
 
   @doc false

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -104,14 +104,20 @@ defmodule LogflareWeb.ConnCase do
   def login_user(conn, user, team_user) do
     conn
     |> login_user(user)
+    |> Plug.Conn.put_private(:logflare_test_team_id, team_user.team_id)
     |> Plug.Conn.assign(:team_user, team_user)
     |> Plug.Conn.put_session(:current_email, team_user.email)
   end
 
   def login_user(conn, user) do
     conn
+    |> Plug.Conn.put_private(:logflare_test_team_id, loaded_team_id(user))
+    |> Plug.Conn.put_private(:logflare_test_user_id, user.id)
     |> Plug.Test.init_test_session(%{current_email: user.email})
   end
+
+  defp loaded_team_id(%{team: %Logflare.Teams.Team{id: id}}), do: id
+  defp loaded_team_id(_user), do: nil
 
   # for api use
   def add_partner_access_token(conn, partner) do
@@ -205,12 +211,15 @@ defmodule LogflareWeb.ConnCase do
   end
 
   @doc """
-  Call live/3 and automatically follow the first live redirect.
+  Calls `live/3` with the signed-in user's selected team and follows the first
+  application redirect when the resource belongs to another team.
 
-  Useful for the common case of a live view redirecting to add the `t=` param.
+  Supplying the common `t=` parameter up front avoids mounting the LiveView
+  twice solely to discover the default team.
   """
   defmacro live_with_redirect(conn, path \\ nil, opts \\ []) do
     quote bind_quoted: [conn: conn, path: path, opts: opts] do
+      path = LogflareWeb.ConnCase.put_default_team_param(conn, path)
       result = Phoenix.LiveViewTest.live(conn, path, opts)
 
       case result do
@@ -218,7 +227,11 @@ defmodule LogflareWeb.ConnCase do
           result
 
         {:error, {:live_redirect, %{to: to}}} ->
-          Phoenix.LiveViewTest.live(conn, to, opts)
+          if LogflareWeb.ConnCase.redirected_to_different_team?(path, to) do
+            Phoenix.LiveViewTest.live(conn, to, opts)
+          else
+            result
+          end
 
         {:error, {:redirect, %{to: to}}} ->
           {:ok, Phoenix.ConnTest.get(conn, to)}
@@ -226,6 +239,63 @@ defmodule LogflareWeb.ConnCase do
         _ ->
           result
       end
+    end
+  end
+
+  @doc false
+  def redirected_to_different_team?(from, to) when is_binary(from) and is_binary(to) do
+    from_team = from |> URI.parse() |> then(&URI.decode_query(&1.query || "")) |> Map.get("t")
+    to_team = to |> URI.parse() |> then(&URI.decode_query(&1.query || "")) |> Map.get("t")
+
+    not is_nil(to_team) and to_team != from_team
+  end
+
+  def redirected_to_different_team?(_from, _to), do: false
+
+  @doc false
+  def put_default_team_param(_conn, nil), do: nil
+
+  def put_default_team_param(conn, path) when is_binary(path) do
+    uri = URI.parse(path)
+    query = URI.decode_query(uri.query || "")
+
+    if Map.has_key?(query, "t") do
+      path
+    else
+      case default_team_id(conn) do
+        nil -> path
+        team_id -> %{uri | query: URI.encode_query(Map.put(query, "t", team_id))} |> to_string()
+      end
+    end
+  end
+
+  defp default_team_id(conn) do
+    conn.private[:logflare_test_team_id] || default_user_team_id(conn)
+  end
+
+  defp default_user_team_id(conn) do
+    case conn.private[:logflare_test_user_id] do
+      nil ->
+        nil
+
+      user_id ->
+        case Logflare.Teams.get_team_by(user_id: user_id) do
+          nil -> create_default_team(user_id)
+          team -> team.id
+        end
+    end
+  end
+
+  defp create_default_team(user_id) do
+    case Logflare.Users.get(user_id) do
+      nil ->
+        nil
+
+      user ->
+        {:ok, team} =
+          Logflare.Teams.create_team(user, %{name: Logflare.Generators.team_name()})
+
+        team.id
     end
   end
 end


### PR DESCRIPTION
## Summary

- include the signed-in user's selected team when mounting test LiveViews
- follow redirects only when a resource selects a genuinely different team
- add focused coverage for team query-parameter handling
- reuse each search LiveView across shorthand timestamp filter cases

## Stack

- [#3775](https://github.com/Logflare/logflare/pull/3775) — Backend adaptor integration tests
- [#3776](https://github.com/Logflare/logflare/pull/3776) — Queue fixtures and worker synchronization
- [#3777](https://github.com/Logflare/logflare/pull/3777) — Lifecycle and side-effect synchronization
- [#3778](https://github.com/Logflare/logflare/pull/3778) — LiveView setup reuse **(this PR)**
