### PR TITLE
fix: cache spool memory stats in ETS

### DIFF
--- a/lib/logflare/backends/spool/memory_monitor.ex
+++ b/lib/logflare/backends/spool/memory_monitor.ex
@@ -9,10 +9,10 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
   stay watched permanently once registered — no TTL/expiry — until they no
   longer resolve to a real source.
 
-  Mirrors `Logflare.LogEvent.DayBucket`'s pattern: a GenServer refreshes a
-  `:persistent_term` on a timer, so hot-path readers pay only the cost of a
-  `:persistent_term.get/1` (no GC, no locking) rather than repeating the
-  underlying `:erlang.memory/1` + `:memsup` computation themselves.
+  A GenServer refreshes a read-optimized ETS cache on a timer, so hot-path
+  readers avoid repeating the underlying `:erlang.memory/1` + `:memsup`
+  computation themselves. ETS avoids repeatedly replacing a non-immediate
+  `:persistent_term` value, which can trigger VM-wide literal-area scans.
 
   Started once, shared by both sides — see `Logflare.Backends.Supervisor`.
   """
@@ -21,7 +21,11 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
 
   alias Logflare.Backends
 
-  @pt_key {__MODULE__, :stats}
+  @table __MODULE__
+  @cache_key :stats
+  @throttled_position 2
+  @consumer_throttled_position 3
+  @stats_position 4
   @refresh_interval 1_000
   @default_memory_limit_percent 0.70
   @default_max_ets_percent 0.25
@@ -42,7 +46,11 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
   read racing this GenServer's own boot).
   """
   @spec throttled?() :: boolean()
-  def throttled?, do: stats().throttled?
+  def throttled? do
+    :ets.lookup_element(@table, @cache_key, @throttled_position)
+  rescue
+    ArgumentError -> compute_stats(MapSet.new()).throttled?
+  end
 
   @doc """
   Returns whether any registered spool consumer source has a backed-up
@@ -50,7 +58,11 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
   `throttled?/0`.
   """
   @spec consumer_throttled?() :: boolean()
-  def consumer_throttled?, do: stats().consumer_throttled?
+  def consumer_throttled? do
+    :ets.lookup_element(@table, @cache_key, @consumer_throttled_position)
+  rescue
+    ArgumentError -> compute_stats(MapSet.new()).consumer_throttled?
+  end
 
   @doc """
   Returns the full stats map behind `throttled?/0` and `consumer_throttled?/0`
@@ -59,7 +71,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
   """
   @spec stats() :: stats()
   def stats do
-    :persistent_term.get(@pt_key)
+    :ets.lookup_element(@table, @cache_key, @stats_position)
   rescue
     ArgumentError -> compute_stats(MapSet.new())
   end
@@ -85,6 +97,7 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
 
   @impl GenServer
   def init(_opts) do
+    :ets.new(@table, [:named_table, :set, :protected, read_concurrency: true])
     {:ok, %{registered_sources: MapSet.new()}, {:continue, :refresh}}
   end
 
@@ -121,7 +134,10 @@ defmodule Logflare.Backends.Spool.MemoryMonitor do
       %{}
     )
 
-    :persistent_term.put(@pt_key, stats)
+    :ets.insert(
+      @table,
+      {@cache_key, stats.throttled?, stats.consumer_throttled?, stats}
+    )
   end
 
   defp compute_stats(registered_sources) do

--- a/lib/logflare/backends/spool/producer_pipeline.ex
+++ b/lib/logflare/backends/spool/producer_pipeline.ex
@@ -225,7 +225,7 @@ defmodule Logflare.Backends.Spool.ProducerPipeline do
   # Throttle state is sampled once per batch (on the first message after a
   # reset), not once per message — the :pending sentinel marks "not yet
   # decided for this batch". Logflare.Backends.Spool.MemoryMonitor.throttled?/0
-  # is a cheap :persistent_term read, but even that isn't worth paying on
+  # is a cheap ETS tuple-element lookup, but even that isn't worth paying on
   # every single message when a batch can be up to @max_batch_size messages.
   #
   # Public (not private) so the returned {initial_acc, reducer_fn} tuple can

--- a/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
+++ b/test/logflare/backends/spool/consumer_pipeline/queue_producer_test.exs
@@ -22,13 +22,9 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline.QueueProducerTest do
       end
     end)
 
-    # MemoryMonitor's stats() are cached in :persistent_term — global, and
-    # NOT reset between tests or test files. Without this, a test here could
-    # inherit a stale "throttled" value left by any test anywhere in the
-    # suite that ran MemoryMonitor last, hanging tests that have nothing to
-    # do with throttling (e.g. prefetch/happy-path tests below). Starting a
-    # fresh, explicitly non-throttled MemoryMonitor for every test in this
-    # file guarantees a known baseline; throttled!/0 overrides it as needed.
+    # MemoryMonitor publishes stats through a node-global named ETS table.
+    # Start a fresh, explicitly non-throttled monitor for every test so the
+    # queue producer has a known baseline; throttled!/0 overrides it as needed.
     Application.put_env(:logflare, :spool,
       spool_memory_limit_percent: 1.0,
       spool_max_ets_percent: 1.0

--- a/test/logflare/backends/spool/memory_monitor_test.exs
+++ b/test/logflare/backends/spool/memory_monitor_test.exs
@@ -44,6 +44,31 @@ defmodule Logflare.Backends.Spool.MemoryMonitorTest do
     assert MemoryMonitor.throttled?() == false
   end
 
+  test "falls back to live stats before the ETS cache is available" do
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 0.0,
+      spool_max_ets_percent: 0.0
+    )
+
+    assert :ets.whereis(MemoryMonitor) == :undefined
+    assert MemoryMonitor.throttled?()
+    refute MemoryMonitor.consumer_throttled?()
+    assert MemoryMonitor.stats().throttled?
+  end
+
+  test "caches refreshed stats in ETS" do
+    Application.put_env(:logflare, :spool,
+      spool_memory_limit_percent: 1.0,
+      spool_max_ets_percent: 1.0
+    )
+
+    start_supervised!(MemoryMonitor)
+    :sys.get_state(MemoryMonitor)
+
+    assert [{:stats, false, false, stats}] = :ets.lookup(MemoryMonitor, :stats)
+    assert stats == MemoryMonitor.stats()
+  end
+
   test "periodically refreshes cached memory pressure without an explicit message" do
     Application.put_env(:logflare, :spool,
       spool_memory_limit_percent: 1.0,


### PR DESCRIPTION
## Summary

- replace the spool memory monitor's once-per-second `:persistent_term` replacement with a protected, read-concurrent ETS cache
- keep hot throttling checks allocation-light with direct tuple-position lookups
- preserve live-computation fallbacks while the cache is unavailable and retain the full diagnostic stats map

## Why

Replacing the monitor's non-immediate stats map in `:persistent_term` initiates literal-area reclamation across the VM. Since the map contains changing memory ratios and refreshes every second, production nodes continuously schedule process-wide scans through `erts_literal_area_collector`.

ETS keeps the update bounded to the cache table. A local OTP 27 synthetic comparison with 20,000 processes and 100 updates measured 335 microseconds for ETS updates versus 2.46 seconds for persistent-term updates through completed reclamation. This is directional rather than a production capacity measurement.
