### PR TITLE
fix(clickhouse): honour endpoint max_limit as a ClickHouse row cap

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -172,7 +172,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @spec max_event_age_hours(Backend.t()) :: non_neg_integer()
   defp max_event_age_hours(%Backend{config: %{max_event_age_hours: hours}})
-       when is_integer(hours) and hours >= 0,
+       when is_non_negative_integer(hours),
        do: hours
 
   defp max_event_age_hours(_backend), do: @default_max_event_age_hours
@@ -1165,7 +1165,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
     case execute_ch_query(backend, converted_query, ch_params, opts) do
       {:ok, {rows, bytes}} ->
-        rows = if is_integer(max_rows), do: Enum.take(rows, max_rows), else: rows
+        rows = if is_pos_integer(max_rows), do: Enum.take(rows, max_rows), else: rows
         {:ok, QueryResult.new(rows, %{total_bytes_processed: bytes})}
 
       error ->
@@ -1176,7 +1176,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @spec limit_endpoint_query(String.t(), term()) ::
           {:ok, {String.t(), pos_integer() | nil}} | {:error, String.t()}
   defp limit_endpoint_query(query_string, %{max_limit: max_limit})
-       when is_integer(max_limit) and max_limit > 0 do
+       when is_pos_integer(max_limit) do
     with {:ok, limited_query} <- ClickHouseSqlTransformer.apply_limit(query_string, max_limit) do
       {:ok, {limited_query, max_limit}}
     end
@@ -1215,7 +1215,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @spec maybe_start_query_connection_manager(pid() | nil, pos_integer(), String.t() | nil) ::
           :ok | {:error, term()}
-  defp maybe_start_query_connection_manager(nil, backend_id, label) when is_integer(backend_id) do
+  defp maybe_start_query_connection_manager(nil, backend_id, label)
+       when is_pos_integer(backend_id) do
     backend = Backends.Cache.get_backend(backend_id)
 
     with child_spec <- ConnectionManager.child_spec(backend, label),

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -34,6 +34,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   alias Logflare.LogEvent
   alias Logflare.LogEvent.TypeDetection
   alias Logflare.Sources.Source
+  alias Logflare.Sql.DialectTransformer.ClickHouse, as: ClickHouseSqlTransformer
 
   @min_pipelines 1
   @resolve_interval 10_000
@@ -120,13 +121,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       )
       when is_non_empty_binary(query_string) and is_list(declared_params) and is_map(input_params) and
              is_list(opts) do
-    execute_query_with_params(
-      backend,
-      query_string,
-      declared_params,
-      input_params,
-      put_endpoint_row_cap(opts, endpoint_query)
-    )
+    with {:ok, {limited_query, max_rows}} <- limit_endpoint_query(query_string, endpoint_query) do
+      execute_query_with_params(
+        backend,
+        limited_query,
+        declared_params,
+        input_params,
+        opts,
+        max_rows
+      )
+    end
   end
 
   def execute_query(%Backend{} = backend, %Ecto.Query{} = query, opts) when is_list(opts) do
@@ -547,23 +551,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   def execute_ch_query(%Backend{} = backend, statement, params, opts)
       when is_list_or_map(params) and is_list(opts) do
     requested = Keyword.get(opts, :read_cluster)
-    settings = Keyword.get(opts, :settings, [])
     label = resolve_read_cluster_label(backend, requested)
 
     warn_on_unconfigured_read_cluster(backend, requested, label)
 
-    case do_ch_query_on_label(backend, statement, params, label, settings) do
+    case do_ch_query_on_label(backend, statement, params, label) do
       {:error, %QueryError{kind: :connection_error}} = error ->
-        maybe_retry_on_default_cluster(backend, statement, params, label, settings, error)
+        maybe_retry_on_default_cluster(backend, statement, params, label, error)
 
       result ->
         result
     end
   end
 
-  @spec do_ch_query_on_label(Backend.t(), iodata(), term(), String.t() | nil, Keyword.t()) ::
+  @spec do_ch_query_on_label(Backend.t(), iodata(), term(), String.t() | nil) ::
           {:ok, {[map()], non_neg_integer() | :not_supported}} | {:error, term()}
-  defp do_ch_query_on_label(%Backend{} = backend, statement, params, label, settings) do
+  defp do_ch_query_on_label(%Backend{} = backend, statement, params, label) do
     with :ok <- ensure_query_connection_manager_started(backend, label) do
       pool_via = connection_pool_via(backend, label)
 
