### PR TITLE
feat: measure routing rule evaluation time

### DIFF
--- a/lib/logflare/sources/source_router.ex
+++ b/lib/logflare/sources/source_router.ex
@@ -16,18 +16,51 @@ defmodule Logflare.Sources.SourceRouter do
   @spec route_to_sinks_and_ingest(LE.t() | [LE.t()], Source.t(), module()) :: LE.t() | [LE.t()]
   def route_to_sinks_and_ingest(events, source, router \\ @default_router)
 
-  def route_to_sinks_and_ingest(events, source, router) when is_list(events),
-    do: Enum.map(events, &route_to_sinks_and_ingest(&1, source, router))
+  def route_to_sinks_and_ingest(events, source, router) when is_list(events) do
+    {events, measurements} =
+      Enum.map_reduce(events, {0, 0}, fn event, totals ->
+        {event, measurements} = route_event(event, source, router)
+        {event, add_measurements(totals, measurements)}
+      end)
 
-  def route_to_sinks_and_ingest(%LE{via_rule_id: id} = le, _source, _router) when id != nil,
-    do: le
+    emit_rule_match_telemetry(measurements)
+    events
+  end
 
-  def route_to_sinks_and_ingest(%LE{via_rule_id: nil} = le, source, router) do
-    for rule <- router.matching_rules(le, source) do
-      do_routing(rule, le, source)
-    end
-
+  def route_to_sinks_and_ingest(%LE{} = le, source, router) do
+    {le, measurements} = route_event(le, source, router)
+    emit_rule_match_telemetry(measurements)
     le
+  end
+
+  defp route_event(%LE{via_rule_id: id} = le, _source, _router) when id != nil,
+    do: {le, {0, 0}}
+
+  defp route_event(%LE{via_rule_id: nil} = le, source, router) do
+    started_at = System.monotonic_time()
+    rules = router.matching_rules(le, source)
+    duration = System.monotonic_time() - started_at
+
+    Enum.each(rules, &do_routing(&1, le, source))
+
+    {le, {duration, 1}}
+  end
+
+  defp add_measurements(
+         {total_duration, total_event_count},
+         {duration, event_count}
+       ) do
+    {total_duration + duration, total_event_count + event_count}
+  end
+
+  defp emit_rule_match_telemetry({_duration, 0}), do: :ok
+
+  defp emit_rule_match_telemetry({duration, event_count}) do
+    :telemetry.execute(
+      [:logflare, :sources, :rules, :match],
+      %{duration: duration, event_count: event_count},
+      %{}
+    )
   end
 
   defp do_routing(%Rule{backend_id: backend_id} = rule, %LE{} = le, source)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -185,6 +185,16 @@ defmodule Logflare.Telemetry do
         tags: [:processor],
         unit: {:native, :millisecond}
       ),
