### PR TITLE
feat(syslog): Add `emerg` syslog severity alias

### DIFF
--- a/lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex
@@ -14,6 +14,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Syslog do
 
   @levels %{
     "emergency" => 0,
+    "emerg" => 0,
     "emer" => 0,
     "alert" => 1,
     "critical" => 2,


### PR DESCRIPTION
## Summary

Adds the standard `emerg` alias to the syslog backend severity map, mapping it to emergency severity code 0. The formatter previously accepted `emer` but treated the conventional `emerg` label as the default `info` severity. Existing aliases remain supported, so this change is backward-compatible.

## Validation

- `mix format --check-formatted lib/logflare/backends/adaptor/syslog_adaptor/syslog.ex test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs`
- `mix test test/logflare/backends/adaptor/syslog_adaptor/syslog_test.exs` — 2 tests and 2 properties, 0 failures
- Direct runtime check that `emerg` produces PRI `<128>1`
