### PR TITLE
fix(test): fix changeset error interpolation test helper

### DIFF
--- a/test/logflare/backends/adaptor/syslog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor_test.exs
@@ -372,6 +372,13 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
   end
 
   describe "config validation" do
+    test "rejects invalid port" do
+      changeset = syslog_changeset(%{host: "localhost", port: 65_536})
+
+      refute changeset.valid?
+      assert %{port: ["is invalid"]} = errors_on(changeset)
+    end
+
     test "rejects invalid structured data" do
       bad_examples = [
         "invalid",

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -112,8 +112,8 @@ defmodule Logflare.DataCase do
   """
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Enum.reduce(opts, message, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)
   end


### PR DESCRIPTION
## Summary

`Logflare.DataCase.errors_on/1` now interpolates only metadata referenced by `%{...}` placeholders, preventing inclusion errors from trying to stringify unrelated values such as ranges.
This preserves the existing error map and numeric placeholder behavior.
The Syslog config test now covers an invalid port through the real inclusion-validation path.

## Validation

- `mix format`
- `git diff --check`
- `mix test test/logflare/backends/adaptor/syslog_adaptor_test.exs` (22 tests, 0 failures)

## Further work

We might also want to update `LogflareWeb.Utils.stringify_changeset_errors/1` since it has similar logic to the prev `errors_on` version that tried to stringify all metadata values.
