### PR TITLE
fix: expose graceful shutdown readiness

### DIFF
--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -61,6 +61,8 @@ Additional environment variable configurations for the OpenTelemetry libraries u
 
 Logflare has a health check endpoint `/health`, which is used to ensure that the system is functioning correctly with sufficient resources for normal functions.
 
+Use `/ready` for readiness probes. It performs the health checks and returns `503` as soon as graceful shutdown begins so load balancers can stop routing new traffic to the instance.
+
 Environment variables that influence the logic are prefixed with `LOGFLARE_HEALTH_*`. Refer to above table for customizing the values.
 
 #### Metadata

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -18,6 +18,8 @@ defmodule Logflare.Application do
   alias Logflare.Utils
 
   def start(_type, _args) do
+    Logflare.Readiness.mark_unready()
+
     # set inspect function to redact sensitive information
     prev = Inspect.Opts.default_inspect_fun()
     Inspect.Opts.default_inspect_fun(&Utils.inspect_fun(prev, &1, &2))
@@ -48,7 +50,11 @@ defmodule Logflare.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Logflare.Supervisor]
-    Supervisor.start_link(children, opts)
+
+    with {:ok, supervisor} <- Supervisor.start_link(children, opts) do
+      Logflare.Readiness.mark_ready()
+      {:ok, supervisor}
+    end
   end
 
   defp get_children(:test) do
@@ -196,6 +202,11 @@ defmodule Logflare.Application do
       end
 
     goth ++ config_cat
+  end
+
+  def prep_stop(state) do
+    Logflare.Readiness.mark_unready()
+    state
   end
 
   def config_change(changed, _new, removed) do

--- a/lib/logflare/application.ex
+++ b/lib/logflare/application.ex
@@ -18,7 +18,7 @@ defmodule Logflare.Application do
   alias Logflare.Utils
 
   def start(_type, _args) do
-    Logflare.Readiness.mark_unready()
+    Logflare.Readiness.initialize()
 
     # set inspect function to redact sensitive information
     prev = Inspect.Opts.default_inspect_fun()
@@ -205,7 +205,7 @@ defmodule Logflare.Application do
   end
 
   def prep_stop(state) do
-    Logflare.Readiness.mark_unready()
+    Logflare.Readiness.begin_draining()
     state
   end
 

--- a/lib/logflare/readiness.ex
+++ b/lib/logflare/readiness.ex
@@ -1,0 +1,19 @@
+defmodule Logflare.Readiness do
+  @moduledoc """
+  Tracks whether this node should receive traffic.
+
+  Readiness is stored outside the application supervision tree so signal handling
+  can mark the node unready before the supervised processes begin shutting down.
+  """
+
+  @key {__MODULE__, :ready?}
+
+  @spec ready?() :: boolean()
+  def ready?, do: :persistent_term.get(@key, false)
+
+  @spec mark_ready() :: :ok
+  def mark_ready, do: :persistent_term.put(@key, true)
+
+  @spec mark_unready() :: :ok
+  def mark_unready, do: :persistent_term.put(@key, false)
+end

--- a/lib/logflare/readiness.ex
+++ b/lib/logflare/readiness.ex
@@ -3,17 +3,47 @@ defmodule Logflare.Readiness do
   Tracks whether this node should receive traffic.
 
   Readiness is stored outside the application supervision tree so signal handling
