### PR TITLE
fix(syslog): Prevent Syslog TCP SSRF

### DIFF
--- a/lib/logflare/backends/adaptor/syslog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor.ex
@@ -188,7 +188,8 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
     with {:error, reason} <- result do
       formatted_error = format_connection_error(reason)
 
-      Logger.warning("Unexpected error when testing Syslog backend connection: #{reason}",
+      Logger.warning(
+        "Unexpected error when testing Syslog backend connection: #{inspect(reason)}",
         backend_id: backend.id,
         user_id: backend.user_id
       )
@@ -204,7 +205,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
   # copied from mint: https://github.com/elixir-mint/mint/blob/0bfcc869b53b83989c24ba681d66d0a447b5a1c3/lib/mint/transport_error.ex#L86-L101
   defp format_connection_error(:closed), do: :socket_closed
   defp format_connection_error(:timeout), do: :timeout
-  defp format_connection_error(reason) when is_binary(reason), do: reason
+  defp format_connection_error({:ssrf, reason}), do: reason
 
   defp format_connection_error(reason) do
     case :ssl.format_error(reason) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor.ex
@@ -189,7 +189,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
       formatted_error = format_connection_error(reason)
 
       Logger.warning(
-        "Unexpected error when testing Syslog backend connection: #{inspect(reason)}",
+        "Unexpected error when testing Syslog backend connection: #{formatted_error}",
         backend_id: backend.id,
         user_id: backend.user_id
       )
@@ -205,7 +205,8 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
   # copied from mint: https://github.com/elixir-mint/mint/blob/0bfcc869b53b83989c24ba681d66d0a447b5a1c3/lib/mint/transport_error.ex#L86-L101
   defp format_connection_error(:closed), do: :socket_closed
   defp format_connection_error(:timeout), do: :timeout
-  defp format_connection_error({:ssrf, reason}), do: reason
+  defp format_connection_error({:ssrf, reason}) when is_binary(reason), do: reason
+  defp format_connection_error({:ssrf, reason}), do: inspect(reason)
 
   defp format_connection_error(reason) do
     case :ssl.format_error(reason) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor.ex
@@ -204,6 +204,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
   # copied from mint: https://github.com/elixir-mint/mint/blob/0bfcc869b53b83989c24ba681d66d0a447b5a1c3/lib/mint/transport_error.ex#L86-L101
   defp format_connection_error(:closed), do: :socket_closed
   defp format_connection_error(:timeout), do: :timeout
+  defp format_connection_error(reason) when is_binary(reason), do: reason
 
   defp format_connection_error(reason) do
     case :ssl.format_error(reason) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor.ex
@@ -205,8 +205,10 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor do
   # copied from mint: https://github.com/elixir-mint/mint/blob/0bfcc869b53b83989c24ba681d66d0a447b5a1c3/lib/mint/transport_error.ex#L86-L101
   defp format_connection_error(:closed), do: :socket_closed
   defp format_connection_error(:timeout), do: :timeout
-  defp format_connection_error({:ssrf, reason}) when is_binary(reason), do: reason
-  defp format_connection_error({:ssrf, reason}), do: inspect(reason)
+
+  defp format_connection_error({:ssrf, reason}) do
+    if is_binary(reason), do: reason, else: inspect(reason)
+  end
 
   defp format_connection_error(reason) do
     case :ssl.format_error(reason) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
@@ -1,7 +1,6 @@
 defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   @moduledoc false
 
-  alias Logflare.SingleTenant
   alias Logflare.Utils.SSRF
 
   @type socket :: :gen_tcp.socket() | :ssl.sslsocket()
@@ -54,7 +53,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   @spec resolve_address(String.t()) ::
           {:ok, :inet.ip_address() | charlist()} | {:error, {:ssrf, String.t()}}
   defp resolve_address(host) do
-    if SingleTenant.single_tenant?() do
+    if Logflare.SingleTenant.single_tenant?() do
       {:ok, String.to_charlist(host)}
     else
       case SSRF.safe_resolve(host) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
@@ -46,53 +46,10 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
     if Logflare.SingleTenant.single_tenant?() do
       {:ok, [String.to_charlist(host)]}
     else
-      hostname = String.to_charlist(host)
-
-      case :inet.parse_address(hostname) do
-        {:ok, address} -> validate_addresses([address])
-        {:error, _reason} -> resolve_hostname(host, hostname)
-      end
-    end
-  end
-
-  @spec resolve_hostname(String.t(), charlist()) ::
-          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}}
-  defp resolve_hostname(host, hostname) do
-    with :unresolved <- resolve_family(hostname, :inet),
-         :unresolved <- resolve_family(hostname, :inet6) do
-      case SSRF.safe_resolve(host) do
-        {:ok, address} -> {:ok, [address]}
+      case SSRF.safe_resolve_all(host) do
+        {:ok, addresses} -> {:ok, addresses}
         {:error, reason} -> {:error, {:ssrf, reason}}
       end
