### PR TITLE
feat: select event chart time ranges by dragging

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  ReferenceArea,
 } from "recharts";
 
 import { BarLoader } from "react-spinners";
@@ -183,6 +184,68 @@ const barTotal = (entry, keys) =>
 
 const periods = ["day", "hour", "minute", "second"];
 
+const formatSearchDatetime = (utcDatetime, tz) => {
+  const datetime = DateTime.fromISO(utcDatetime, { zone: tz });
+  if (!datetime.isValid) return null;
+
+  return datetime.toISO({
+    includeOffset: false,
+    suppressMilliseconds: true,
+    format: "extended",
+  });
+};
+
+const buildTimeRangeQuery = (
+  firstUtcDatetime,
+  secondUtcDatetime,
+  tz,
+  chartPeriod,
+) => {
+  const first = DateTime.fromISO(firstUtcDatetime, { zone: tz });
+  const second = DateTime.fromISO(secondUtcDatetime, { zone: tz });
+  if (!first.isValid || !second.isValid || !periods.includes(chartPeriod)) return null;
+
+  const [start, lastBucket] =
+    first.toMillis() <= second.toMillis() ? [first, second] : [second, first];
+  const end = lastBucket.plus({ [`${chartPeriod}s`]: 1 });
+
+  return `t:${formatSearchDatetime(start.toISO(), tz)}..${formatSearchDatetime(end.toISO(), tz)}`;
+};
+
+const activeChartPoint = (state, chartData = []) => {
+  const activePayload = state?.activePayload?.[0]?.payload;
+  const hasActiveIndex = state?.activeIndex !== null && state?.activeIndex !== undefined;
+  const activeIndex = hasActiveIndex ? Number(state.activeIndex) : null;
+  const indexedPoint = Number.isInteger(activeIndex) ? chartData[activeIndex] : null;
+  const activePoint = activePayload || indexedPoint;
+  const label = state?.activeLabel || activePoint?.timestamp || activePoint?.datetime;
+  const datetime = activePoint?.datetime || activePoint?.timestamp || state?.activeLabel;
+
+  return label && datetime ? { label, datetime } : null;
+};
+
+const activeDatetime = (state, chartData = []) =>
+  activeChartPoint(state, chartData)?.datetime;
+
+const chartPointAtX = (clientX, bounds, chartData = []) => {
+  if (!Number.isFinite(clientX) || !bounds || bounds.width <= 0 || chartData.length === 0) {
+    return null;
+  }
+
+  const relativeX = clientX - bounds.left;
+  if (relativeX < 0 || relativeX > bounds.width) return null;
+
+  const index = Math.min(
+    chartData.length - 1,
+    Math.floor((relativeX / bounds.width) * chartData.length),
+  );
+  const point = chartData[index];
+  const label = point?.timestamp || point?.datetime;
+  const datetime = point?.datetime || point?.timestamp;
+
+  return label && datetime ? { label, datetime } : null;
+};
+
 const LogEventsChart = ({
   data,
   loading,
@@ -192,16 +255,17 @@ const LogEventsChart = ({
   pushEvent,
 }) => {
   const tz = userTz || "Etc/UTC";
+  const chartContainerRef = React.useRef(null);
+  const [dragRange, setDragRange] = React.useState(null);
+  const dragStartRef = React.useRef(null);
+  const dragEndRef = React.useRef(null);
+  const didDragRef = React.useRef(false);
+  const suppressClickRef = React.useRef(false);
+
   const triggerTimeSearch = (utcDatetime) => {
     if (!utcDatetime) return;
 
-    pushEvent("soft_pause", {});
-
-    const start = DateTime.fromISO(utcDatetime, { zone: tz }).toISO({
-      includeOffset: false,
-      suppressMilliseconds: true,
-      format: "extended",
-    });
+    const start = formatSearchDatetime(utcDatetime, tz);
     const end = DateTime.fromISO(utcDatetime, { zone: tz })
       .plus({ [chartPeriod + "s"]: 1 })
       .toISO({
@@ -209,28 +273,98 @@ const LogEventsChart = ({
         suppressMilliseconds: true,
         format: "extended",
       });
-    const ts = `t:${start}..${end}`;
+    if (!start || !end) return;
+
+    pushEvent("soft_pause", {});
+
     const index = periods.findIndex((p) => p === chartPeriod);
     const newPeriod = index === 3 ? periods[3] : periods[index + 1];
 
     pushEvent("datetime_update", {
-      querystring: ts,
+      querystring: `t:${start}..${end}`,
       period: newPeriod,
     });
   };
 
-  const handleBarClick = (entry) => {
-    const payload = entry?.payload;
-    if (!payload) return;
-    const utcDatetime = payload.datetime || payload.timestamp;
-    triggerTimeSearch(utcDatetime);
+  const triggerTimeRangeSearch = (firstUtcDatetime, secondUtcDatetime) => {
+    const querystring = buildTimeRangeQuery(
+      firstUtcDatetime,
+      secondUtcDatetime,
+      tz,
+      chartPeriod,
+    );
+    if (!querystring) return;
+
+    pushEvent("soft_pause", {});
+    pushEvent("datetime_update", { querystring });
   };
 
-  const handleChartClick = (state) => {
-    const activePoint = state?.activePayload?.[0]?.payload;
-    const utcDatetime =
-      activePoint?.datetime || activePoint?.timestamp || state?.activeLabel;
-    triggerTimeSearch(utcDatetime);
+  const shouldSuppressClick = () => didDragRef.current || suppressClickRef.current;
+  const pointForMouseEvent = (state, event) =>
+    chartPointAtX(
+      event?.clientX,
+      chartContainerRef.current?.getBoundingClientRect(),
+      chartData,
+    ) || activeChartPoint(state, chartData);
+
+  const handleChartClick = (state, event) => {
+    if (shouldSuppressClick()) return;
+    triggerTimeSearch(pointForMouseEvent(state, event)?.datetime);
+  };
+
+  const handleMouseDown = (state, event) => {
+    const point = pointForMouseEvent(state, event);
+    if (!point) return;
+
+    dragStartRef.current = point;
+    dragEndRef.current = point;
+    didDragRef.current = false;
+    suppressClickRef.current = false;
+    setDragRange({ start: point.label, end: point.label });
+  };
+
+  const handleMouseMove = (state, event) => {
+    if (!dragStartRef.current) return;
+
+    const point = pointForMouseEvent(state, event);
+    if (!point) return;
+
+    dragEndRef.current = point;
+    didDragRef.current = point.label !== dragStartRef.current.label;
+    setDragRange({ start: dragStartRef.current.label, end: point.label });
+  };
+
+  const resetDrag = () => {
+    dragStartRef.current = null;
+    dragEndRef.current = null;
+    setDragRange(null);
+  };
+
+  const handleMouseUp = (state, event) => {
+    const start = dragStartRef.current;
+    const end = pointForMouseEvent(state, event) || dragEndRef.current;
+    const didDrag = Boolean(start && end && start.label !== end.label);
+
+    if (didDrag) {
+      didDragRef.current = true;
+      suppressClickRef.current = true;
+      triggerTimeRangeSearch(start.datetime, end.datetime);
+
+      requestAnimationFrame(() => {
+        didDragRef.current = false;
+        suppressClickRef.current = false;
+      });
+    }
+
+    resetDrag();
+  };
+
+  const handleMouseLeave = () => {
+    if (!dragStartRef.current) return;
+
+    didDragRef.current = false;
+    suppressClickRef.current = false;
+    resetDrag();
   };
 
   const TooltipContent = tooltipFactory(chartDataShapeId);
@@ -274,7 +408,7 @@ const LogEventsChart = ({
             width={width}
             height={highlightHeight}
             fill={highlightFill}
-            onClick={() => handleBarClick({ payload })}
+            pointerEvents="none"
           />
         )}
         <rect
@@ -283,7 +417,7 @@ const LogEventsChart = ({
           width={width}
           height={height}
           fill={fill}
-          onClick={() => handleBarClick({ payload })}
+          pointerEvents="none"
         />
       </g>
     );
@@ -291,6 +425,7 @@ const LogEventsChart = ({
 
   return (
     <div
+      ref={chartContainerRef}
       style={{
         height: 100,
         display: "flex",
@@ -314,8 +449,12 @@ const LogEventsChart = ({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: 0, bottom: 0, left: 0 }}
-            style={{ cursor: "pointer" }}
+            style={{ cursor: dragRange ? "crosshair" : "pointer" }}
             onClick={handleChartClick}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseLeave}
           >
             <CartesianGrid
               stroke={chartGridLineColor}
@@ -331,6 +470,18 @@ const LogEventsChart = ({
               content={<TooltipContent />}
               cursor={{ fill: "rgba(255,255,255,0.05)" }}
             />
+            {dragRange?.start !== dragRange?.end && (
+              <ReferenceArea
+                x1={dragRange.start}
+                x2={dragRange.end}
+                fill={brandGreen}
+                fillOpacity={0.15}
+                stroke={brandGreen}
+                strokeOpacity={0.5}
+                ifOverflow="visible"
+                style={{ pointerEvents: "none" }}
+              />
+            )}
             {settings.keys.map((key) => (
               <Bar
                 key={key}
@@ -340,7 +491,6 @@ const LogEventsChart = ({
                 isAnimationActive={false}
                 minPointSize={minPointSizeForDataKey(chartData, key)}
                 shape={key === topStackKey ? renderBarWithHighlight : undefined}
-                onClick={handleBarClick}
               />
             ))}
           </BarChart>
@@ -350,4 +500,4 @@ const LogEventsChart = ({
   );
 };
 
-export { LogEventsChart };
+export { activeDatetime, buildTimeRangeQuery, chartPointAtX, LogEventsChart };

--- a/assets/js/test/log_events_chart.test.js
+++ b/assets/js/test/log_events_chart.test.js
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeDatetime,
+  buildTimeRangeQuery,
+  chartPointAtX,
+} from "../LogEventsChart.jsx";
+
+describe("buildTimeRangeQuery", () => {
+  it("includes the complete final selected chart bucket", () => {
+    expect(
+      buildTimeRangeQuery(
+        "2026-08-14T10:00:00Z",
+        "2026-08-14T10:05:00Z",
+        "Etc/UTC",
+        "minute",
+      ),
+    ).toBe("t:2026-08-14T10:00:00..2026-08-14T10:06:00");
+  });
+
+  it("orders a right-to-left drag chronologically", () => {
+    expect(
+      buildTimeRangeQuery(
+        "2026-08-14T10:05:00Z",
+        "2026-08-14T10:00:00Z",
+        "Etc/UTC",
+        "minute",
+      ),
+    ).toBe("t:2026-08-14T10:00:00..2026-08-14T10:06:00");
+  });
+
+  it("uses the configured display timezone", () => {
+    expect(
+      buildTimeRangeQuery(
+        "2026-08-14T10:00:00Z",
+        "2026-08-14T10:05:00Z",
+        "America/New_York",
+        "minute",
+      ),
+    ).toBe("t:2026-08-14T06:00:00..2026-08-14T06:06:00");
+  });
+
+  it("rejects invalid timestamps", () => {
+    expect(
+      buildTimeRangeQuery(
+        "invalid",
+        "2026-08-14T10:05:00Z",
+        "Etc/UTC",
+        "minute",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("activeDatetime", () => {
+  it("prefers the active payload datetime", () => {
+    expect(
+      activeDatetime({
+        activeLabel: "fallback",
+        activePayload: [{ payload: { datetime: "2026-08-14T10:00:00Z" } }],
+      }),
+    ).toBe("2026-08-14T10:00:00Z");
+  });
+
+  it("maps the formatted active label back to the chart datetime", () => {
+    expect(
+      activeDatetime(
+        { activeIndex: 1, activeLabel: "Fri Aug 14 2026 10:00:00" },
+        [
+          { datetime: "2026-08-14T09:59:00Z", timestamp: "Fri Aug 14 2026 09:59:00" },
+          { datetime: "2026-08-14T10:00:00Z", timestamp: "Fri Aug 14 2026 10:00:00" },
+        ],
+      ),
+    ).toBe("2026-08-14T10:00:00Z");
+  });
+
+  it("does not treat a null active index as the first chart point", () => {
+    expect(
+      activeDatetime(
+        { activeIndex: null },
+        [{ datetime: "2026-08-14T10:00:00Z", timestamp: "first" }],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("falls back to an ISO active label when chart data is unavailable", () => {
+    expect(activeDatetime({ activeLabel: "2026-08-14T10:00:00Z" })).toBe(
+      "2026-08-14T10:00:00Z",
+    );
+  });
+});
+
+describe("chartPointAtX", () => {
+  const chartData = [
+    { datetime: "2026-08-14T10:00:00Z", timestamp: "10:00" },
+    { datetime: "2026-08-14T10:01:00Z", timestamp: "10:01" },
+    { datetime: "2026-08-14T10:02:00Z", timestamp: "10:02" },
+  ];
+  const bounds = { left: 100, width: 300 };
+
+  it("maps the pointer position to the matching chart bucket", () => {
+    expect(chartPointAtX(250, bounds, chartData)).toEqual({
+      label: "10:01",
+      datetime: "2026-08-14T10:01:00Z",
+    });
+  });
+
+  it("rejects pointer positions outside the chart", () => {
+    expect(chartPointAtX(99, bounds, chartData)).toBeNull();
+    expect(chartPointAtX(401, bounds, chartData)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- add click-and-drag range selection to the Logflare event histogram
- render a live `ReferenceArea` brush while dragging and search the full selected buckets on mouseup
- preserve single-bar clicks while suppressing the post-drag click and collapsing duplicate click paths
- cover chronological range construction, timezone conversion, active-point lookup, and pointer-to-bucket mapping

Linear: [O11Y-2337](https://linear.app/supabase/issue/O11Y-2337/logflare-search-click-and-drag-on-event-chart-to-select-a-time-range)

## Media

### Before selection

![Event chart ready for range selection](https://github.com/user-attachments/assets/e4bfef51-aa66-4c9d-bf85-32377963eaa9)

### Drag selection

![Event chart showing the selected time range](https://github.com/user-attachments/assets/06821e0c-7d9d-457e-b3ea-13ae274f1db3)

### Applied range

![Search results and LQL query after applying the selected range](https://github.com/user-attachments/assets/f65f0554-bf62-4f6b-b492-bcd049005aeb)

### Video

https://github.com/user-attachments/assets/04e85777-e0e6-40d4-88b4-671bc9497da7
