### PR TITLE
Support multiple OTLP endpoints for metrics export

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -441,10 +441,27 @@ if System.get_env("LOGFLARE_OTEL_ENDPOINT") do
       value -> String.to_float(value)
     end
 
+  # A JSON array of `{"endpoint": "https://...", "headers": {"x-api-key": "..."}}`
+  # objects, sent to in addition to LOGFLARE_OTEL_ENDPOINT for metrics only
+  # (see Logflare.Telemetry.MultiEndpointMetricsExporter).
+  otel_metrics_extra_endpoints =
+    case System.get_env("LOGFLARE_OTEL_METRICS_EXTRA_ENDPOINTS") do
+      nil ->
+        []
+
+      json ->
+        json
+        |> Jason.decode!()
+        |> Enum.map(fn %{"endpoint" => endpoint} = entry ->
+          %{otlp_endpoint: endpoint, otlp_headers: Map.get(entry, "headers", %{})}
+        end)
+    end
+
   config :logflare,
     opentelemetry_enabled?: true,
     ingest_sample_ratio: ingest_sample_ratio,
-    endpoint_sample_ratio: endpoint_sample_ratio
+    endpoint_sample_ratio: endpoint_sample_ratio,
+    otel_metrics_extra_endpoints: otel_metrics_extra_endpoints
 
   logflare_trace_metadata =
     ["service.cluster": System.get_env("LOGFLARE_METADATA_CLUSTER")]

--- a/lib/logflare/telemetry/multi_endpoint_metrics_exporter.ex
+++ b/lib/logflare/telemetry/multi_endpoint_metrics_exporter.ex
@@ -1,0 +1,78 @@
+defmodule Logflare.Telemetry.MultiEndpointMetricsExporter do
+  @moduledoc """
+  `OtelMetricExporter` `:export_callback` used to fan a single metrics batch
+  out to multiple OTLP collectors.
+
+  `OtelMetricExporter` only supports one `otlp_endpoint` per instance, and
+  setting `:export_callback` replaces its default HTTP export entirely. This
+  module re-implements that default export (build request, gzip, POST) in a
+  loop over the primary endpoint plus any configured extra endpoints, so a
+  single `MetricStore`/ETS table/telemetry subscription can still ship to
+  more than one destination.
+  """
+
+  alias OtelMetricExporter.OtelApi.Config
+  alias OtelMetricExporter.Protocol
+
+  @type endpoint :: %{otlp_endpoint: String.t(), otlp_headers: map()}
+
+  @doc """
+  Sends a metrics batch to the primary endpoint from `config` plus every
+  endpoint in `extra_endpoints`.
+
+  Requests run concurrently. If any endpoint fails, the whole batch is
+  reported as failed so `OtelMetricExporter.MetricStore` retries it on the
+  next export cycle rather than losing data for the endpoints that did fail
+  — the same generation may then be resent to endpoints that already
+  succeeded, which mirrors the retry/duplicate-on-retry behavior the library
+  already has for a single endpoint.
+  """
+  @spec export_metrics({:metrics, list()}, %Config{}, [endpoint()]) :: :ok | {:error, term()}
+  def export_metrics({:metrics, metrics}, %Config{} = config, extra_endpoints) do
+    primary = %{otlp_endpoint: config.otlp_endpoint, otlp_headers: config.otlp_headers}
+
+    body =
+      metrics
+      |> Protocol.build_metric_service_request(config.resource)
+      |> Protobuf.encode_to_iodata()
+      |> :zlib.gzip()
+
+    [primary | extra_endpoints]
+    |> Task.async_stream(&send_to_endpoint(&1, body), timeout: :timer.seconds(30))
+    |> Enum.map(fn
+      {:ok, result} -> result
+      {:exit, reason} -> {:error, reason}
+    end)
+    |> collect_result()
+  end
+
+  @spec send_to_endpoint(endpoint(), iodata()) :: :ok | {:error, {String.t(), term()}}
+  defp send_to_endpoint(%{otlp_endpoint: endpoint, otlp_headers: extra_headers}, body) do
+    request = Finch.build(:post, endpoint <> "/v1/metrics", request_headers(extra_headers), body)
+
+    case Finch.request(request, OtelMetricExporter.Finch) do
+      {:ok, %{status: status}} when status in 200..202 -> :ok
+      {:ok, response} -> {:error, {endpoint, {:unexpected_status, response}}}
+      {:error, reason} -> {:error, {endpoint, reason}}
+    end
+  end
+
+  @spec request_headers(map()) :: [{String.t(), String.t()}]
+  defp request_headers(extra_headers) do
+    %{
+      "content-type" => "application/x-protobuf",
+      "accept" => "application/x-protobuf",
+      "content-encoding" => "gzip"
+    }
+    |> Map.merge(extra_headers)
+    |> Map.to_list()
+  end
+
+  @spec collect_result([:ok | {:error, term()}]) :: :ok | {:error, term()}
+  defp collect_result(results) do
+    case Enum.filter(results, &match?({:error, _}, &1)) do
+      [] -> :ok
+      errors -> {:error, errors}
+    end
+  end
+end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -5,6 +5,8 @@ defmodule Logflare.Telemetry do
   import Logflare.Utils, only: [ets_info: 1]
   import Logflare.Utils.Guards, only: [is_non_empty_binary: 1]
 