@@ -573,9 +576,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       log_fun = fn entry -> log_slow_checkout(entry, backend_id) end
 
       ch_opts = [decode: false, timeout: timeout, log: log_fun]
-
-      ch_opts =
-        if settings == [], do: ch_opts, else: Keyword.put(ch_opts, :settings, settings)
 
       case Ch.query(pool_via, statement, params, ch_opts) do
         {:ok, %Ch.Result{} = result} ->
@@ -619,17 +619,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
           iodata(),
           term(),
           String.t() | nil,
-          Keyword.t(),
           {:error, term()}
         ) :: {:ok, {[map()], non_neg_integer() | :not_supported}} | {:error, term()}
-  defp maybe_retry_on_default_cluster(
-         %Backend{} = backend,
-         statement,
-         params,
-         label,
-         settings,
-         error
-       ) do
+  defp maybe_retry_on_default_cluster(%Backend{} = backend, statement, params, label, error) do
     default = default_read_cluster_label(backend)
 
     if is_non_empty_binary(default) and default != label do
@@ -641,7 +633,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
         default_read_cluster: default
       )
 
-      do_ch_query_on_label(backend, statement, params, default, settings)
+      do_ch_query_on_label(backend, statement, params, default)
     else
       error
     end
@@ -1148,31 +1140,49 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
          input_params,
          opts
        ) do
+    execute_query_with_params(backend, query_string, declared_params, input_params, opts, nil)
+  end
+
+  @spec execute_query_with_params(
+          Backend.t(),
+          query_string :: String.t(),
+          declared_params :: [String.t()],
+          input_params :: map(),
+          opts :: Keyword.t(),
+          max_rows :: pos_integer() | nil
+        ) ::
+          {:ok, QueryResult.t()} | {:error, any()}
+  defp execute_query_with_params(
+         %Backend{} = backend,
+         query_string,
+         declared_params,
+         input_params,
+         opts,
+         max_rows
+       ) do
     converted_query = convert_query_params(query_string, declared_params)
     ch_params = Map.take(input_params, declared_params)
 
     case execute_ch_query(backend, converted_query, ch_params, opts) do
-      {:ok, {rows, bytes}} -> {:ok, QueryResult.new(rows, %{total_bytes_processed: bytes})}
-      error -> error
+      {:ok, {rows, bytes}} ->
+        rows = if is_integer(max_rows), do: Enum.take(rows, max_rows), else: rows
+        {:ok, QueryResult.new(rows, %{total_bytes_processed: bytes})}
+
+      error ->
+        error
     end
   end
 
-  # Mirrors the BigQuery adaptor, which caps endpoint results via `maxResults`.
-  # `result_overflow_mode: "break"` truncates instead of raising; ClickHouse stops on
-  # block boundaries, so slightly more than `max_result_rows` can come back.
-  @spec put_endpoint_row_cap(Keyword.t(), term()) :: Keyword.t()
-  defp put_endpoint_row_cap(opts, %{max_limit: max_limit})
-       when is_list(opts) and is_integer(max_limit) and max_limit > 0 do
-    settings =
-      opts
-      |> Keyword.get(:settings, [])
-      |> Keyword.put_new(:max_result_rows, max_limit)
-      |> Keyword.put_new(:result_overflow_mode, "break")
-
-    Keyword.put(opts, :settings, settings)
+  @spec limit_endpoint_query(String.t(), term()) ::
+          {:ok, {String.t(), pos_integer() | nil}} | {:error, String.t()}
+  defp limit_endpoint_query(query_string, %{max_limit: max_limit})
+       when is_integer(max_limit) and max_limit > 0 do
+    with {:ok, limited_query} <- ClickHouseSqlTransformer.apply_limit(query_string, max_limit) do
+      {:ok, {limited_query, max_limit}}
+    end
   end
 
-  defp put_endpoint_row_cap(opts, _endpoint_query) when is_list(opts), do: opts
+  defp limit_endpoint_query(query_string, _endpoint_query), do: {:ok, {query_string, nil}}
 
   @spec convert_query_params(sql_statement :: String.t(), allowed_params :: [String.t()]) ::
           String.t()

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -115,12 +115,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   def execute_query(
         %Backend{} = backend,
-        {query_string, declared_params, input_params, _endpoint_query},
+        {query_string, declared_params, input_params, endpoint_query},
         opts
       )
       when is_non_empty_binary(query_string) and is_list(declared_params) and is_map(input_params) and
              is_list(opts) do
