### PR TITLE
chore: trim whitespace in log filter fields

### DIFF
--- a/assets/js/lql_editor_wrapper_hook.js
+++ b/assets/js/lql_editor_wrapper_hook.js
@@ -15,6 +15,32 @@ const parseSuggestedSearches = (suggestedSearchesJson) => {
   return JSON.parse(suggestedSearchesJson);
 };
 
+const FIELD_NAME_PATTERN = /^fields\[(.+)\]$/;
+
+export const trimFieldInput = (input) => {
+  const match = input?.name?.match?.(FIELD_NAME_PATTERN);
+
+  if (!match) return null;
+
+  input.value = input.value.trim();
+
+  return { name: match[1], value: input.value };
+};
+
+export const collectTrimmedFields = (inputs) => {
+  const fields = {};
+
+  inputs.forEach((input) => {
+    const field = trimFieldInput(input);
+
+    if (field) {
+      fields[field.name] = field.value;
+    }
+  });
+
+  return fields;
+};
+
 const LqlEditorWrapper = {
   mounted() {
     this._schemaFields = parseSchemaFields(this.el.dataset.schemaFieldsJson);
@@ -28,6 +54,9 @@ const LqlEditorWrapper = {
     this._lastServerQuerystring = this.el.dataset.querystring ?? "";
     this._handleSubmitRequest = () => {
       this.submitSearch();
+    };
+    this._handleFieldFocusOut = (event) => {
+      trimFieldInput(event.target);
     };
     this._handleEditorMounted = (event) => {
       const { editor } = event.detail;
@@ -79,6 +108,12 @@ const LqlEditorWrapper = {
 
     this.el.addEventListener("lql:submit", this._handleSubmitRequest);
     this.el.addEventListener("lme:editor_mounted", this._handleEditorMounted);
+
+    this._fieldsContainer = this.searchControl();
+    this._fieldsContainer?.addEventListener(
+      "focusout",
+      this._handleFieldFocusOut
+    );
   },
 
   updated() {
@@ -139,22 +174,19 @@ const LqlEditorWrapper = {
     }
   },
 
+  searchControl() {
+    return (
+      this.el.closest("#source-logs-search-control") || this.el.parentElement
+    );
+  },
+
   collectRecommendedFields() {
-    const searchControl =
-      this.el.closest("#source-logs-search-control") || this.el.parentElement;
-    const fields = {};
+    const inputs =
+      this.searchControl()?.querySelectorAll(
+        '#recommended_fields input[name^="fields["]'
+      ) ?? [];
 
-    searchControl
-      ?.querySelectorAll('#recommended_fields input[name^="fields["]')
-      .forEach((input) => {
-        const match = input.name.match(/^fields\[(.+)\]$/);
-
-        if (match) {
-          fields[match[1]] = input.value;
-        }
-      });
-
-    return fields;
+    return collectTrimmedFields(inputs);
   },
 
   submitSearch() {
@@ -178,6 +210,12 @@ const LqlEditorWrapper = {
 
   destroyed() {
     this.disposeEditorBindings();
+
+    this._fieldsContainer?.removeEventListener(
+      "focusout",
+      this._handleFieldFocusOut
+    );
+    this._fieldsContainer = null;
   },
 };
 

--- a/assets/js/test/lql_editor_wrapper_hook.test.js
+++ b/assets/js/test/lql_editor_wrapper_hook.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+const { collectTrimmedFields, trimFieldInput } = await import(
+  "../lql_editor_wrapper_hook.js"
+);
+
+const input = (name, value) => ({ name, value });
+
+describe("trimFieldInput", () => {
+  it("trims the input value in place", () => {
+    const field = input("fields[metadata.project_ref]", "  abcdef  ");
+
+    expect(trimFieldInput(field)).toEqual({
+      name: "metadata.project_ref",
+      value: "abcdef",
+    });
+    expect(field.value).toBe("abcdef");
+  });
+
+  it("trims tabs and newlines", () => {
+    const field = input("fields[metadata.level]", "\terror\n");
+
+    trimFieldInput(field);
+
+    expect(field.value).toBe("error");
+  });
+
+  it("returns null and leaves unrelated inputs alone", () => {
+    const field = input("querystring", "  event_message:timeout  ");
+
+    expect(trimFieldInput(field)).toBeNull();
+    expect(field.value).toBe("  event_message:timeout  ");
+  });
+});
+
+describe("collectTrimmedFields", () => {
+  it("collects trimmed values keyed by field path", () => {
+    const fields = collectTrimmedFields([
+      input("fields[metadata.organization_slug]", " abcdef "),
+      input("fields[metadata.project_ref]", "ghijkl"),
+      input("fields[metadata.request_id]", "   "),
+      input("tailing?", " true "),
+    ]);
+
+    expect(fields).toEqual({
+      "metadata.organization_slug": "abcdef",
+      "metadata.project_ref": "ghijkl",
+      "metadata.request_id": "",
+    });
+  });
+
+  it("returns an empty map when there are no inputs", () => {
+    expect(collectTrimmedFields([])).toEqual({});
+  });
+});

--- a/assets/js/test/lql_editor_wrapper_hook.test.js
+++ b/assets/js/test/lql_editor_wrapper_hook.test.js
@@ -1,10 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const { collectTrimmedFields, trimFieldInput } = await import(
-  "../lql_editor_wrapper_hook.js"
-);
+const {
+  collectTrimmedFields,
+  trimFieldInput,
+  default: LqlEditorWrapper,
+} = await import("../lql_editor_wrapper_hook.js");
 
 const input = (name, value) => ({ name, value });
+
+const mountHook = () => {
+  const container = {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+
+  const hook = Object.create(LqlEditorWrapper);
+
+  hook.el = {
+    dataset: {},
+    addEventListener: vi.fn(),
+    closest: () => container,
+    parentElement: null,
+  };
+
+  hook.mounted();
+
+  return { container, hook };
+};
 
 describe("trimFieldInput", () => {
   it("trims the input value in place", () => {
@@ -51,5 +73,53 @@ describe("collectTrimmedFields", () => {
 
   it("returns an empty map when there are no inputs", () => {
     expect(collectTrimmedFields([])).toEqual({});
+  });
+});
+
+describe("focusout handler lifecycle", () => {
+  it("registers a focusout handler on the search control when mounted", () => {
+    const { container } = mountHook();
+
+    expect(container.addEventListener).toHaveBeenCalledWith(
+      "focusout",
+      expect.any(Function)
+    );
+  });
+
+  it("trims the focused out field via the registered handler", () => {
+    const { container } = mountHook();
+    const [, handler] = container.addEventListener.mock.calls[0];
+    const field = input("fields[metadata.project_ref]", "  abcdef  ");
+
+    handler({ target: field });
+
+    expect(field.value).toBe("abcdef");
+  });
+
+  it("removes the same handler when destroyed", () => {
+    const { container, hook } = mountHook();
+    const [, handler] = container.addEventListener.mock.calls[0];
+
+    hook.destroyed();
+
+    expect(container.removeEventListener).toHaveBeenCalledWith(
+      "focusout",
+      handler
+    );
+  });
+
+  it("does not blow up when destroyed without a search control", () => {
+    const hook = Object.create(LqlEditorWrapper);
+
+    hook.el = {
+      dataset: {},
+      addEventListener: vi.fn(),
+      closest: () => null,
+      parentElement: null,
+    };
+
+    hook.mounted();
+
+    expect(() => hook.destroyed()).not.toThrow();
   });
 });

--- a/lib/logflare_web/live/search_live/logs_search_lv.ex
+++ b/lib/logflare_web/live/search_live/logs_search_lv.ex
@@ -578,7 +578,8 @@ defmodule LogflareWeb.Source.SearchLV do
          {:ok, lql_rules} <- Lql.decode(qs, schema) do
       recommended_filter_rules =
         recommended_fields
-        |> Enum.reject(fn {_path, value} -> is_nil(value) or String.trim(value) == "" end)
+        |> Enum.map(fn {path, value} -> {path, trim_field_value(value)} end)
+        |> Enum.reject(fn {_path, value} -> value == "" end)
         |> Enum.map(fn {path, value} ->
           FilterRule.build(path: path, operator: :=, value: value)
         end)
@@ -593,6 +594,9 @@ defmodule LogflareWeb.Source.SearchLV do
       _ -> qs
     end
   end
+
+  defp trim_field_value(value) when is_binary(value), do: String.trim(value)
+  defp trim_field_value(_value), do: ""
 
   defp maybe_update_chart_controls(socket, new_chart_agg, new_chart_period) do
     prev_chart_rule =

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -2190,6 +2190,60 @@ defmodule LogflareWeb.Source.SearchLVTest do
       refute qs =~ "event_message:timeout"
       refute qs =~ "m.request_id:"
     end
+
+    test "start_search trims whitespace from field values", %{conn: conn, user: user} do
+      source = insert(:source, user: user, suggested_keys: "metadata.level!,m.user_id")
+
+      insert(:source_schema,
+        source: source,
+        bigquery_schema:
+          TestUtils.build_bq_schema(%{"metadata" => %{"level" => "error", "user_id" => "123"}})
+      )
+
+      Cachex.clear(Logflare.SourceSchemas.Cache)
+
+      {:ok, view, _html} = live_with_redirect(conn, Routes.live_path(conn, SearchLV, source.id))
+
+      %{executor_pid: search_executor_pid} = get_view_assigns(view)
+      allow_sandbox(search_executor_pid)
+
+      render_change(view, :start_search, %{
+        "querystring" => "c:count(*) c:group_by(t::minute)",
+        "fields" => %{
+          "metadata.level" => "  error  ",
+          "metadata.user_id" => "\t123\n",
+          "metadata.request_id" => "   "
+        }
+      })
+
+      qs = render(view) |> find_querystring()
+
+      assert qs =~ "m.level:error"
+      assert qs =~ "m.user_id:123"
+      refute qs =~ "m.request_id:"
+    end
+
+    # Search initiated from SourceController.show
+    test "search with field params are trimmed", %{conn: conn, source: source} do
+      query_params = [
+        {"fields[metadata.level]", " error "},
+        {"fields[metadata.user_id]", "\t123\n"},
+        {"fields[metadata.request_id]", "   "},
+        querystring: "c:count(*) c:group_by(t::minute)"
+      ]
+
+      path = ~p"/sources/#{source.id}/search?#{query_params}"
+
+      {:error, {:live_redirect, %{to: to}}} = live_with_redirect(conn, path)
+
+      {:ok, view, _html} = live(conn, to)
+
+      qs = render(view) |> find_querystring()
+
+      assert qs =~ "m.level:error"
+      assert qs =~ "m.user_id:123"
+      refute qs =~ "m.request_id:"
+    end
   end
 
   describe "source disable tailing" do


### PR DESCRIPTION
Trims any whitespace around log filter fields on the LV backend as well as the presentation side via a JS hook.

This is a QOL improvement for people copy/pasting values in.