+  alias Logflare.Telemetry.MultiEndpointMetricsExporter
+
   def start_link(arg), do: Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
 
   context_caches_with_metrics = Logflare.ContextCache.Supervisor.list_caches_with_metrics()
@@ -43,6 +45,7 @@ defmodule Logflare.Telemetry do
           |> Keyword.put(:otlp_concurrent_requests, max(base * 4, 50))
           |> Keyword.put(:spawn_opt, fullsweep_after: 10_000)
           |> Keyword.put(:hibernate_after, 5_000)
+          |> put_multi_endpoint_export_callback()
 
         [{OtelMetricExporter, otel_exporter_opts}]
       else
@@ -55,6 +58,20 @@ defmodule Logflare.Telemetry do
       ] ++ otel_exporter
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # Only overrides the exporter's default single-endpoint HTTP export when
+  # extra endpoints are configured, so the common case is unaffected.
+  @spec put_multi_endpoint_export_callback(keyword()) :: keyword()
+  defp put_multi_endpoint_export_callback(otel_exporter_opts) do
+    case Application.get_env(:logflare, :otel_metrics_extra_endpoints, []) do
+      [] ->
+        otel_exporter_opts
+
+      extra_endpoints ->
+        callback = &MultiEndpointMetricsExporter.export_metrics(&1, &2, extra_endpoints)
+        Keyword.put(otel_exporter_opts, :export_callback, callback)
+    end
   end
 
   @spec resource() :: map()