-  can mark the node unready before the supervised processes begin shutting down.
+  can begin draining before the supervised processes shut down. Draining is a
+  terminal state for an application lifecycle, so startup cannot make a draining
+  node ready again.
   """
 
-  @key {__MODULE__, :ready?}
+  @key {__MODULE__, :state}
+  @starting 0
+  @ready 1
+  @draining 2
+
+  @spec initialize() :: :ok
+  def initialize do
+    state = :atomics.new(1, signed: false)
+    :persistent_term.put(@key, state)
+  end
 
   @spec ready?() :: boolean()
-  def ready?, do: :persistent_term.get(@key, false)
+  def ready? do
+    case :persistent_term.get(@key, nil) do
+      nil -> false
+      state -> :atomics.get(state, 1) == @ready
+    end
+  end
 
   @spec mark_ready() :: :ok
-  def mark_ready, do: :persistent_term.put(@key, true)
+  def mark_ready do
+    case :persistent_term.get(@key, nil) do
+      nil ->
+        :ok
 
-  @spec mark_unready() :: :ok
-  def mark_unready, do: :persistent_term.put(@key, false)
+      state ->
+        _previous_state = :atomics.compare_exchange(state, 1, @starting, @ready)
+        :ok
+    end
+  end
+
+  @spec begin_draining() :: :ok
+  def begin_draining do
+    case :persistent_term.get(@key, nil) do
+      nil -> :ok
+      state -> :atomics.put(state, 1, @draining)
+    end
+  end
 end

--- a/lib/logflare_web/controllers/health_check_controller.ex
+++ b/lib/logflare_web/controllers/health_check_controller.ex
@@ -3,9 +3,22 @@ defmodule LogflareWeb.HealthCheckController do
 
   alias Logflare.JSON
   alias Logflare.Cluster
+  alias Logflare.Readiness
   alias Logflare.SingleTenant
   alias Logflare.Sources
   alias Logflare.System
+
+  def ready(conn, params) do
+    if Readiness.ready?() do
+      check(conn, params)
+    else
+      response = JSON.encode!(%{status: :not_ready})
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(503, response)
+    end
+  end
 
   def check(conn, _params) do
     repo_uptime = Logflare.Repo.get_uptime()

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -442,6 +442,11 @@ defmodule LogflareWeb.Router do
     get("/", HealthCheckController, :check)
   end
 
+  scope "/ready", LogflareWeb do
+    pipe_through(:api)
+    get("/", HealthCheckController, :ready)
+  end
+
   # Account management API.
   scope "/api", LogflareWeb do
     pipe_through([:api, :require_mgmt_api_auth])

--- a/lib/sig_term_handler.ex
+++ b/lib/sig_term_handler.ex
@@ -26,7 +26,7 @@ defmodule Logflare.SigtermHandler do
 
   @impl true
   def handle_event(:sigterm, state) do
-    Readiness.mark_unready()
+    Readiness.begin_draining()
 
     Logger.warning(
       "#{__MODULE__}: SIGTERM received: waiting for #{env_grace_period() / 1_000} seconds"
@@ -41,7 +41,7 @@ defmodule Logflare.SigtermHandler do
   end
 
   def handle_event(:sigquit, state) do
-    Readiness.mark_unready()
+    Readiness.begin_draining()
 
     Logger.warning(
       "#{__MODULE__}: SIGQUIT received: waiting for #{env_grace_period() / 1_000} seconds"

--- a/lib/sig_term_handler.ex
+++ b/lib/sig_term_handler.ex
@@ -3,6 +3,8 @@ defmodule Logflare.SigtermHandler do
   @behaviour :gen_event
   require Logger
 
+  alias Logflare.Readiness
+
   defp env_grace_period,
     do:
       Application.get_env(:logflare, :sigterm_shutdown_grace_period_ms) ||
@@ -24,6 +26,8 @@ defmodule Logflare.SigtermHandler do
 
   @impl true
   def handle_event(:sigterm, state) do
+    Readiness.mark_unready()
+
     Logger.warning(
       "#{__MODULE__}: SIGTERM received: waiting for #{env_grace_period() / 1_000} seconds"
     )
@@ -37,6 +41,8 @@ defmodule Logflare.SigtermHandler do
   end
 
   def handle_event(:sigquit, state) do
+    Readiness.mark_unready()
+
     Logger.warning(
       "#{__MODULE__}: SIGQUIT received: waiting for #{env_grace_period() / 1_000} seconds"
     )

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -9,6 +9,9 @@ defmodule LogflareWeb.HealthCheckControllerTest do
   alias Logflare.Sources.Source
 
   setup do
+    reset_readiness()
+    on_exit(&reset_readiness/0)
+
     Logflare.Google.BigQuery
     |> stub(:init_table!, fn _, _, _, _, _, _ -> :ok end)
 
@@ -39,10 +42,12 @@ defmodule LogflareWeb.HealthCheckControllerTest do
   end
 
   test "readiness check while draining", %{conn: conn} do
-    on_exit(&Readiness.mark_ready/0)
-    Readiness.mark_unready()
+    start_supervised!(Source.Supervisor)
+    :timer.sleep(1000)
+    Readiness.begin_draining()
 
     assert %{"status" => "not_ready"} = conn |> get("/ready") |> json_response(503)
+    assert %{"status" => "ok"} = conn |> get("/health") |> json_response(200)
   end
 
   test "memory check", %{conn: conn} do
@@ -78,6 +83,11 @@ defmodule LogflareWeb.HealthCheckControllerTest do
 
       assert %{"status" => "coming_up"} = conn |> get("/ready") |> json_response(503)
     end
+  end
+
+  defp reset_readiness do
+    Readiness.initialize()
+    Readiness.mark_ready()
   end
 
   describe "Supabase mode - with seed" do

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -3,6 +3,8 @@ defmodule LogflareWeb.HealthCheckControllerTest do
   For node-level health check only.
   """
   use LogflareWeb.ConnCase
