### PR TITLE
Fix/otlp body format

### DIFF
--- a/lib/logflare/backends/adaptor/otlp_adaptor.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor.ex
@@ -45,7 +45,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
       protocol: :string,
       gzip: :boolean,
       headers: {:map, :string},
-      flatten_attributes: :boolean
+      flatten_to_attributes: :boolean
     }
 
     {existing_config, types}
@@ -54,7 +54,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
     |> Utils.default_field_value(:gzip, true)
     |> Utils.default_field_value(:protocol, "http/protobuf")
     |> Utils.default_field_value(:headers, %{})
-    |> Utils.default_field_value(:flatten_attributes, false)
+    |> Utils.default_field_value(:flatten_to_attributes, false)
   end
 
   # Canonicalizes submitted header names to lower case so stored config cannot
@@ -101,7 +101,8 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
   def client_opts(%Backend{config: config}) do
     [
       url: config.endpoint,
-      formatter: {ProtobufFormatter, %{flatten_attributes: config[:flatten_attributes] || false}},
+      formatter:
+        {ProtobufFormatter, %{flatten_to_attributes: config[:flatten_to_attributes] || false}},
       gzip: config.gzip,
       json: false,
       headers: config.headers

--- a/lib/logflare/backends/adaptor/otlp_adaptor.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor.ex
@@ -44,7 +44,8 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
       endpoint: :string,
       protocol: :string,
       gzip: :boolean,
-      headers: {:map, :string}
+      headers: {:map, :string},
+      flatten_attributes: :boolean
     }
 
     {existing_config, types}
@@ -53,6 +54,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
     |> Utils.default_field_value(:gzip, true)
     |> Utils.default_field_value(:protocol, "http/protobuf")
     |> Utils.default_field_value(:headers, %{})
+    |> Utils.default_field_value(:flatten_attributes, false)
   end
 
   # Canonicalizes submitted header names to lower case so stored config cannot
