### PR TITLE
fix(bigquery): bound schema sample queues

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,7 +41,7 @@ config :logflare, :clickhouse_backend_adaptor,
 
 config :logflare, Logflare.Sources.Source.BigQuery.Schema,
   updates_per_minute: 6,
-  max_pending_samples: 32
+  max_pending_samples: 8
 
 # Configures the endpoint
 config :logflare, LogflareWeb.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,9 @@ config :logflare, :clickhouse_backend_adaptor,
   pool_size: 3,
   native_pool_size: 10
 
-config :logflare, Logflare.Sources.Source.BigQuery.Schema, updates_per_minute: 6
+config :logflare, Logflare.Sources.Source.BigQuery.Schema,
+  updates_per_minute: 6,
+  max_pending_samples: 32
 
 # Configures the endpoint
 config :logflare, LogflareWeb.Endpoint,

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -69,14 +69,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       system_source: source.system_source
     )
 
-    schema_sample_counter = :atomics.new(1, [])
-
-    max_pending_samples =
-      Application.get_env(:logflare, Schema, [])
-      |> Keyword.fetch!(:max_pending_samples)
-
-    # The pipeline shares Schema's admission generation. Keeping Schema first with
-    # rest_for_one prevents producers from reserving against a restarting generation.
     children = [
       {Schema,
        [
@@ -84,7 +76,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
          source: source,
          bigquery_project_id: project_id,
          bigquery_dataset_id: dataset_id,
-         sample_counter: schema_sample_counter,
          name: Backends.via_source(source, Schema, backend.id)
        ]},
       {
@@ -96,9 +87,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
           source: source,
           backend: backend,
           bigquery_project_id: project_id,
-          bigquery_dataset_id: dataset_id,
-          schema_sample_counter: schema_sample_counter,
-          schema_sample_limit: max_pending_samples
+          bigquery_dataset_id: dataset_id
         ],
         min_pipelines: 0,
         max_pipelines: System.schedulers_online(),
@@ -114,7 +103,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       }
     ]
 
-    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 10)
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10)
   end
 
   def insert_log_events_via_storage_write_api(log_events, opts) do

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -69,7 +69,24 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
       system_source: source.system_source
     )
 
+    schema_sample_counter = :atomics.new(1, [])
+
+    max_pending_samples =
+      Application.get_env(:logflare, Schema, [])
+      |> Keyword.fetch!(:max_pending_samples)
+
+    # The pipeline shares Schema's admission generation. Keeping Schema first with
+    # rest_for_one prevents producers from reserving against a restarting generation.
     children = [
+      {Schema,
+       [
+         plan: plan,
+         source: source,
+         bigquery_project_id: project_id,
+         bigquery_dataset_id: dataset_id,
+         sample_counter: schema_sample_counter,
+         name: Backends.via_source(source, Schema, backend.id)
+       ]},
       {
         DynamicPipeline,
         # soft limit before a new pipeline is created
@@ -79,7 +96,9 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
           source: source,
           backend: backend,
           bigquery_project_id: project_id,
-          bigquery_dataset_id: dataset_id
+          bigquery_dataset_id: dataset_id,
+          schema_sample_counter: schema_sample_counter,
+          schema_sample_limit: max_pending_samples
         ],
         min_pipelines: 0,
         max_pipelines: System.schedulers_online(),
@@ -92,18 +111,10 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
 
           Backends.handle_resolve_count(state, lens, source.metrics.avg)
         end
-      },
-      {Schema,
-       [
-         plan: plan,
-         source: source,
-         bigquery_project_id: project_id,
-         bigquery_dataset_id: dataset_id,
-         name: Backends.via_source(source, Schema, backend.id)
-       ]}
+      }
     ]
 
-    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10)
+    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 10)
   end
 
   def insert_log_events_via_storage_write_api(log_events, opts) do

--- a/lib/logflare/backends/supervisor.ex
+++ b/lib/logflare/backends/supervisor.ex
@@ -7,6 +7,7 @@ defmodule Logflare.Backends.Supervisor do
 
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
+  alias Logflare.Sources.Source.BigQuery.SchemaMetrics
 
   def start_link(_) do
     Supervisor.start_link(__MODULE__, [])
@@ -39,6 +40,7 @@ defmodule Logflare.Backends.Supervisor do
 
     children =
       [
+        SchemaMetrics,
         Backends.IngestEventQueue,
         Backends.IngestEventQueue.BufferCacheWorker,
         Backends.IngestEventQueue.MapperJanitor,

--- a/lib/logflare/erl_sys_mon.ex
+++ b/lib/logflare/erl_sys_mon.ex
@@ -68,14 +68,23 @@ defmodule Logflare.ErlSysMon do
   end
 
   defp get_process_info(pid) do
-    pid
-    |> Process.info(:dictionary)
-    |> case do
-      {:dictionary, dict} when is_list(dict) ->
-        Keyword.take(dict, [:"$ancestors", :"$initial_call"])
+    dictionary =
+      pid
+      |> Process.info(:dictionary)
+      |> case do
+        {:dictionary, dict} when is_list(dict) ->
+          Keyword.take(dict, [:"$ancestors", :"$initial_call"])
 
-      other ->
-        other
-    end
+        other ->
+          other
+      end
+
+    %{dictionary: dictionary, source_registry_keys: source_registry_keys(pid)}
+  end
+
+  defp source_registry_keys(pid) do
+    Registry.keys(Logflare.Backends.SourceRegistry, pid)
+  catch
+    :exit, _reason -> []
   end
 end

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -94,8 +94,6 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
             bq_storage_write_api: source.bq_storage_write_api,
             source_id: source.id,
             backend_id: Map.get(backend || %{}, :id),
-            schema_sample_counter: args[:schema_sample_counter],
-            schema_sample_limit: args[:schema_sample_limit],
             user_id: source.user_id,
             system_source: source.system_source
           }
@@ -480,7 +478,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
         SchemaMetrics.record_sample(rate_mode)
 
         schema_server = Backends.via_source(source, {Schema, Map.get(context, :backend_id)})
-        maybe_update_schema(schema_server, log_event, source, context)
+        Schema.update(schema_server, log_event, source)
       end
     end
 
@@ -498,27 +496,6 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
       rate > 100_000 -> {0.00001, :floor}
       true -> {1.0 / rate, :normal}
     end
-  end
-
-  defp maybe_update_schema(
-         schema_server,
-         log_event,
-         source,
-         %{schema_sample_counter: counter, schema_sample_limit: limit}
-       )
-       when is_reference(counter) and is_integer(limit) do
-    with pid when is_pid(pid) <- GenServer.whereis(schema_server),
-         {:ok, reservation} <- Schema.reserve_update_slot(counter, limit) do
-      SchemaMetrics.record_admission(:admitted)
-      Schema.update(pid, log_event, source, reservation)
-    else
-      _reason -> SchemaMetrics.record_admission(:rejected)
-    end
-  end
-
-  defp maybe_update_schema(schema_server, log_event, source, _context) do
-    SchemaMetrics.record_admission(:admitted)
-    Schema.update(schema_server, log_event, source)
   end
 
   def name(source_id) when is_atom(source_id) do

--- a/lib/logflare/sources/source/bigquery/pipeline.ex
+++ b/lib/logflare/sources/source/bigquery/pipeline.ex
@@ -18,6 +18,7 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
   alias Logflare.Backends.IngestEventQueue.LogEventPointer
   alias Logflare.Backends.BufferProducer
   alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Sources.Source.BigQuery.SchemaMetrics
   alias Logflare.Sources.Source.Supervisor
   alias Logflare.Sources
   alias Logflare.Users
@@ -93,6 +94,8 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
             bq_storage_write_api: source.bq_storage_write_api,
             source_id: source.id,
             backend_id: Map.get(backend || %{}, :id),
+            schema_sample_counter: args[:schema_sample_counter],
+            schema_sample_limit: args[:schema_sample_limit],
             user_id: source.user_id,
             system_source: source.system_source
           }
@@ -470,25 +473,52 @@ defmodule Logflare.Sources.Source.BigQuery.Pipeline do
     # random sample if local ingest rate is above a certain level
     # dynamic calculation maintains ~1 schema update per second across all rate levels
     if source && not source.lock_schema do
-      probability =
-        case PubSubRates.Cache.get_local_rates(source.token) do
-          %{average_rate: avg} when avg > 0 ->
-            # probability = 1.0 / avg with safety bounds
-            # supports rates up to 100K+/sec: at 100K/sec -> 0.00001 (samples ~1/sec)
-            min(1.0, max(0.00001, 1.0 / avg))
-
-          _ ->
-            1.0
-        end
+      rates = PubSubRates.Cache.get_local_rates(source.token)
+      {probability, rate_mode} = schema_sampling_probability(rates)
 
       if :rand.uniform() <= probability do
-        :ok =
-          Backends.via_source(source, {Schema, Map.get(context, :backend_id)})
-          |> Schema.update(log_event, source)
+        SchemaMetrics.record_sample(rate_mode)
+
+        schema_server = Backends.via_source(source, {Schema, Map.get(context, :backend_id)})
+        maybe_update_schema(schema_server, log_event, source, context)
       end
     end
 
     log_event