-    execute_query_with_params(backend, query_string, declared_params, input_params, opts)
+    execute_query_with_params(
+      backend,
+      query_string,
+      declared_params,
+      input_params,
+      put_endpoint_row_cap(opts, endpoint_query)
+    )
   end
 
   def execute_query(%Backend{} = backend, %Ecto.Query{} = query, opts) when is_list(opts) do
@@ -541,22 +547,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   def execute_ch_query(%Backend{} = backend, statement, params, opts)
       when is_list_or_map(params) and is_list(opts) do
     requested = Keyword.get(opts, :read_cluster)
+    settings = Keyword.get(opts, :settings, [])
     label = resolve_read_cluster_label(backend, requested)
 
     warn_on_unconfigured_read_cluster(backend, requested, label)
 
-    case do_ch_query_on_label(backend, statement, params, label) do
+    case do_ch_query_on_label(backend, statement, params, label, settings) do
       {:error, %QueryError{kind: :connection_error}} = error ->
-        maybe_retry_on_default_cluster(backend, statement, params, label, error)
+        maybe_retry_on_default_cluster(backend, statement, params, label, settings, error)
 
       result ->
         result
     end
   end
 
-  @spec do_ch_query_on_label(Backend.t(), iodata(), term(), String.t() | nil) ::
+  @spec do_ch_query_on_label(Backend.t(), iodata(), term(), String.t() | nil, Keyword.t()) ::
           {:ok, {[map()], non_neg_integer() | :not_supported}} | {:error, term()}
-  defp do_ch_query_on_label(%Backend{} = backend, statement, params, label) do
+  defp do_ch_query_on_label(%Backend{} = backend, statement, params, label, settings) do
     with :ok <- ensure_query_connection_manager_started(backend, label) do
       pool_via = connection_pool_via(backend, label)
 
@@ -566,6 +573,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       log_fun = fn entry -> log_slow_checkout(entry, backend_id) end
 
       ch_opts = [decode: false, timeout: timeout, log: log_fun]
+
+      ch_opts =
+        if settings == [], do: ch_opts, else: Keyword.put(ch_opts, :settings, settings)
 
       case Ch.query(pool_via, statement, params, ch_opts) do
         {:ok, %Ch.Result{} = result} ->
@@ -609,9 +619,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
           iodata(),
           term(),
           String.t() | nil,
+          Keyword.t(),
           {:error, term()}
         ) :: {:ok, {[map()], non_neg_integer() | :not_supported}} | {:error, term()}
-  defp maybe_retry_on_default_cluster(%Backend{} = backend, statement, params, label, error) do
+  defp maybe_retry_on_default_cluster(
+         %Backend{} = backend,
+         statement,
+         params,
+         label,
+         settings,
+         error
+       ) do
     default = default_read_cluster_label(backend)
 
     if is_non_empty_binary(default) and default != label do
@@ -623,7 +641,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
         default_read_cluster: default
       )
 
-      do_ch_query_on_label(backend, statement, params, default)
+      do_ch_query_on_label(backend, statement, params, default, settings)
     else
       error
     end
@@ -1138,6 +1156,23 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       error -> error
     end
   end
+
+  # Mirrors the BigQuery adaptor, which caps endpoint results via `maxResults`.
+  # `result_overflow_mode: "break"` truncates instead of raising; ClickHouse stops on
+  # block boundaries, so slightly more than `max_result_rows` can come back.
+  @spec put_endpoint_row_cap(Keyword.t(), term()) :: Keyword.t()
+  defp put_endpoint_row_cap(opts, %{max_limit: max_limit})
+       when is_list(opts) and is_integer(max_limit) and max_limit > 0 do
+    settings =
+      opts
+      |> Keyword.get(:settings, [])
+      |> Keyword.put_new(:max_result_rows, max_limit)
+      |> Keyword.put_new(:result_overflow_mode, "break")
+
+    Keyword.put(opts, :settings, settings)
+  end
+
+  defp put_endpoint_row_cap(opts, _endpoint_query) when is_list(opts), do: opts
 
   @spec convert_query_params(sql_statement :: String.t(), allowed_params :: [String.t()]) ::
           String.t()