--- a/test/logflare/telemetry/multi_endpoint_metrics_exporter_test.exs
+++ b/test/logflare/telemetry/multi_endpoint_metrics_exporter_test.exs
@@ -1,0 +1,99 @@
+defmodule Logflare.Telemetry.MultiEndpointMetricsExporterTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Logflare.Telemetry.MultiEndpointMetricsExporter
+  alias OtelMetricExporter.OtelApi.Config
+
+  @config %Config{
+    otlp_endpoint: "https://primary.example.com",
+    otlp_headers: %{"x-api-key" => "primary-key"},
+    resource: %{"service.name" => "logflare"}
+  }
+
+  describe "export_metrics/3" do
+    test "posts the same batch to the primary endpoint and every extra endpoint" do
+      extra_endpoints = [
+        %{
+          otlp_endpoint: "https://secondary.example.com",
+          otlp_headers: %{"x-api-key" => "secondary-key"}
+        }
+      ]
+
+      this = self()
+
+      expect(Finch, :request, 2, fn request, OtelMetricExporter.Finch ->
+        send(this, {:request, request})
+        {:ok, %Finch.Response{status: 200, body: "", headers: []}}
+      end)
+
+      assert :ok =
+               MultiEndpointMetricsExporter.export_metrics(
+                 {:metrics, []},
+                 @config,
+                 extra_endpoints
+               )
+
+      assert_receive {:request, %Finch.Request{host: "primary.example.com"} = primary_req}
+      assert_receive {:request, %Finch.Request{host: "secondary.example.com"} = secondary_req}
+
+      assert primary_req.path == "/v1/metrics"
+      assert secondary_req.path == "/v1/metrics"
+      assert {"x-api-key", "primary-key"} in primary_req.headers
+      assert {"x-api-key", "secondary-key"} in secondary_req.headers
+      assert {"content-encoding", "gzip"} in primary_req.headers
+      assert {"content-encoding", "gzip"} in secondary_req.headers
+    end
+
+    test "returns :ok and only hits the primary endpoint when there are no extra endpoints" do
+      expect(Finch, :request, fn %Finch.Request{host: "primary.example.com"}, _pool ->
+        {:ok, %Finch.Response{status: 202, body: "", headers: []}}
+      end)
+
+      assert :ok = MultiEndpointMetricsExporter.export_metrics({:metrics, []}, @config, [])
+    end
+
+    test "fails the whole batch when any endpoint fails, identifying which one" do
+      extra_endpoints = [%{otlp_endpoint: "https://secondary.example.com", otlp_headers: %{}}]
+
+      expect(Finch, :request, 2, fn
+        %Finch.Request{host: "primary.example.com"}, _pool ->
+          {:ok, %Finch.Response{status: 200, body: "", headers: []}}
+
+        %Finch.Request{host: "secondary.example.com"}, _pool ->
+          {:ok, %Finch.Response{status: 500, body: "boom", headers: []}}
+      end)
+
+      assert {:error, errors} =
+               MultiEndpointMetricsExporter.export_metrics(
+                 {:metrics, []},
+                 @config,
+                 extra_endpoints
+               )
+
+      assert [
+               {:error,
+                {"https://secondary.example.com", {:unexpected_status, %Finch.Response{}}}}
+             ] = errors
+    end
+
+    test "reports a transport error against the offending endpoint" do
+      extra_endpoints = [%{otlp_endpoint: "https://secondary.example.com", otlp_headers: %{}}]
+
+      expect(Finch, :request, 2, fn
+        %Finch.Request{host: "primary.example.com"}, _pool ->
+          {:ok, %Finch.Response{status: 200, body: "", headers: []}}
+
+        %Finch.Request{host: "secondary.example.com"}, _pool ->
+          {:error, %Mint.TransportError{reason: :econnrefused}}
+      end)
+
+      assert {:error, [{:error, {"https://secondary.example.com", %Mint.TransportError{}}}]} =
+               MultiEndpointMetricsExporter.export_metrics(
+                 {:metrics, []},
+                 @config,
+                 extra_endpoints
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `OtelMetricExporter` only supports one `otlp_endpoint` per instance, and running a second instance to reach a second collector would duplicate the entire metrics ETS table and double telemetry handler invocations on the hot path (every tracked event gets recorded twice, not just exported twice).
- Adds `Logflare.Telemetry.MultiEndpointMetricsExporter`, an `export_callback` that fans a single already-built batch out to the primary endpoint plus any endpoints configured via `LOGFLARE_OTEL_METRICS_EXTRA_ENDPOINTS` (JSON array of `{"endpoint": "...", "headers": {...}}`), so there's still only one `MetricStore`/ETS table/telemetry subscription — only the periodic export step does N requests instead of one.
- No-op when no extra endpoints are configured: `lib/telemetry.ex` only installs the callback if `otel_metrics_extra_endpoints` is non-empty, so current single-endpoint behavior is unchanged.
- If any endpoint fails, the whole batch is reported as failed (identifying which endpoint) so it's retried on the next export cycle, mirroring the retry-on-error behavior the library already has for a single endpoint.