### PR TITLE
fix: cover every Datadog region in Finch pool config and metrics

### DIFF
--- a/lib/logflare/backends/adaptor/datadog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/datadog_adaptor.ex
@@ -21,7 +21,23 @@ defmodule Logflare.Backends.Adaptor.DatadogAdaptor do
   }
   @regions Map.keys(@api_url_mapping)
 
+  @intake_origins @api_url_mapping
+                  |> Map.values()
+                  |> Enum.map(fn url ->
+                    uri = URI.parse(url)
+                    URI.to_string(%URI{scheme: uri.scheme, host: uri.host})
+                  end)
+                  |> Enum.uniq()
+                  |> Enum.sort()
+
   def regions, do: @regions
+
+  @doc """
+  Scheme-and-host origins of every regional logs intake, in the form used as a
+  `Finch` pool key.
+  """
+  @spec intake_origins() :: [String.t()]
+  def intake_origins, do: @intake_origins
 
   @behaviour Logflare.Backends.Adaptor
 

--- a/lib/logflare/networking.ex
+++ b/lib/logflare/networking.ex
@@ -2,6 +2,7 @@ defmodule Logflare.Networking do
   @moduledoc false
 
   alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
+  alias Logflare.Backends.Adaptor.DatadogAdaptor
   alias Logflare.SingleTenant
 
   def pools do
@@ -132,28 +133,9 @@ defmodule Logflare.Networking do
   end
 
   defp all_datadog_pools do
-    %{
-      "https://http-intake.logs.datadoghq.com" => [
-        protocols: [:http1],
-        start_pool_metrics?: true
-      ],
-      "https://http-intake.logs.us3.datadoghq.com" => [
-        protocols: [:http1],
-        start_pool_metrics?: true
-      ],
-      "https://http-intake.logs.us5.datadoghq.com" => [
-        protocols: [:http1],
-        start_pool_metrics?: true
-      ],
-      "https://http-intake.logs.datadoghq.eu" => [
-        protocols: [:http1],
-        start_pool_metrics?: true
-      ],
-      "https://http-intake.logs.ap1.datadoghq.com" => [
-        protocols: [:http1],
-        start_pool_metrics?: true
-      ]
-    }
+    for origin <- DatadogAdaptor.intake_origins(), into: %{} do
+      {origin, [protocols: [:http1], start_pool_metrics?: true]}
+    end
   end
 
   defp grpc_pools do

--- a/lib/logflare/system_metrics/cluster.ex
+++ b/lib/logflare/system_metrics/cluster.ex
@@ -3,6 +3,7 @@ defmodule Logflare.SystemMetrics.Cluster do
 
   require Logger
 
+  alias Logflare.Backends.Adaptor.DatadogAdaptor
   alias Logflare.Cluster.Utils
 
   def dispatch_stats do
@@ -20,15 +21,7 @@ defmodule Logflare.SystemMetrics.Cluster do
   end
 
   def finch do