--- a/lib/logflare/sql/dialect_transformer/clickhouse.ex
+++ b/lib/logflare/sql/dialect_transformer/clickhouse.ex
@@ -5,6 +5,7 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouse do
 
   @behaviour Logflare.Sql.DialectTransformer
 
+  alias Logflare.Sql.Parser
   alias Logflare.User
 
   @impl true
@@ -15,6 +16,43 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouse do
 
   @impl true
   def transform_source_name(source_name, _data), do: source_name
+
+  @doc """
+  Applies an exact upper bound to the top-level result while preserving any
+  existing, stricter limit and offset.
+  """
+  @spec apply_limit(String.t(), pos_integer()) :: {:ok, String.t()} | {:error, String.t()}
+  def apply_limit(query, max_rows)
+      when is_binary(query) and is_integer(max_rows) and max_rows > 0 do
+    with {:ok, [%{"Query" => query_ast} = statement]} <- Parser.parse(dialect(), query),
+         {:ok, limit} <- build_limit(query_ast["limit"], max_rows) do
+      statement
+      |> put_in(["Query", "limit"], limit)
+      |> then(&Parser.to_string([&1]))
+    else
+      {:ok, _statements} -> {:error, "Expected one ClickHouse query"}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp build_limit(nil, max_rows), do: parse_limit("SELECT 1 LIMIT #{max_rows}")
+
+  defp build_limit(existing_limit, max_rows) do
+    with {:ok, limit} <- parse_limit("SELECT 1 LIMIT least(1, #{max_rows})") do
+      limited =
+        update_in(limit, ["Function", "args", "List", "args"], fn [_placeholder, maximum] ->
+          [%{"Unnamed" => %{"Expr" => existing_limit}}, maximum]
+        end)
+
+      {:ok, limited}
+    end
+  end
+
+  defp parse_limit(query) do
+    with {:ok, [%{"Query" => %{"limit" => limit}}]} <- Parser.parse(dialect(), query) do
+      {:ok, limit}
+    end
+  end
 
   @doc """
   Builds transformation data for ClickHouse from a user and base data.

--- a/lib/logflare/sql/dialect_transformer/clickhouse.ex
+++ b/lib/logflare/sql/dialect_transformer/clickhouse.ex
@@ -5,6 +5,8 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouse do
 
   @behaviour Logflare.Sql.DialectTransformer
 
+  import Logflare.Utils.Guards, only: [is_non_empty_binary: 1, is_pos_integer: 1]
+
   alias Logflare.Sql.Parser
   alias Logflare.User
 
@@ -23,15 +25,63 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouse do
   """
   @spec apply_limit(String.t(), pos_integer()) :: {:ok, String.t()} | {:error, String.t()}
   def apply_limit(query, max_rows)
-      when is_binary(query) and is_integer(max_rows) and max_rows > 0 do
-    with {:ok, [%{"Query" => query_ast} = statement]} <- Parser.parse(dialect(), query),
-         {:ok, limit} <- build_limit(query_ast["limit"], max_rows) do
-      statement
-      |> put_in(["Query", "limit"], limit)
-      |> then(&Parser.to_string([&1]))
+      when is_non_empty_binary(query) and is_pos_integer(max_rows) do
+    with {:ok, statements} <- Parser.parse(dialect(), query) do
+      apply_limit_to_statements(statements, query, max_rows)
+    end
+  end
+
+  defp apply_limit_to_statements(
+         [%{"Query" => query_ast} = statement],
+         _query,
+         max_rows
+       ) do
+    if requires_outer_limit?(query_ast) do
+      wrap_with_limit(statement, max_rows)
     else