+  end
+
+  @doc false
+  def schema_sampling_probability(rates) when is_map(rates) do
+    average_rate = Map.get(rates, :average_rate, 0)
+    last_rate = Map.get(rates, :last_rate, 0)
+    rate = max(average_rate, last_rate)
+
+    cond do
+      rate <= 0 -> {1.0, :zero_rate}
+      rate > 100_000 -> {0.00001, :floor}
+      true -> {1.0 / rate, :normal}
+    end
+  end
+
+  defp maybe_update_schema(
+         schema_server,
+         log_event,
+         source,
+         %{schema_sample_counter: counter, schema_sample_limit: limit}
+       )
+       when is_reference(counter) and is_integer(limit) do
+    with pid when is_pid(pid) <- GenServer.whereis(schema_server),
+         {:ok, reservation} <- Schema.reserve_update_slot(counter, limit) do
+      SchemaMetrics.record_admission(:admitted)
+      Schema.update(pid, log_event, source, reservation)
+    else
+      _reason -> SchemaMetrics.record_admission(:rejected)
+    end
+  end
+
+  defp maybe_update_schema(schema_server, log_event, source, _context) do
+    SchemaMetrics.record_admission(:admitted)
+    Schema.update(schema_server, log_event, source)
   end
 
   def name(source_id) when is_atom(source_id) do

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -59,9 +59,9 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     :ok
   end
 
-  def update(pid, %LogEvent{} = log_event, %Source{} = source)
-      when is_pid(pid) or is_tuple(pid) do
-    GenServer.cast(pid, {:update, log_event, source})
+  def update(server, %LogEvent{}, %Source{}) do
+    raise ArgumentError,
+          "expected the Schema server to use a Registry name, got: #{inspect(server)}"
   end
 
   @doc false
@@ -106,7 +106,14 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     {:via, Registry, {registry, key, {@admission_value_tag, sample_counter, max_pending_samples}}}
   end
 
-  defp register_admission_counter(name, _max_pending_samples), do: name
+  defp register_admission_counter({:via, Registry, _name}, max_pending_samples) do
+    raise ArgumentError,
+          "expected :max_pending_samples to be a positive integer, got: #{inspect(max_pending_samples)}"
+  end
+
+  defp register_admission_counter(name, _max_pending_samples) do
+    raise ArgumentError, "expected :name to be a Registry name, got: #{inspect(name)}"
+  end
 
   # Public for profiling: benchmarks can target the GenServer's pure schema
   # planning work without measuring mailbox scheduling or BigQuery side effects.
@@ -162,10 +169,6 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     release_update_slot(sample_counter)
 
     SchemaMetrics.record_handled()
-    handle_update(log_event, source, state)
-  end
-
-  def handle_cast({:update, %LogEvent{} = log_event, %Source{} = source}, state) do
     handle_update(log_event, source, state)
   end
 

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -24,6 +24,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
   @admission_value_tag :schema_admission
 
+  @type admission_counter :: :atomics.atomics_ref()
+
   def start_link(args) when is_list(args) do
     {name, args} = Keyword.pop(args, :name)
     {max_pending_samples, args} = Keyword.pop(args, :max_pending_samples)
@@ -63,8 +65,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   @doc false
-  def reserve_update_slot(sample_counter, limit)
-      when is_reference(sample_counter) and is_integer(limit) and limit > 0 do
+  @spec reserve_update_slot(admission_counter(), pos_integer()) :: :ok | :full
+  def reserve_update_slot(sample_counter, limit) when is_integer(limit) and limit > 0 do
     current = :atomics.get(sample_counter, 1)
 
     if current >= limit do
@@ -78,8 +80,15 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   @doc false
-  def pending_update_slots(sample_counter) when is_reference(sample_counter) do
+  @spec pending_update_slots(admission_counter()) :: non_neg_integer()
+  def pending_update_slots(sample_counter) do
     :atomics.get(sample_counter, 1)
+  end
+
+  @spec release_update_slot(admission_counter()) :: :ok
+  defp release_update_slot(sample_counter) do
+    :atomics.sub(sample_counter, 1, 1)
+    :ok
   end
 
   defp configured_max_pending_samples do
@@ -150,7 +159,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
         {:update, %LogEvent{} = log_event, %Source{} = source, sample_counter},
         state
       ) do
-    :atomics.sub(sample_counter, 1, 1)
+    release_update_slot(sample_counter)
 
     SchemaMetrics.record_handled()
     handle_update(log_event, source, state)

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -22,10 +22,15 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   alias Logflare.TeamUsers
   alias Logflare.SingleTenant
 
-  @sample_counter_scale 1_000_000
+  @admission_value_tag :schema_admission
 
   def start_link(args) when is_list(args) do
     {name, args} = Keyword.pop(args, :name)
+    {max_pending_samples, args} = Keyword.pop(args, :max_pending_samples)
+
+    max_pending_samples = max_pending_samples || configured_max_pending_samples()
+
+    name = register_admission_counter(name, max_pending_samples)
 
     GenServer.start_link(__MODULE__, args,
       name: name,
@@ -34,30 +39,39 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     )
   end
 
-  @spec update(atom(), LogEvent.t(), Source.t()) :: :ok
+  @spec update(GenServer.server(), LogEvent.t(), Source.t()) :: :ok
+  def update(
+        {:via, Registry, {registry, key}},
+        %LogEvent{} = log_event,
+        %Source{} = source
+      ) do
+    with [{pid, {@admission_value_tag, sample_counter, limit}}] <-
+           Registry.lookup(registry, key),
+         :ok <- reserve_update_slot(sample_counter, limit) do
+      SchemaMetrics.record_admission(:admitted)
+      GenServer.cast(pid, {:update, log_event, source, sample_counter})
+    else
+      _reason -> SchemaMetrics.record_admission(:rejected)
+    end
+
+    :ok
+  end
+
   def update(pid, %LogEvent{} = log_event, %Source{} = source)
       when is_pid(pid) or is_tuple(pid) do
     GenServer.cast(pid, {:update, log_event, source})
   end
 
   @doc false
-  def update(pid, %LogEvent{} = log_event, %Source{} = source, reservation)
-      when is_pid(pid) and is_tuple(reservation) do
-    GenServer.cast(pid, {:update, log_event, source, reservation})
-  end
-
-  @doc false
   def reserve_update_slot(sample_counter, limit)
-      when is_reference(sample_counter) and is_integer(limit) and limit > 0 and
-             limit < @sample_counter_scale do
+      when is_reference(sample_counter) and is_integer(limit) and limit > 0 do
     current = :atomics.get(sample_counter, 1)
-    generation = div(current, @sample_counter_scale)
 
-    if rem(current, @sample_counter_scale) >= limit do
+    if current >= limit do
       :full
     else
       case :atomics.compare_exchange(sample_counter, 1, current, current + 1) do
-        :ok -> {:ok, {sample_counter, generation}}
+        :ok -> :ok
         _actual -> reserve_update_slot(sample_counter, limit)
       end
     end
@@ -65,37 +79,25 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
   @doc false
   def pending_update_slots(sample_counter) when is_reference(sample_counter) do
-    sample_counter
-    |> :atomics.get(1)
-    |> rem(@sample_counter_scale)
+    :atomics.get(sample_counter, 1)
   end
 
-  @doc false
-  def reset_update_slots(sample_counter) when is_reference(sample_counter) do
-    current = :atomics.get(sample_counter, 1)
-    generation = div(current, @sample_counter_scale) + 1
-    :atomics.put(sample_counter, 1, generation * @sample_counter_scale)
-    :ok
+  defp configured_max_pending_samples do
+    Application.get_env(:logflare, __MODULE__, [])
+    |> Keyword.fetch!(:max_pending_samples)
   end
 
-  @doc false
-  def release_update_slot(sample_counter, generation) do
-    current = :atomics.get(sample_counter, 1)
+  defp register_admission_counter(
+         {:via, Registry, {registry, key}},
+         max_pending_samples
+       )
+       when is_integer(max_pending_samples) and max_pending_samples > 0 do
+    sample_counter = :atomics.new(1, signed: false)
 
-    cond do
-      div(current, @sample_counter_scale) != generation ->
-        :ok
-
-      rem(current, @sample_counter_scale) == 0 ->
-        :ok
-
-      :atomics.compare_exchange(sample_counter, 1, current, current - 1) == :ok ->
-        :ok
-
-      true ->
-        release_update_slot(sample_counter, generation)
-    end
+    {:via, Registry, {registry, key, {@admission_value_tag, sample_counter, max_pending_samples}}}
   end
+
+  defp register_admission_counter(name, _max_pending_samples), do: name
 
   # Public for profiling: benchmarks can target the GenServer's pure schema
   # planning work without measuring mailbox scheduling or BigQuery side effects.
@@ -123,10 +125,6 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
     Process.flag(:trap_exit, true)
 