-    # TODO(ziinc): add in datadog pools
-    for url <- [
-          "https://bigquery.googleapis.com",
-          "https://http-intake.logs.datadoghq.com",
-          "https://http-intake.logs.us3.datadoghq.com",
-          "https://http-intake.logs.us5.datadoghq.com",
-          "https://http-intake.logs.datadoghq.eu",
-          "https://http-intake.logs.ap1.datadoghq.com"
-        ],
+    for url <- ["https://bigquery.googleapis.com" | DatadogAdaptor.intake_origins()],
         pool <- [
           Logflare.FinchDefault,
           Logflare.FinchIngest,

--- a/test/logflare/application_test.exs
+++ b/test/logflare/application_test.exs
@@ -2,6 +2,8 @@ defmodule Logflare.ApplicationTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  alias Logflare.Backends.Adaptor.DatadogAdaptor
+
   describe "datadog_connection_pools/0" do
     setup do
       original_config = Application.get_env(:logflare, :http_connection_pools)
@@ -24,9 +26,9 @@ defmodule Logflare.ApplicationTest do
           else: Application.delete_env(:logflare, :http_connection_pools)
 
         pools = get_pools()
-        assert map_size(pools) == 9
-        assert Map.has_key?(pools, "https://http-intake.logs.datadoghq.com")
-        assert Map.has_key?(pools, "https://http-intake.logs.uk1.datadoghq.com")
+
+        assert MapSet.new(Map.keys(pools)) ==
+                 MapSet.new(DatadogAdaptor.intake_origins())
       end
     end
 
@@ -34,9 +36,9 @@ defmodule Logflare.ApplicationTest do
       for config <- [["datadog"], ["datadog", "elastic"], ["elastic", "all", "loki"]] do
         Application.put_env(:logflare, :http_connection_pools, config)
         pools = get_pools()
-        assert map_size(pools) == 9
-        assert Map.has_key?(pools, "https://http-intake.logs.datadoghq.com")
-        assert Map.has_key?(pools, "https://http-intake.logs.uk1.datadoghq.com")
+
+        assert MapSet.new(Map.keys(pools)) ==
+                 MapSet.new(DatadogAdaptor.intake_origins())
       end
     end
 

--- a/test/logflare/application_test.exs
+++ b/test/logflare/application_test.exs
@@ -24,8 +24,9 @@ defmodule Logflare.ApplicationTest do
           else: Application.delete_env(:logflare, :http_connection_pools)
 
         pools = get_pools()
-        assert map_size(pools) == 5
+        assert map_size(pools) == 9
         assert Map.has_key?(pools, "https://http-intake.logs.datadoghq.com")
+        assert Map.has_key?(pools, "https://http-intake.logs.uk1.datadoghq.com")
       end
     end
 
@@ -33,8 +34,9 @@ defmodule Logflare.ApplicationTest do
       for config <- [["datadog"], ["datadog", "elastic"], ["elastic", "all", "loki"]] do
         Application.put_env(:logflare, :http_connection_pools, config)
         pools = get_pools()
-        assert map_size(pools) == 5
+        assert map_size(pools) == 9
         assert Map.has_key?(pools, "https://http-intake.logs.datadoghq.com")
+        assert Map.has_key?(pools, "https://http-intake.logs.uk1.datadoghq.com")
       end
     end
 

--- a/test/logflare/networking_test.exs
+++ b/test/logflare/networking_test.exs
@@ -2,6 +2,7 @@ defmodule Logflare.NetworkingTest do
   @moduledoc false
   use Logflare.DataCase
 
+  alias Logflare.Backends.Adaptor.DatadogAdaptor
   alias Logflare.Networking
 
   describe "single tenant mode using Big Query" do
@@ -32,33 +33,18 @@ defmodule Logflare.NetworkingTest do
     TestUtils.setup_single_tenant(backend_type: :postgres)
 
     test "returns only datadog connection pools" do
+      expected_datadog_pools =
+        DatadogAdaptor.intake_origins()
+        |> Map.new(fn origin ->
+          {origin, [protocols: [:http1], start_pool_metrics?: true]}
+        end)
+        |> Map.put(:default, protocols: [:http1])
+
       assert [
                {Finch,
                 [
                   name: Logflare.FinchDefault,
-                  pools: %{
-                    :default => [protocols: [:http1]],
-                    "https://http-intake.logs.ap1.datadoghq.com" => [
-                      protocols: [:http1],
-                      start_pool_metrics?: true
-                    ],
-                    "https://http-intake.logs.datadoghq.com" => [
-                      protocols: [:http1],
-                      start_pool_metrics?: true
-                    ],
-                    "https://http-intake.logs.datadoghq.eu" => [
-                      protocols: [:http1],
-                      start_pool_metrics?: true
-                    ],
-                    "https://http-intake.logs.us3.datadoghq.com" => [
-                      protocols: [:http1],
-                      start_pool_metrics?: true
-                    ],
-                    "https://http-intake.logs.us5.datadoghq.com" => [
-                      protocols: [:http1],
-                      start_pool_metrics?: true
-                    ]
-                  }
+                  pools: datadog_pools
                 ]},
                {Finch,
                 name: Logflare.FinchClickHouseIngest,
@@ -71,6 +57,8 @@ defmodule Logflare.NetworkingTest do
                   :default => _async_config
                 }}
              ] = Networking.pools()
+
+      assert datadog_pools == expected_datadog_pools
     end
   end
 end


### PR DESCRIPTION
Stacked on #3790 — review that first; this PR's base is its branch.

`Logflare.Networking.all_datadog_pools/0` and the URL list `SystemMetrics.Cluster.finch/0` polls were both hand-maintained copies of the Datadog adaptor's region map, and both had drifted: neither listed `AP2`, added several regions ago.

A missing entry is not a connectivity problem. Finch treats the `:default` entry as a catch-all *configuration* ([docs](https://hexdocs.pm/finch/Finch.html#start_link/1)), so an unlisted intake host still gets its own pool with the same protocol and sizing. The only difference is `start_pool_metrics?`, which gates `Finch.get_pool_status/2`. So the effect was silently absent pool telemetry for the omitted regions — worth noting since adding pool entries alone wouldn't have fixed it, as `Cluster.finch/0` is what actually emits.

Both lists now derive from the adaptor map via `DatadogAdaptor.intake_origins/0`, so a new region can't be metered inconsistently. Also drops the `# TODO(ziinc): add in datadog pools` comment, which sat above a list that already contained Datadog pools.