-      {:ok, _statements} -> {:error, "Expected one ClickHouse query"}
-      {:error, _reason} = error -> error
+      with {:ok, limit} <- build_limit(query_ast["limit"], max_rows) do
+        statement
+        |> put_in(["Query", "limit"], limit)
+        |> Parser.to_string()
+      end
+    end
+  end
+
+  # Endpoint validation admits EXPLAIN in addition to Query statements. Preserve
+  # it and let the adaptor's decoded-row cap provide the fallback bound.
+  defp apply_limit_to_statements([%{"Explain" => _explain}], query, _max_rows),
+    do: {:ok, query}
+
+  defp apply_limit_to_statements(_statements, _query, _max_rows),
+    do: {:error, "Expected one ClickHouse query"}
+
+  # LIMIT BY is per group, while negative, fractional, and arbitrary expressions
+  # do not have ordinary row-count semantics. Cap their completed result from an
+  # outer query instead of comparing the original expression numerically.
+  defp requires_outer_limit?(%{"limit_by" => [_ | _]}), do: true
+  defp requires_outer_limit?(%{"limit" => nil}), do: false
+
+  defp requires_outer_limit?(%{
+         "limit" => %{"Value" => %{"Number" => [value, _long]}}
+       }) do
+    case Integer.parse(value) do
+      {_integer, ""} -> false
+      _other -> true
+    end
+  end
+
+  defp requires_outer_limit?(_query_ast), do: true
+
+  defp wrap_with_limit(%{"Query" => query_ast} = statement, max_rows) do
+    format_clause = query_ast["format_clause"]
+    statement = put_in(statement, ["Query", "format_clause"], nil)
+
+    with {:ok, inner_query} <- Parser.to_string(statement),
+         {:ok, [%{"Query" => outer_query} = outer_statement]} <-
+           Parser.parse(dialect(), "SELECT * FROM (#{inner_query}) LIMIT #{max_rows}") do
+      outer_statement
+      |> put_in(["Query", "format_clause"], format_clause || outer_query["format_clause"])
+      |> Parser.to_string()
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -781,7 +781,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
         )
 
       start_supervised!({ClickHouseAdaptor, backend})
-      stub_read_cluster_connection_error(backend, "api")
+      stub_read_cluster_connection_error(backend, "api", self())
 
       assert {:ok, %QueryResult{rows: rows}} =
                ClickHouseAdaptor.execute_query(
@@ -791,6 +791,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
                )
 
       assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+
+      assert_receive {:ch_query, _api_pool,
+                      "SELECT number FROM numbers(100) ORDER BY number LIMIT 10"}
+
+      assert_receive {:ch_query, _default_pool,
+                      "SELECT number FROM numbers(100) ORDER BY number LIMIT 10"}
+
       assert ConnectionManager.pool_active?(backend, "dashboard_logs")
     end
 
@@ -1377,8 +1384,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert {:ok, %QueryResult{rows: [%{"param_result" => "hello"}]}} = result
     end
 
-    test "enforces an endpoint max_limit exactly", %{backend: backend} do
+    test "enforces an endpoint max_limit exactly in the submitted SQL", %{backend: backend} do
       query = "SELECT number FROM numbers(100) ORDER BY number"
+      parent = self()
+
+      expect(Ch, :query, fn pool, statement, params, opts ->
+        send(parent, {:submitted_sql, IO.iodata_to_binary(statement)})
+        Mimic.call_original(Ch, :query, [pool, statement, params, opts])
+      end)
 
       assert {:ok, %QueryResult{rows: rows}} =
                ClickHouseAdaptor.execute_query(
@@ -1387,7 +1400,36 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
                  []
                )
 
+      assert_received {:submitted_sql, "SELECT number FROM numbers(100) ORDER BY number LIMIT 10"}
+
       assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+    end
+
+    test "truncates decoded rows as a fallback", %{backend: backend} do
+      data = [
+        Ch.RowBinary.encode_names_and_types(["number"], ["UInt64"]),
+        Ch.RowBinary.encode_rows(Enum.map(0..9, &[&1]), ["UInt64"])
+      ]
+
+      expect(Ch, :query, fn _pool, statement, _params, _opts ->
+        assert IO.iodata_to_binary(statement) ==
+                 "SELECT number FROM numbers(10) ORDER BY number LIMIT 3"
+
+        {:ok,
+         %Ch.Result{
+           headers: [{"x-clickhouse-format", "RowBinaryWithNamesAndTypes"}],
+           data: data
+         }}
+      end)
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args("SELECT number FROM numbers(10) ORDER BY number", 3),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == [0, 1, 2]
     end
 
     test "returns all endpoint rows when fewer than max_limit are available", %{backend: backend} do
@@ -1425,6 +1467,53 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
                )
 
       assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+    end