-    if sample_counter = args[:sample_counter] do
-      reset_update_slots(sample_counter)
-    end
-
     state = %{
       source_id: source_id,
       source_token: source_token,
@@ -149,10 +147,10 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   def handle_cast(
-        {:update, %LogEvent{} = log_event, %Source{} = source, {sample_counter, generation}},
+        {:update, %LogEvent{} = log_event, %Source{} = source, sample_counter},
         state
       ) do
-    release_update_slot(sample_counter, generation)
+    :atomics.sub(sample_counter, 1, 1)
 
     SchemaMetrics.record_handled()
     handle_update(log_event, source, state)

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -101,10 +101,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   # planning work without measuring mailbox scheduling or BigQuery side effects.
   @doc false
   def plan_update(body, db_schema, state) do
-    schema = try_schema_update(body, db_schema)
-
-    if schema_needs_update?(db_schema, schema, state) do
-      {:update, schema}
+    if schema_update_allowed?(state) do
+      plan_schema_update(body, db_schema)
     else
       :noop
     end
@@ -175,33 +173,40 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
        do: {:noreply, state}
 
   defp handle_update(%LogEvent{body: body, id: event_id}, _source, state) do
-    LogflareLogger.context(source_id: state.source_token, log_event_id: event_id)
+    if schema_update_allowed?(state) do
+      LogflareLogger.context(source_id: state.source_token, log_event_id: event_id)
 
-    source_schema = SourceSchemas.Cache.get_source_schema_by(source_id: state.source_id)
+      source_schema = SourceSchemas.Cache.get_source_schema_by(source_id: state.source_id)
 
-    db_schema =
-      if source_schema,
-        do: source_schema.bigquery_schema,
-        else: SchemaBuilder.initial_table_schema()
+      db_schema =
+        if source_schema,
+          do: source_schema.bigquery_schema,
+          else: SchemaBuilder.initial_table_schema()
 
-    case plan_update(body, db_schema, state) do
-      {:update, schema} ->
-        case patch_bigquery_table(state, schema) do
-          {:ok, _table_info} ->
-            handle_successful_patch(state, schema, db_schema)
-
-          {:error, response} ->
-            handle_patch_error(body, state, response)
-        end
-
-      :noop ->
-        {:noreply, state}
+      case plan_schema_update(body, db_schema) do
+        {:update, schema} -> patch_schema_update(body, db_schema, schema, state)
+        :noop -> {:noreply, state}
+      end
+    else
+      {:noreply, state}
     end
   end
 
-  defp schema_needs_update?(db_schema, schema, state) do
-    not same_schemas?(db_schema, schema) and
-      state.next_update <= System.system_time(:millisecond) and
+  defp patch_schema_update(body, db_schema, schema, state) do
+    case patch_bigquery_table(state, schema) do
+      {:ok, _table_info} -> handle_successful_patch(state, schema, db_schema)
+      {:error, response} -> handle_patch_error(body, state, response)
+    end
+  end
+
+  defp plan_schema_update(body, db_schema) do
+    schema = try_schema_update(body, db_schema)
+
+    if same_schemas?(db_schema, schema), do: :noop, else: {:update, schema}
+  end
+
+  defp schema_update_allowed?(state) do
+    state.next_update <= System.system_time(:millisecond) and
       not SingleTenant.postgres_backend?()
   end
 
@@ -303,14 +308,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     next_update_ts(updates_per_minute)
   end
 
-  defp same_schemas?(old_schema, new_schema) do
-    old_flatmap = SchemaUtils.bq_schema_to_flat_typemap(old_schema)
-    new_flatmap = SchemaUtils.bq_schema_to_flat_typemap(new_schema)
-
-    diff_keys = Map.keys(new_flatmap) -- Map.keys(old_flatmap)
-
-    old_schema == new_schema and Enum.empty?(diff_keys)
-  end
+  defp same_schemas?(old_schema, new_schema), do: old_schema == new_schema
 
   defp try_schema_update(body, schema) do
     SchemaBuilder.build_table_schema(body, schema)

--- a/lib/logflare/sources/source/bigquery/schema.ex
+++ b/lib/logflare/sources/source/bigquery/schema.ex
@@ -11,6 +11,7 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
   alias Logflare.Google.BigQuery
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
+  alias Logflare.Sources.Source.BigQuery.SchemaMetrics
   alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.Sources
   alias Logflare.SourceSchemas
@@ -20,6 +21,8 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   alias Logflare.Mailer
   alias Logflare.TeamUsers
   alias Logflare.SingleTenant
+
+  @sample_counter_scale 1_000_000
 
   def start_link(args) when is_list(args) do
     {name, args} = Keyword.pop(args, :name)
@@ -35,6 +38,63 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   def update(pid, %LogEvent{} = log_event, %Source{} = source)
       when is_pid(pid) or is_tuple(pid) do
     GenServer.cast(pid, {:update, log_event, source})
+  end
+
+  @doc false
+  def update(pid, %LogEvent{} = log_event, %Source{} = source, reservation)
+      when is_pid(pid) and is_tuple(reservation) do
+    GenServer.cast(pid, {:update, log_event, source, reservation})
+  end
+
+  @doc false
+  def reserve_update_slot(sample_counter, limit)
+      when is_reference(sample_counter) and is_integer(limit) and limit > 0 and
+             limit < @sample_counter_scale do
+    current = :atomics.get(sample_counter, 1)
+    generation = div(current, @sample_counter_scale)
+
+    if rem(current, @sample_counter_scale) >= limit do
+      :full
+    else
+      case :atomics.compare_exchange(sample_counter, 1, current, current + 1) do
+        :ok -> {:ok, {sample_counter, generation}}
+        _actual -> reserve_update_slot(sample_counter, limit)
+      end
+    end
+  end
+
+  @doc false
+  def pending_update_slots(sample_counter) when is_reference(sample_counter) do
+    sample_counter
+    |> :atomics.get(1)
+    |> rem(@sample_counter_scale)
+  end
+
+  @doc false
+  def reset_update_slots(sample_counter) when is_reference(sample_counter) do
+    current = :atomics.get(sample_counter, 1)
+    generation = div(current, @sample_counter_scale) + 1
+    :atomics.put(sample_counter, 1, generation * @sample_counter_scale)
+    :ok
+  end
+
+  @doc false
+  def release_update_slot(sample_counter, generation) do
+    current = :atomics.get(sample_counter, 1)
+
+    cond do
+      div(current, @sample_counter_scale) != generation ->
+        :ok
+
+      rem(current, @sample_counter_scale) == 0 ->
+        :ok
+
+      :atomics.compare_exchange(sample_counter, 1, current, current - 1) == :ok ->
+        :ok
+
+      true ->
+        release_update_slot(sample_counter, generation)
+    end
   end
 
   # Public for profiling: benchmarks can target the GenServer's pure schema
@@ -65,6 +125,10 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
 
     Process.flag(:trap_exit, true)
 
+    if sample_counter = args[:sample_counter] do
+      reset_update_slots(sample_counter)
+    end
+
     state = %{
       source_id: source_id,
       source_token: source_token,
@@ -87,19 +151,30 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   def handle_cast(
-        {:update, %LogEvent{}, %Source{lock_schema: true}},
+        {:update, %LogEvent{} = log_event, %Source{} = source, {sample_counter, generation}},
         state
-      ),
-      do: {:noreply, state}
+      ) do
+    release_update_slot(sample_counter, generation)
 
-  def handle_cast(
-        {:update, %LogEvent{}, _source},
-        %{field_count: fc, field_count_limit: limit} = state
-      )
-      when fc > limit,
-      do: {:noreply, state}
+    SchemaMetrics.record_handled()
+    handle_update(log_event, source, state)
+  end
 
-  def handle_cast({:update, %LogEvent{body: body, id: event_id}, _source}, state) do
+  def handle_cast({:update, %LogEvent{} = log_event, %Source{} = source}, state) do
+    handle_update(log_event, source, state)
+  end
+
+  defp handle_update(%LogEvent{}, %Source{lock_schema: true}, state), do: {:noreply, state}
+
+  defp handle_update(
+         %LogEvent{},
+         _source,
+         %{field_count: fc, field_count_limit: limit} = state
+       )
+       when fc > limit,
+       do: {:noreply, state}
+
+  defp handle_update(%LogEvent{body: body, id: event_id}, _source, state) do
     LogflareLogger.context(source_id: state.source_token, log_event_id: event_id)
 
     source_schema = SourceSchemas.Cache.get_source_schema_by(source_id: state.source_id)
@@ -131,17 +206,22 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   defp patch_bigquery_table(state, schema) do
-    BigQuery.patch_table(
-      state.source_token,
-      schema,
-      state.bigquery_dataset_id,
-      state.bigquery_project_id
-    )
+    instrument_phase(:patch, state.source_id, fn ->
+      BigQuery.patch_table(
+        state.source_token,
+        schema,
+        state.bigquery_dataset_id,
+        state.bigquery_project_id
+      )
+    end)
   end
 
   defp handle_successful_patch(state, schema, db_schema) do
-    persist(state.source_id, schema)
-    notify_maybe(state.source_token, schema, db_schema)
+    instrument_phase(:persist, state.source_id, fn -> persist(state.source_id, schema) end)
+
+    instrument_phase(:notify, state.source_id, fn ->
+      notify_maybe(state.source_token, schema, db_schema)
+    end)
 
     {:noreply, %{state | field_count: count_fields(schema), next_update: next_update()}}
   end
@@ -157,11 +237,14 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
   end
 
   defp handle_schema_mismatch(body, state) do
-    with {:ok, table} <- BigQuery.get_table(state.source_token),
+    with {:ok, table} <-
+           instrument_phase(:refresh, state.source_id, fn ->
+             BigQuery.get_table(state.source_token)
+           end),
          schema <- try_schema_update(body, table.schema),
          {:ok, _table_info} <- patch_bigquery_table(state, schema) do
       field_count = count_fields(schema)
-      persist(state.source_id, schema)
+      instrument_phase(:persist, state.source_id, fn -> persist(state.source_id, schema) end)
       {:noreply, %{state | field_count: field_count, next_update: next_update()}}
     else
       {:error, response} ->
@@ -197,6 +280,18 @@ defmodule Logflare.Sources.Source.BigQuery.Schema do
     |> BigQuery.SchemaUtils.flatten_typemap()
     |> Enum.count()
   end
+
+  defp instrument_phase(phase, source_id, function) do
+    metadata = %{phase: phase, source_id: source_id}
+
+    :telemetry.span([:logflare, :bigquery, :schema, :operation], metadata, fn ->
+      result = function.()
+      {result, Map.put(metadata, :result, telemetry_result(result))}
+    end)
+  end
+
+  defp telemetry_result({:error, _reason}), do: :error
+  defp telemetry_result(_result), do: :ok
 
   def next_update_ts(max_updates_per_min) do
     ms = 60 * 1000 / max_updates_per_min

--- a/lib/logflare/sources/source/bigquery/schema_metrics.ex
+++ b/lib/logflare/sources/source/bigquery/schema_metrics.ex
@@ -1,0 +1,116 @@
+defmodule Logflare.Sources.Source.BigQuery.SchemaMetrics do
+  @moduledoc false
+
+  use GenServer
+
+  @counter_key {__MODULE__, :counters}
+  @counter_count 6
+  @selected 1
+  @selected_zero_rate 2
+  @selected_floor 3
+  @admitted 4
+  @rejected 5
+  @handled 6
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @spec record_sample(:normal | :zero_rate | :floor) :: :ok
+  def record_sample(mode) do
+    increment(@selected)
+
+    case mode do
+      :zero_rate -> increment(@selected_zero_rate)
+      :floor -> increment(@selected_floor)
+      :normal -> :ok
+    end
+  end
+
+  @spec record_admission(:admitted | :rejected) :: :ok
+  def record_admission(:admitted), do: increment(@admitted)
+  def record_admission(:rejected), do: increment(@rejected)
+
+  @spec record_handled() :: :ok
+  def record_handled, do: increment(@handled)
+
+  @spec report() :: :ok
+  def report do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      _pid -> GenServer.call(__MODULE__, :report)
+    end
+  end
+
+  @doc false
+  def reset do
+    GenServer.call(__MODULE__, :reset)
+  end
+
+  @impl GenServer
+  def init(_args) do
+    counters = :counters.new(@counter_count, [:write_concurrency])
+    :persistent_term.put(@counter_key, counters)
+    {:ok, %{counters: counters, previous: zero_counts()}}
+  end
+
+  @impl GenServer
+  def handle_call(:report, _from, state) do
+    current = read_counts(state.counters)
+    deltas = Enum.zip_with(current, state.previous, &max(&1 - &2, 0))
+
+    :telemetry.execute(
+      [:logflare, :bigquery, :schema, :report],
+      counter_measurements(deltas),
+      %{}
+    )
+
+    {:reply, :ok, %{state | previous: current}}
+  end
+
+  def handle_call(:reset, _from, state) do
+    for index <- 1..@counter_count, do: :counters.put(state.counters, index, 0)
+    {:reply, :ok, %{state | previous: zero_counts()}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %{counters: counters}) do
+    if :persistent_term.get(@counter_key, nil) == counters do
+      :persistent_term.erase(@counter_key)
+    end
+
+    :ok
+  end
+
+  defp increment(index) do
+    case :persistent_term.get(@counter_key, nil) do
+      nil -> :ok
+      counters -> :counters.add(counters, index, 1)
+    end
+
+    :ok
+  end
+
+  defp zero_counts, do: List.duplicate(0, @counter_count)
+
+  defp read_counts(counters),
+    do: for(index <- 1..@counter_count, do: :counters.get(counters, index))
+
+  defp counter_measurements([
+         selected,
+         selected_zero_rate,
+         selected_floor,
+         admitted,
+         rejected,
+         handled
+       ]) do
+    %{
+      samples_selected: selected,
+      samples_selected_zero_rate: selected_zero_rate,
+      samples_selected_floor: selected_floor,
+      samples_admitted: admitted,
+      samples_rejected: rejected,
+      samples_handled: handled
+    }
+  end
+end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -269,6 +269,61 @@ defmodule Logflare.Telemetry do
         description: "Top processes by memory usage",
         unit: {:byte, :megabyte}
       ),
