### PR TITLE
fix: preserve unsaved read cluster edits

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -422,7 +422,7 @@ jobs:
         run: cargo test -p mapper_ex
 
   frontend:
-    name: Frontend Tests
+    name: Frontend JavaScript Unit Tests (assets)
     runs-on: ubuntu-latest
     needs: versions
     if: needs.versions.outputs.frontend == 'true'
@@ -439,5 +439,5 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci --prefix assets
 
-      - name: Run frontend unit tests
+      - name: Run frontend JavaScript unit tests
         run: npm test --prefix assets

--- a/lib/logflare_web/live/backends/read_cluster_urls_component.ex
+++ b/lib/logflare_web/live/backends/read_cluster_urls_component.ex
@@ -80,14 +80,16 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
               placeholder: "caller label",
               class: "form-control",
               phx_change: "sync",
-              phx_target: @myself
+              phx_target: @myself,
+              phx_debounce: "blur"
             )}
             {text_input(@form, "read_cluster_url_#{row_ref}",
               value: row_url,
               placeholder: "https://read-cluster:8443",
               class: "form-control",
               phx_change: "sync",
-              phx_target: @myself
+              phx_target: @myself,
+              phx_debounce: "blur"
             )}
             <button type="button" class="btn btn-outline-danger" phx-click="remove_row" phx-value-ref={row_ref} phx-target={@myself}>
               <i class="fas fa-minus"></i>
@@ -107,7 +109,8 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
           class: "form-control",
           placeholder: "caller label",
           phx_change: "sync",
-          phx_target: @myself
+          phx_target: @myself,
+          phx_debounce: "blur"
         )}
         <small class="form-text text-muted">
           The caller label whose cluster absorbs unrecognized or absent callers. Must match a label above.

--- a/lib/logflare_web/live/backends/read_cluster_urls_component.ex
+++ b/lib/logflare_web/live/backends/read_cluster_urls_component.ex
@@ -18,11 +18,35 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
   def update(assigns, socket) do
     socket = assign(socket, assigns)
     socket = assign_new(socket, :rows, fn -> initial_rows(socket.assigns.backend) end)
+    socket = assign_new(socket, :next_ref, fn -> length(socket.assigns.rows) end)
 
-    {:ok, assign_new(socket, :next_ref, fn -> length(socket.assigns.rows) end)}
+    {:ok,
+     assign_new(socket, :default_read_cluster, fn ->
+       input_value(socket.assigns.form, :default_read_cluster) || ""
+     end)}
   end
 
   @impl true
+  def handle_event("sync", %{"backend" => %{"config" => config}}, socket) when is_map(config) do
+    rows =
+      Enum.map(socket.assigns.rows, fn {ref, label, url} ->
+        {
+          ref,
+          Map.get(config, "read_cluster_label_#{ref}", label),
+          Map.get(config, "read_cluster_url_#{ref}", url)
+        }
+      end)
+
+    {:noreply,
+     assign(socket,
+       rows: rows,
+       default_read_cluster:
+         Map.get(config, "default_read_cluster", socket.assigns.default_read_cluster)
+     )}
+  end
+
+  def handle_event("sync", _params, socket), do: {:noreply, socket}
+
   def handle_event("add_row", _params, socket) do
     %{next_ref: ref, rows: rows} = socket.assigns
 
@@ -54,12 +78,16 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
             {text_input(@form, "read_cluster_label_#{row_ref}",
               value: row_label,
               placeholder: "caller label",
-              class: "form-control"
+              class: "form-control",
+              phx_change: "sync",
+              phx_target: @myself
             )}
             {text_input(@form, "read_cluster_url_#{row_ref}",
               value: row_url,
               placeholder: "https://read-cluster:8443",
-              class: "form-control"
+              class: "form-control",
+              phx_change: "sync",
+              phx_target: @myself
             )}
             <button type="button" class="btn btn-outline-danger" phx-click="remove_row" phx-value-ref={row_ref} phx-target={@myself}>
               <i class="fas fa-minus"></i>
@@ -74,7 +102,13 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
 
       <div class="form-group">
         {label(@form, :default_read_cluster, "Default Read Cluster (Optional)")}
-        {text_input(@form, :default_read_cluster, class: "form-control", placeholder: "caller label")}
+        {text_input(@form, :default_read_cluster,
+          value: @default_read_cluster,
+          class: "form-control",
+          placeholder: "caller label",
+          phx_change: "sync",
+          phx_target: @myself
+        )}
         <small class="form-text text-muted">
           The caller label whose cluster absorbs unrecognized or absent callers. Must match a label above.
         </small>

