### PR TITLE
fix: incidentio dedup-key as a min 3 hour window

### DIFF
--- a/docs/docs.logflare.com/docs/backends/incidentio/index.mdx
+++ b/docs/docs.logflare.com/docs/backends/incidentio/index.mdx
@@ -43,7 +43,7 @@ Alert events are sent to the Incident.io HTTP Alert Events endpoint at `https://
 
 The backend automatically handles:
 
-- **Deduplication**: Uses a hash of the batch data combined with the current minute for deduplication keys. The deduplication key is a combination of the data sent and the current minute.
+- **Deduplication**: Uses the alert title combined with the current 3-hour time window for deduplication keys, so repeated firings of the same alert within a window are deduplicated by incident.io regardless of the batch data sent.
 - **Metadata merging**: Combines configured metadata with the actual alert data. See [Metadata management](#metadata-management).
 - **Status management**: Sets alert event status to "firing".
 

--- a/lib/logflare/backends/adaptor/incidentio_adaptor.ex
+++ b/lib/logflare/backends/adaptor/incidentio_adaptor.ex
@@ -30,6 +30,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptor do
       |> Map.put(:source_url, url(~p"/alerts/#{alert_query.id}"))
       |> Map.put(:title, alert_query.name)
       |> Map.put(:description, alert_query.description)
+      |> Map.put(:alert_query_id, alert_query.id)
 
     updated_backend = %{backend | config: updated_config}
 
@@ -51,13 +52,14 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptor do
       end)
 
     alert_name = Map.get(config, :title, "unknown")
+    alert_query_id = Map.get(config, :alert_query_id, "unknown")
     window = div(DateTime.to_unix(DateTime.utc_now()), 3 * 60 * 60)
 
     metadata = Map.get(config, :metadata, %{})
     merged_metadata = Map.merge(metadata, %{"data" => batch})
 
     %{
-      "deduplication_key" => "#{alert_name}-#{window}",
+      "deduplication_key" => "#{alert_query_id}-#{alert_name}-#{window}",
       "description" => Map.get(config, :description),
       "metadata" => merged_metadata,
       "source_url" => Map.get(config, :source_url),

--- a/lib/logflare/backends/adaptor/incidentio_adaptor.ex
+++ b/lib/logflare/backends/adaptor/incidentio_adaptor.ex
@@ -51,15 +51,15 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptor do
         other -> other
       end)
 
-    alert_name = Map.get(config, :title, "unknown")
     alert_query_id = Map.get(config, :alert_query_id, "unknown")
+    # for simplicity, we use unix epoch for window alignment
     window = div(DateTime.to_unix(DateTime.utc_now()), 3 * 60 * 60)
 
     metadata = Map.get(config, :metadata, %{})
     merged_metadata = Map.merge(metadata, %{"data" => batch})
 
     %{
-      "deduplication_key" => "#{alert_query_id}-#{alert_name}-#{window}",
+      "deduplication_key" => "#{alert_query_id}-#{window}",
       "description" => Map.get(config, :description),
       "metadata" => merged_metadata,
       "source_url" => Map.get(config, :source_url),

--- a/lib/logflare/backends/adaptor/incidentio_adaptor.ex
+++ b/lib/logflare/backends/adaptor/incidentio_adaptor.ex
@@ -50,14 +50,14 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptor do
         other -> other
       end)
 
-    now = DateTime.utc_now()
-    hash = :erlang.phash2(batch)
+    alert_name = Map.get(config, :title, "unknown")
+    window = div(DateTime.to_unix(DateTime.utc_now()), 3 * 60 * 60)
 
     metadata = Map.get(config, :metadata, %{})
     merged_metadata = Map.merge(metadata, %{"data" => batch})
 
     %{
-      "deduplication_key" => "#{hash}-#{now.minute}",
+      "deduplication_key" => "#{alert_name}-#{window}",
       "description" => Map.get(config, :description),
       "metadata" => merged_metadata,
       "source_url" => Map.get(config, :source_url),

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -152,8 +152,8 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
       # link to the backend
       assert alert_source_url =~ "/backends/"
       assert title =~ "events detected"
-      # no alert title is configured for raw log ingestion, so dedup key falls back to "unknown"
-      assert deduplication_key =~ ~r/^unknown-\d+$/
+      # no alert query is configured for raw log ingestion, so dedup key falls back to "unknown"
+      assert deduplication_key =~ ~r/^unknown-unknown-\d+$/
     end
   end
 
@@ -220,7 +220,8 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
       assert alert_source_url =~ "/alerts/"
       assert title =~ alert_query.name
       assert description =~ alert_query.description
-      assert deduplication_key =~ ~r/^#{Regex.escape(alert_query.name)}-\d+$/
+      assert deduplication_key =~
+               ~r/^#{alert_query.id}-#{Regex.escape(alert_query.name)}-\d+$/
     end
   end
 end

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -141,15 +141,19 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
       assert_receive payload, 2000
 
       assert %{
-               "title" => _,
+               "title" => title,
                "status" => "firing",
                "description" => _,
                "metadata" => %{"data" => [%{"event_message" => ^message}]},
-               "source_url" => alert_source_url
+               "source_url" => alert_source_url,
+               "deduplication_key" => deduplication_key
              } = payload
 
       # link to the backend
       assert alert_source_url =~ "/backends/"
+      assert title =~ "events detected"
+      # no alert title is configured for raw log ingestion, so dedup key falls back to "unknown"
+      assert deduplication_key =~ ~r/^unknown-\d+$/
     end
   end
 
@@ -208,13 +212,15 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
                "metadata" => %{
                  "data" => [%{"testing" => "123"}]
                },
-               "source_url" => alert_source_url
+               "source_url" => alert_source_url,
+               "deduplication_key" => deduplication_key
              } = payload
 
       # link to the alert
       assert alert_source_url =~ "/alerts/"
       assert title =~ alert_query.name
       assert description =~ alert_query.description
+      assert deduplication_key =~ ~r/^#{Regex.escape(alert_query.name)}-\d+$/
     end
   end
 end

--- a/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/incidentio_adaptor_test.exs
@@ -153,7 +153,7 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
       assert alert_source_url =~ "/backends/"
       assert title =~ "events detected"
       # no alert query is configured for raw log ingestion, so dedup key falls back to "unknown"
-      assert deduplication_key =~ ~r/^unknown-unknown-\d+$/
+      assert deduplication_key =~ ~r/^unknown-\d+$/
     end
   end
 
@@ -220,8 +220,8 @@ defmodule Logflare.Backends.Adaptor.IncidentioAdaptorTest do
       assert alert_source_url =~ "/alerts/"
       assert title =~ alert_query.name
       assert description =~ alert_query.description
-      assert deduplication_key =~
-               ~r/^#{alert_query.id}-#{Regex.escape(alert_query.name)}-\d+$/
+
+      assert deduplication_key =~ ~r/^#{alert_query.id}-\d+$/
     end
   end
 end


### PR DESCRIPTION
Remove minutely deduplication key in incidentio adaptor
Fixes the issue where an alert constantly pages due to the changing minute