+
+    test "caps endpoint LIMIT BY results globally", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT 1 BY number"
+
+      assert_endpoint_query(
+        backend,
+        query,
+        3,
+        "SELECT * FROM (#{query}) LIMIT 3",
+        [0, 1, 2]
+      )
+    end
+
+    test "caps negative endpoint limits after selecting from the end", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT -50"
+
+      assert_endpoint_query(
+        backend,
+        query,
+        10,
+        "SELECT * FROM (#{query}) LIMIT 10",
+        Enum.to_list(50..59)
+      )
+    end
+
+    test "caps fractional endpoint limits", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT 0.5"
+
+      assert_endpoint_query(
+        backend,
+        query,
+        10,
+        "SELECT * FROM (#{query}) LIMIT 10",
+        Enum.to_list(0..9)
+      )
+    end
+
+    test "preserves supported non-query endpoint statements", %{backend: backend} do
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args("EXPLAIN SELECT 1", 10),
+                 []
+               )
+
+      assert rows != []
     end
 
     test "limits endpoint groups after computing aggregates", %{backend: backend} do
@@ -1916,12 +2005,35 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  defp assert_endpoint_query(backend, query, max_limit, expected_sql, expected_numbers) do
+    parent = self()
+
+    expect(Ch, :query, fn pool, statement, params, opts ->
+      send(parent, {:submitted_sql, IO.iodata_to_binary(statement)})
+      Mimic.call_original(Ch, :query, [pool, statement, params, opts])
+    end)
+
+    assert {:ok, %QueryResult{rows: rows}} =
+             ClickHouseAdaptor.execute_query(
+               backend,
+               endpoint_query_args(query, max_limit),
+               []
+             )
+
+    assert_received {:submitted_sql, ^expected_sql}
+    assert Enum.map(rows, & &1["number"]) == expected_numbers
+  end
+
   defp endpoint_query_args(query, max_limit, declared_params \\ [], input_params \\ %{}) do
     {query, declared_params, input_params, %EndpointQuery{max_limit: max_limit}}
   end
 
-  defp stub_read_cluster_connection_error(%Backend{id: backend_id}, label) do
+  defp stub_read_cluster_connection_error(%Backend{id: backend_id}, label, notify \\ nil) do
     stub(Ch, :query, fn pool, statement, params, opts ->
+      if is_pid(notify) do
+        send(notify, {:ch_query, pool, IO.iodata_to_binary(statement)})
+      end
+
       case pool do
         {:via, Registry, {_registry, {_mod, ^backend_id, ^label}}} ->
           {:error, %DBConnection.ConnectionError{message: "unreachable"}}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -15,6 +15,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.QueryError
+  alias Logflare.Endpoints.EndpointQuery
   alias Logflare.LogEvent
   alias Logflare.Lql.BackendTransformer.ClickHouse, as: ClickHouseLQLTransformer
   alias Logflare.Lql.Rules.FilterRule
@@ -767,6 +768,32 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert ConnectionManager.pool_active?(backend, "dashboard_logs")
     end
 
+    test "preserves the endpoint limit when falling back to the default cluster" do
+      {_source, backend} =
+        setup_clickhouse_test(
+          config: %{
+            read_only_urls: %{
+              "api" => "http://localhost:8123",
+              "dashboard_logs" => "http://localhost:8123"
+            },
+            default_read_cluster: "dashboard_logs"
+          }
+        )
+
+      start_supervised!({ClickHouseAdaptor, backend})
+      stub_read_cluster_connection_error(backend, "api")
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args("SELECT number FROM numbers(100) ORDER BY number", 10),
+                 read_cluster: "api"
+               )
+
+      assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+      assert ConnectionManager.pool_active?(backend, "dashboard_logs")
+    end
+
     test "does not fall back when the unhealthy cluster is already the default" do
       {_source, backend} =
         setup_clickhouse_test(
@@ -1350,6 +1377,122 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert {:ok, %QueryResult{rows: [%{"param_result" => "hello"}]}} = result
     end
 
+    test "enforces an endpoint max_limit exactly", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number"
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+    end
+
+    test "returns all endpoint rows when fewer than max_limit are available", %{backend: backend} do
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args("SELECT number FROM numbers(3) ORDER BY number", 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == [0, 1, 2]
+    end
+
+    test "preserves a stricter endpoint limit and offset", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT 5 OFFSET 2"
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == Enum.to_list(2..6)
+    end
+
+    test "caps an endpoint limit larger than max_limit", %{backend: backend} do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT 50"
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+    end
+
+    test "limits endpoint groups after computing aggregates", %{backend: backend} do
+      query = """
+      SELECT number % 20 AS bucket, count() AS total
+      FROM numbers(100)
+      GROUP BY bucket
+      ORDER BY bucket
+      """
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["bucket"]) == Enum.to_list(0..9)
+      assert Enum.all?(rows, &(&1["total"] == 5))
+    end
+
+    test "limits endpoint CTE and UNION results", %{backend: backend} do
+      query = """
+      WITH query_rows AS (SELECT number FROM numbers(20))
+      SELECT number FROM query_rows
+      UNION ALL
+      SELECT number + 20 AS number FROM query_rows
+      ORDER BY number
+      """
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 10),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == Enum.to_list(0..9)
+    end
+
+    test "limits parameterized endpoint queries", %{backend: backend} do
+      args =
+        endpoint_query_args(
+          "SELECT @test_value AS value FROM numbers(20)",
+          3,
+          ["test_value"],
+          %{"test_value" => "hello"}
+        )
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(backend, args, [])
+
+      assert rows == List.duplicate(%{"value" => "hello"}, 3)
+    end
+
+    test "limits endpoint queries with allowed query-level settings", %{backend: backend} do
+      query = "SELECT number FROM numbers(20) ORDER BY number SETTINGS max_threads = 1"
+
+      assert {:ok, %QueryResult{rows: rows}} =
+               ClickHouseAdaptor.execute_query(
+                 backend,
+                 endpoint_query_args(query, 3),
+                 []
+               )
+
+      assert Enum.map(rows, & &1["number"]) == [0, 1, 2]
+    end
+
     test "handles query errors gracefully", %{backend: backend} do
       result = ClickHouseAdaptor.execute_query(backend, "INVALID SQL SYNTAX", [])
 