--- a/lib/logflare_web/live/backends/read_cluster_urls_component.ex
+++ b/lib/logflare_web/live/backends/read_cluster_urls_component.ex
@@ -10,6 +10,8 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
 
   import Logflare.Utils.Guards, only: [is_non_empty_binary: 1, is_non_empty_map: 1]
 
+  require Logger
+
   alias Logflare.Backends.Backend
 
   @type row :: {non_neg_integer(), String.t(), String.t()}
@@ -45,7 +47,13 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponent do
      )}
   end
 
-  def handle_event("sync", _params, socket), do: {:noreply, socket}
+  def handle_event("sync", _params, socket) do
+    Logger.warning("Unexpected sync payload shape in ReadClusterUrlsComponent",
+      backend_id: socket.assigns.backend && socket.assigns.backend.id
+    )
+
+    {:noreply, socket}
+  end
 
   def handle_event("add_row", _params, socket) do
     %{next_ref: ref, rows: rows} = socket.assigns

--- a/test/e2e/features/backends_test.exs
+++ b/test/e2e/features/backends_test.exs
@@ -56,6 +56,57 @@ defmodule E2e.Features.BackendsTest do
       |> refute_has("#read-cluster-row-1")
       |> assert_has("#read-cluster-row-0 input[value='reporting']")
     end
+
+    test "adding a row preserves unsaved cluster and default edits", %{
+      backend: backend,
+      conn: conn
+    } do
+      session = visit(conn, ~p"/backends/#{backend.id}/edit")
+
+      unwrap(session, fn %{frame_id: frame_id} ->
+        Frame.fill(frame_id,
+          selector: label_selector(0),
+          value: "reporting-edited",
+          timeout: 5_000
+        )
+
+        Frame.fill(frame_id,
+          selector: url_selector(0),
+          value: "https://reporting-edited.example.com:8443",
+          timeout: 5_000
+        )
+
+        Frame.fill(frame_id,
+          selector: default_cluster_selector(),
+          value: "reporting-edited",
+          timeout: 5_000
+        )
+      end)
+
+      session = click_button(session, "Add read cluster")
+
+      session
+      |> assert_has("#read-cluster-row-1")
+      |> unwrap(fn %{frame_id: frame_id} ->
+        assert {:ok, "reporting-edited"} = input_value(frame_id, label_selector(0))
+
+        assert {:ok, "https://reporting-edited.example.com:8443"} =
+                 input_value(frame_id, url_selector(0))
+
+        assert {:ok, "reporting-edited"} =
+                 input_value(frame_id, default_cluster_selector())
+      end)
+      |> click_button("Save changes")
+      |> assert_has("*", text: "Successfully updated backend")
+
+      config = Logflare.Backends.get_backend(backend.id).config
+
+      assert config.read_only_urls == %{
+               "reporting-edited" => "https://reporting-edited.example.com:8443"
+             }
+
+      assert config.default_read_cluster == "reporting-edited"
+    end
   end
 
   describe "clickhouse read cluster row removal" do
@@ -119,7 +170,7 @@ defmodule E2e.Features.BackendsTest do
              }
     end
 
