### PR TITLE
ci: validate Docker base image compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,16 @@
 /_build
 /db
 /deps
+/target
+/priv/native
 /*.ez
 .DS_Store
+
+# Files that cannot affect the production image
+/.git
+/.github
+/bench
+/test
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/.github/workflows/docker-base-runner-daily.yml
+++ b/.github/workflows/docker-base-runner-daily.yml
@@ -51,8 +51,8 @@ jobs:
             supabase/logflare:base-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:base-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=base-${{ matrix.arch }}
+          cache-to: type=gha,scope=base-${{ matrix.arch }},mode=max
 
   build_runner:
     needs: settings
@@ -85,8 +85,8 @@ jobs:
             supabase/logflare:runner-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:runner-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=runner-${{ matrix.arch }}
+          cache-to: type=gha,scope=runner-${{ matrix.arch }},mode=max
 
   merge_publish:
     needs:

--- a/.github/workflows/docker-base-runner-daily.yml
+++ b/.github/workflows/docker-base-runner-daily.yml
@@ -19,6 +19,8 @@ jobs:
         id: env
         run: |
           echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Validate Docker base images
+        run: python3 bin/docker-base-images check --warn-age-days 45
 
   build_base:
     needs: settings

--- a/.github/workflows/docker-base-runner-daily.yml
+++ b/.github/workflows/docker-base-runner-daily.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       short_sha: ${{steps.env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup outputs
         id: env
         run: |
@@ -32,9 +32,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         with:
           endpoint: builders
       - name: Login to DockerHub
@@ -43,10 +43,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Dockerfile.base
           push: true
+          pull: true
           tags: |
             supabase/logflare:base-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:base-${{ matrix.arch }}
@@ -66,9 +67,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         with:
           endpoint: builders
       - name: Login to DockerHub
@@ -77,10 +78,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Dockerfile.runner
           push: true
+          pull: true
           tags: |
             supabase/logflare:runner-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:runner-${{ matrix.arch }}

--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -4,9 +4,17 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore:
+      - "test/**"
+      - "bench/**"
+      - "*.md"
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   settings:
@@ -57,9 +65,9 @@ jobs:
           # resource attribute at runtime (see Dockerfile / Logflare.Telemetry).
           build-args: |
             COMMIT_SHA=${{ needs.settings.outputs.short_sha }}
-          # caching
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Keep architecture-specific caches from overwriting each other.
+          cache-from: type=gha,scope=app-${{ matrix.arch }}
+          cache-to: type=gha,scope=app-${{ matrix.arch }},mode=max
 
   merge_publish:
     needs:

--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{steps.env.outputs.version}}
       short_sha: ${{steps.env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup outputs
         id: env
         run: |
@@ -42,23 +42,24 @@ jobs:
     timeout-minutes: 120
     steps:
       # checkout git commit
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       # Setup docker
       # https://github.com/supabase/postgres/blob/develop/.github/workflows/dockerhub-release.yml#LL41C11-L42C44
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v4
         with:
           endpoint: builders
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Build and push
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           push: true
+          pull: true
           tags: supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           # Baked into the image as LOGFLARE_COMMIT_SHA and emitted as an OTel
@@ -75,7 +76,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           echo "version=$(cat ./VERSION)" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Validate Docker base images
+        run: python3 bin/docker-base-images check --warn-age-days 45
   build:
     needs: settings
     strategy:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:
-          file: ./Dockerfile.multi-step
+          file: ./Dockerfile
           push: false
           platforms: linux/amd64
           cache-from: type=gha,scope=docker-build-check

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -20,6 +20,9 @@ on:
       - '!assets/**'
       - '*.sh'
       - '.tool-versions'
+      - 'bin/docker-base-images'
+      - 'bin/docker_base_images.py'
+      - 'test/bin/docker_base_images_test.py'
       # Run suite when this file is changed
       - ".github/workflows/docker-test.yml"
 
@@ -32,6 +35,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - name: Validate Docker base images
+        run: |
+          python3 -m unittest discover -s test/bin -p '*_test.py' -v
+          python3 bin/docker-base-images check --warn-age-days 45
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - 'native/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - 'priv/**'
       - 'rel/**'
       - 'config/**'
@@ -14,6 +16,7 @@ on:
       - 'Dockerfile.multi-step'
       - 'Dockerfile.base'
       - 'Dockerfile.runner'
+      - '.dockerignore'
       - '!assets/**'
       - '*.sh'
       - '.tool-versions'
@@ -35,6 +38,5 @@ jobs:
           file: ./Dockerfile.multi-step
           push: false
           platforms: linux/amd64
-          # caching
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-build-check
+          cache-to: type=gha,scope=docker-build-check,mode=max

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           file: ./Dockerfile
           push: false
+          pull: true
           platforms: linux/amd64
           cache-from: type=gha,scope=docker-build-check
           cache-to: type=gha,scope=docker-build-check,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ erl_crash.dump
 # Generated on crash by NPM
 npm-debug.log
 
+# Python bytecode
+__pycache__/
+*.py[cod]
+
 # Static artifacts
 /assets/node_modules
 /assets/yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,19 @@ RUN mix do local.rebar --force + local.hex --force + deps.get + deps.compile
 COPY assets/package.json assets/package-lock.json assets/
 RUN npm --prefix assets ci
 
-COPY . ./
-
-# rust bin path and release optimizations
+# Compile native extensions before copying application source so ordinary Elixir
+# changes can reuse the expensive architecture-specific Rust build.
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CARGO_PROFILE_RELEASE_LTO="thin"
 ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+COPY Cargo.toml Cargo.lock ./
+COPY native native/
+RUN set -e; \
+    for crate in arrowipc_ex ch_compression_ex mapper_ex sqlparser_ex; do \
+      cargo rustc --package "$crate" --release --locked; \
+    done
 
-# check installed correctly
-RUN cargo version
+COPY . ./
 
 # release
 RUN mix release  && \

--- a/bin/docker-base-images
+++ b/bin/docker-base-images
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from docker_base_images import main
+
+raise SystemExit(main())

--- a/bin/docker_base_images.py
+++ b/bin/docker_base_images.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Validate and update the Docker base images used by Logflare."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import pathlib
+import re
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable
+
+DOCKERFILES = ("Dockerfile", "Dockerfile.base", "Dockerfile.runner")
+REQUIRED_ARCHITECTURES = frozenset({"amd64", "arm64"})
+DOCKER_HUB_API = "https://hub.docker.com/v2/repositories"
+
+
+class BaseImageError(RuntimeError):
+    """Raised when the base-image configuration is invalid or unavailable."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Versions:
+    elixir: str
+    otp: str
+    rust: str
+    debian: str
+
+    @property
+    def debian_series(self) -> str:
+        match = re.fullmatch(r"(?P<series>[a-z]+)-\d{8}-slim", self.debian)
+        if not match:
+            raise BaseImageError(f"unsupported Debian version format: {self.debian}")
+        return match.group("series")
+
+    @property
+    def debian_date(self) -> dt.date:
+        match = re.fullmatch(r"[a-z]+-(?P<date>\d{8})-slim", self.debian)
+        if not match:
+            raise BaseImageError(f"unsupported Debian version format: {self.debian}")
+        return dt.datetime.strptime(match.group("date"), "%Y%m%d").date()
+
+    @property
+    def builder_tag(self) -> str:
+        return f"{self.elixir}-erlang-{self.otp}-debian-{self.debian}"
+
+
+@dataclasses.dataclass(frozen=True)
+class TagInfo:
+    name: str
+    architectures: frozenset[str]
+
+    @classmethod
+    def from_api(cls, payload: dict[str, object]) -> "TagInfo":
+        images = payload.get("images") or []
+        architectures = {
+            image.get("architecture")
+            for image in images
+            if isinstance(image, dict) and isinstance(image.get("architecture"), str)
+        }
+        name = payload.get("name")
+        if not isinstance(name, str):
+            raise BaseImageError("Docker Hub returned a tag without a name")
+        return cls(name=name, architectures=frozenset(architectures))
+
+
+class DockerHubClient:
+    def __init__(self, timeout: float = 30.0) -> None:
+        self.timeout = timeout
+
+    def tags(self, repository: str, name_filter: str) -> list[TagInfo]:
+        encoded_repository = "/".join(urllib.parse.quote(part, safe="") for part in repository.split("/"))
+        query = urllib.parse.urlencode({"page_size": 100, "name": name_filter})
+        url: str | None = f"{DOCKER_HUB_API}/{encoded_repository}/tags?{query}"
+        tags: list[TagInfo] = []
+        pages = 0
+
+        while url:
+            pages += 1
+            if pages > 20:
+                raise BaseImageError(f"too many Docker Hub result pages for {repository}")
+            request = urllib.request.Request(
+                url,
+                headers={"Accept": "application/json", "User-Agent": "logflare-base-image-check/1"},
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    payload = json.load(response)
+            except Exception as error:  # urllib exposes several unrelated error types
+                raise BaseImageError(f"failed to query Docker Hub for {repository}: {error}") from error
+
+            results = payload.get("results")
+            if not isinstance(results, list):
+                raise BaseImageError(f"Docker Hub returned invalid tag results for {repository}")
+            tags.extend(TagInfo.from_api(result) for result in results if isinstance(result, dict))
+            next_url = payload.get("next")
+            url = next_url if isinstance(next_url, str) and next_url else None
+
+        return tags
+
+
+def _arg_values(path: pathlib.Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        match = re.fullmatch(r"ARG ([A-Z][A-Z0-9_]*)=(.+)", line)
+        if match:
+            values[match.group(1)] = match.group(2).strip('"')
+    return values
+
+
+def _tool_versions(path: pathlib.Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        tool, version = line.split(maxsplit=1)
+        values[tool] = version
+    return values
+
+
+def load_versions(root: pathlib.Path) -> Versions:
+    dockerfile_values = {name: _arg_values(root / name) for name in DOCKERFILES}
+
+    def require_matching(argument: str, files: Iterable[str]) -> str:
+        values = {name: dockerfile_values[name].get(argument) for name in files}
+        missing = [name for name, value in values.items() if value is None]
+        if missing:
+            raise BaseImageError(f"{argument} is missing from {', '.join(missing)}")
+        unique = set(values.values())
+        if len(unique) != 1:
+            rendered = ", ".join(f"{name}={value}" for name, value in values.items())
+            raise BaseImageError(f"{argument} is inconsistent: {rendered}")
+        value = next(iter(unique))
+        assert value is not None
+        return value
+
+    versions = Versions(
+        elixir=require_matching("ELIXIR_VERSION", ("Dockerfile", "Dockerfile.base")),
+        otp=require_matching("OTP_VERSION", ("Dockerfile", "Dockerfile.base")),
+        rust=require_matching("RUST_VERSION", ("Dockerfile", "Dockerfile.base")),
+        debian=require_matching("DEBIAN_VERSION", DOCKERFILES),
+    )
+
+    tools = _tool_versions(root / ".tool-versions")
+    elixir_tool_version = tools.get("elixir", "")
+    elixir_match = re.fullmatch(r"(?P<version>.+)-otp-(?P<otp_major>\d+)", elixir_tool_version)
+    if not elixir_match:
+        raise BaseImageError(f"unsupported .tool-versions Elixir format: {elixir_tool_version}")
+    otp_major = versions.otp.split(".", maxsplit=1)[0]
+    if elixir_match.group("otp_major") != otp_major:
+        raise BaseImageError(
+            ".tool-versions Elixir OTP suffix is inconsistent: "
+            f"elixir={elixir_match.group('otp_major')}, erlang={otp_major}"
+        )
+
+    expected_tools = {
+        "elixir": elixir_match.group("version"),
+        "erlang": tools.get("erlang"),
+        "rust": tools.get("rust"),
+    }
+    actual_tools = {"elixir": versions.elixir, "erlang": versions.otp, "rust": versions.rust}
+    mismatches = [
+        f"{tool}: Dockerfile={actual_tools[tool]}, .tool-versions={expected_tools[tool]}"
+        for tool in actual_tools
+        if actual_tools[tool] != expected_tools[tool]
+    ]
+    if mismatches:
+        raise BaseImageError("tool versions are inconsistent: " + "; ".join(mismatches))
+
+    # Validate the date format while loading so every command gets the same guarantees.
+    versions.debian_date
+    return versions
+
+
+def _tag_map(tags: Iterable[TagInfo]) -> dict[str, TagInfo]:
+    return {tag.name: tag for tag in tags}
+
+
+def compatible_debian_versions(
+    versions: Versions, hex_tags: Iterable[TagInfo], debian_tags: Iterable[TagInfo]
+) -> list[str]:
+    hex_by_name = _tag_map(hex_tags)
+    debian_by_name = _tag_map(debian_tags)
+    prefix = f"{versions.elixir}-erlang-{versions.otp}-debian-"
+    pattern = re.compile(rf"^{re.escape(prefix)}({re.escape(versions.debian_series)}-\d{{8}}-slim)$")
+    compatible: list[str] = []
+
+    for hex_name, hex_tag in hex_by_name.items():
+        match = pattern.fullmatch(hex_name)
+        if not match:
+            continue
+        debian_version = match.group(1)
+        debian_tag = debian_by_name.get(debian_version)
+        if not debian_tag:
+            continue
+        if REQUIRED_ARCHITECTURES.issubset(hex_tag.architectures) and REQUIRED_ARCHITECTURES.issubset(
+            debian_tag.architectures
+        ):
+            compatible.append(debian_version)
+
+    return sorted(compatible, key=lambda value: dt.datetime.strptime(value.split("-")[1], "%Y%m%d"))
+
+
+def fetch_compatible_versions(versions: Versions, client: DockerHubClient) -> list[str]:
+    builder_prefix = f"{versions.elixir}-erlang-{versions.otp}-debian-{versions.debian_series}-"
+    hex_tags = client.tags("hexpm/elixir", builder_prefix)
+    debian_tags = client.tags("library/debian", f"{versions.debian_series}-")
+    compatible = compatible_debian_versions(versions, hex_tags, debian_tags)
+    if not compatible:
+        raise BaseImageError(
+            "no compatible amd64/arm64 Debian and Hex builder tags were found for "
+            f"Elixir {versions.elixir} / OTP {versions.otp}"
+        )
+    return compatible
+
+
+def _write_atomic(path: pathlib.Path, contents: str, mode: int) -> None:
+    temporary_path: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False) as temporary:
+            temporary.write(contents)
+            temporary_path = pathlib.Path(temporary.name)
+        temporary_path.chmod(mode)
+        temporary_path.replace(path)
+        temporary_path = None
+    finally:
+        if temporary_path and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def replace_debian_version(root: pathlib.Path, current: str, replacement: str) -> None:
+    originals: dict[pathlib.Path, tuple[str, int]] = {}
+    rendered: dict[pathlib.Path, str] = {}
+    pattern = re.compile(rf"^ARG DEBIAN_VERSION={re.escape(current)}$", re.MULTILINE)
+
+    for name in DOCKERFILES:
+        path = root / name
+        contents = path.read_text()
+        updated, count = pattern.subn(f"ARG DEBIAN_VERSION={replacement}", contents)
+        if count != 1:
+            raise BaseImageError(f"expected exactly one DEBIAN_VERSION={current} in {name}, found {count}")
+        originals[path] = (contents, path.stat().st_mode)
+        rendered[path] = updated
+
+    try:
+        for path, contents in rendered.items():
+            _write_atomic(path, contents, originals[path][1])
+    except Exception as error:
+        rollback_errors: list[str] = []
+        for path, (contents, mode) in originals.items():
+            try:
+                _write_atomic(path, contents, mode)
+            except Exception as rollback_error:
+                rollback_errors.append(f"{path.name}: {rollback_error}")
+        details = f"; rollback failures: {', '.join(rollback_errors)}" if rollback_errors else ""
+        raise BaseImageError(f"failed to update Dockerfiles: {error}{details}") from error
+
+
+def _age_days(versions: Versions, today: dt.date | None = None) -> int:
+    return ((today or dt.datetime.now(dt.UTC).date()) - versions.debian_date).days
+
+
+def check(root: pathlib.Path, client: DockerHubClient, warn_age_days: int, fail_age_days: int | None) -> int:
+    versions = load_versions(root)
+    compatible = fetch_compatible_versions(versions, client)
+    if versions.debian not in compatible:
+        raise BaseImageError(
+            f"current Debian snapshot {versions.debian} is not available for amd64/arm64 in both Debian and Hex images"
+        )
+
+    age = _age_days(versions)
+    latest = compatible[-1]
+    print(f"current Debian snapshot: {versions.debian} ({age} days old)")
+    print(f"latest compatible snapshot: {latest}")
+    print(f"builder image: hexpm/elixir:{versions.builder_tag}")
+    print(f"runner image: debian:{versions.debian}")
+
+    if age > warn_age_days:
+        print(f"warning: Debian snapshot exceeds {warn_age_days} days", file=sys.stderr)
+    if fail_age_days is not None and age > fail_age_days:
+        raise BaseImageError(f"Debian snapshot is {age} days old; maximum allowed age is {fail_age_days} days")
+    if latest != versions.debian:
+        print(f"update available: {versions.debian} -> {latest}")
+    return 0
+
+
+def apply(root: pathlib.Path, client: DockerHubClient, dry_run: bool) -> int:
+    versions = load_versions(root)
+    compatible = fetch_compatible_versions(versions, client)
+    latest = compatible[-1]
+    if latest == versions.debian:
+        print(f"Docker base snapshot is current: {versions.debian}")
+        return 0
+
+    print(f"Docker base snapshot update: {versions.debian} -> {latest}")
+    if not dry_run:
+        replace_debian_version(root, versions.debian, latest)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path.cwd())
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser("check", help="validate configured images and report freshness")
+    check_parser.add_argument("--warn-age-days", type=int, default=45)
+    check_parser.add_argument("--fail-age-days", type=int)
+
+    apply_parser = subparsers.add_parser("apply", help="update Dockerfiles to the latest compatible snapshot")
+    apply_parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        if args.command == "check":
+            return check(root, DockerHubClient(), args.warn_age_days, args.fail_age_days)
+        return apply(root, DockerHubClient(), args.dry_run)
+    except BaseImageError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/bin/docker_base_images_test.py
+++ b/test/bin/docker_base_images_test.py
@@ -1,0 +1,139 @@
+import datetime as dt
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "bin"))
+
+import docker_base_images as subject
+
+
+class DockerBaseImagesTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary_directory.name)
+        self.write_fixture()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_fixture(self, debian="trixie-20260112-slim"):
+        shared = (
+            "ARG ELIXIR_VERSION=1.19.5\n"
+            "ARG OTP_VERSION=27.3.4.6\n"
+            f"ARG DEBIAN_VERSION={debian}\n"
+            "ARG RUST_VERSION=1.96.0\n"
+        )
+        (self.root / "Dockerfile").write_text(shared + "FROM example\n")
+        (self.root / "Dockerfile.base").write_text(shared + "FROM example\n")
+        (self.root / "Dockerfile.runner").write_text(
+            f"ARG DEBIAN_VERSION={debian}\nFROM example\n"
+        )
+        (self.root / ".tool-versions").write_text(
+            "elixir 1.19.5-otp-27\nerlang 27.3.4.6\nrust 1.96.0\n"
+        )
+
+    def test_load_versions_requires_synchronized_toolchains(self):
+        versions = subject.load_versions(self.root)
+
+        self.assertEqual("1.19.5", versions.elixir)
+        self.assertEqual("27.3.4.6", versions.otp)
+        self.assertEqual("1.96.0", versions.rust)
+        self.assertEqual("trixie-20260112-slim", versions.debian)
+        self.assertEqual(dt.date(2026, 1, 12), versions.debian_date)
+
+    def test_load_versions_rejects_dockerfile_drift(self):
+        runner = self.root / "Dockerfile.runner"
+        runner.write_text(runner.read_text().replace("20260112", "20260202"))
+
+        with self.assertRaisesRegex(subject.BaseImageError, "DEBIAN_VERSION is inconsistent"):
+            subject.load_versions(self.root)
+
+    def test_load_versions_rejects_tool_versions_drift(self):
+        (self.root / ".tool-versions").write_text(
+            "elixir 1.19.4-otp-27\nerlang 27.3.4.6\nrust 1.96.0\n"
+        )
+
+        with self.assertRaisesRegex(subject.BaseImageError, "tool versions are inconsistent"):
+            subject.load_versions(self.root)
+
+    def test_load_versions_rejects_elixir_otp_suffix_drift(self):
+        (self.root / ".tool-versions").write_text(
+            "elixir 1.19.5-otp-28\nerlang 27.3.4.6\nrust 1.96.0\n"
+        )
+
+        with self.assertRaisesRegex(subject.BaseImageError, "Elixir OTP suffix is inconsistent"):
+            subject.load_versions(self.root)
+
+    def test_compatible_versions_require_both_architectures_and_images(self):
+        versions = subject.load_versions(self.root)
+        both = frozenset({"amd64", "arm64"})
+        hex_tags = [
+            subject.TagInfo(
+                "1.19.5-erlang-27.3.4.6-debian-trixie-20260112-slim", both
+            ),
+            subject.TagInfo(
+                "1.19.5-erlang-27.3.4.6-debian-trixie-20260202-slim", both
+            ),
+            subject.TagInfo(
+                "1.19.5-erlang-27.3.4.6-debian-trixie-20260303-slim",
+                frozenset({"amd64"}),
+            ),
+            subject.TagInfo(
+                "1.20.0-erlang-28.0-debian-trixie-20260404-slim", both
+            ),
+        ]
+        debian_tags = [
+            subject.TagInfo("trixie-20260112-slim", both),
+            subject.TagInfo("trixie-20260202-slim", both),
+            subject.TagInfo("trixie-20260303-slim", both),
+        ]
+
+        self.assertEqual(
+            ["trixie-20260112-slim", "trixie-20260202-slim"],
+            subject.compatible_debian_versions(versions, hex_tags, debian_tags),
+        )
+
+    def test_replace_debian_version_updates_all_dockerfiles(self):
+        subject.replace_debian_version(
+            self.root, "trixie-20260112-slim", "trixie-20260202-slim"
+        )
+
+        for name in subject.DOCKERFILES:
+            contents = (self.root / name).read_text()
+            self.assertIn("ARG DEBIAN_VERSION=trixie-20260202-slim", contents)
+            self.assertNotIn("trixie-20260112-slim", contents)
+
+    def test_replace_debian_version_rolls_back_partial_updates(self):
+        write_atomic = subject._write_atomic
+        failed = False
+
+        def fail_second_update(path, contents, mode):
+            nonlocal failed
+            if path.name == "Dockerfile.base" and "20260202" in contents and not failed:
+                failed = True
+                raise OSError("injected write failure")
+            write_atomic(path, contents, mode)
+
+        with mock.patch.object(subject, "_write_atomic", side_effect=fail_second_update):
+            with self.assertRaisesRegex(subject.BaseImageError, "failed to update Dockerfiles"):
+                subject.replace_debian_version(
+                    self.root, "trixie-20260112-slim", "trixie-20260202-slim"
+                )
+
+        for name in subject.DOCKERFILES:
+            contents = (self.root / name).read_text()
+            self.assertIn("ARG DEBIAN_VERSION=trixie-20260112-slim", contents)
+            self.assertNotIn("trixie-20260202-slim", contents)
+
+    def test_age_days_uses_snapshot_date(self):
+        versions = subject.load_versions(self.root)
+
+        self.assertEqual(49, subject._age_days(versions, dt.date(2026, 3, 2)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Python tool that keeps Dockerfile Elixir, OTP, Rust, and Debian pins synchronized
- query Docker Hub for Debian and Hex builder tags that both support amd64 and arm64
- report base-image age and the latest compatible Debian snapshot
- safely update all three Dockerfiles together with rollback on write failure
- run compatibility checks in Docker PR, production, and daily base workflows

## Validation

- 10 focused Python tests pass
- live Docker Hub validation found the current images for amd64/arm64
- live discovery identified `trixie-20260610-slim` as the latest compatible snapshot
- `actionlint` passes after excluding the repository's custom Blacksmith runner-label diagnostic
- production Docker workflow passed ([run 31847054018](https://github.com/Logflare/logflare/actions/runs/31847054018))

## Stack

- Depends on #3832
- This is security stack PR 1 of 4
