### PR TITLE
feat: support Datadog UK1 and US2-FED log drain regions

### DIFF
--- a/lib/logflare/backends/adaptor/datadog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/datadog_adaptor.ex
@@ -15,7 +15,9 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptor do
     "EU" => "https://http-intake.logs.datadoghq.eu/api/v2/logs",
     "AP1" => "https://http-intake.logs.ap1.datadoghq.com/api/v2/logs",
     "AP2" => "https://http-intake.logs.ap2.datadoghq.com/api/v2/logs",
-    "US1-FED" => "https://http-intake.logs.ddog-gov.com/api/v2/logs"
+    "UK1" => "https://http-intake.logs.uk1.datadoghq.com/api/v2/logs",
+    "US1-FED" => "https://http-intake.logs.ddog-gov.com/api/v2/logs",
+    "US2-FED" => "https://http-intake.logs.us2.ddog-gov.com/api/v2/logs"
   }
   @regions Map.keys(@api_url_mapping)
 

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -346,7 +346,7 @@ defmodule LogflareWeb.BackendsLiveTest do
       |> element("select#type")
       |> render_change(%{backend: %{type: "datadog"}})
 
-      for region <- ["US1", "US3", "US5", "EU", "AP1", "US1-FED"] do
+      for region <- ["US1", "US3", "US5", "EU", "AP1", "AP2", "UK1", "US1-FED", "US2-FED"] do
         assert has_element?(view, "#datadog-region option", region)
       end
     end


### PR DESCRIPTION
Adds the two Datadog sites missing from the adaptor's region map, prompted by a customer on UK1:

- `UK1` → `https://http-intake.logs.uk1.datadoghq.com/api/v2/logs`
- `US2-FED` → `https://http-intake.logs.us2.ddog-gov.com/api/v2/logs`

Hostnames per [Datadog's site list](https://docs.datadoghq.com/getting_started/site/) and the [logs intake reference](https://docs.datadoghq.com/api/latest/logs/#send-logs).

The region assertions in `backends_live_test.exs` also gain `AP2`, which that list never picked up when the region was added.