-    else
-      result -> result
-    end
-  end
-
-  @spec resolve_family(charlist(), :inet | :inet6) ::
-          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}} | :unresolved
-  defp resolve_family(hostname, family) do
-    case :inet.getaddrs(hostname, family) do
-      {:ok, [_ | _] = addresses} -> validate_addresses(addresses)
-      {:ok, []} -> :unresolved
-      {:error, _reason} -> :unresolved
-    end
-  end
-
-  @spec validate_addresses([:inet.ip_address()]) ::
-          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}}
-  defp validate_addresses(addresses) do
-    Enum.reduce_while(addresses, {:ok, []}, fn address, {:ok, safe_addresses} ->
-      host = address |> :inet.ntoa() |> List.to_string()
-
-      case SSRF.safe_resolve(host) do
-        {:ok, ^address} -> {:cont, {:ok, [address | safe_addresses]}}
-        {:error, reason} -> {:halt, {:error, {:ssrf, reason}}}
-      end
-    end)
-    |> case do
-      {:ok, safe_addresses} -> {:ok, Enum.reverse(safe_addresses)}
-      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
@@ -3,29 +3,20 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
 
   alias Logflare.Utils.SSRF
 
+  @typep address :: :inet.ip_address() | charlist()
+  @typep reason :: :closed | :timeout | :inet.posix() | :ssl.reason() | {:ssrf, String.t()}
   @type socket :: :gen_tcp.socket() | :ssl.sslsocket()
 
   # see https://www.erlang.org/doc/apps/kernel/inet#setopts/2 for details
   @default_transport_opts mode: :binary, packet: :raw, active: true, nodelay: true
 
   @spec connect(map, timeout) :: {:ok, socket} | {:error, reason}
-        when reason:
-               :closed
-               | :timeout
-               | :inet.posix()
-               | :ssl.reason()
-               | {:ssrf, String.t()}
   def connect(config, timeout) do
     host = Map.fetch!(config, :host)
     port = Map.fetch!(config, :port)
 
-    with {:ok, address} <- resolve_address(host) do
-      if Map.get(config, :tls) do
-        opts = ssl_opts(@default_transport_opts, config, host)
-        :ssl.connect(address, port, opts, timeout)
-      else
-        :gen_tcp.connect(address, port, @default_transport_opts, timeout)
-      end
+    with {:ok, addresses} <- resolve_addresses(host) do
+      connect_addresses(addresses, config, host, port, deadline(timeout), {:error, :einval})
     end
   end
 
@@ -50,17 +41,105 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
 
   def stream(_socket, _message), do: :ignore
 
-  @spec resolve_address(String.t()) ::
-          {:ok, :inet.ip_address() | charlist()} | {:error, {:ssrf, String.t()}}
-  defp resolve_address(host) do
+  @spec resolve_addresses(String.t()) :: {:ok, [address]} | {:error, {:ssrf, String.t()}}
+  defp resolve_addresses(host) do
     if Logflare.SingleTenant.single_tenant?() do
-      {:ok, String.to_charlist(host)}
+      {:ok, [String.to_charlist(host)]}
     else
-      case SSRF.safe_resolve(host) do
-        {:ok, address} -> {:ok, address}
-        {:error, reason} -> {:error, {:ssrf, reason}}
+      hostname = String.to_charlist(host)
+
+      case :inet.parse_address(hostname) do
+        {:ok, address} -> validate_addresses([address])
+        {:error, _reason} -> resolve_hostname(host, hostname)
       end
     end