+      sum("logflare.bigquery.schema.samples.selected",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_selected
+      ),
+      sum("logflare.bigquery.schema.samples.selected_zero_rate",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_selected_zero_rate
+      ),
+      sum("logflare.bigquery.schema.samples.selected_floor",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_selected_floor
+      ),
+      sum("logflare.bigquery.schema.samples.admitted",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_admitted
+      ),
+      sum("logflare.bigquery.schema.samples.rejected",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_rejected
+      ),
+      sum("logflare.bigquery.schema.samples.handled",
+        event_name: [:logflare, :bigquery, :schema, :report],
+        measurement: :samples_handled
+      ),
+      last_value("logflare.bigquery.schema.queues.observed_process_count",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :observed_process_count
+      ),
+      last_value("logflare.bigquery.schema.queues.queue_length_max",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :queue_length_max
+      ),
+      last_value("logflare.bigquery.schema.queues.queue_length_sum",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :queue_length_sum
+      ),
+      last_value("logflare.bigquery.schema.queues.above_32",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :queues_above_32
+      ),
+      last_value("logflare.bigquery.schema.queues.above_100",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :queues_above_100
+      ),
+      last_value("logflare.bigquery.schema.queues.above_1000",
+        event_name: [:logflare, :bigquery, :schema, :queues],
+        measurement: :queues_above_1000
+      ),
+      distribution("logflare.bigquery.schema.operation.stop.duration",
+        tags: [:phase, :result],
+        unit: {:native, :millisecond}
+      ),
+      counter("logflare.bigquery.schema.operation.exception.count",
+        tags: [:phase]
+      ),
       last_value("logflare.system.top_ets_tables.individual.memory",
         tags: [:name],
         description: "Top ETS individual tables by memory usage"
@@ -458,7 +513,8 @@ defmodule Logflare.Telemetry do
       [
         {__MODULE__, :process_message_queue_metrics, []},
         {__MODULE__, :process_memory_metrics, []},
-        {__MODULE__, :ets_table_metrics, []}
+        {__MODULE__, :ets_table_metrics, []},
+        {Logflare.Sources.Source.BigQuery.SchemaMetrics, :report, []}
       ]
 
     cachex_metrics ++ process_metrics
@@ -490,17 +546,20 @@ defmodule Logflare.Telemetry do
     end)
   end
 
-  def process_message_queue_metrics,
-    do: process_attribute_metrics(:message_queue)
+  def process_message_queue_metrics do
+    :message_queue
+    |> process_attribute_metrics()
+    |> emit_schema_queue_metrics()
+  end
 
   def process_memory_metrics,
     do: process_attribute_metrics(:memory)
 
   defp process_attribute_metrics(type) do
     metric_params = @process_metrics[type]
+    processes = :recon.proc_count(metric_params.process_attribute, 10)
 
