### PR TITLE
perf(clickhouse): bound in-flight pipeline buffering

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,10 +46,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @batch_timeout 5_000
   @batcher_concurrency 32
   @max_retries 1
-  # Two full batches across every batcher, used as a generous safety valve rather
-  # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
-  # It should only cap genuinely runaway backlog during healthy operation.
-  @max_in_flight 2 * @batch_size * @batcher_concurrency
+  # One full batch across every batcher keeps all insert workers available without
+  # allowing a second complete wave of claimed pointers to accumulate in Broadway.
+  # See BufferProducer.capped_fetch_amount/2.
+  @max_in_flight @batch_size * @batcher_concurrency
 
   @doc false
   @spec max_retries() :: non_neg_integer()

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -94,6 +94,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     assert Enum.sort_by(result, sort_key) == Enum.sort_by(expected, sort_key)
   end
 
+  describe "configuration" do
+    test "limits in-flight pointers to one full batch per batcher" do
+      assert Pipeline.max_in_flight() == 32 * Pipeline.max_batch_size()
+    end
+  end
+
   describe "child_spec/1" do
     test "returns proper child specification" do
       spec = Pipeline.child_spec(:some_arg)


### PR DESCRIPTION
## Summary

- reduce the ClickHouse Broadway in-flight pointer cap from two full batches per batcher to one
- lower the cap from 3,840,000 to 1,920,000 claimed pointers while retaining enough capacity to fill all 32 batchers concurrently
- add regression coverage for the one-batch-per-batcher relationship

## Why

Canary throughput improved after v1.50.2, but VM process, binary, and ETS memory became more oscillatory. The ClickHouse producer could claim a second complete wave of pointers into Broadway before the first wave was acknowledged. Keeping only one full batch per batcher available limits hidden Broadway buffering without changing ClickHouse batch size, timeout, or insert concurrency.

This is a conservative bound rather than a throughput reduction: each batcher can still accumulate its configured 60,000-event maximum.