@@ -99,7 +101,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor do
   def client_opts(%Backend{config: config}) do
     [
       url: config.endpoint,
-      formatter: ProtobufFormatter,
+      formatter: {ProtobufFormatter, %{flatten_attributes: config[:flatten_attributes] || false}},
       gzip: config.gzip,
       json: false,
       headers: config.headers

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -18,14 +18,15 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   @protobuf_content_type "application/x-protobuf"
 
   @impl true
-  def call(env, next, _opts) do
+  def call(env, next, opts) do
     source = env.opts[:source] || %{}
     project_ref = env.opts |> Keyword.get(:metadata, %{}) |> Map.get("backend.project_ref")
+    flatten_attributes? = opts[:flatten_attributes] || false
 
     response =
       env
       |> put_content_type_header()
-      |> Tesla.put_body(transform_batch(env.body, source, project_ref))
+      |> Tesla.put_body(transform_batch(env.body, source, project_ref, flatten_attributes?))
       |> Tesla.run(next)
 
     with {:ok, %{status: 200} = env} <- response do
@@ -55,12 +56,12 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   @spec reserved_headers() :: [String.t()]
   def reserved_headers, do: ["content-type"]
 
-  defp transform_batch(events, source, project_ref) do
+  defp transform_batch(events, source, project_ref, flatten_attributes?) do
     %ExportLogsServiceRequest{
       resource_logs: [
         %ResourceLogs{
           resource: build_resource(source, project_ref),
-          scope_logs: build_scope_logs(events),
+          scope_logs: build_scope_logs(events, flatten_attributes?),
           schema_url: "https://opentelemetry.io/schemas/1.26.0"
         }
       ]
@@ -112,19 +113,19 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   # Scope identifies the instrumentation library producing the telemetry (i.e.
   # Logflare's own exporter), which is correctly Logflare regardless of source —
   # unlike Resource, this is not customer-specific.
-  defp build_scope_logs(logs) do
+  defp build_scope_logs(logs, flatten_attributes?) do
     [
       %ScopeLogs{
         scope: %InstrumentationScope{
           name: "Logflare",
           version: Application.spec(:logflare, :vsn) |> to_string()
         },
-        log_records: Enum.map(logs, &build_log_record/1)
+        log_records: Enum.map(logs, &build_log_record(&1, flatten_attributes?))
       }
     ]
   end
 
-  defp build_log_record(%LogEvent{} = ev) do
+  defp build_log_record(%LogEvent{} = ev, flatten_attributes?) do
     observed_ts =
       if ev.ingested_at, do: DateTime.to_unix(ev.ingested_at, :nanosecond), else: 0
 
@@ -141,16 +142,30 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
 
     fields =
       known_entries
-      |> Enum.flat_map(&build_log_record_fields/1)
+      |> Enum.flat_map(&build_log_record_fields(&1, flatten_attributes?))
       |> maybe_derive_severity(ev.body)
-      |> add_extra_attributes(extra)
 
-    struct!(LogRecord, [observed_time_unix_nano: observed_ts, body: log_body(ev.body)] ++ fields)
+    {body, fields} = build_body_and_attributes(flatten_attributes?, ev.body, extra, fields)
+
+    struct!(LogRecord, [observed_time_unix_nano: observed_ts, body: body] ++ fields)
   end
 
-  # body is the human-readable message per the OTel Logs data model — everything
-  # else the source sends (metadata, ids, etc.) belongs in attributes instead of
-  # being crammed into body as a nested blob most receivers don't parse as structured.
+  # Opt-in (backend config `flatten_attributes: true`, defaults to false): body
+  # becomes the human-readable message, and everything else the source sends
+  # (metadata, ids, etc.) is flattened into attributes instead. AnyValue permits
+  # a structured body per the OTel spec, but attributes is the field most
+  # backends actually build search/filter UI against — Dash0 confirmed
+  # stringifying non-scalar attribute values, though we haven't verified it does
+  # the same to a structured body specifically. Defaults to the legacy behavior
+  # (everything in body, unflattened) so existing backends are unaffected.
+  defp build_body_and_attributes(true, raw_body, extra, fields) do
+    {log_body(raw_body), add_extra_attributes(fields, extra)}
+  end
+
+  defp build_body_and_attributes(false, _raw_body, extra, fields) do
+    {make_value(extra), fields}
+  end
+
   defp log_body(%{"event_message" => msg}) when is_binary(msg), do: make_value(msg)
   defp log_body(_body), do: make_value("")
 
@@ -247,29 +262,40 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp severity_from_status_code(status) when status >= 400, do: :SEVERITY_NUMBER_WARN
   defp severity_from_status_code(_status), do: :SEVERITY_NUMBER_INFO
 
-  defp build_log_record_fields({"timestamp", ts}),
+  defp build_log_record_fields({"timestamp", ts}, _flatten_attributes?),
     do: [time_unix_nano: System.convert_time_unit(ts, :microsecond, :nanosecond)]
 
-  # event_message drives body (see log_body/1) instead — event_name is meant to be
-  # a low-cardinality event-type identifier, and the full message is the opposite of that.
-  defp build_log_record_fields({"event_message", _msg}), do: []
+  # In legacy (non-structured) mode, event_name carries the message, same as before
+  # the body/attributes split existed.
+  defp build_log_record_fields({"event_message", msg}, false) when is_binary(msg),
+    do: [event_name: msg]
 
-  defp build_log_record_fields({"attributes", attrs}) when is_map(attrs),
+  # In structured mode, event_message drives body (see log_body/1) instead —
+  # event_name is meant to be a low-cardinality event-type identifier, and the
+  # full message is the opposite of that.
+  defp build_log_record_fields({"event_message", _msg}, true), do: []
+
+  defp build_log_record_fields({"attributes", attrs}, true) when is_map(attrs),
     do: [attributes: flatten_attributes(attrs)]
 
-  defp build_log_record_fields({"severity_number", number}) when is_integer(number),
-    do: [severity_number: SeverityNumber.key(number)]
+  defp build_log_record_fields({"attributes", attrs}, false) when is_map(attrs),
+    do: [attributes: Enum.map(attrs, &make_key_value/1)]
 
-  defp build_log_record_fields({"severity_text", msg}) when is_binary(msg),
-    do: [severity_text: msg]
+  defp build_log_record_fields({"severity_number", number}, _flatten_attributes?)
+       when is_integer(number),
+       do: [severity_number: SeverityNumber.key(number)]
 
-  defp build_log_record_fields({"trace_id", id}) when is_binary(id),
+  defp build_log_record_fields({"severity_text", msg}, _flatten_attributes?)
+       when is_binary(msg),
+       do: [severity_text: msg]
+
+  defp build_log_record_fields({"trace_id", id}, _flatten_attributes?) when is_binary(id),
     do: build_id_field(:trace_id, id)
 
-  defp build_log_record_fields({"span_id", id}) when is_binary(id),
+  defp build_log_record_fields({"span_id", id}, _flatten_attributes?) when is_binary(id),
     do: build_id_field(:span_id, id)
 
-  defp build_log_record_fields(_unmatched), do: []
+  defp build_log_record_fields(_unmatched, _flatten_attributes?), do: []
 
   # trace_id/span_id arrive as hex-encoded strings (the standard OTel textual
   # representation); the protobuf fields require raw bytes, so this must decode

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -21,12 +21,12 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   def call(env, next, opts) do
     source = env.opts[:source] || %{}
     project_ref = env.opts |> Keyword.get(:metadata, %{}) |> Map.get("backend.project_ref")
-    flatten_attributes? = opts[:flatten_attributes] || false
+    flatten_to_attributes? = opts[:flatten_to_attributes] || false
 
     response =
       env
       |> put_content_type_header()
-      |> Tesla.put_body(transform_batch(env.body, source, project_ref, flatten_attributes?))
+      |> Tesla.put_body(transform_batch(env.body, source, project_ref, flatten_to_attributes?))
       |> Tesla.run(next)
 
     with {:ok, %{status: 200} = env} <- response do
@@ -56,12 +56,12 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   @spec reserved_headers() :: [String.t()]
   def reserved_headers, do: ["content-type"]
 
-  defp transform_batch(events, source, project_ref, flatten_attributes?) do
+  defp transform_batch(events, source, project_ref, flatten_to_attributes?) do
     %ExportLogsServiceRequest{
       resource_logs: [
         %ResourceLogs{
           resource: build_resource(source, project_ref),
-          scope_logs: build_scope_logs(events, flatten_attributes?),
+          scope_logs: build_scope_logs(events, flatten_to_attributes?),
           schema_url: "https://opentelemetry.io/schemas/1.26.0"
         }
       ]
@@ -113,19 +113,19 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   # Scope identifies the instrumentation library producing the telemetry (i.e.
   # Logflare's own exporter), which is correctly Logflare regardless of source —
   # unlike Resource, this is not customer-specific.
-  defp build_scope_logs(logs, flatten_attributes?) do
+  defp build_scope_logs(logs, flatten_to_attributes?) do
     [
       %ScopeLogs{
         scope: %InstrumentationScope{
           name: "Logflare",
           version: Application.spec(:logflare, :vsn) |> to_string()
         },
-        log_records: Enum.map(logs, &build_log_record(&1, flatten_attributes?))
+        log_records: Enum.map(logs, &build_log_record(&1, flatten_to_attributes?))
       }
     ]
   end
 
-  defp build_log_record(%LogEvent{} = ev, flatten_attributes?) do
+  defp build_log_record(%LogEvent{} = ev, flatten_to_attributes?) do
     observed_ts =
       if ev.ingested_at, do: DateTime.to_unix(ev.ingested_at, :nanosecond), else: 0
 
@@ -142,15 +142,15 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
 
     fields =
       known_entries
-      |> Enum.flat_map(&build_log_record_fields(&1, flatten_attributes?))
+      |> Enum.flat_map(&build_log_record_fields(&1, flatten_to_attributes?))
       |> maybe_derive_severity(ev.body)
 
-    {body, fields} = build_body_and_attributes(flatten_attributes?, ev.body, extra, fields)
+    {body, fields} = build_body_and_attributes(flatten_to_attributes?, ev.body, extra, fields)
 
     struct!(LogRecord, [observed_time_unix_nano: observed_ts, body: body] ++ fields)
   end
 
-  # Opt-in (backend config `flatten_attributes: true`, defaults to false): body
+  # Opt-in (backend config `flatten_to_attributes: true`, defaults to false): body
   # becomes the human-readable message, and everything else the source sends
   # (metadata, ids, etc.) is flattened into attributes instead. AnyValue permits
   # a structured body per the OTel spec, but attributes is the field most
@@ -262,7 +262,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp severity_from_status_code(status) when status >= 400, do: :SEVERITY_NUMBER_WARN
   defp severity_from_status_code(_status), do: :SEVERITY_NUMBER_INFO
 
-  defp build_log_record_fields({"timestamp", ts}, _flatten_attributes?),
+  defp build_log_record_fields({"timestamp", ts}, _flatten_to_attributes?),
     do: [time_unix_nano: System.convert_time_unit(ts, :microsecond, :nanosecond)]
 
   # In legacy (non-structured) mode, event_name carries the message, same as before
@@ -281,21 +281,21 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp build_log_record_fields({"attributes", attrs}, false) when is_map(attrs),
     do: [attributes: Enum.map(attrs, &make_key_value/1)]
 
-  defp build_log_record_fields({"severity_number", number}, _flatten_attributes?)
+  defp build_log_record_fields({"severity_number", number}, _flatten_to_attributes?)
        when is_integer(number),
        do: [severity_number: SeverityNumber.key(number)]
 
-  defp build_log_record_fields({"severity_text", msg}, _flatten_attributes?)
+  defp build_log_record_fields({"severity_text", msg}, _flatten_to_attributes?)
        when is_binary(msg),
        do: [severity_text: msg]
 
-  defp build_log_record_fields({"trace_id", id}, _flatten_attributes?) when is_binary(id),
+  defp build_log_record_fields({"trace_id", id}, _flatten_to_attributes?) when is_binary(id),
     do: build_id_field(:trace_id, id)
 
-  defp build_log_record_fields({"span_id", id}, _flatten_attributes?) when is_binary(id),
+  defp build_log_record_fields({"span_id", id}, _flatten_to_attributes?) when is_binary(id),
     do: build_id_field(:span_id, id)
 
-  defp build_log_record_fields(_unmatched, _flatten_attributes?), do: []
+  defp build_log_record_fields(_unmatched, _flatten_to_attributes?), do: []
 
   # trace_id/span_id arrive as hex-encoded strings (the standard OTel textual
   # representation); the protobuf fields require raw bytes, so this must decode

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -234,8 +234,9 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp build_log_record_fields({"timestamp", ts}),
     do: [time_unix_nano: System.convert_time_unit(ts, :microsecond, :nanosecond)]
 
-  defp build_log_record_fields({"event_message", msg}) when is_binary(msg),
-    do: [event_name: msg]
+  # event_message drives body (see log_body/1) instead — event_name is meant to be
+  # a low-cardinality event-type identifier, and the full message is the opposite of that.
+  defp build_log_record_fields({"event_message", _msg}), do: []
 
   defp build_log_record_fields({"attributes", attrs}) when is_map(attrs),
     do: [attributes: Enum.map(attrs, &make_key_value/1)]

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -128,7 +128,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
     observed_ts =
       if ev.ingested_at, do: DateTime.to_unix(ev.ingested_at, :nanosecond), else: 0
 
-    {known_entries, body} =
+    {known_entries, extra} =
       Map.split(ev.body, [
         "timestamp",
         "event_message",
@@ -143,8 +143,24 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
       known_entries
       |> Enum.flat_map(&build_log_record_fields/1)
       |> maybe_derive_severity(ev.body)
+      |> add_extra_attributes(extra)
 
-    struct!(LogRecord, [observed_time_unix_nano: observed_ts, body: make_value(body)] ++ fields)
+    struct!(LogRecord, [observed_time_unix_nano: observed_ts, body: log_body(ev.body)] ++ fields)
+  end
+
+  # body is the human-readable message per the OTel Logs data model — everything
+  # else the source sends (metadata, ids, etc.) belongs in attributes instead of
+  # being crammed into body as a nested blob most receivers don't parse as structured.
+  defp log_body(%{"event_message" => msg}) when is_binary(msg), do: make_value(msg)
+  defp log_body(_body), do: make_value("")
+
+  # Merges the source's leftover fields into attributes rather than overwriting
+  # any explicit "attributes" the source already provided via build_log_record_fields.
+  defp add_extra_attributes(fields, extra) when extra == %{}, do: fields
+
+  defp add_extra_attributes(fields, extra) do
+    extra_attributes = Enum.map(extra, &make_key_value/1)
+    Keyword.update(fields, :attributes, extra_attributes, &(&1 ++ extra_attributes))
   end
 
   # None of the Supabase log sources set an explicit "severity_number", but most

--- a/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
+++ b/lib/logflare/backends/adaptor/otlp_adaptor/protobuf_formatter.ex
@@ -159,8 +159,24 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp add_extra_attributes(fields, extra) when extra == %{}, do: fields
 
   defp add_extra_attributes(fields, extra) do
-    extra_attributes = Enum.map(extra, &make_key_value/1)
+    extra_attributes = flatten_attributes(extra)
     Keyword.update(fields, :attributes, extra_attributes, &(&1 ++ extra_attributes))
+  end
+
+  # Recurses into nested maps, turning each leaf into its own dotted top-level
+  # attribute (e.g. "metadata.response.status_code") instead of one attribute
+  # whose value is itself a nested kvlist_value. Receivers commonly only index
+  # flat scalar attribute values, storing anything else (a whole sub-object) as
+  # an opaque JSON string instead — flattening keeps every field queryable.
+  defp flatten_attributes(map, prefix \\ nil) do
+    Enum.flat_map(map, fn {k, v} ->
+      key = if prefix, do: "#{prefix}.#{k}", else: to_string(k)
+
+      case v do
+        v when is_map(v) -> flatten_attributes(v, key)
+        v -> [make_key_value({key, v})]
+      end
+    end)
   end
 
   # None of the Supabase log sources set an explicit "severity_number", but most
@@ -239,7 +255,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptor.ProtobufFormatter do
   defp build_log_record_fields({"event_message", _msg}), do: []
 
   defp build_log_record_fields({"attributes", attrs}) when is_map(attrs),
-    do: [attributes: Enum.map(attrs, &make_key_value/1)]
+    do: [attributes: flatten_attributes(attrs)]
 
   defp build_log_record_fields({"severity_number", number}) when is_integer(number),
     do: [severity_number: SeverityNumber.key(number)]

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -372,7 +372,10 @@
         <% "otlp" -> %>
           <div class="form-group">
             {label(f_config, :endpoint, "Endpoint")}
-            {text_input(f_config, :endpoint, class: "form-control", value: "https://otlp-endpoint.com/v1/logs")}
+            {text_input(f_config, :endpoint,
+              class: "form-control",
+              placeholder: "https://otlp-endpoint.com/v1/logs"
+            )}
             <small class="form-text text-muted">
               Address of the OTLP Endpoint
             </small>
@@ -406,6 +409,13 @@
             )}
             <small class="form-text text-muted">
               Transport protocol used for OTLP
+            </small>
+          </div>
+          <div class="form-group">
+            {label(f_config, :flatten_attributes, "Flatten attributes")}
+            {checkbox(f_config, :flatten_attributes, id: "flatten-attributes")}
+            <small class="form-text text-muted">
+              Send the log body as a plain message and flatten everything else into individual, filterable attributes instead of one nested body. Off by default to preserve existing behavior.
             </small>
           </div>
         <% "last9" -> %>

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -412,10 +412,10 @@
             </small>
           </div>
           <div class="form-group">
-            {label(f_config, :flatten_attributes, "Flatten attributes")}
-            {checkbox(f_config, :flatten_attributes, id: "flatten-attributes")}
+            {label(f_config, :flatten_to_attributes, "Flatten to attributes")}
+            {checkbox(f_config, :flatten_to_attributes, id: "flatten-attributes")}
             <small class="form-text text-muted">
-              Send the log body as a plain message and flatten everything else into individual, filterable attributes instead of one nested body. Off by default to preserve existing behavior.
+              Sends the log event_message as a text string in the body field and flattens other fields into individual attributes, instead of the default nested body. Defaults to false.
             </small>
           </div>
         <% "last9" -> %>

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -435,7 +435,13 @@ defmodule LogflareWeb.OpenApiSchemas do
       endpoint: %Schema{type: :string},
       protocol: %Schema{type: :string, nullable: true},
       gzip: %Schema{type: :boolean},
-      headers: %Schema{type: :object}
+      headers: %Schema{type: :object},
+      flatten_attributes: %Schema{
+        type: :boolean,
+        nullable: true,
+        description:
+          "Sends the log body as a plain message and flattens everything else into individual attributes instead of one nested body. Defaults to false."
+      }
     }
 
     use LogflareWeb.OpenApi, properties: @properties, required: [:endpoint]

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -436,11 +436,11 @@ defmodule LogflareWeb.OpenApiSchemas do
       protocol: %Schema{type: :string, nullable: true},
       gzip: %Schema{type: :boolean},
       headers: %Schema{type: :object},
-      flatten_attributes: %Schema{
+      flatten_to_attributes: %Schema{
         type: :boolean,
         nullable: true,
         description:
-          "Sends the log body as a plain message and flattens everything else into individual attributes instead of one nested body. Defaults to false."
+          "Sends the log event_message as a text string in the body field and flattens other fields into individual attributes, instead of the default nested body. Defaults to false."
       }
     }
 

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -279,6 +279,39 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
       assert log_record.trace_id == "not-valid-hex"
     end
+
+    test "merges an explicit attributes field with the source's other fields rather than one overwriting the other",
+         %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      mock_adapter(fn env ->
+        send(this, {ref, IO.iodata_to_binary(env.body)})
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      log_event =
+        build(:log_event,
+          source: source,
+          attributes: %{"explicit_key" => "explicit_value"},
+          other_field: "other_value",
+          timestamp: System.system_time(:microsecond)
+        )
+
+      assert {:ok, _} = Backends.ingest_logs([log_event], source)
+      assert_receive {^ref, body}, 5000
+
+      assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+               Protobuf.decode(body, ExportLogsServiceRequest)
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} ->
+          {key, any_value_to_term(value)}
+        end)
+
+      assert attrs["explicit_key"] == "explicit_value"
+      assert attrs["other_field"] == "other_value"
+    end
   end
 
   describe "content-type header handling" do
@@ -490,19 +523,25 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       end
     end
 
-    # Customer complaint #4 (body/attributes split) is not yet fixed — tracked for
-    # a follow-up PR. This pins down the current (still-unstructured) behavior so
-    # it's obvious what to update once that change lands.
-    test "body still carries everything as one unstructured blob, not structured attributes",
-         %{source: source} do
+    test "body is the plain event_message string, and everything else lands in attributes", %{
+      source: source
+    } do
       log_event = load_fixture_log_event("storage", source)
       body = capture_request_body(source, log_event)
 
       %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
         Protobuf.decode(body, ExportLogsServiceRequest)
 
-      assert log_record.attributes == []
-      assert {:kvlist_value, _} = log_record.body.value
+      assert log_record.body.value == {:string_value, log_event.body["event_message"]}
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} ->
+          {key, any_value_to_term(value)}
+        end)
+
+      assert get_in(attrs, ["metadata", "level"]) == "info"
+      assert attrs["project"] == "test-project"
+      refute Map.has_key?(attrs, "event_message")
     end
 
     test "severity_number maps HTTP status ranges to WARN/ERROR, not just INFO", %{

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -59,8 +59,19 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
       assert changeset.valid?, inspect(changeset)
 
-      assert %{gzip: true, protocol: "http/protobuf", headers: %{}} =
+      assert %{gzip: true, protocol: "http/protobuf", headers: %{}, flatten_attributes: false} =
                Ecto.Changeset.apply_changes(changeset)
+    end
+
+    test "flatten_attributes defaults to false but can be enabled" do
+      changeset =
+        Adaptor.cast_and_validate_config(
+          @subject,
+          Map.put(@valid_config_input, "flatten_attributes", "true")
+        )
+
+      assert changeset.valid?
+      assert %{flatten_attributes: true} = Ecto.Changeset.apply_changes(changeset)
     end
 
     test "allows to override the defaults" do
@@ -197,8 +208,9 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
       assert log_record.time_unix_nano == ts_us * 1000
-      assert log_record.event_name == ""
-      assert log_record.body.value == {:string_value, msg}
+      # legacy (default) shape: flatten_attributes isn't set on this backend,
+      # so event_name still carries the message and everything else stays in body
+      assert log_record.event_name == msg
       assert body =~ "random_attribute"
       assert body =~ "nothing"
     end
@@ -279,43 +291,6 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
                Protobuf.decode(body, ExportLogsServiceRequest)
 
       assert log_record.trace_id == "not-valid-hex"
-    end
-
-    test "merges an explicit attributes field with the source's other fields rather than one overwriting the other",
-         %{source: source} do
-      this = self()
-      ref = make_ref()
-
-      mock_adapter(fn env ->
-        send(this, {ref, IO.iodata_to_binary(env.body)})
-        {:ok, %Tesla.Env{status: 200, body: ""}}
-      end)
-
-      log_event =
-        build(:log_event,
-          source: source,
-          attributes: %{"explicit_key" => "explicit_value", "nested" => %{"leaf" => "value"}},
-          other_field: "other_value",
-          timestamp: System.system_time(:microsecond)
-        )
-
-      assert {:ok, _} = Backends.ingest_logs([log_event], source)
-      assert_receive {^ref, body}, 5000
-
-      assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
-               Protobuf.decode(body, ExportLogsServiceRequest)
-
-      attrs =
-        Map.new(log_record.attributes, fn %{key: key, value: value} ->
-          {key, any_value_to_term(value)}
-        end)
-
-      assert attrs["explicit_key"] == "explicit_value"
-      assert attrs["other_field"] == "other_value"
-
-      # explicit attributes are flattened the same way as the leftover fields
-      assert attrs["nested.leaf"] == "value"
-      refute Map.has_key?(attrs, "nested")
     end
   end
 
@@ -528,48 +503,6 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       end
     end
 
-    test "body is the plain event_message string, and everything else lands in attributes", %{
-      source: source
-    } do
-      log_event = load_fixture_log_event("storage", source)
-      body = capture_request_body(source, log_event)
-
-      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
-        Protobuf.decode(body, ExportLogsServiceRequest)
-
-      assert log_record.body.value == {:string_value, log_event.body["event_message"]}
-
-      attrs =
-        Map.new(log_record.attributes, fn %{key: key, value: value} ->
-          {key, any_value_to_term(value)}
-        end)
-
-      assert attrs["metadata.level"] == "info"
-      refute Map.has_key?(attrs, "metadata")
-      assert attrs["project"] == "test-project"
-      refute Map.has_key?(attrs, "event_message")
-    end
-
-    test "nested metadata fields become their own typed scalar attributes, not a stringified blob",
-         %{source: source} do
-      log_event = load_fixture_log_event("edge_log", source)
-      body = capture_request_body(source, log_event)
-
-      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
-        Protobuf.decode(body, ExportLogsServiceRequest)
-
-      attrs =
-        Map.new(log_record.attributes, fn %{key: key, value: value} -> {key, value.value} end)
-
-      # a real, typed int_value — not a string containing "200" and not buried
-      # inside a JSON-stringified "metadata" blob
-      assert attrs["metadata.response.status_code"] == {:int_value, 200}
-      assert attrs["metadata.request.method"] == {:string_value, "GET"}
-      assert attrs["metadata.request.cf.botManagement.score"] == {:int_value, 1}
-
-      refute Map.has_key?(attrs, "metadata")
-    end
-
     test "severity_number maps HTTP status ranges to WARN/ERROR, not just INFO", %{
       source: source
     } do
@@ -632,6 +565,145 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
         assert log_record.severity_number == expected
       end
+    end
+  end
+
+  describe "flatten_attributes config option" do
+    test "defaults to false and matches the legacy shape (everything in body, unflattened)" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      backend = insert(:backend, type: :otlp, sources: [source], config: @valid_config)
+
+      start_supervised!({AdaptorSupervisor, {source, backend}}, id: :legacy_shape_test_adaptor)
+      :timer.sleep(250)
+
+      log_event = load_fixture_log_event("storage", source)
+      body = capture_request_body(source, log_event)
+
+      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+        Protobuf.decode(body, ExportLogsServiceRequest)
+
+      assert log_record.event_name == log_event.body["event_message"]
+      assert log_record.attributes == []
+
+      body_map = any_value_to_term(log_record.body)
+      assert body_map["project"] == "test-project"
+      assert get_in(body_map, ["metadata", "level"]) == "info"
+    end
+
+    test "when enabled, body is the plain event_message string and everything else is flattened into attributes" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :otlp,
+          sources: [source],
+          config: Map.put(@valid_config, :flatten_attributes, true)
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}},
+        id: :structured_shape_test_adaptor
+      )
+
+      :timer.sleep(250)
+
+      log_event = load_fixture_log_event("storage", source)
+      body = capture_request_body(source, log_event)
+
+      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+        Protobuf.decode(body, ExportLogsServiceRequest)
+
+      assert log_record.event_name == ""
+      assert log_record.body.value == {:string_value, log_event.body["event_message"]}
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} ->
+          {key, any_value_to_term(value)}
+        end)
+
+      assert attrs["metadata.level"] == "info"
+      refute Map.has_key?(attrs, "metadata")
+      assert attrs["project"] == "test-project"
+      refute Map.has_key?(attrs, "event_message")
+    end
+
+    test "when enabled, nested metadata fields become their own typed scalar attributes, not a stringified blob" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :otlp,
+          sources: [source],
+          config: Map.put(@valid_config, :flatten_attributes, true)
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}},
+        id: :structured_flatten_test_adaptor
+      )
+
+      :timer.sleep(250)
+
+      log_event = load_fixture_log_event("edge_log", source)
+      body = capture_request_body(source, log_event)
+
+      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+        Protobuf.decode(body, ExportLogsServiceRequest)
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} -> {key, value.value} end)
+
+      # a real, typed int_value — not a string containing "200" and not buried
+      # inside a JSON-stringified "metadata" blob
+      assert attrs["metadata.response.status_code"] == {:int_value, 200}
+      assert attrs["metadata.request.method"] == {:string_value, "GET"}
+      assert attrs["metadata.request.cf.botManagement.score"] == {:int_value, 1}
+
+      refute Map.has_key?(attrs, "metadata")
+    end
+
+    test "when enabled, merges an explicit attributes field with the source's other fields rather than one overwriting the other" do
+      user = insert(:user)
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :otlp,
+          sources: [source],
+          config: Map.put(@valid_config, :flatten_attributes, true)
+        )
+
+      start_supervised!({AdaptorSupervisor, {source, backend}},
+        id: :structured_merge_test_adaptor
+      )
+
+      :timer.sleep(250)
+
+      log_event =
+        build(:log_event,
+          source: source,
+          attributes: %{"explicit_key" => "explicit_value", "nested" => %{"leaf" => "value"}},
+          other_field: "other_value",
+          timestamp: System.system_time(:microsecond)
+        )
+
+      body = capture_request_body(source, log_event)
+
+      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+        Protobuf.decode(body, ExportLogsServiceRequest)
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} ->
+          {key, any_value_to_term(value)}
+        end)
+
+      assert attrs["explicit_key"] == "explicit_value"
+      assert attrs["other_field"] == "other_value"
+
+      # explicit attributes are flattened the same way as the leftover fields
+      assert attrs["nested.leaf"] == "value"
+      refute Map.has_key?(attrs, "nested")
     end
   end
 

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -294,7 +294,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       log_event =
         build(:log_event,
           source: source,
-          attributes: %{"explicit_key" => "explicit_value"},
+          attributes: %{"explicit_key" => "explicit_value", "nested" => %{"leaf" => "value"}},
           other_field: "other_value",
           timestamp: System.system_time(:microsecond)
         )
