### PR TITLE
ci: make Supabase integration workflow manual-only

### DIFF
--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -1,24 +1,8 @@
 name: Integration Tests with Supabase
 
+# Temporarily manual-only while the BigQuery CI service account IAM is repaired.
 on:
-  pull_request:
-    branches:
-      - main
-    paths: &watched_paths
-      - 'config/**'
-      - 'assets/**'
-      - 'lib/**'
-      - 'priv/**'
-      - 'mix.exs'
-      - 'mix.lock'
-      - 'Dockerfile'
-      - 'run.sh'
-      - 'test/e2e/supabase/**'
-      - '.github/workflows/integration-supabase.yml'
-  push:
-    branches:
-      - main
-    paths: *watched_paths
+  workflow_dispatch:
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:


### PR DESCRIPTION
## Summary

- temporarily remove automatic `pull_request` and `push` triggers from the Supabase integration workflow
- retain `workflow_dispatch` so trusted manual runs remain available
- leave all integration jobs and test coverage unchanged

This prevents the current BigQuery IAM failure from keeping `main` red while the `logflare-ci-testing` service account permissions are repaired.

Failed run: https://github.com/Logflare/logflare/actions/runs/31481859113