### PR TITLE
fix: noisy grpc-otel-permission-denied error logs 

### DIFF
--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -113,7 +113,8 @@ defmodule Logflare.Application do
          endpoint: LogflareGrpc.Endpoint,
          port: grpc_port,
          start_server: true,
-         adapter_opts: [cred: grpc_creds]},
+         adapter_opts: [cred: grpc_creds],
+         exception_log_filter: {LogflareGrpc.ExceptionLogFilter, :emit_log?}},
         # Monitor system level metrics
         SystemMetricsSup,
         Logflare.Telemetry,

--- a/lib/logflare_grpc/exception_log_filter.ex
+++ b/lib/logflare_grpc/exception_log_filter.ex
@@ -8,7 +8,7 @@ defmodule LogflareGrpc.ExceptionLogFilter do
 
   alias GRPC.Server.Adapters.ReportException
 
-  @spec emit_log?(ReportException.t()) :: boolean()
+  @spec emit_log?(%ReportException{}) :: boolean()
   def emit_log?(%ReportException{reason: %GRPC.RPCError{status: :permission_denied}}), do: false
   def emit_log?(%ReportException{reason: %GRPC.RPCError{status: :unauthenticated}}), do: false
   def emit_log?(%ReportException{}), do: true

--- a/lib/logflare_grpc/exception_log_filter.ex
+++ b/lib/logflare_grpc/exception_log_filter.ex
@@ -1,0 +1,15 @@
+defmodule LogflareGrpc.ExceptionLogFilter do
+  @moduledoc """
+  Filters expected `GRPC.RPCError` rejections (bad api keys, missing sources,
+  insufficient scopes, etc.) out of the crash-level exception logs emitted by
+  `GRPC.Server.Adapters.Cowboy.Handler`, since they are normal control flow
+  rather than bugs. Unexpected exceptions are still logged.
+  """
+
+  alias GRPC.Server.Adapters.ReportException
+
+  @spec emit_log?(ReportException.t()) :: boolean()
+  def emit_log?(%ReportException{reason: %GRPC.RPCError{status: :permission_denied}}), do: false
+  def emit_log?(%ReportException{reason: %GRPC.RPCError{status: :unauthenticated}}), do: false
+  def emit_log?(%ReportException{}), do: true
+end

--- a/test/logflare_grpc/exception_log_filter_test.exs
+++ b/test/logflare_grpc/exception_log_filter_test.exs
@@ -1,0 +1,32 @@
+defmodule LogflareGrpc.ExceptionLogFilterTest do
+  use ExUnit.Case, async: true
+
+  alias GRPC.Server.Adapters.ReportException
+  alias LogflareGrpc.ExceptionLogFilter
+
+  describe "emit_log?/1" do
+    test "returns false for a permission_denied GRPC.RPCError rejection" do
+      exception = ReportException.new([req: :ok], %GRPC.RPCError{status: :permission_denied})
+
+      refute ExceptionLogFilter.emit_log?(exception)
+    end
+
+    test "returns false for an unauthenticated GRPC.RPCError rejection" do
+      exception = ReportException.new([req: :ok], %GRPC.RPCError{status: :unauthenticated})
+
+      refute ExceptionLogFilter.emit_log?(exception)
+    end
+
+    test "returns true for a GRPC.RPCError with an unrecognized status" do
+      exception = ReportException.new([req: :ok], %GRPC.RPCError{status: :internal})
+
+      assert ExceptionLogFilter.emit_log?(exception)
+    end
+
+    test "returns true for unexpected exceptions raised by handlers" do
+      exception = ReportException.new([req: :ok], %RuntimeError{message: "boom"})
+
+      assert ExceptionLogFilter.emit_log?(exception)
+    end
+  end
+end


### PR DESCRIPTION
Suppress noisy crash-level logs for expected gRPC RPCError auth rejections on the OTLP endpoint