-    test "removing a row drops the clicked row and discards unsaved edits elsewhere", %{
+    test "removing a row preserves unsaved edits in surviving rows and the default", %{
       backend: backend,
       conn: conn
     } do
@@ -127,25 +178,64 @@ defmodule E2e.Features.BackendsTest do
 
       unwrap(session, fn %{frame_id: frame_id} ->
         Frame.fill(frame_id, selector: label_selector(2), value: "gamma-edited", timeout: 5_000)
+
+        Frame.fill(frame_id,
+          selector: url_selector(2),
+          value: "https://gamma-edited.example.com:8443",
+          timeout: 5_000
+        )
+
+        Frame.fill(frame_id,
+          selector: default_cluster_selector(),
+          value: "gamma-edited",
+          timeout: 5_000
+        )
       end)
 
+      session = click(session, "#read-cluster-row-0 button[phx-click='remove_row']")
+
       session
-      |> click("#read-cluster-row-0 button[phx-click='remove_row']")
+      |> refute_has("#read-cluster-row-0")
+      |> unwrap(fn %{frame_id: frame_id} ->
+        assert {:ok, "gamma-edited"} = input_value(frame_id, label_selector(2))
+
+        assert {:ok, "https://gamma-edited.example.com:8443"} =
+                 input_value(frame_id, url_selector(2))
+
+        assert {:ok, "gamma-edited"} =
+                 input_value(frame_id, default_cluster_selector())
+      end)
       |> click_button("Save changes")
       |> assert_has("*", text: "Successfully updated backend")
 
-      assert Logflare.Backends.get_backend(backend.id).config.read_only_urls == %{
+      config = Logflare.Backends.get_backend(backend.id).config
+
+      assert config.read_only_urls == %{
                "beta" => "https://b.example.com:8443",
-               "gamma" => "https://c.example.com:8443"
+               "gamma-edited" => "https://gamma-edited.example.com:8443"
              }
+
+      assert config.default_read_cluster == "gamma-edited"
     end
   end
 
-  defp input_value(frame_id, ref) do
-    Frame.input_value(frame_id, selector: label_selector(ref), timeout: 5_000)
+  defp input_value(frame_id, ref) when is_integer(ref) do
+    input_value(frame_id, label_selector(ref))
+  end
+
+  defp input_value(frame_id, selector) do
+    Frame.input_value(frame_id, selector: selector, timeout: 5_000)
   end
 
   defp label_selector(ref) do
     "#read-cluster-row-#{ref} input[name='backend[config][read_cluster_label_#{ref}]']"
+  end
+
+  defp url_selector(ref) do
+    "#read-cluster-row-#{ref} input[name='backend[config][read_cluster_url_#{ref}]']"
+  end
+
+  defp default_cluster_selector do
+    "input[name='backend[config][default_read_cluster]']"
   end
 end

--- a/test/e2e/features/backends_test.exs
+++ b/test/e2e/features/backends_test.exs
@@ -57,6 +57,59 @@ defmodule E2e.Features.BackendsTest do
       |> assert_has("#read-cluster-row-0 input[value='reporting']")
     end
 
+    test "typing into a read cluster field does not sync to the server until blurred", %{
+      backend: backend,
+      conn: conn
+    } do
+      session = visit(conn, ~p"/backends/#{backend.id}/edit")
+
+      unwrap(session, fn %{frame_id: frame_id} ->
+        {:ok, _} = Frame.fill(frame_id, selector: url_selector(0), value: "", timeout: 5_000)
+
+        {:ok, _} =
+          Frame.evaluate(frame_id,
+            expression: """
+            (() => {
+              window.__sentFrames = [];
+              const originalSend = WebSocket.prototype.send;
+              WebSocket.prototype.send = function (data) {
+                window.__sentFrames.push(data);
+                return originalSend.apply(this, arguments);
+              };
+              return true;
+            })()
+            """,
+            timeout: 5_000
+          )
+
+        {:ok, _} =
+          Frame.type(frame_id,
+            selector: url_selector(0),
+            text: "https://reader-b.example.com:8443",
+            delay: 10,
+            timeout: 5_000
+          )
+
+        {:ok, sent_before_blur} = sent_sync_frame_count(frame_id)
+        assert sent_before_blur == 0
+
+        {:ok, _} = Frame.blur(frame_id, selector: url_selector(0), timeout: 5_000)
+
+        {:ok, _} =
+          Frame.wait_for_function(frame_id,
+            expression:
+              "() => window.__sentFrames.some((f) => typeof f === 'string' && f.includes('\"sync\"'))",
+            is_function: true,
+            timeout: 5_000
+          )
+
+        {:ok, sent_after_blur} = sent_sync_frame_count(frame_id)
+        assert sent_after_blur == 1
+
+        assert {:ok, "https://reader-b.example.com:8443"} = input_value(frame_id, url_selector(0))
+      end)
+    end
+
     test "adding a row preserves unsaved cluster and default edits", %{
       backend: backend,
       conn: conn
@@ -217,6 +270,14 @@ defmodule E2e.Features.BackendsTest do
 
       assert config.default_read_cluster == "gamma-edited"
     end
+  end
+
+  defp sent_sync_frame_count(frame_id) do
+    Frame.evaluate(frame_id,
+      expression:
+        "window.__sentFrames.filter((f) => typeof f === 'string' && f.includes('\"sync\"')).length",
+      timeout: 5_000
+    )
   end
 
   defp input_value(frame_id, ref) when is_integer(ref) do

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -669,6 +669,84 @@ defmodule LogflareWeb.BackendsLiveTest do
              |> has_element?()
     end
 
+    test "row actions preserve unsaved read cluster inputs", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :clickhouse,
+          config: %{
+            url: "http://localhost:8123",
+            database: "test_db",
+            port: 8123,
+            read_only_urls: %{"reporting" => "http://reporting.local:8123"},
+            default_read_cluster: "reporting"
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> element("input[name='backend[config][read_cluster_label_0]']")
+      |> render_change(%{
+        "backend" => %{"config" => %{"read_cluster_label_0" => "reporting-edited"}}
+      })
+
+      view
+      |> element("input[name='backend[config][read_cluster_url_0]']")
+      |> render_change(%{
+        "backend" => %{
+          "config" => %{"read_cluster_url_0" => "http://reporting-edited.local:8123"}
+        }
+      })
+
+      view
+      |> element("input[name='backend[config][default_read_cluster]']")
+      |> render_change(%{
+        "backend" => %{"config" => %{"default_read_cluster" => "reporting-edited"}}
+      })
+
+      view
+      |> element("button[phx-click='add_row']")
+      |> render_click()
+
+      assert view
+             |> element("input[name='backend[config][read_cluster_label_0]']")
+             |> render() =~ ~s(value="reporting-edited")
+
+      assert view
+             |> element("input[name='backend[config][read_cluster_url_0]']")
+             |> render() =~ ~s(value="http://reporting-edited.local:8123")
+
+      assert view
+             |> element("input[name='backend[config][default_read_cluster]']")
+             |> render() =~ ~s(value="reporting-edited")
+
+      assert has_element?(view, "#read-cluster-row-1")
+
+      view
+      |> element("#read-cluster-row-1 button[phx-click='remove_row']")
+      |> render_click()
+
+      refute has_element?(view, "#read-cluster-row-1")
+
+      assert view
+             |> element("input[name='backend[config][read_cluster_label_0]']")
+             |> render() =~ ~s(value="reporting-edited")
+
+      assert view
+             |> element("input[name='backend[config][read_cluster_url_0]']")
+             |> render() =~ ~s(value="http://reporting-edited.local:8123")
+
+      assert view
+             |> element("input[name='backend[config][default_read_cluster]']")
+             |> render() =~ ~s(value="reporting-edited")
+    end
+
     test "removing a read cluster row drops that specific row's cluster on save", %{
       conn: conn,
       source: source,

--- a/test/logflare_web/live/backends/read_cluster_urls_component_test.exs
+++ b/test/logflare_web/live/backends/read_cluster_urls_component_test.exs
@@ -1,7 +1,9 @@
 defmodule LogflareWeb.Backends.ReadClusterUrlsComponentTest do
   use ExUnit.Case, async: true
 
+  alias Logflare.Backends.Backend
   alias LogflareWeb.Backends.ReadClusterUrlsComponent
+  alias Phoenix.LiveView.Socket
 
   describe "assemble_read_only_urls/1" do
     test "assembles flat form params into the read_only_urls map" do
@@ -74,5 +76,61 @@ defmodule LogflareWeb.Backends.ReadClusterUrlsComponentTest do
                  "url" => "http://ingest.local:8123"
                })
     end
+  end
+
+  describe "handle_event/3 sync fallback" do
+    test "logs a warning with the backend id when the payload shape is unexpected" do
+      socket = %Socket{assigns: %{backend: %Backend{id: 123}, __changed__: %{}}}
+
+      event =
+        capture_log_event(fn ->
+          assert {:noreply, ^socket} =
+                   ReadClusterUrlsComponent.handle_event(
+                     "sync",
+                     %{"unexpected" => "shape"},
+                     socket
+                   )
+        end)
+
+      assert %{level: :warning, meta: %{backend_id: 123}} = event
+      assert {:string, message} = event.msg
+
+      assert IO.iodata_to_binary(message) =~
+               "Unexpected sync payload shape in ReadClusterUrlsComponent"
+    end
+
+    test "logs a nil backend id when the backend has not been created yet" do
+      socket = %Socket{assigns: %{backend: nil, __changed__: %{}}}
+
+      event =
+        capture_log_event(fn ->
+          assert {:noreply, _socket} = ReadClusterUrlsComponent.handle_event("sync", %{}, socket)
+        end)
+
+      assert %{meta: %{backend_id: nil}} = event
+    end
+  end
+
+  defmodule CaptureHandler do
+    def log(event, %{config: %{pid: pid}}), do: send(pid, {:log_event, event})
+  end
+
+  defp capture_log_event(fun) do
+    handler_id = :"read_cluster_urls_test_#{System.unique_integer([:positive])}"
+
+    :ok =
+      :logger.add_handler(handler_id, __MODULE__.CaptureHandler, %{
+        level: :all,
+        config: %{pid: self()}
+      })
+
+    try do
+      fun.()
+    after
+      :logger.remove_handler(handler_id)
+    end
+
+    assert_receive {:log_event, event}, 1_000
+    event
   end
 end


### PR DESCRIPTION
## Dependency

This draft is intentionally based on `adammokan/o11y-2312-fix-ux-for-clickhouse-multiple-read-clusters` and should be reviewed/merged after #3821.

## Issue

`LogflareWeb.Backends.ReadClusterUrlsComponent` keeps its row values in component assigns so it can add and remove rows with stable refs. Before this change, those assigns were initialized from the persisted backend and were never updated while the user typed.

The inputs therefore had two different states:

- the browser DOM contained the user's unsaved label, URL, and default-cluster edits;
- the LiveComponent still contained the original persisted values.

Clicking **Add read cluster** or a row's remove button sends a component event and rerenders the component. That rerender wrote the stale assigned values back into the inputs, silently discarding every unsaved edit in the component. On a new backend, the normal flow of filling the first row and then clicking **Add read cluster** cleared the first row entirely, making multi-row entry especially error-prone.

The E2E coverage added in #3821 also explicitly asserted the destructive behavior by expecting an edited surviving row to revert before save.

## Reproduction

1. Open a new ClickHouse backend.
2. Enter:
   - label: `customer-a`
   - URL: `https://reader-a.example.com:8443`
   - default read cluster: `customer-a`
3. Click **Add read cluster**.
4. Observe that a second row appears while all three entered values are cleared.

| Before clicking Add | After clicking Add |
| --- | --- |
| ![Read-cluster values populated before Add](https://github.com/user-attachments/assets/2ed6a97f-d7ed-4435-ae22-15329974f76a) | ![Read-cluster values cleared after Add](https://github.com/user-attachments/assets/858f0d4e-cea4-4ca8-b71f-631e9fbeba50) |

[Video: complete reproduction](https://github.com/user-attachments/assets/05d7c4e8-b1b7-4810-8a21-ae055a32dbc1)

## Fix

- Add input-level `phx-change` synchronization targeted at the LiveComponent.
- Merge each individual change payload into the existing stable-ref row state instead of rebuilding or renumbering rows.
- Keep the unsaved default read cluster in component state as well.
- Preserve `next_ref`, stable field names, backend-specific component IDs, and final form parameter assembly from #3821.

Phoenix LiveView serializes only the changed input for an input-level `phx-change`, so the synchronization handler preserves all row/default values that are absent from a given event payload.

## Result

Both Add and Remove now preserve browser edits:

| Add preserves row/default values | Remove preserves the surviving row/default values |
| --- | --- |
| ![Values preserved after adding a row](https://github.com/user-attachments/assets/f8cd3858-3308-4fad-a18a-b33c077a1d74) | ![Values preserved after removing another row](https://github.com/user-attachments/assets/ee436b09-04c7-44d9-a2f0-e37587970ab7) |

## Coverage

- Added deterministic LiveView coverage that changes the row label, row URL, and default cluster, then adds and removes a row while asserting the unsaved values remain.
- Added browser coverage for Add that verifies the edited DOM values survive and persist on save.
- Replaced the E2E assertion that blessed lost edits with coverage proving Remove preserves edited surviving rows and the default cluster through save.

## Validation

Passed locally:

- `../bin/format --check-formatted`
- `MIX_ENV=test ../bin/x mix test.compile`
- `MIX_ENV=test ../bin/x mix lint.all`
- `../bin/test test/logflare_web/live/backends/read_cluster_urls_component_test.exs test/logflare_web/live/backends/backends_live_test.exs` — 61 tests, 0 failures
- Manual Playwright Add flow — label, URL, and default preserved with two rows
- Manual Playwright Remove flow — surviving label, URL, and default preserved

The full local E2E task was not reliable in the shared agent environment: the browser suite experienced database sandbox/pool teardown and timed out in both pre-existing and new row-action cases. The hosted E2E workflow is expected to provide the authoritative browser-suite result for this draft.
