### PR TITLE
test: stabilize recurring CI failures

### DIFF
--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -111,16 +111,20 @@ defmodule Logflare.Backends.UserMonitoringTest do
         backend: Logflare.Backends.Adaptor.BigQueryAdaptor
       }
 
-      assert capture_log(fn ->
-               QueryError.log(error,
-                 user_id: user.id,
-                 source_token: source.token
-               )
-             end) == ""
+      log =
+        capture_log(fn ->
+          QueryError.log(error,
+            user_id: user.id,
+            source_token: source.token
+          )
+        end)
+
+      refute log =~ "Backend query error"
+      refute log =~ "raw user query detail"
 
       refute Enum.any?(
                Backends.list_recent_logs(system_source),
-               &query_error_log_event?/1
+               &invalid_query_error_log_event?/1
              )
     end
 
@@ -153,6 +157,27 @@ defmodule Logflare.Backends.UserMonitoringTest do
   end
 
   defp query_error_log_event?(_event), do: false
+
+  defp invalid_query_error_log_event?(%{
+         body: %{
+           "metadata" => %{
+             "error_kind" => "invalid_query"
+           }
+         }
+       }),
+       do: true
+
+  defp invalid_query_error_log_event?(%{
+         body: %{
+           "metadata" => %{
+             "error_string" => error_string
+           }
+         }
+       })
+       when is_binary(error_string),
+       do: error_string =~ "raw user query detail"
+
+  defp invalid_query_error_log_event?(_event), do: false
 
   describe "system monitoring labels" do
     setup :start_otel_exporter

--- a/test/logflare/networking/grpc_channel_monitor_test.exs
+++ b/test/logflare/networking/grpc_channel_monitor_test.exs
@@ -33,10 +33,15 @@ defmodule Logflare.Networking.GrpcChannelMonitorTest do
 
     if Keyword.get(opts, :connect?, true) do
       assert_receive {:send_after, 0}
-      send(pid, :connect)
+      send_and_sync(pid, :connect)
     end
 
     pid
+  end
+
+  defp send_and_sync(pid, message) do
+    send(pid, message)
+    :sys.get_state(pid)
   end
 
   test "successful connect", %{
@@ -61,7 +66,7 @@ defmodule Logflare.Networking.GrpcChannelMonitorTest do
         {:error, :econnrefused}
       end)
 
-      send(pid, :connect)
+      send_and_sync(pid, :connect)
 
       assert_receive :connect_attempt
       expected_timeout = timeout * 1000
@@ -76,8 +81,8 @@ defmodule Logflare.Networking.GrpcChannelMonitorTest do
     pid = start_monitor(registry)
     assert_receive {:register, ^registry, 0, _partition, ^channel}
 
-    send(pid, :connect)
-    refute_receive {:register, ^registry, 0, _partition, _channel}
+    send_and_sync(pid, :connect)
+    refute_received {:register, ^registry, 0, _partition, _channel}
 
     assert [{^pid, ^channel}] = Registry.lookup(registry, 0)
   end
@@ -92,10 +97,9 @@ defmodule Logflare.Networking.GrpcChannelMonitorTest do
 
       pid = start_monitor(registry)
       allow(GRPC.Stub, self(), pid)
-      send(pid, :connect)
       assert_receive {:register, ^registry, 0, _partition, ^channel}
 
-      send(pid, {:elixir_grpc, :connection_down, channel.ref})
+      send_and_sync(pid, {:elixir_grpc, :connection_down, channel.ref})
 
       assert_receive {:unregister, ^registry, 0, _partition}
       assert_receive {:send_after, 0}
@@ -110,10 +114,9 @@ defmodule Logflare.Networking.GrpcChannelMonitorTest do
 
       pid = start_monitor(registry)
       allow(GRPC.Stub, self(), pid)
-      send(pid, :connect)
       assert_receive {:register, ^registry, 0, _partition, ^channel}
 
-      send(pid, {:elixir_grpc, :connection_down, channel.ref})
+      send_and_sync(pid, {:EXIT, self(), :closed})
 
       assert_receive {:unregister, ^registry, 0, _partition}
       assert_receive {:send_after, 0}

--- a/test/logflare_web/live_views/query_live_test.exs
+++ b/test/logflare_web/live_views/query_live_test.exs
@@ -121,18 +121,16 @@ defmodule LogflareWeb.QueryLiveTest do
     end
 
     test "shows backend adaptor error", %{conn: conn, user: user} do
-      source = insert(:source, user: user)
+      source = insert(:source, user: user, name: "query_live_backend_error")
 
       {source, backend} = Logflare.DataCase.setup_clickhouse_test(user: user, source: source)
 
       start_supervised!({ClickHouseAdaptor, backend})
 
-      {:ok, view, _html} = live_with_redirect(conn, "/query?backend_id=#{backend.id}")
+      query = ~s(select non_existent from "#{source.name}")
 
-      view
-      |> render_hook("parse-query", %{
-        value: ~s(select non_existent from "#{source.name}")
-      })
+      {:ok, view, _html} =
+        live_with_redirect(conn, ~p"/query?#{%{backend_id: backend.id, q: query}}")
 
       html =
         view


### PR DESCRIPTION
## Summary

- synchronize `GrpcChannelMonitorTest` with the GenServer mailbox instead of relying on 100 ms scheduling windows
- initialize the Query LiveView with the intended backend-error query before submitting it
- assert specifically that invalid-query errors are not logged or routed to user monitoring, while allowing unrelated background warnings

## Investigation

These failures recurred across unrelated Elixir CI runs, including all three attempts of run [31635682480](https://github.com/Logflare/logflare/actions/runs/31635682480). No distributed Erlang or `epmd` startup failures were found. The recurring failures were test synchronization/isolation issues.

The QueryLive failure reproduced locally on the third iteration of the unchanged test.

## Validation

- `GrpcChannelMonitorTest`: 100 repeated passes
- focused QueryLive backend-error test: 30 repeated passes after the fix
- focused UserMonitoring test: 20 repeated passes, plus a post-review pass after strengthening event assertions
- all three affected files together: 36 tests, 0 failures
- `MIX_ENV=test ../bin/format --check-formatted`
- `../bin/x mix lint.all`
- `../bin/x mix compile`

No production code is changed.