+      distribution("logflare.sources.rules.match.duration",
+        unit: {:native, :microsecond},
+        reporter_options: rules_duration_reporter_opts(),
+        description: "Total routing-rule matching time for an evaluated batch"
+      ),
+      sum("logflare.sources.rules.match.evaluated_events.count",
+        event_name: [:logflare, :sources, :rules, :match],
+        measurement: :event_count,
+        description: "Total events evaluated against routing rules"
+      ),
       counter("logflare.total_http_requests",
         measurement: :duration,
         event_name: "bandit.request.stop.duration"
@@ -605,5 +615,26 @@ defmodule Logflare.Telemetry do
 
   defp batch_size_reporter_opts do
     [buckets: [0, 1, 50, 100, 250, 500, 1_000, 5_000, 10_000, 20_000, 50_000]]
+  end
+
+  defp rules_duration_reporter_opts do
+    [
+      buckets: [
+        0,
+        10,
+        25,
+        50,
+        100,
+        250,
+        500,
+        1_000,
+        2_500,
+        5_000,
+        10_000,
+        25_000,
+        50_000,
+        100_000
+      ]
+    ]
   end
 end

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -9,6 +9,15 @@ defmodule Logflare.Sources.SourceRouterTest do
   alias Logflare.Sources.SourceRouter
   alias Logflare.SystemMetrics.AllLogsLogged
 
+  defmodule TelemetryRouter do
+    alias Logflare.LogEvent
+    alias Logflare.Rules.Rule
+
+    def matching_rules(%LogEvent{body: %{"match_count" => count}}, _source) do
+      List.duplicate(%Rule{}, count)
+    end
+  end
+
   @routers [SourceRouter.Sequential, SourceRouter.RulesTree]
 
   setup do
@@ -16,6 +25,48 @@ defmodule Logflare.Sources.SourceRouterTest do
     insert(:plan)
     user = insert(:user)
     [user: user, backend: insert(:backend, user: user)]
+  end
+
+  describe "routing telemetry" do
+    test "aggregates matching measurements once per batch", %{user: user} do
+      event_name = [:logflare, :sources, :rules, :match]
+      TestUtils.attach_forwarder(event_name)
+
+      source = insert(:source, user: user)
+
+      events = [
+        %{build(:log_event, source: source) | body: %{"match_count" => 2}},
+        %{build(:log_event, source: source) | body: %{"match_count" => 1}},
+        %{
+          build(:log_event, source: source)
+          | body: %{"match_count" => 5},
+            via_rule_id: 123
+        }
+      ]
+
+      assert SourceRouter.route_to_sinks_and_ingest(events, source, TelemetryRouter) == events
+
+      assert_receive {:telemetry_event, ^event_name, %{duration: duration, event_count: 2}, %{}}
+
+      assert is_integer(duration)
+      assert duration >= 0
+      refute_receive {:telemetry_event, ^event_name, _, _}
+    end
+
+    test "emits matching measurements for a single event", %{user: user} do
+      event_name = [:logflare, :sources, :rules, :match]
+      TestUtils.attach_forwarder(event_name)
+
+      source = insert(:source, user: user)
+      event = %{build(:log_event, source: source) | body: %{"match_count" => 0}}
+
+      assert SourceRouter.route_to_sinks_and_ingest(event, source, TelemetryRouter) == event
+
+      assert_receive {:telemetry_event, ^event_name, %{duration: duration, event_count: 1}, %{}}
+
+      assert is_integer(duration)
+      assert duration >= 0
+    end
   end
 
   for router <- @routers do

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -39,6 +39,32 @@ defmodule Logflare.TelemetryTest do
              end)
     end
 
+    test "defines untagged routing-rule matching metrics" do
+      metrics =
+        Telemetry.metrics()
+        |> Enum.filter(&(&1.event_name == [:logflare, :sources, :rules, :match]))
+
+      assert Enum.map(metrics, & &1.name) |> Enum.sort() == [
+               [:logflare, :sources, :rules, :match, :duration],
+               [:logflare, :sources, :rules, :match, :evaluated_events, :count]
+             ]
+
+      assert Enum.all?(metrics, &(&1.tags == []))
+
+      duration =
+        Enum.find(metrics, &(&1.name == [:logflare, :sources, :rules, :match, :duration]))
+
+      event_count = Enum.find(metrics, &(&1.name != duration.name))
+
+      assert to_string(duration.__struct__) == "Elixir.Telemetry.Metrics.Distribution"
+      assert duration.unit == :microsecond
+      assert hd(duration.reporter_options[:buckets]) == 0
+      assert List.last(duration.reporter_options[:buckets]) == 100_000
+
+      assert to_string(event_count.__struct__) == "Elixir.Telemetry.Metrics.Sum"
+      assert event_count.measurement == :event_count
+    end
+
     test "includes the spool telemetry metrics added for throttling/storage/queue observability" do
       names = Telemetry.metrics() |> Enum.map(& &1.name)
 


### PR DESCRIPTION
## Summary

- measure routing-rule matching time without including sink/backend dispatch
- aggregate measurements once per routed batch and export an untagged microsecond histogram
- export the evaluated-event count so matching time can be normalized per event

## Performance

Benchmarked the adjacent baseline and this change with one scheduler, an attached `OtelMetricExporter`, and an empty router to isolate instrumentation overhead:

| Batch size | Baseline | Instrumented | Added per batch | Added per event |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.0446 µs | 1.23 µs | 1.19 µs | 1.19 µs |
| 100 | 1.73 µs | 6.81 µs | 5.08 µs | 0.051 µs |
| 1,000 | 16.19 µs | 58.50 µs | 42.31 µs | 0.042 µs |

The fixed cost is the single telemetry event and two exporter updates per batch. The per-event cost is the matching timer and aggregation.

## Validation

- `../bin/test test/logflare/sources/source_router_test.exs test/logflare/telemetry_test.exs`
- `MIX_ENV=test ../bin/x mix format --check-formatted`
- `MIX_ENV=test ../bin/x mix lint.all`