+
+  alias Logflare.Readiness
   alias Logflare.SingleTenant
   alias Logflare.Sources.Source
 
@@ -27,6 +29,20 @@ defmodule LogflareWeb.HealthCheckControllerTest do
                "Elixir.Logflare.Auth.Cache" => "ok"
              }
            } = json_response(conn, 200)
+  end
+
+  test "readiness check", %{conn: conn} do
+    start_supervised!(Source.Supervisor)
+    :timer.sleep(1000)
+
+    assert %{"status" => "ok"} = conn |> get("/ready") |> json_response(200)
+  end
+
+  test "readiness check while draining", %{conn: conn} do
+    on_exit(&Readiness.mark_ready/0)
+    Readiness.mark_unready()
+
+    assert %{"status" => "not_ready"} = conn |> get("/ready") |> json_response(503)
   end
 
   test "memory check", %{conn: conn} do

--- a/test/logflare_web/controllers/health_check_controller_test.exs
+++ b/test/logflare_web/controllers/health_check_controller_test.exs
@@ -72,6 +72,12 @@ defmodule LogflareWeb.HealthCheckControllerTest do
     test "not ok", %{conn: conn} do
       assert %{"status" => "coming_up"} = conn |> get("/health") |> json_response(503)
     end
+
+    test "not ready even when the application is accepting traffic", %{conn: conn} do
+      Readiness.mark_ready()
+
+      assert %{"status" => "coming_up"} = conn |> get("/ready") |> json_response(503)
+    end
   end
 
   describe "Supabase mode - with seed" do

--- a/test/sig_term_handler_test.exs
+++ b/test/sig_term_handler_test.exs
@@ -6,8 +6,8 @@ defmodule Logflare.SigtermHandlerTest do
   alias Logflare.SigtermHandler
 
   setup do
-    Readiness.mark_ready()
-    on_exit(&Readiness.mark_ready/0)
+    reset_readiness()
+    on_exit(&reset_readiness/0)
   end
 
   test "marks the node unready immediately after SIGTERM" do
@@ -25,5 +25,17 @@ defmodule Logflare.SigtermHandlerTest do
 
     assert Application.prep_stop(state) == state
     refute Readiness.ready?()
+  end
+
+  test "cannot become ready after shutdown begins" do
+    Readiness.begin_draining()
+    Readiness.mark_ready()
+
+    refute Readiness.ready?()
+  end
+
+  defp reset_readiness do
+    Readiness.initialize()
+    Readiness.mark_ready()
   end
 end

--- a/test/sig_term_handler_test.exs
+++ b/test/sig_term_handler_test.exs
@@ -1,0 +1,29 @@
+defmodule Logflare.SigtermHandlerTest do
+  use ExUnit.Case, async: false
+
+  alias Logflare.Application
+  alias Logflare.Readiness
+  alias Logflare.SigtermHandler
+
+  setup do
+    Readiness.mark_ready()
+    on_exit(&Readiness.mark_ready/0)
+  end
+
+  test "marks the node unready immediately after SIGTERM" do
+    assert {:ok, %{}} = SigtermHandler.handle_event(:sigterm, %{})
+    refute Readiness.ready?()
+  end
+
+  test "marks the node unready immediately after SIGQUIT" do
+    assert {:ok, %{}} = SigtermHandler.handle_event(:sigquit, %{})
+    refute Readiness.ready?()
+  end
+
+  test "marks the node unready before application shutdown" do
+    state = %{test: :state}
+
+    assert Application.prep_stop(state) == state
+    refute Readiness.ready?()
+  end
+end


### PR DESCRIPTION
## Why

Logflare currently waits 15 seconds after receiving `SIGTERM` before stopping, but `/health` continues to return `200` during that grace period. When `/health` is used as the Kubernetes readiness probe, the pod can continue receiving new traffic while it is terminating.

A dedicated readiness endpoint lets Kubernetes remove a terminating pod from service immediately while still allowing Logflare's existing grace period to complete in-flight work.

## What changed

- expose `/ready` as a health-gated readiness endpoint
- mark nodes unready immediately when `SIGTERM`, `SIGQUIT`, or OTP application shutdown begins
- retain the existing `/health` behavior for node health checks
- document readiness probe behavior and cover health gating and shutdown transitions with tests

Readiness is defined as the application accepting traffic **and** the existing health checks passing. Nonessential asynchronous startup work does not hold the pod unready.