@@ -312,6 +312,10 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
       assert attrs["explicit_key"] == "explicit_value"
       assert attrs["other_field"] == "other_value"
+
+      # explicit attributes are flattened the same way as the leftover fields
+      assert attrs["nested.leaf"] == "value"
+      refute Map.has_key?(attrs, "nested")
     end
   end
 
@@ -540,9 +544,30 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
           {key, any_value_to_term(value)}
         end)
 
-      assert get_in(attrs, ["metadata", "level"]) == "info"
+      assert attrs["metadata.level"] == "info"
+      refute Map.has_key?(attrs, "metadata")
       assert attrs["project"] == "test-project"
       refute Map.has_key?(attrs, "event_message")
+    end
+
+    test "nested metadata fields become their own typed scalar attributes, not a stringified blob",
+         %{source: source} do
+      log_event = load_fixture_log_event("edge_log", source)
+      body = capture_request_body(source, log_event)
+
+      %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} =
+        Protobuf.decode(body, ExportLogsServiceRequest)
+
+      attrs =
+        Map.new(log_record.attributes, fn %{key: key, value: value} -> {key, value.value} end)
+
+      # a real, typed int_value — not a string containing "200" and not buried
+      # inside a JSON-stringified "metadata" blob
+      assert attrs["metadata.response.status_code"] == {:int_value, 200}
+      assert attrs["metadata.request.method"] == {:string_value, "GET"}
+      assert attrs["metadata.request.cf.botManagement.score"] == {:int_value, 1}
+
+      refute Map.has_key?(attrs, "metadata")
     end
 
     test "severity_number maps HTTP status ranges to WARN/ERROR, not just INFO", %{

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -59,19 +59,19 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
 
       assert changeset.valid?, inspect(changeset)
 
-      assert %{gzip: true, protocol: "http/protobuf", headers: %{}, flatten_attributes: false} =
+      assert %{gzip: true, protocol: "http/protobuf", headers: %{}, flatten_to_attributes: false} =
                Ecto.Changeset.apply_changes(changeset)
     end
 
-    test "flatten_attributes defaults to false but can be enabled" do
+    test "flatten_to_attributes defaults to false but can be enabled" do
       changeset =
         Adaptor.cast_and_validate_config(
           @subject,
-          Map.put(@valid_config_input, "flatten_attributes", "true")
+          Map.put(@valid_config_input, "flatten_to_attributes", "true")
         )
 
       assert changeset.valid?
-      assert %{flatten_attributes: true} = Ecto.Changeset.apply_changes(changeset)
+      assert %{flatten_to_attributes: true} = Ecto.Changeset.apply_changes(changeset)
     end
 
     test "allows to override the defaults" do
@@ -208,7 +208,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
       assert log_record.time_unix_nano == ts_us * 1000
-      # legacy (default) shape: flatten_attributes isn't set on this backend,
+      # legacy (default) shape: flatten_to_attributes isn't set on this backend,
       # so event_name still carries the message and everything else stays in body
       assert log_record.event_name == msg
       assert body =~ "random_attribute"
@@ -568,7 +568,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
     end
   end
 
-  describe "flatten_attributes config option" do
+  describe "flatten_to_attributes config option" do
     test "defaults to false and matches the legacy shape (everything in body, unflattened)" do
       user = insert(:user)
       source = insert(:source, user: user)
@@ -599,7 +599,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
         insert(:backend,
           type: :otlp,
           sources: [source],
-          config: Map.put(@valid_config, :flatten_attributes, true)
+          config: Map.put(@valid_config, :flatten_to_attributes, true)
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}},
@@ -636,7 +636,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
         insert(:backend,
           type: :otlp,
           sources: [source],
-          config: Map.put(@valid_config, :flatten_attributes, true)
+          config: Map.put(@valid_config, :flatten_to_attributes, true)
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}},
@@ -671,7 +671,7 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
         insert(:backend,
           type: :otlp,
           sources: [source],
-          config: Map.put(@valid_config, :flatten_attributes, true)
+          config: Map.put(@valid_config, :flatten_to_attributes, true)
         )
 
       start_supervised!({AdaptorSupervisor, {source, backend}},

--- a/test/logflare/backends/adaptor/otlp_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/otlp_adaptor_test.exs
@@ -197,7 +197,8 @@ defmodule Logflare.Backends.Adaptor.OtlpAdaptorTest do
       assert request = Protobuf.decode(body, ExportLogsServiceRequest)
       assert %{resource_logs: [%{scope_logs: [%{log_records: [log_record]}]}]} = request
       assert log_record.time_unix_nano == ts_us * 1000
-      assert log_record.event_name == msg
+      assert log_record.event_name == ""
+      assert log_record.body.value == {:string_value, msg}
       assert body =~ "random_attribute"
       assert body =~ "nothing"
     end

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -404,6 +404,35 @@ defmodule LogflareWeb.BackendsLiveTest do
       assert html =~ "Successfully created backend"
       assert html =~ "my clickhouse"
     end
+
+    test "can create otlp backend with flatten_to_attributes enabled", %{conn: conn, user: user} do
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/new")
+
+      view
+      |> element("select#type")
+      |> render_change(%{backend: %{type: "otlp"}})
+
+      html =
+        view
+        |> form("form", %{
+          backend: %{
+            name: "my otlp",
+            type: "otlp",
+            config: %{
+              endpoint: "https://otlp.example.com/v1/logs",
+              flatten_to_attributes: "true"
+            }
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Successfully created backend"
+      assert html =~ "my otlp"
+
+      [backend] = Backends.list_backends_by_user_access(user, type: :otlp)
+      assert backend.config.endpoint == "https://otlp.example.com/v1/logs"
+      assert backend.config.flatten_to_attributes == true
+    end
   end
 
   describe "edit" do


### PR DESCRIPTION
<img width="2288" height="1214" alt="Screenshot 2026-08-06 at 15 56 10" src="https://github.com/user-attachments/assets/6436c0cf-f9a2-4ac1-b306-b7dc50a6034e" />


Sets the LogRecord.body to be the human readable text event_message as this is what is displayed on dash0 and other provider uis.

Sets the attributes to be a flattened list of keys corresponding to the metadata in the logevent body. See the screenshot above. This allows dash0 and likely others that don't supported nested json to query and filter attributes.

closes O11Y-2280