-    :recon.proc_count(metric_params.process_attribute, 10)
-    |> Enum.each(fn {pid, val, call_info} ->
+    Enum.each(processes, fn {pid, val, call_info} ->
       [current_function, initial_call] = get_current_and_initial_call(call_info)
       name = get_display_flag(call_info, initial_call, pid)
 
@@ -509,13 +568,46 @@ defmodule Logflare.Telemetry do
       metadata = %{
         pid: inspect(pid),
         name: name,
-        current_fuction: mfa_to_string(current_function),
+        current_function: mfa_to_string(current_function),
         initial_call: mfa_to_string(initial_call)
       }
 
       :telemetry.execute([:logflare, :system, :top_processes, type], metrics, metadata)
     end)
+
+    processes
   end
+
+  defp emit_schema_queue_metrics(processes) do
+    queue_lengths =
+      for {pid, queue_length, call_info} <- processes,
+          [_, initial_call] = get_current_and_initial_call(call_info),
+          schema_process?(pid, initial_call),
+          do: queue_length
+
+    :telemetry.execute(
+      [:logflare, :bigquery, :schema, :queues],
+      %{
+        observed_process_count: length(queue_lengths),
+        queue_length_max: Enum.max(queue_lengths, fn -> 0 end),
+        queue_length_sum: Enum.sum(queue_lengths),
+        queues_above_32: Enum.count(queue_lengths, &(&1 >= 32)),
+        queues_above_100: Enum.count(queue_lengths, &(&1 >= 100)),
+        queues_above_1000: Enum.count(queue_lengths, &(&1 >= 1_000))
+      },
+      %{}
+    )
+  end
+
+  defp schema_process?(pid, {:proc_lib, :init_p, 5}) do
+    :proc_lib.translate_initial_call(pid) ==
+      {Logflare.Sources.Source.BigQuery.Schema, :init, 1}
+  catch
+    :exit, _reason -> false
+  end
+
+  defp schema_process?(_pid, initial_call),
+    do: initial_call == {Logflare.Sources.Source.BigQuery.Schema, :init, 1}
 
   defp get_current_and_initial_call(call_info) do
     [:current_function, :initial_call]

--- a/test/logflare/backends/adaptor/bigquery_adaptor_supervision_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_supervision_test.exs
@@ -12,29 +12,43 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorSupervisionTest do
     :ok
   end
 
-  test "restarts pipeline shards after their Schema admission generation restarts" do
+  test "restarts Schema with fresh admission state without restarting pipelines" do
     user = insert(:user)
     source = insert(:source, user: user)
     start_supervised!({SourceSup, source})
 
     schema_name = Backends.via_source(source, Schema, nil)
     pipeline_name = Backends.via_source(source, Pipeline, nil)
-    schema_pid = GenServer.whereis(schema_name)
+    {:via, Registry, {registry, key}} = schema_name
+
+    assert [{schema_pid, {:schema_admission, counter, limit}}] = Registry.lookup(registry, key)
     pipeline_pid = GenServer.whereis(pipeline_name)
 
-    assert is_pid(schema_pid)
     assert is_pid(pipeline_pid)
+    assert :ok = Schema.reserve_update_slot(counter, limit)
 
     Process.exit(schema_pid, :kill)
 
-    TestUtils.retry_assert(fn ->
-      restarted_schema_pid = GenServer.whereis(schema_name)
-      restarted_pipeline_pid = GenServer.whereis(pipeline_name)
+    {restarted_schema_pid, restarted_counter} =
+      TestUtils.retry_assert(fn ->
+        assert [{restarted_schema_pid, {:schema_admission, restarted_counter, ^limit}}] =
+                 Registry.lookup(registry, key)
 
-      assert is_pid(restarted_schema_pid)
-      assert is_pid(restarted_pipeline_pid)
-      refute restarted_schema_pid == schema_pid
-      refute restarted_pipeline_pid == pipeline_pid
-    end)
+        assert is_pid(restarted_schema_pid)
+        refute restarted_schema_pid == schema_pid
+        refute restarted_counter == counter
+        assert GenServer.whereis(pipeline_name) == pipeline_pid
+
+        {restarted_schema_pid, restarted_counter}
+      end)
+
+    # A producer that reserved immediately before the crash can only cast to the
+    # stale pid/counter pair; it cannot consume capacity from the replacement.
+    event = build(:log_event, source: source)
+    assert :ok = GenServer.cast(schema_pid, {:update, event, source, counter})
+    :sys.get_state(restarted_schema_pid)
+
+    assert Schema.pending_update_slots(counter) == 1
+    assert Schema.pending_update_slots(restarted_counter) == 0
   end
 end

--- a/test/logflare/backends/adaptor/bigquery_adaptor_supervision_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_supervision_test.exs
@@ -1,0 +1,40 @@
+defmodule Logflare.Backends.Adaptor.BigQueryAdaptorSupervisionTest do
+  @moduledoc false
+  use Logflare.DataCase
+
+  alias Logflare.Backends
+  alias Logflare.Backends.SourceSup
+  alias Logflare.Sources.Source.BigQuery.Pipeline
+  alias Logflare.Sources.Source.BigQuery.Schema
+
+  setup do
+    insert(:plan)
+    :ok
+  end
+
+  test "restarts pipeline shards after their Schema admission generation restarts" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+    start_supervised!({SourceSup, source})
+
+    schema_name = Backends.via_source(source, Schema, nil)
+    pipeline_name = Backends.via_source(source, Pipeline, nil)
+    schema_pid = GenServer.whereis(schema_name)
+    pipeline_pid = GenServer.whereis(pipeline_name)
+
+    assert is_pid(schema_pid)
+    assert is_pid(pipeline_pid)
+
+    Process.exit(schema_pid, :kill)
+
+    TestUtils.retry_assert(fn ->
+      restarted_schema_pid = GenServer.whereis(schema_name)
+      restarted_pipeline_pid = GenServer.whereis(pipeline_name)
+
+      assert is_pid(restarted_schema_pid)
+      assert is_pid(restarted_pipeline_pid)
+      refute restarted_schema_pid == schema_pid
+      refute restarted_pipeline_pid == pipeline_pid
+    end)
+  end
+end

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -798,7 +798,6 @@ defmodule Logflare.BigQuery.PipelineTest do
       context: context
     } do
       source = insert(:source, user_id: user.id, lock_schema: false)
-      counter = :atomics.new(1, [])
       schema_name = Backends.via_source(source, {Schema, nil})
 
       schema_pid =
