### PR TITLE
revert(clickhouse): restore in-flight buffer capacity

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -46,10 +46,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @batch_timeout 5_000
   @batcher_concurrency 32
   @max_retries 1
-  # One full batch across every batcher keeps all insert workers available without
-  # allowing a second complete wave of claimed pointers to accumulate in Broadway.
-  # See BufferProducer.capped_fetch_amount/2.
-  @max_in_flight @batch_size * @batcher_concurrency
+  # Two full batches across every batcher, used as a generous safety valve rather
+  # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
+  # It should only cap genuinely runaway backlog during healthy operation.
+  @max_in_flight 2 * @batch_size * @batcher_concurrency
 
   @doc false
   @spec max_retries() :: non_neg_integer()

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -94,12 +94,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     assert Enum.sort_by(result, sort_key) == Enum.sort_by(expected, sort_key)
   end
 
-  describe "configuration" do
-    test "limits in-flight pointers to one full batch per batcher" do
-      assert Pipeline.max_in_flight() == 32 * Pipeline.max_batch_size()
-    end
-  end
-
   describe "child_spec/1" do
     test "returns proper child specification" do
       spec = Pipeline.child_spec(:some_arg)


### PR DESCRIPTION
## Summary

- revert #3817 and restore the ClickHouse Broadway in-flight cap from 1,920,000 to 3,840,000 pointers
- retain capacity for two complete 60,000-event batches across each of the 32 batchers
- remove the one-batch-per-batcher regression assertion introduced by #3817

## Why

After reviewing what happens when the lower in-flight cap is reached, the tradeoff is not worthwhile right now. The lower cap moves backlog out of Broadway sooner and into the consolidated ingest queue, which has substantially less pending capacity and can reach existing drop behavior earlier.

There is no immediate OOM risk requiring that reduction, so retaining the established two-batch safety capacity is safer until consolidated queue admission and backpressure behavior are addressed directly.

This is the exact behavioral revert of #3817. It does not change ClickHouse batch size, timeout, concurrency, queue admission, or generation retention.