+  end
+
+  @spec resolve_hostname(String.t(), charlist()) ::
+          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}}
+  defp resolve_hostname(host, hostname) do
+    with :unresolved <- resolve_family(hostname, :inet),
+         :unresolved <- resolve_family(hostname, :inet6) do
+      case SSRF.safe_resolve(host) do
+        {:ok, address} -> {:ok, [address]}
+        {:error, reason} -> {:error, {:ssrf, reason}}
+      end
+    else
+      result -> result
+    end
+  end
+
+  @spec resolve_family(charlist(), :inet | :inet6) ::
+          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}} | :unresolved
+  defp resolve_family(hostname, family) do
+    case :inet.getaddrs(hostname, family) do
+      {:ok, [_ | _] = addresses} -> validate_addresses(addresses)
+      {:ok, []} -> :unresolved
+      {:error, _reason} -> :unresolved
+    end
+  end
+
+  @spec validate_addresses([:inet.ip_address()]) ::
+          {:ok, [:inet.ip_address()]} | {:error, {:ssrf, String.t()}}
+  defp validate_addresses(addresses) do
+    Enum.reduce_while(addresses, {:ok, []}, fn address, {:ok, safe_addresses} ->
+      host = address |> :inet.ntoa() |> List.to_string()
+
+      case SSRF.safe_resolve(host) do
+        {:ok, ^address} -> {:cont, {:ok, [address | safe_addresses]}}
+        {:error, reason} -> {:halt, {:error, {:ssrf, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, safe_addresses} -> {:ok, Enum.reverse(safe_addresses)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec connect_addresses(
+          [address],
+          map,
+          String.t(),
+          :inet.port_number(),
+          integer | :infinity,
+          term
+        ) ::
+          {:ok, socket} | {:error, reason}
+  defp connect_addresses([address | addresses], config, host, port, deadline, _last_error) do
+    case connect_address(address, config, host, port, remaining_timeout(deadline)) do
+      {:ok, _socket} = result ->
+        result
+
+      {:error, reason} = error when reason in [:einval, :timeout] ->
+        error
+
+      {:error, _reason} = error ->
+        connect_addresses(addresses, config, host, port, deadline, error)
+    end
+  end
+
+  defp connect_addresses([], _config, _host, _port, _deadline, last_error), do: last_error
+
+  @spec connect_address(address, map, String.t(), :inet.port_number(), timeout) ::
+          {:ok, socket} | {:error, reason}
+  defp connect_address(address, config, host, port, timeout) do
+    if Map.get(config, :tls) do
+      opts = ssl_opts(@default_transport_opts, config, host)
+      :ssl.connect(address, port, opts, timeout)
+    else
+      :gen_tcp.connect(address, port, @default_transport_opts, timeout)
+    end
+  end
+
+  @spec deadline(timeout) :: integer | :infinity
+  defp deadline(:infinity), do: :infinity
+  defp deadline(timeout), do: System.monotonic_time(:millisecond) + timeout
+
+  @spec remaining_timeout(integer | :infinity) :: timeout
+  defp remaining_timeout(:infinity), do: :infinity
+
+  defp remaining_timeout(deadline) do
+    max(deadline - System.monotonic_time(:millisecond), 0)
   end
 
   defp ssl_opts(opts, config, host) do

--- a/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
@@ -1,22 +1,28 @@
 defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   @moduledoc false
 
+  alias Logflare.SingleTenant
+  alias Logflare.Utils.SSRF
+
   @type socket :: :gen_tcp.socket() | :ssl.sslsocket()
 
   # see https://www.erlang.org/doc/apps/kernel/inet#setopts/2 for details
   @default_transport_opts mode: :binary, packet: :raw, active: true, nodelay: true
 
   @spec connect(map, timeout) :: {:ok, socket} | {:error, reason}
-        when reason: :closed | :timeout | :inet.posix() | :ssl.reason()
+        when reason: :closed | :timeout | :inet.posix() | :ssl.reason() | String.t()
   def connect(config, timeout) do
-    host = config |> Map.fetch!(:host) |> String.to_charlist()
+    host = Map.fetch!(config, :host)
+    hostname = String.to_charlist(host)
     port = Map.fetch!(config, :port)
 
-    if Map.get(config, :tls) do
-      opts = ssl_opts(@default_transport_opts, config, host)
-      :ssl.connect(host, port, opts, timeout)
-    else
-      :gen_tcp.connect(host, port, @default_transport_opts, timeout)
+    with {:ok, address} <- resolve_address(host) do
+      if Map.get(config, :tls) do
+        opts = ssl_opts(@default_transport_opts, config, hostname)
+        :ssl.connect(address, port, opts, timeout)
+      else
+        :gen_tcp.connect(address, port, @default_transport_opts, timeout)
+      end
     end
   end
 
@@ -40,6 +46,26 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   end
 
   def stream(_socket, _message), do: :ignore
+
+  @spec resolve_address(String.t()) ::
+          {:ok, :inet.ip_address()} | {:error, :inet.posix() | String.t()}
+  defp resolve_address(host) do
+    if SingleTenant.single_tenant?() do
+      resolve_unrestricted(host)
+    else
+      SSRF.safe_resolve(host)
+    end
+  end
+
+  @spec resolve_unrestricted(String.t()) ::
+          {:ok, :inet.ip_address()} | {:error, :inet.posix()}
+  defp resolve_unrestricted(host) do
+    hostname = String.to_charlist(host)
+
+    with {:error, _reason} <- :inet.getaddr(hostname, :inet) do
+      :inet.getaddr(hostname, :inet6)
+    end
+  end
 
   defp ssl_opts(opts, config, host) do
     ssl_opts = [

--- a/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
+++ b/lib/logflare/backends/adaptor/syslog_adaptor/socket.ex
@@ -10,15 +10,19 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   @default_transport_opts mode: :binary, packet: :raw, active: true, nodelay: true
 
   @spec connect(map, timeout) :: {:ok, socket} | {:error, reason}
-        when reason: :closed | :timeout | :inet.posix() | :ssl.reason() | String.t()
+        when reason:
+               :closed
+               | :timeout
+               | :inet.posix()
+               | :ssl.reason()
+               | {:ssrf, String.t()}
   def connect(config, timeout) do
     host = Map.fetch!(config, :host)
-    hostname = String.to_charlist(host)
     port = Map.fetch!(config, :port)
 
     with {:ok, address} <- resolve_address(host) do
       if Map.get(config, :tls) do
-        opts = ssl_opts(@default_transport_opts, config, hostname)
+        opts = ssl_opts(@default_transport_opts, config, host)
         :ssl.connect(address, port, opts, timeout)
       else
         :gen_tcp.connect(address, port, @default_transport_opts, timeout)
@@ -48,28 +52,21 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.Socket do
   def stream(_socket, _message), do: :ignore
 
   @spec resolve_address(String.t()) ::
-          {:ok, :inet.ip_address()} | {:error, :inet.posix() | String.t()}
+          {:ok, :inet.ip_address() | charlist()} | {:error, {:ssrf, String.t()}}
   defp resolve_address(host) do
     if SingleTenant.single_tenant?() do
-      resolve_unrestricted(host)
+      {:ok, String.to_charlist(host)}
     else
-      SSRF.safe_resolve(host)
-    end
-  end
-
-  @spec resolve_unrestricted(String.t()) ::
-          {:ok, :inet.ip_address()} | {:error, :inet.posix()}
-  defp resolve_unrestricted(host) do
-    hostname = String.to_charlist(host)
-
-    with {:error, _reason} <- :inet.getaddr(hostname, :inet) do
-      :inet.getaddr(hostname, :inet6)
+      case SSRF.safe_resolve(host) do
+        {:ok, address} -> {:ok, address}
+        {:error, reason} -> {:error, {:ssrf, reason}}
+      end
     end
   end
 
   defp ssl_opts(opts, config, host) do
     ssl_opts = [
-      server_name_indication: host,
+      server_name_indication: String.to_charlist(host),
       verify: :verify_peer,
       depth: 100,
       customize_hostname_check: [

--- a/lib/logflare/utils/ssrf.ex
+++ b/lib/logflare/utils/ssrf.ex
@@ -54,19 +54,29 @@ defmodule Logflare.Utils.SSRF do
   Used to obtain an IP to connect to directly, eliminating DNS re-resolution.
   """
   @spec safe_resolve(String.t() | nil) :: {:ok, :inet.ip_address()} | {:error, String.t()}
-  def safe_resolve(host) when is_non_empty_binary(host) do
+  def safe_resolve(host) do
+    with {:ok, [addr | _]} <- safe_resolve_all(host), do: {:ok, addr}
+  end
+
+  @doc """
+  Resolves `host` and returns every IP address from the first available address
+  family, or an error if any address is private/reserved or none can be resolved.
+  """
+  @spec safe_resolve_all(String.t() | nil) ::
+          {:ok, [:inet.ip_address(), ...]} | {:error, String.t()}
+  def safe_resolve_all(host) when is_non_empty_binary(host) do
     charlist = String.to_charlist(host)
 
     with {:ok, addr} <- :inet.parse_address(charlist),
          {:private, false} <- {:private, private_ip?(addr)} do
-      {:ok, addr}
+      {:ok, [addr]}
     else
       {:error, _} -> resolve_hostname(charlist)
       {:private, true} -> {:error, @private_ip_error}
     end
   end
 
-  def safe_resolve(_), do: {:error, "invalid host"}
+  def safe_resolve_all(_), do: {:error, "invalid host"}
 
   @doc "Formats an IP address tuple as a URL host component (IPv6 wrapped in brackets)."
   @spec url_host(:inet.ip_address()) :: String.t()
@@ -85,11 +95,12 @@ defmodule Logflare.Utils.SSRF do
   end
 
   defp resolve_hostname(charlist, family) do
-    with {:ok, addrs} <- :inet.getaddrs(charlist, family),
+    with {:ok, [_ | _] = addrs} <- :inet.getaddrs(charlist, family),
          {:private, false} <- {:private, Enum.any?(addrs, &private_ip?/1)} do
-      {:ok, List.first(addrs)}
+      {:ok, addrs}
     else
       {:private, true} -> {:error, @private_ip_error}
+      {:ok, []} -> :unresolved
       {:error, _} -> :unresolved
     end
   end

--- a/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
@@ -44,6 +44,52 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
     :ok = :gen_tcp.close(listener)
   end
 
+  test "tries each safely resolved address until one connects" do
+    host = "syslog-multi.test"
+    first_address = non_loopback_ipv4_address()
+    second_address = {127, 0, 0, 1}
+    put_host_addresses(host, [first_address, second_address])
+
+    expect(SSRF, :safe_resolve, 2, fn host ->
+      {:ok, address} = host |> String.to_charlist() |> :inet.parse_address()
+      assert address in [first_address, second_address]
+      {:ok, address}
+    end)
+
+    {:ok, listener, port} = listen_tcp()
+
+    assert {:ok, client} =
+             Socket.connect(%{host: host, port: port}, to_timeout(second: 1))
+
+    assert {:ok, server} = :gen_tcp.accept(listener, 1_000)
+
+    :ok = Socket.close(client)
+    :ok = :gen_tcp.close(server)
+    :ok = :gen_tcp.close(listener)
+  end
+
+  test "validates every resolved address before connecting" do
+    host = "syslog-rebinding.test"
+    first_address = {127, 0, 0, 1}
+    private_address = {127, 0, 0, 2}
+    put_host_addresses(host, [first_address, private_address])
+
+    expect(SSRF, :safe_resolve, 2, fn
+      "127.0.0.1" -> {:ok, first_address}
+      "127.0.0.2" -> Mimic.call_original(SSRF, :safe_resolve, ["127.0.0.2"])
+    end)
+
+    {:ok, listener, port} = listen_tcp()
+
+    assert {:error, {:ssrf, reason}} =
+             Socket.connect(%{host: host, port: port}, to_timeout(second: 1))
+
+    assert reason =~ "private or reserved"
+    assert {:error, :timeout} = :gen_tcp.accept(listener, 50)
+
+    :ok = :gen_tcp.close(listener)
+  end
+
   test "retains the original hostname for TLS SNI and hostname verification" do
     {:ok, listener, port, server} = listen_tls()
 
@@ -86,6 +132,30 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
     {:ok, listener} = :gen_tcp.listen(0, active: false, ip: {127, 0, 0, 1}, reuseaddr: true)
     {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listener)
     {:ok, listener, port}
+  end
+
+  defp non_loopback_ipv4_address do
+    {:ok, interfaces} = :inet.getifaddrs()
+
+    Enum.find_value(interfaces, fn {_name, options} ->
+      Enum.find_value(options, fn
+        {:addr, {first, _, _, _} = address} when first not in [0, 127] -> address
+        _option -> nil
+      end)
+    end) || flunk("expected a non-loopback IPv4 interface")
+  end
+
+  defp put_host_addresses(host, addresses) do
+    previous_lookup = :inet_db.res_option(:lookup)
+    hostname = String.to_charlist(host)
+
+    :ok = :inet_db.set_lookup([:file])
+    Enum.each(addresses, &(:ok = :inet_db.add_host(&1, [hostname])))
+
+    on_exit(fn ->
+      Enum.each(addresses, &(:ok = :inet_db.del_host(&1)))
+      :ok = :inet_db.set_lookup(previous_lookup)
+    end)
   end
 
   defp listen_tls do

--- a/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
@@ -32,7 +32,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
   test "connects directly to the address returned by the safe resolver" do
     {:ok, listener, port} = listen_tcp()
 
-    expect(SSRF, :safe_resolve, fn "syslog.invalid" -> {:ok, {127, 0, 0, 1}} end)
+    expect(SSRF, :safe_resolve_all, fn "syslog.invalid" -> {:ok, [{127, 0, 0, 1}]} end)
 
     assert {:ok, client} =
              Socket.connect(%{host: "syslog.invalid", port: port}, to_timeout(second: 1))
@@ -48,12 +48,9 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
     host = "syslog-multi.test"
     first_address = non_loopback_ipv4_address()
     second_address = {127, 0, 0, 1}
-    put_host_addresses(host, [first_address, second_address])
 
-    expect(SSRF, :safe_resolve, 2, fn host ->
-      {:ok, address} = host |> String.to_charlist() |> :inet.parse_address()
-      assert address in [first_address, second_address]
-      {:ok, address}
+    expect(SSRF, :safe_resolve_all, fn ^host ->
+      {:ok, [first_address, second_address]}
     end)
 
     {:ok, listener, port} = listen_tcp()
@@ -68,32 +65,10 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
     :ok = :gen_tcp.close(listener)
   end
 
-  test "validates every resolved address before connecting" do
-    host = "syslog-rebinding.test"
-    first_address = {127, 0, 0, 1}
-    private_address = {127, 0, 0, 2}
-    put_host_addresses(host, [first_address, private_address])
-
-    expect(SSRF, :safe_resolve, 2, fn
-      "127.0.0.1" -> {:ok, first_address}
-      "127.0.0.2" -> Mimic.call_original(SSRF, :safe_resolve, ["127.0.0.2"])
-    end)
-
-    {:ok, listener, port} = listen_tcp()
-
-    assert {:error, {:ssrf, reason}} =
-             Socket.connect(%{host: host, port: port}, to_timeout(second: 1))
-
-    assert reason =~ "private or reserved"
-    assert {:error, :timeout} = :gen_tcp.accept(listener, 50)
-
-    :ok = :gen_tcp.close(listener)
-  end
-
   test "retains the original hostname for TLS SNI and hostname verification" do
     {:ok, listener, port, server} = listen_tls()
 
-    expect(SSRF, :safe_resolve, fn "telegraf" -> {:ok, @ipv6_loopback} end)
+    expect(SSRF, :safe_resolve_all, fn "telegraf" -> {:ok, [@ipv6_loopback]} end)
 
     config = %{
       host: "telegraf",
@@ -114,7 +89,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
 
   test "allows private destinations only in explicitly configured single-tenant mode" do
     stub(SingleTenant, :single_tenant?, fn -> true end)
-    stub(SSRF, :safe_resolve, fn _host -> flunk("safe resolver should be bypassed") end)
+    stub(SSRF, :safe_resolve_all, fn _host -> flunk("safe resolver should be bypassed") end)
 
     {:ok, listener, port} = listen_tcp()
 
@@ -143,19 +118,6 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
         _option -> nil
       end)
     end) || flunk("expected a non-loopback IPv4 interface")
-  end
-
-  defp put_host_addresses(host, addresses) do
-    previous_lookup = :inet_db.res_option(:lookup)
-    hostname = String.to_charlist(host)
-
-    :ok = :inet_db.set_lookup([:file])
-    Enum.each(addresses, &(:ok = :inet_db.add_host(&1, [hostname])))
-
-    on_exit(fn ->
-      Enum.each(addresses, &(:ok = :inet_db.del_host(&1)))
-      :ok = :inet_db.set_lookup(previous_lookup)
-    end)
   end
 
   defp listen_tls do

--- a/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
@@ -20,7 +20,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
   test "rejects private destinations before opening a connection" do
     {:ok, listener, port} = listen_tcp()
 
-    assert {:error, reason} =
+    assert {:error, {:ssrf, reason}} =
              Socket.connect(%{host: "127.0.0.1", port: port}, to_timeout(second: 1))
 
     assert reason =~ "private or reserved"

--- a/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor/socket_test.exs
@@ -1,0 +1,133 @@
+defmodule Logflare.Backends.Adaptor.SyslogAdaptor.SocketTest do
+  use ExUnit.Case, async: false
+
+  import Mimic
+
+  alias Logflare.Backends.Adaptor.SyslogAdaptor.Socket
+  alias Logflare.SingleTenant
+  alias Logflare.Utils.SSRF
+
+  @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup do
+    stub(SingleTenant, :single_tenant?, fn -> false end)
+    :ok
+  end
+
+  test "rejects private destinations before opening a connection" do
+    {:ok, listener, port} = listen_tcp()
+
+    assert {:error, reason} =
+             Socket.connect(%{host: "127.0.0.1", port: port}, to_timeout(second: 1))
+
+    assert reason =~ "private or reserved"
+    assert {:error, :timeout} = :gen_tcp.accept(listener, 50)
+
+    :ok = :gen_tcp.close(listener)
+  end
+
+  test "connects directly to the address returned by the safe resolver" do
+    {:ok, listener, port} = listen_tcp()
+
+    expect(SSRF, :safe_resolve, fn "syslog.invalid" -> {:ok, {127, 0, 0, 1}} end)
+
+    assert {:ok, client} =
+             Socket.connect(%{host: "syslog.invalid", port: port}, to_timeout(second: 1))
+
+    assert {:ok, server} = :gen_tcp.accept(listener, 1_000)
+
+    :ok = Socket.close(client)
+    :ok = :gen_tcp.close(server)
+    :ok = :gen_tcp.close(listener)
+  end
+
+  test "retains the original hostname for TLS SNI and hostname verification" do
+    {:ok, listener, port, server} = listen_tls()
+
+    expect(SSRF, :safe_resolve, fn "telegraf" -> {:ok, @ipv6_loopback} end)
+
+    config = %{
+      host: "telegraf",
+      port: port,
+      tls: true,
+      ca_cert: File.read!("priv/telegraf/ca.crt")
+    }
+
+    assert {:ok, client} = Socket.connect(config, to_timeout(second: 1))
+    assert_receive {:sni, ~c"telegraf"}
+    assert_receive {:tls_server, {:ok, _server_socket}}
+
+    :ok = Socket.close(client)
+    send(server.pid, :close)
+    assert :ok = Task.await(server)
+    :ok = :ssl.close(listener)
+  end
+
+  test "allows private destinations only in explicitly configured single-tenant mode" do
+    stub(SingleTenant, :single_tenant?, fn -> true end)
+    stub(SSRF, :safe_resolve, fn _host -> flunk("safe resolver should be bypassed") end)
+
+    {:ok, listener, port} = listen_tcp()
+
+    assert {:ok, client} =
+             Socket.connect(%{host: "127.0.0.1", port: port}, to_timeout(second: 1))
+
+    assert {:ok, server} = :gen_tcp.accept(listener, 1_000)
+
+    :ok = Socket.close(client)
+    :ok = :gen_tcp.close(server)
+    :ok = :gen_tcp.close(listener)
+  end
+
+  defp listen_tcp do
+    {:ok, listener} = :gen_tcp.listen(0, active: false, ip: {127, 0, 0, 1}, reuseaddr: true)
+    {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listener)
+    {:ok, listener, port}
+  end
+
+  defp listen_tls do
+    test_pid = self()
+
+    opts = [
+      :inet6,
+      active: false,
+      certfile: String.to_charlist(Path.expand("priv/telegraf/server.crt")),
+      keyfile: String.to_charlist(Path.expand("priv/telegraf/server.key")),
+      ip: @ipv6_loopback,
+      reuseaddr: true,
+      sni_fun: fn hostname ->
+        send(test_pid, {:sni, hostname})
+        []
+      end
+    ]
+
+    {:ok, listener} = :ssl.listen(0, opts)
+    {:ok, {@ipv6_loopback, port}} = :ssl.sockname(listener)
+
+    server =
+      Task.async(fn ->
+        result =
+          with {:ok, socket} <- :ssl.transport_accept(listener, 1_000),
+               {:ok, socket} <- :ssl.handshake(socket, 1_000) do
+            {:ok, socket}
+          end
+
+        send(test_pid, {:tls_server, result})
+
+        case result do
+          {:ok, socket} ->
+            receive do
+              :close -> :ssl.close(socket)
+            end
+
+          {:error, _reason} ->
+            :ok
+        end
+      end)
+
+    {:ok, listener, port, server}
+  end
+end

--- a/test/logflare/backends/adaptor/syslog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor_test.exs
@@ -20,6 +20,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
   setup do
     stub(SSRF, :safe_resolve, fn
       "localhost" -> {:ok, {127, 0, 0, 1}}
+      "127.0.0.1" -> {:ok, {127, 0, 0, 1}}
       host -> Mimic.call_original(SSRF, :safe_resolve, [host])
     end)
 
@@ -497,7 +498,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
     end
 
     test "rejects private destinations instead of probing them" do
-      {_, backend} = start_syslog(%{host: "127.0.0.1", port: 6514})
+      {_, backend} = start_syslog(%{host: "127.0.0.2", port: 6514})
       assert {:error, :unknown_error} = SyslogAdaptor.test_connection(backend)
     end
 

--- a/test/logflare/backends/adaptor/syslog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor_test.exs
@@ -18,10 +18,9 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
   end
 
   setup do
-    stub(SSRF, :safe_resolve, fn
-      "localhost" -> {:ok, {127, 0, 0, 1}}
-      "127.0.0.1" -> {:ok, {127, 0, 0, 1}}
-      host -> Mimic.call_original(SSRF, :safe_resolve, [host])
+    stub(SSRF, :safe_resolve_all, fn
+      "localhost" -> {:ok, [{127, 0, 0, 1}]}
+      host -> Mimic.call_original(SSRF, :safe_resolve_all, [host])
     end)
 
     :ok

--- a/test/logflare/backends/adaptor/syslog_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/syslog_adaptor_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
 
   alias Logflare.Backends.Adaptor.SyslogAdaptor
   alias Logflare.Backends.IngestEventQueue
+  alias Logflare.Utils.SSRF
 
   @moduletag :telegraf
 
@@ -14,6 +15,15 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
         File.write!(@telegraf_output_path, _empty = "")
       end
     end)
+  end
+
+  setup do
+    stub(SSRF, :safe_resolve, fn
+      "localhost" -> {:ok, {127, 0, 0, 1}}
+      host -> Mimic.call_original(SSRF, :safe_resolve, [host])
+    end)
+
+    :ok
   end
 
   test "basic fields check" do
@@ -483,6 +493,11 @@ defmodule Logflare.Backends.Adaptor.SyslogAdaptorTest do
 
     test "for invalid host" do
       {_, backend} = start_syslog(%{host: "invalid-host", port: 6514})
+      assert {:error, :unknown_error} = SyslogAdaptor.test_connection(backend)
+    end
+
+    test "rejects private destinations instead of probing them" do
+      {_, backend} = start_syslog(%{host: "127.0.0.1", port: 6514})
       assert {:error, :unknown_error} = SyslogAdaptor.test_connection(backend)
     end
 

--- a/test/logflare/utils/ssrf_test.exs
+++ b/test/logflare/utils/ssrf_test.exs
@@ -1,6 +1,5 @@
 defmodule Logflare.Utils.SSRFTest do
-  @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Logflare.Utils.SSRF
 
@@ -87,6 +86,30 @@ defmodule Logflare.Utils.SSRFTest do
     end
   end
 
+  describe "safe_resolve_all/1" do
+    test "returns every public address while safe_resolve/1 keeps the first" do
+      host = "ssrf-public.test"
+      addresses = [{1, 1, 1, 1}, {8, 8, 8, 8}]
+      put_host_addresses(host, addresses)
+
+      assert {:ok, ^addresses} = SSRF.safe_resolve_all(host)
+      assert {:ok, {1, 1, 1, 1}} = SSRF.safe_resolve(host)
+    end
+
+    test "rejects the entire answer when any address is private" do
+      host = "ssrf-mixed.test"
+      put_host_addresses(host, [{1, 1, 1, 1}, {127, 0, 0, 1}])
+
+      assert {:error, reason} = SSRF.safe_resolve_all(host)
+      assert reason =~ "private or reserved"
+    end
+
+    test "returns one-element lists for literal addresses" do
+      assert {:ok, [{1, 1, 1, 1}]} = SSRF.safe_resolve_all("1.1.1.1")
+      assert {:error, _reason} = SSRF.safe_resolve_all("127.0.0.1")
+    end
+  end
+
   describe "url_host/1" do
     test "formats IPv4 as plain string" do
       assert SSRF.url_host({1, 2, 3, 4}) == "1.2.3.4"
@@ -98,5 +121,18 @@ defmodule Logflare.Utils.SSRFTest do
       assert SSRF.url_host({0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888}) ==
                "[2001:4860:4860::8888]"
     end
+  end
+
+  defp put_host_addresses(host, addresses) do
+    previous_lookup = :inet_db.res_option(:lookup)
+    hostname = String.to_charlist(host)
+
+    :ok = :inet_db.set_lookup([:file])
+    Enum.each(addresses, &(:ok = :inet_db.add_host(&1, [hostname])))
+
+    on_exit(fn ->
+      Enum.each(addresses, &(:ok = :inet_db.del_host(&1)))
+      :ok = :inet_db.set_lookup(previous_lookup)
+    end)
   end
 end


### PR DESCRIPTION
Syslog TCP/TLS connections now resolve configured hosts at connection time with `SSRF.safe_resolve_all/1`, validate every address from one DNS result, and retry the pinned IPs sequentially, preventing DNS rebinding and internal port probing without losing OTP's hostname fallback behavior.

TLS still uses the original hostname for SNI and certificate verification, while explicitly configured single-tenant deployments retain private-network access.

`safe_resolve/1` preserves its first-address contract for existing webhook/Finch consumers, and focused tests cover rejection, full-answer validation, address fallback, IP pinning, TLS identity, and the single-tenant exception.

Validated with 27 Syslog tests, 14 SSRF utility tests, targeted Credo, formatting, and diff checks.