@@ -806,7 +805,7 @@ defmodule Logflare.BigQuery.PipelineTest do
           {Schema,
            [
              source: source,
-             sample_counter: counter,
+             max_pending_samples: 1,
              plan: %{limit_source_fields_limit: 500},
              bigquery_project_id: "some-id",
              bigquery_dataset_id: "some-id",
@@ -822,12 +821,11 @@ defmodule Logflare.BigQuery.PipelineTest do
       le =
         %{le | body: %{"event_message" => "test", "id" => le.id, "timestamp" => 0}}
 
-      context =
-        Map.merge(context, %{schema_sample_counter: counter, schema_sample_limit: 1})
-
       assert ^le = Pipeline.process_data(le, context, source)
       assert ^le = Pipeline.process_data(le, context, source)
 
+      {:via, Registry, {registry, key}} = schema_name
+      assert [{^schema_pid, {:schema_admission, counter, 1}}] = Registry.lookup(registry, key)
       assert Schema.pending_update_slots(counter) == 1
       assert {:message_queue_len, 1} = Process.info(schema_pid, :message_queue_len)
     end

--- a/test/logflare/bigquery/pipeline_test.exs
+++ b/test/logflare/bigquery/pipeline_test.exs
@@ -748,6 +748,21 @@ defmodule Logflare.BigQuery.PipelineTest do
       [user: user, context: %{backend_id: nil}]
     end
 
+    test "uses the freshest local rate for schema sampling" do
+      assert {probability, :normal} =
+               Pipeline.schema_sampling_probability(%{average_rate: 2, last_rate: 100})
+
+      assert_in_delta probability, 0.01, 0.000001
+    end
+
+    test "identifies zero-rate and probability-floor sampling" do
+      assert Pipeline.schema_sampling_probability(%{average_rate: 0, last_rate: 0}) ==
+               {1.0, :zero_rate}
+
+      assert Pipeline.schema_sampling_probability(%{average_rate: 200_000, last_rate: 0}) ==
+               {0.00001, :floor}
+    end
+
     test "skips schema update when the passed source has lock_schema set", %{
       user: user,
       context: context
@@ -776,6 +791,45 @@ defmodule Logflare.BigQuery.PipelineTest do
 
       assert ^le = Pipeline.process_data(le, context, source)
       assert_received :schema_updated
+    end
+
+    test "caps pending sampled updates across processor calls", %{
+      user: user,
+      context: context
+    } do
+      source = insert(:source, user_id: user.id, lock_schema: false)
+      counter = :atomics.new(1, [])
+      schema_name = Backends.via_source(source, {Schema, nil})
+
+      schema_pid =
+        start_supervised!(
+          {Schema,
+           [
+             source: source,
+             sample_counter: counter,
+             plan: %{limit_source_fields_limit: 500},
+             bigquery_project_id: "some-id",
+             bigquery_dataset_id: "some-id",
+             name: schema_name
+           ]}
+        )
+
+      :ok = :sys.suspend(schema_pid)
+      on_exit(fn -> if Process.alive?(schema_pid), do: :sys.resume(schema_pid) end)
+
+      le = build(:log_event, source: source)
+
+      le =
+        %{le | body: %{"event_message" => "test", "id" => le.id, "timestamp" => 0}}
+
+      context =
+        Map.merge(context, %{schema_sample_counter: counter, schema_sample_limit: 1})
+
+      assert ^le = Pipeline.process_data(le, context, source)
+      assert ^le = Pipeline.process_data(le, context, source)
+
+      assert Schema.pending_update_slots(counter) == 1
+      assert {:message_queue_len, 1} = Process.info(schema_pid, :message_queue_len)
     end
 
     test "does not crash when the passed source is nil", %{context: context} do

--- a/test/logflare/source/bigquery/schema_metrics_test.exs
+++ b/test/logflare/source/bigquery/schema_metrics_test.exs
@@ -64,15 +64,18 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaMetricsTest do
     user = insert(:user)
     source = insert(:source, user: user, lock_schema: true)
 
+    name = Backends.via_source(source, Schema, nil)
+
     pid =
       start_supervised!(
         {Schema,
          [
            source: source,
+           max_pending_samples: 40,
            plan: %{limit_source_fields_limit: 500},
            bigquery_project_id: "some-id",
            bigquery_dataset_id: "some-id",
-           name: Backends.via_source(source, Schema, nil)
+           name: name
          ]}
       )
 
@@ -80,7 +83,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaMetricsTest do
     on_exit(fn -> if Process.alive?(pid), do: :sys.resume(pid) end)
 
     for _ <- 1..40 do
-      Schema.update(pid, build(:log_event, source: source), source)
+      Schema.update(name, build(:log_event, source: source), source)
     end
 
     Logflare.Telemetry.process_message_queue_metrics()

--- a/test/logflare/source/bigquery/schema_metrics_test.exs
+++ b/test/logflare/source/bigquery/schema_metrics_test.exs
@@ -63,14 +63,12 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaMetricsTest do
   test "aggregates Schema queues without source-level metric dimensions" do
     user = insert(:user)
     source = insert(:source, user: user, lock_schema: true)
-    counter = :atomics.new(1, [])
 
     pid =
       start_supervised!(
         {Schema,
          [
            source: source,
-           sample_counter: counter,
            plan: %{limit_source_fields_limit: 500},
            bigquery_project_id: "some-id",
            bigquery_dataset_id: "some-id",

--- a/test/logflare/source/bigquery/schema_metrics_test.exs
+++ b/test/logflare/source/bigquery/schema_metrics_test.exs
@@ -1,0 +1,103 @@
+defmodule Logflare.Sources.Source.BigQuery.SchemaMetricsTest do
+  @moduledoc false
+  use Logflare.DataCase
+
+  alias Logflare.Backends
+  alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Sources.Source.BigQuery.SchemaMetrics
+
+  setup do
+    SchemaMetrics.reset()
+
+    handler_id = "schema-metrics-#{System.unique_integer()}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:logflare, :bigquery, :schema, :report],
+        [:logflare, :bigquery, :schema, :queues]
+      ],
+      fn event, measurements, _metadata, pid ->
+        send(pid, {:schema_telemetry, event, measurements})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :ok
+  end
+
+  test "reports sampler deltas without per-sample telemetry" do
+    SchemaMetrics.record_sample(:zero_rate)
+    SchemaMetrics.record_sample(:floor)
+    SchemaMetrics.record_sample(:normal)
+    SchemaMetrics.record_admission(:admitted)
+    SchemaMetrics.record_admission(:rejected)
+    SchemaMetrics.record_handled()
+
+    assert :ok = SchemaMetrics.report()
+
+    assert_receive {:schema_telemetry, [:logflare, :bigquery, :schema, :report],
+                    %{
+                      samples_selected: 3,
+                      samples_selected_zero_rate: 1,
+                      samples_selected_floor: 1,
+                      samples_admitted: 1,
+                      samples_rejected: 1,
+                      samples_handled: 1
+                    }}
+
+    assert :ok = SchemaMetrics.report()
+
+    assert_receive {:schema_telemetry, [:logflare, :bigquery, :schema, :report],
+                    %{
+                      samples_selected: 0,
+                      samples_selected_zero_rate: 0,
+                      samples_selected_floor: 0,
+                      samples_admitted: 0,
+                      samples_rejected: 0,
+                      samples_handled: 0
+                    }}
+  end
+
+  test "aggregates Schema queues without source-level metric dimensions" do
+    user = insert(:user)
+    source = insert(:source, user: user, lock_schema: true)
+    counter = :atomics.new(1, [])
+
+    pid =
+      start_supervised!(
+        {Schema,
+         [
+           source: source,
+           sample_counter: counter,
+           plan: %{limit_source_fields_limit: 500},
+           bigquery_project_id: "some-id",
+           bigquery_dataset_id: "some-id",
+           name: Backends.via_source(source, Schema, nil)
+         ]}
+      )
+
+    :ok = :sys.suspend(pid)
+    on_exit(fn -> if Process.alive?(pid), do: :sys.resume(pid) end)
+
+    for _ <- 1..40 do
+      Schema.update(pid, build(:log_event, source: source), source)
+    end
+
+    Logflare.Telemetry.process_message_queue_metrics()
+
+    assert_receive {:schema_telemetry, [:logflare, :bigquery, :schema, :queues],
+                    %{
+                      observed_process_count: process_count,
+                      queue_length_max: queue_length_max,
+                      queue_length_sum: queue_length_sum,
+                      queues_above_32: queues_above_32
+                    }}
+
+    assert process_count >= 1
+    assert queue_length_max >= 40
+    assert queue_length_sum >= 40
+    assert queues_above_32 >= 1
+  end
+end

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -2,9 +2,10 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
   @moduledoc false
   use Logflare.DataCase
 
+  alias Logflare.Backends
+  alias Logflare.Google.BigQuery.SchemaUtils
   alias Logflare.Sources.Source.BigQuery.Schema
   alias Logflare.Sources.Source.BigQuery.SchemaBuilder
-  alias Logflare.Google.BigQuery.SchemaUtils
 
   setup do
     insert(:plan)
@@ -49,53 +50,59 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
              TestUtils.get_bq_field_schema(updated_schema, "new_field")
   end
 
-  test "reserve_update_slot/2 caps concurrent pending updates" do
+  test "reserve_update_slot/2 caps pending updates" do
     counter = :atomics.new(1, [])
 
-    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 2)
-    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 2)
+    assert :ok = Schema.reserve_update_slot(counter, 2)
+    assert :ok = Schema.reserve_update_slot(counter, 2)
     assert :full = Schema.reserve_update_slot(counter, 2)
     assert Schema.pending_update_slots(counter) == 2
   end
 
-  test "stale reservations cannot decrement a restarted Schema generation" do
+  test "reserve_update_slot/2 caps concurrent callers" do
     counter = :atomics.new(1, [])
-    :ok = Schema.reset_update_slots(counter)
-    assert {:ok, {^counter, stale_generation}} = Schema.reserve_update_slot(counter, 2)
+    limit = 32
 
-    :ok = Schema.reset_update_slots(counter)
-    assert {:ok, {^counter, current_generation}} = Schema.reserve_update_slot(counter, 2)
-    assert current_generation > stale_generation
+    results =
+      1..1_000
+      |> Task.async_stream(
+        fn _index -> Schema.reserve_update_slot(counter, limit) end,
+        max_concurrency: 64,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+      |> Enum.frequencies()
 
-    assert :ok = Schema.release_update_slot(counter, stale_generation)
-    assert Schema.pending_update_slots(counter) == 1
-    assert :ok = Schema.release_update_slot(counter, current_generation)
-    assert Schema.pending_update_slots(counter) == 0
+    assert results == %{ok: limit, full: 1_000 - limit}
+    assert Schema.pending_update_slots(counter) == limit
   end
 
-  test "reserved updates release their slot when handling starts" do
+  test "registered updates release their slot when handling starts" do
     user = insert(:user)
     source = insert(:source, user: user, lock_schema: true)
-    counter = :atomics.new(1, [])
+    name = Backends.via_source(source, Schema, nil)
 
     pid =
       start_supervised!(
         {Schema,
          [
            source: source,
-           sample_counter: counter,
+           max_pending_samples: 1,
            plan: %{limit_source_fields_limit: 500},
            bigquery_project_id: "some-id",
-           bigquery_dataset_id: "some-id"
+           bigquery_dataset_id: "some-id",
+           name: name
          ]}
       )
 
-    assert {:ok, reservation} = Schema.reserve_update_slot(counter, 1)
-    assert :ok = Schema.update(pid, build(:log_event, source: source), source, reservation)
+    {:via, Registry, {registry, key}} = name
+    assert [{^pid, {:schema_admission, counter, 1}}] = Registry.lookup(registry, key)
+
+    assert :ok = Schema.update(name, build(:log_event, source: source), source)
     :sys.get_state(pid)
 
     assert Schema.pending_update_slots(counter) == 0
-    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 1)
+    assert :ok = Schema.reserve_update_slot(counter, 1)
   end
 
   test "updates correctly" do

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -77,6 +77,41 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     assert Schema.pending_update_slots(counter) == limit
   end
 
+  test "requires a Registry name for admission" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+    log_event = build(:log_event, source: source)
+
+    assert_raise ArgumentError, ~r/expected :name to be a Registry name/, fn ->
+      Schema.start_link(
+        source: source,
+        plan: %{limit_source_fields_limit: 500},
+        bigquery_project_id: "some-id",
+        bigquery_dataset_id: "some-id"
+      )
+    end
+
+    assert_raise ArgumentError, ~r/expected the Schema server to use a Registry name/, fn ->
+      Schema.update(self(), log_event, source)
+    end
+  end
+
+  test "rejects invalid admission limits instead of starting ungated" do
+    user = insert(:user)
+    source = insert(:source, user: user)
+
+    assert_raise ArgumentError, ~r/expected :max_pending_samples to be a positive integer/, fn ->
+      Schema.start_link(
+        source: source,
+        max_pending_samples: 0,
+        plan: %{limit_source_fields_limit: 500},
+        bigquery_project_id: "some-id",
+        bigquery_dataset_id: "some-id",
+        name: Backends.via_source(source, Schema, nil)
+      )
+    end
+  end
+
   test "registered updates release their slot when handling starts" do
     user = insert(:user)
     source = insert(:source, user: user, lock_schema: true)
@@ -148,6 +183,8 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
 
     on_exit(fn -> :telemetry.detach(handler_id) end)
 
+    name = Backends.via_source(source, Schema, nil)
+
     pid =
       start_supervised!(
         {Schema,
@@ -155,12 +192,13 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
            source: source,
            plan: %{limit_source_fields_limit: 500},
            bigquery_project_id: "some-id",
-           bigquery_dataset_id: "some-id"
+           bigquery_dataset_id: "some-id",
+           name: name
          ]}
       )
 
     le = build(:log_event, source: source, metadata: %{"test" => 123})
-    assert :ok = Schema.update(pid, le, source)
+    assert :ok = Schema.update(name, le, source)
 
     TestUtils.retry_assert(fn ->
       assert_received :ok

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
   use Logflare.DataCase
 
   alias Logflare.Sources.Source.BigQuery.Schema
+  alias Logflare.Sources.Source.BigQuery.SchemaBuilder
   alias Logflare.Google.BigQuery.SchemaUtils
 
   setup do
@@ -16,6 +17,36 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     seconds = (next_update - System.system_time(:millisecond)) / 1000
     assert seconds <= 10
     assert seconds > 9
+  end
+
+  test "plan_update/3 skips schema building during the update cooldown" do
+    schema =
+      %{}
+      |> SchemaBuilder.build_table_schema(SchemaBuilder.initial_table_schema())
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert :noop =
+                 Schema.plan_update(%{"invalid" => []}, schema, %{
+                   next_update: System.system_time(:millisecond) + 60_000
+                 })
+      end)
+
+    refute log =~ "Field schema type change error"
+  end
+
+  test "plan_update/3 compares schemas without changing update behavior" do
+    schema =
+      %{}
+      |> SchemaBuilder.build_table_schema(SchemaBuilder.initial_table_schema())
+
+    state = %{next_update: 0}
+
+    assert :noop = Schema.plan_update(%{}, schema, state)
+    assert {:update, updated_schema} = Schema.plan_update(%{"new_field" => 1}, schema, state)
+
+    assert %_{name: "new_field", type: "INTEGER"} =
+             TestUtils.get_bq_field_schema(updated_schema, "new_field")
   end
 
   test "reserve_update_slot/2 caps concurrent pending updates" do

--- a/test/logflare/source/bigquery/schema_test.exs
+++ b/test/logflare/source/bigquery/schema_test.exs
@@ -18,6 +18,55 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     assert seconds > 9
   end
 
+  test "reserve_update_slot/2 caps concurrent pending updates" do
+    counter = :atomics.new(1, [])
+
+    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 2)
+    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 2)
+    assert :full = Schema.reserve_update_slot(counter, 2)
+    assert Schema.pending_update_slots(counter) == 2
+  end
+
+  test "stale reservations cannot decrement a restarted Schema generation" do
+    counter = :atomics.new(1, [])
+    :ok = Schema.reset_update_slots(counter)
+    assert {:ok, {^counter, stale_generation}} = Schema.reserve_update_slot(counter, 2)
+
+    :ok = Schema.reset_update_slots(counter)
+    assert {:ok, {^counter, current_generation}} = Schema.reserve_update_slot(counter, 2)
+    assert current_generation > stale_generation
+
+    assert :ok = Schema.release_update_slot(counter, stale_generation)
+    assert Schema.pending_update_slots(counter) == 1
+    assert :ok = Schema.release_update_slot(counter, current_generation)
+    assert Schema.pending_update_slots(counter) == 0
+  end
+
+  test "reserved updates release their slot when handling starts" do
+    user = insert(:user)
+    source = insert(:source, user: user, lock_schema: true)
+    counter = :atomics.new(1, [])
+
+    pid =
+      start_supervised!(
+        {Schema,
+         [
+           source: source,
+           sample_counter: counter,
+           plan: %{limit_source_fields_limit: 500},
+           bigquery_project_id: "some-id",
+           bigquery_dataset_id: "some-id"
+         ]}
+      )
+
+    assert {:ok, reservation} = Schema.reserve_update_slot(counter, 1)
+    assert :ok = Schema.update(pid, build(:log_event, source: source), source, reservation)
+    :sys.get_state(pid)
+
+    assert Schema.pending_update_slots(counter) == 0
+    assert {:ok, _reservation} = Schema.reserve_update_slot(counter, 1)
+  end
+
   test "updates correctly" do
     user = insert(:user)
     source = insert(:source, user: user)