@@ -1771,6 +1914,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       assert ClickHouseAdaptor.resolve_pipeline_count(state, []) == 1
     end
+  end
+
+  defp endpoint_query_args(query, max_limit, declared_params \\ [], input_params \\ %{}) do
+    {query, declared_params, input_params, %EndpointQuery{max_limit: max_limit}}
   end
 
   defp stub_read_cluster_connection_error(%Backend{id: backend_id}, label) do

--- a/test/logflare/sql/dialect_transformer/clickhouse_test.exs
+++ b/test/logflare/sql/dialect_transformer/clickhouse_test.exs
@@ -42,6 +42,54 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouseTest do
                ClickHouse.apply_limit("SELECT number FROM numbers(100) LIMIT 50", 10)
     end
 
+    test "adds a global limit after LIMIT BY" do
+      query = "SELECT number FROM numbers(100) LIMIT 1 BY number"
+
+      assert {:ok, "SELECT * FROM (SELECT number FROM numbers(100) LIMIT 1 BY number) LIMIT 3"} =
+               ClickHouse.apply_limit(query, 3)
+    end
+
+    test "caps negative limits after applying their end-relative semantics" do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT -50"
+
+      assert {:ok,
+              "SELECT * FROM (SELECT number FROM numbers(100) ORDER BY number LIMIT -50) LIMIT 10"} =
+               ClickHouse.apply_limit(query, 10)
+    end
+
+    test "caps fractional limits after applying their proportional semantics" do
+      query = "SELECT number FROM numbers(100) ORDER BY number LIMIT 0.5"
+
+      assert {:ok,
+              "SELECT * FROM (SELECT number FROM numbers(100) ORDER BY number LIMIT 0.5) LIMIT 10"} =
+               ClickHouse.apply_limit(query, 10)
+    end
+
+    test "caps arbitrary limit expressions after evaluating them" do
+      query = "SELECT number FROM numbers(100) LIMIT least(50, 100)"
+
+      assert {:ok,
+              "SELECT * FROM (SELECT number FROM numbers(100) LIMIT least(50, 100)) LIMIT 10"} =
+               ClickHouse.apply_limit(query, 10)
+    end
+
+    test "preserves a single read-only non-query statement" do
+      assert {:ok, "EXPLAIN SELECT 1"} = ClickHouse.apply_limit("EXPLAIN SELECT 1", 10)
+    end
+
+    test "rejects a single mutating non-query statement" do
+      assert {:error, "Expected one ClickHouse query"} =
+               ClickHouse.apply_limit("OPTIMIZE TABLE foo FINAL", 10)
+    end
+
+    test "moves a format clause outside the wrapping limit" do
+      query = "SELECT number FROM numbers(100) LIMIT -50 FORMAT JSONEachRow"
+
+      assert {:ok,
+              "SELECT * FROM (SELECT number FROM numbers(100) LIMIT -50) LIMIT 10 FORMAT JSONEachRow"} =
+               ClickHouse.apply_limit(query, 10)
+    end
+
     test "places the limit before query-level settings" do
       assert {:ok, "SELECT number FROM numbers(100) LIMIT 10 SETTINGS max_threads = 1"} =
                ClickHouse.apply_limit(

--- a/test/logflare/sql/dialect_transformer/clickhouse_test.exs
+++ b/test/logflare/sql/dialect_transformer/clickhouse_test.exs
@@ -23,6 +23,39 @@ defmodule Logflare.Sql.DialectTransformer.ClickHouseTest do
     end
   end
 
+  describe "apply_limit/2" do
+    test "adds a top-level limit" do
+      assert {:ok, "SELECT number FROM numbers(100) LIMIT 10"} =
+               ClickHouse.apply_limit("SELECT number FROM numbers(100)", 10)
+    end
+
+    test "preserves a stricter existing limit and its offset" do
+      assert {:ok, "SELECT number FROM numbers(100) LIMIT least(5, 10) OFFSET 2"} =
+               ClickHouse.apply_limit(
+                 "SELECT number FROM numbers(100) LIMIT 5 OFFSET 2",
+                 10
+               )
+    end
+
+    test "caps a larger existing limit" do
+      assert {:ok, "SELECT number FROM numbers(100) LIMIT least(50, 10)"} =
+               ClickHouse.apply_limit("SELECT number FROM numbers(100) LIMIT 50", 10)
+    end
+
+    test "places the limit before query-level settings" do
+      assert {:ok, "SELECT number FROM numbers(100) LIMIT 10 SETTINGS max_threads = 1"} =
+               ClickHouse.apply_limit(
+                 "SELECT number FROM numbers(100) SETTINGS max_threads = 1",
+                 10
+               )
+    end
+
+    test "rejects multiple statements" do
+      assert {:error, "Expected one ClickHouse query"} =
+               ClickHouse.apply_limit("SELECT 1; SELECT 2", 10)
+    end
+  end
+
   describe "build_transformation_data/2" do
     test "passes through base data unchanged" do
       user = insert(:user)


### PR DESCRIPTION
## Problem

Endpoint queries carry a `max_limit` (default `1_000`, maximum `10_000`). The BigQuery adaptor honours it through `maxResults`, but the ClickHouse adaptor discarded the endpoint query:

```elixir
{query_string, declared_params, input_params, _endpoint_query}
```

ClickHouse-backed endpoints could therefore return and decode more rows than their configured maximum.

## Change

Apply `max_limit` as an exact top-level ClickHouse `LIMIT` using the existing SQL parser and AST.

For queries without a limit, the adaptor adds one:

```sql
SELECT ...
LIMIT 1000
```

For queries with an existing limit, it preserves the stricter value:

```sql
LIMIT least(existing_limit, endpoint_max_limit)
```

Existing offsets are preserved. The limited SQL is also reused during read-cluster failover.

As defense in depth, the adaptor applies `Enum.take/2` to decoded rows before constructing the endpoint result.

This affects only endpoint queries with a positive integer `max_limit`. Non-endpoint ClickHouse queries are unchanged.

## Coverage

Regression coverage includes:

- exact endpoint limits
- result sets smaller than the configured maximum
- stricter and larger existing limits
- offsets and ordering
- aggregates and `GROUP BY`
- CTE and `UNION` queries
- parameterized queries
- allowed query-level settings
- read-cluster failover

## Verification

- 123 affected tests pass
- formatting passes
- clean test compilation passes
- `mix lint.all` passes
- Elixir CI passes
- Playwright CI passes

## Why

This closes a behavioral gap between the BigQuery and ClickHouse endpoint adaptors. It was identified while investigating memory pressure in the query endpoint path, but this PR does not add ClickHouse execution, memory, byte, or scan limits; those can be enforced separately through database-user settings.