@@ -50,6 +99,17 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
     Logflare.Mailer
     |> expect(:deliver, 1, fn _ -> :ok end)
 
+    handler_id = "schema-operation-#{System.unique_integer()}"
+
+    :telemetry.attach(
+      handler_id,
+      [:logflare, :bigquery, :schema, :operation, :stop],
+      fn _event, _measurements, metadata, pid -> send(pid, {:schema_phase, metadata}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
     pid =
       start_supervised!(
         {Schema,
@@ -68,9 +128,10 @@ defmodule Logflare.Sources.Source.BigQuery.SchemaTest do
       assert_received :ok
     end)
 
-    # subsequent updates do not increase mock count
-    le = build(:log_event, source: source, metadata: %{"change" => 123})
-    assert :ok = Schema.update(pid, le, source)
+    :sys.get_state(pid)
+    assert_receive {:schema_phase, %{phase: :patch, result: :ok}}
+    assert_receive {:schema_phase, %{phase: :persist}}
+    assert_receive {:schema_phase, %{phase: :notify, result: :ok}}
   end
 
   test "default notifications config" do

--- a/test/logflare_web/live/search_live/logs_search_lv_test.exs
+++ b/test/logflare_web/live/search_live/logs_search_lv_test.exs
@@ -893,8 +893,10 @@ defmodule LogflareWeb.Source.SearchLVTest do
       le = build(:log_event, metadata: %{"nested" => "something"}, top: "level", source: source)
       :timer.sleep(100)
 
-      # Backends.via_source(source, Schema, nil)
-      Schema.handle_cast({:update, le, source}, %{
+      sample_counter = :atomics.new(1, signed: false)
+      :atomics.put(sample_counter, 1, 1)
+
+      Schema.handle_cast({:update, le, source, sample_counter}, %{
         source_id: source.id,
         source_token: source.token,
         bigquery_project_id: nil,

--- a/test/profiling/bq_schema_admission_bench.exs
+++ b/test/profiling/bq_schema_admission_bench.exs
@@ -4,14 +4,14 @@
 #   MIX_ENV=test mix run --no-start test/profiling/bq_schema_admission_bench.exs
 #
 # Optional env:
-#   MESSAGES=50000 FIELDS=50 LIMIT=32
+#   MESSAGES=50000 FIELDS=50 LIMIT=8
 
 alias Logflare.Sources.Source.BigQuery.Schema
 alias Logflare.Sources.Source.BigQuery.SchemaMetrics
 
 messages = String.to_integer(System.get_env("MESSAGES") || "50000")
 fields = String.to_integer(System.get_env("FIELDS") || "50")
-limit = String.to_integer(System.get_env("LIMIT") || "32")
+limit = String.to_integer(System.get_env("LIMIT") || "8")
 
 body = Map.new(1..fields, &{"field_#{&1}", String.duplicate("value", 4)})
 message = {:update, %{body: body, id: "benchmark"}, %{lock_schema: false}}

--- a/test/profiling/bq_schema_admission_bench.exs
+++ b/test/profiling/bq_schema_admission_bench.exs
@@ -26,10 +26,10 @@ run = fn mode ->
       Enum.reduce(1..messages, 0, fn _, admitted ->
         reservation =
           if mode == :unbounded,
-            do: {:ok, :unbounded},
+            do: :ok,
             else: Schema.reserve_update_slot(counter, limit)
 
-        if match?({:ok, _reservation}, reservation) do
+        if reservation == :ok do
           GenServer.cast(sink, message)
           admitted + 1
         else
@@ -69,7 +69,7 @@ accepted_counter = :atomics.new(1, [])
 {accepted_us, _result} =
   :timer.tc(fn ->
     Enum.each(1..messages, fn _ ->
-      {:ok, _reservation} = Schema.reserve_update_slot(accepted_counter, limit)
+      :ok = Schema.reserve_update_slot(accepted_counter, limit)
       :atomics.sub(accepted_counter, 1, 1)
     end)
   end)

--- a/test/profiling/bq_schema_admission_bench.exs
+++ b/test/profiling/bq_schema_admission_bench.exs
@@ -1,0 +1,106 @@
+# credo:disable-for-this-file Credo.Check.Refactor.IoPuts
+#
+# Usage:
+#   MIX_ENV=test mix run --no-start test/profiling/bq_schema_admission_bench.exs
+#
+# Optional env:
+#   MESSAGES=50000 FIELDS=50 LIMIT=32
+
+alias Logflare.Sources.Source.BigQuery.Schema
+alias Logflare.Sources.Source.BigQuery.SchemaMetrics
+
+messages = String.to_integer(System.get_env("MESSAGES") || "50000")
+fields = String.to_integer(System.get_env("FIELDS") || "50")
+limit = String.to_integer(System.get_env("LIMIT") || "32")
+
+body = Map.new(1..fields, &{"field_#{&1}", String.duplicate("value", 4)})
+message = {:update, %{body: body, id: "benchmark"}, %{lock_schema: false}}
+
+run = fn mode ->
+  {:ok, sink} = Agent.start(fn -> nil end)
+  :ok = :sys.suspend(sink)
+  counter = :atomics.new(1, [])
+
+  {elapsed_us, admitted} =
+    :timer.tc(fn ->
+      Enum.reduce(1..messages, 0, fn _, admitted ->
+        reservation =
+          if mode == :unbounded,
+            do: {:ok, :unbounded},
+            else: Schema.reserve_update_slot(counter, limit)
+
+        if match?({:ok, _reservation}, reservation) do
+          GenServer.cast(sink, message)
+          admitted + 1
+        else
+          admitted
+        end
+      end)
+    end)
+
+  {:message_queue_len, queue_length} = Process.info(sink, :message_queue_len)
+  {:memory, memory_bytes} = Process.info(sink, :memory)
+  Process.exit(sink, :kill)
+
+  %{
+    mode: mode,
+    elapsed_us: elapsed_us,
+    admitted: admitted,
+    queue_length: queue_length,
+    memory_bytes: memory_bytes
+  }
+end
+
+unbounded = run.(:unbounded)
+bounded = run.(:bounded)
+
+full_counter = :atomics.new(1, [])
+:atomics.put(full_counter, 1, limit)
+
+{rejection_us, _result} =
+  :timer.tc(fn ->
+    Enum.each(1..messages, fn _ ->
+      :full = Schema.reserve_update_slot(full_counter, limit)
+    end)
+  end)
+
+accepted_counter = :atomics.new(1, [])
+
+{accepted_us, _result} =
+  :timer.tc(fn ->
+    Enum.each(1..messages, fn _ ->
+      {:ok, _reservation} = Schema.reserve_update_slot(accepted_counter, limit)
+      :atomics.sub(accepted_counter, 1, 1)
+    end)
+  end)
+
+{:ok, metrics_pid} = SchemaMetrics.start_link(nil)
+
+{instrumented_rejection_us, _result} =
+  :timer.tc(fn ->
+    Enum.each(1..messages, fn _ ->
+      SchemaMetrics.record_sample(:zero_rate)
+      :full = Schema.reserve_update_slot(full_counter, limit)
+      SchemaMetrics.record_admission(:rejected)
+    end)
+  end)
+
+GenServer.stop(metrics_pid)
+
+format_mb = &Float.round(&1 / 1_048_576, 2)
+
+result = %{
+  inputs: %{messages: messages, fields: fields, limit: limit},
+  unbounded: Map.put(unbounded, :memory_mb, format_mb.(unbounded.memory_bytes)),
+  bounded: Map.put(bounded, :memory_mb, format_mb.(bounded.memory_bytes)),
+  reductions: %{
+    queue: Float.round(unbounded.queue_length / max(bounded.queue_length, 1), 2),
+    memory: Float.round(unbounded.memory_bytes / max(bounded.memory_bytes, 1), 2)
+  },
+  saturated_gate_ns_per_attempt: Float.round(rejection_us * 1_000 / messages, 2),
+  accepted_gate_ns_per_cycle: Float.round(accepted_us * 1_000 / messages, 2),
+  instrumented_rejection_ns_per_attempt:
+    Float.round(instrumented_rejection_us * 1_000 / messages, 2)
+}
+
+IO.puts(inspect(result, pretty: true))

--- a/test/profiling/bq_schema_update_internals_bench.exs
+++ b/test/profiling/bq_schema_update_internals_bench.exs
@@ -185,6 +185,9 @@ profile_after =
 suite =
   Benchee.run(
     %{
+      "cooldown" => fn %{update_body: body, schema: schema} ->
+        Schema.plan_update(body, schema, %{next_update: 9_999_999_999_999})
+      end,
       "noop" => fn %{body: body, schema: schema} ->
         Schema.plan_update(body, schema, %{next_update: 0})
       end,


### PR DESCRIPTION
## Summary

- bound pending processor-side BigQuery schema samples to 8 per source/backend
- keep existing asynchronous sampling semantics while using the freshest available rate estimate
- skip schema cache/planning work while updates are throttled or disabled
- remove redundant full-schema conversions from exact equality checks
- add low-cardinality admission, queue, and schema-operation telemetry
- isolate admission state in each Schema Registry registration so Schema restarts leave pipelines running

## Problem

`Pipeline.process_data/3` sampled events for schema discovery and cast every selected sample to the Schema GenServer. When schema processing fell behind, these casts could grow the mailbox without a bound and retain large event payloads.

Admitted samples also continued fetching and rebuilding schemas during the update cooldown, even though they could not patch BigQuery. Every allowed planning attempt additionally converted both schemas to flat typemaps before requiring exact structural equality.

## Implementation

- store a fresh `:atomics` admission counter and configured limit in each Schema process's Registry value
- look up the registered `{pid, counter}` pair, reserve before casting, and release when Schema dequeues the sample
- use compare-and-exchange reservations so rejected concurrent attempts never inflate the pending count
- use `max(average_rate, last_rate)` for sampling probability
- keep Schema and Pipeline independently supervised with `:one_for_one` restart semantics
- check cooldown/Postgres eligibility before schema cache access and planning
- compare schemas directly while preserving exact structural-equality behavior
- expose fixed-cardinality node-level selected/admitted/rejected/handled counters
- report bounded Schema queue aggregates from the existing top-10 process sample
- time schema patch, refresh, persist, and notification operations
- enrich ErlSysMon queue diagnostics with source registry keys

```mermaid
flowchart LR
    P[Pipeline processors] --> S[Sample selected]
    S --> R[Registry lookup]
    R --> A{Reserve atomic slot?}
    A -- Full --> X[Record rejection]
    A -- Available --> C[Cast to Schema PID]
    C --> Q[Bounded Schema mailbox, max 8]
    Q --> U[Dequeue and release slot]
    U --> W[Cooldown check and schema work]

    Z[Schema restart creates new PID, counter, and capacity] -.-> R
```

Schema patch attempts are limited to 6 per minute per Schema process, producing a 10-second cooldown after each successful or failed attempt. Sampling and bounded admission continue during that interval, but dequeued samples release their slot and return before schema-cache access or planning. This keeps ingestion asynchronous while avoiding redundant schema work.

Sampling remains best-effort: samples selected while all 8 reservations are occupied are rejected. A Schema restart can drop a sample already reserved against the old PID, but the replacement starts with independent admission capacity and pipelines remain running.

### Why 8

Sampling targets roughly one event per second, so 8 slots absorb about eight seconds of normal sampled backlog while retaining several opportunities to discover sparse fields. A limit of 32 retained roughly 32 seconds of samples, but after a successful patch most queued samples immediately hit the update cooldown; zero-rate/startup bursts are also likely to contain redundant neighboring events.

Because queued samples retain full event payloads, reducing the limit from 32 to 8 cuts bounded synthetic queue memory from 0.15 MiB to 0.04 MiB. Eight is intentionally more conservative than 4 so slow operations still retain useful sample diversity. Rollout can be evaluated with the selected/admitted/rejected counters, queue maximum, and schema-operation latency already added by this PR.

## Benchmarks

### Admission bound

Synthetic run with 50,000 messages containing 50 fields:

| Mode | Queue length | Process memory | Admission/enqueue time |
| --- | ---: | ---: | ---: |
| Unbounded | 50,000 | 233.84 MiB | 96.20 ms |
| Bounded | 8 | 0.04 MiB | 0.344 ms |

- queue reduction: 6,250x
- memory reduction: 5,847.07x
- saturated admission gate: 6.88 ns/attempt
- accepted reserve/release cycle: 17.18 ns
- instrumented rejection: 80.82 ns/attempt

### Schema planning follow-up

Adjacent same-machine before/after runs:

| Workload | Before | After |
| --- | ---: | ---: |
| Cooldown, 500 fields (median) | 3.52 ms | 42 ns |
| Cooldown memory | 4.32 MiB | 0 B |
| Cooldown reductions | 471.27K | 8 |

Across the existing edge-log, list, and scalar fixtures:

- no-op planning median improved **51-67%**
- update planning median improved **57-75%**
- planning allocations fell **57-65%**
- planning reductions fell **35-39%**

The profiling script now retains a dedicated cooldown workload.

## Validation

- [x] 40 focused tests, 0 failures (3 excluded)
- [x] concurrent reservation, Schema restart-race, and pipeline-stability coverage
- [x] `MIX_ENV=test mix compile --warnings-as-errors`
- [x] formatting check
- [x] `MIX_ENV=test mix lint.all`
- [x] admission and schema-planning benchmarks
- [x] independent correctness/restart-race review





