### PR TITLE
build: publish container attestations

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -24,18 +24,25 @@ env:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            architecture: amd64
+          - runner: ubuntu-24.04-arm
+            architecture: arm64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - name: Audit fixed high and critical vulnerabilities
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Audit high and critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}
           format: table
           scanners: vuln
           severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          ignore-unfixed: false
           exit-code: 0
       - name: Generate vulnerability report
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -45,11 +52,11 @@ jobs:
           output: trivy-results.sarif
           scanners: vuln
           severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          ignore-unfixed: false
           exit-code: 0
       - name: Upload vulnerability report
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: trivy-results.sarif
-          category: trivy-container-image
+          category: trivy-container-image-${{ matrix.architecture }}

--- a/.github/workflows/docker-base-runner-daily.yml
+++ b/.github/workflows/docker-base-runner-daily.yml
@@ -8,13 +8,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: docker-base-runner-publish
+  cancel-in-progress: false
+
 jobs:
   settings:
     runs-on: ubuntu-latest
     outputs:
       short_sha: ${{steps.env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup outputs
         id: env
         run: |
@@ -34,28 +38,41 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           endpoint: builders
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           file: ./Dockerfile.base
           push: true
           pull: true
+          sbom: true
+          provenance: mode=max
           tags: |
             supabase/logflare:base-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:base-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha,scope=base-${{ matrix.arch }}
           cache-to: type=gha,scope=base-${{ matrix.arch }},mode=max
+      - name: Export base image digest
+        run: |
+          mkdir -p /tmp/base-digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/base-digests/${digest#sha256:}"
+      - name: Upload base image digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: base-digest-${{ matrix.arch }}
+          path: /tmp/base-digests/*
+          retention-days: 1
 
   build_runner:
     needs: settings
@@ -69,28 +86,41 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           endpoint: builders
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           file: ./Dockerfile.runner
           push: true
           pull: true
+          sbom: true
+          provenance: mode=max
           tags: |
             supabase/logflare:runner-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
             supabase/logflare:runner-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha,scope=runner-${{ matrix.arch }}
           cache-to: type=gha,scope=runner-${{ matrix.arch }},mode=max
+      - name: Export runner image digest
+        run: |
+          mkdir -p /tmp/runner-digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/runner-digests/${digest#sha256:}"
+      - name: Upload runner image digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runner-digest-${{ matrix.arch }}
+          path: /tmp/runner-digests/*
+          retention-days: 1
 
   merge_publish:
     needs:
@@ -99,21 +129,41 @@ jobs:
       - build_runner
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Setup tags
-        run: |
-          echo "base_tag_amd64=supabase/logflare:base-amd64" >> "$GITHUB_ENV"
-          echo "base_tag_arm64=supabase/logflare:base-arm64" >> "$GITHUB_ENV"
-          echo "runner_tag_amd64=supabase/logflare:runner-amd64" >> "$GITHUB_ENV"
-          echo "runner_tag_arm64=supabase/logflare:runner-arm64" >> "$GITHUB_ENV"
+      - name: Download base image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: base-digest-*
+          path: /tmp/base-digests
+          merge-multiple: true
+      - name: Download runner image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: runner-digest-*
+          path: /tmp/runner-digests
+          merge-multiple: true
       - name: Merge multi-arch manifests for base image
         run: |
-          docker buildx imagetools create -t supabase/logflare:base \
-          ${{ env.base_tag_amd64 }} ${{ env.base_tag_arm64 }}
+          sources=()
+          for digest in /tmp/base-digests/*; do
+            sources+=("supabase/logflare@sha256:$(basename "$digest")")
+          done
+          test "${#sources[@]}" -eq 2
+          docker buildx imagetools create -t supabase/logflare:base "${sources[@]}"
       - name: Merge multi-arch manifests for runner image
         run: |
-          docker buildx imagetools create -t supabase/logflare:runner \
-          ${{ env.runner_tag_amd64 }} ${{ env.runner_tag_arm64 }}
+          sources=()
+          for digest in /tmp/runner-digests/*; do
+            sources+=("supabase/logflare@sha256:$(basename "$digest")")
+          done
+          test "${#sources[@]}" -eq 2
+          docker buildx imagetools create -t supabase/logflare:runner "${sources[@]}"
+      - name: Verify image attestations
+        run: |
+          python3 bin/check-image-attestations \
+            supabase/logflare:base \
+            supabase/logflare:runner

--- a/.github/workflows/docker-base-update.yml
+++ b/.github/workflows/docker-base-update.yml
@@ -3,7 +3,6 @@ name: Docker Base Snapshot Update
 on:
   schedule:
     - cron: "23 5 * * 1"
-  workflow_dispatch:
 
 permissions:
   actions: write
@@ -21,7 +20,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Select latest compatible base snapshot
         id: update
         run: |

--- a/.github/workflows/docker-ci-amd-and-arm.yml
+++ b/.github/workflows/docker-ci-amd-and-arm.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{steps.env.outputs.version}}
       short_sha: ${{steps.env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup outputs
         id: env
         run: |
@@ -44,24 +44,26 @@ jobs:
     timeout-minutes: 120
     steps:
       # checkout git commit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       # Setup docker
       # https://github.com/supabase/postgres/blob/develop/.github/workflows/dockerhub-release.yml#LL41C11-L42C44
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           endpoint: builders
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Build and push
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           push: true
           pull: true
+          sbom: true
+          provenance: mode=max
           tags: supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           # Baked into the image as LOGFLARE_COMMIT_SHA and emitted as an OTel
@@ -71,6 +73,17 @@ jobs:
           # Keep architecture-specific caches from overwriting each other.
           cache-from: type=gha,scope=app-${{ matrix.arch }}
           cache-to: type=gha,scope=app-${{ matrix.arch }},mode=max
+      - name: Export image digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload image digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: app-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
 
   merge_publish:
     needs:
@@ -78,20 +91,31 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: app-digest-*
+          path: /tmp/digests
+          merge-multiple: true
       - name: Setup tags
-        run: |
-          echo "tag_amd64=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-amd64" >> "$GITHUB_ENV"
-          echo "tag_arm64=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}-arm64" >> "$GITHUB_ENV"
-          echo "tag_sha=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}" >> "$GITHUB_ENV"
+        run: echo "tag_sha=supabase/logflare:dev-${{ needs.settings.outputs.short_sha }}" >> "$GITHUB_ENV"
       - name: Staging - Merge multi-arch manifests and push the dev image
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
-          docker buildx imagetools create -t ${{ env.tag_sha }}  \
-          ${{ env.tag_amd64 }} ${{ env.tag_arm64 }}
+          sources=()
+          for digest in /tmp/digests/*; do
+            sources+=("supabase/logflare@sha256:$(basename "$digest")")
+          done
+          test "${#sources[@]}" -eq 2
+          docker buildx imagetools create -t ${{ env.tag_sha }} "${sources[@]}"
+      - name: Verify image attestations
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: python3 bin/check-image-attestations ${{ env.tag_sha }}
 
   trigger_cloudbuild:
     uses: ./.github/workflows/trigger-cloudbuild.yml

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -22,7 +22,10 @@ on:
       - '.tool-versions'
       - 'bin/docker-base-images'
       - 'bin/docker_base_images.py'
+      - 'bin/check-image-attestations'
+      - 'bin/image_attestations.py'
       - 'test/bin/docker_base_images_test.py'
+      - 'test/bin/image_attestations_test.py'
       # Run suite when this file is changed
       - ".github/workflows/docker-test.yml"
 
@@ -34,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Validate Docker base images
         run: |
           python3 -m unittest discover -s test/bin -p '*_test.py' -v
           python3 bin/docker-base-images check --warn-age-days 45 --fail-age-days 90
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           file: ./Dockerfile
           push: false
@@ -57,5 +60,5 @@ jobs:
           format: table
           scanners: vuln
           severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          ignore-unfixed: false
           exit-code: 0

--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,7 @@ tag-versioned:
 
 	@echo "Retagging dev image to supabase/logflare:$(VERSION) ..."
 	docker buildx imagetools create -t supabase/logflare:$(VERSION) -t supabase/logflare:latest supabase/logflare:$(SHA_IMAGE_TAG)
+	python3 bin/check-image-attestations supabase/logflare:$(VERSION) supabase/logflare:latest
 	@echo "OK"
 
 .PHONY: tag-versioned

--- a/bin/check-image-attestations
+++ b/bin/check-image-attestations
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from image_attestations import main
+
+raise SystemExit(main())

--- a/bin/docker_base_images.py
+++ b/bin/docker_base_images.py
@@ -54,6 +54,7 @@ class Versions:
 class TagInfo:
     name: str
     architectures: frozenset[str]
+    last_updated: dt.datetime | None = None
 
     @classmethod
     def from_api(cls, payload: dict[str, object]) -> "TagInfo":
@@ -66,7 +67,18 @@ class TagInfo:
         name = payload.get("name")
         if not isinstance(name, str):
             raise BaseImageError("Docker Hub returned a tag without a name")
-        return cls(name=name, architectures=frozenset(architectures))
+        last_updated_value = payload.get("last_updated")
+        last_updated: dt.datetime | None = None
+        if isinstance(last_updated_value, str):
+            try:
+                last_updated = dt.datetime.fromisoformat(last_updated_value.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise BaseImageError(
+                    f"Docker Hub returned an invalid last_updated value for {name}: {last_updated_value}"
+                ) from error
+            if last_updated.tzinfo is None:
+                last_updated = last_updated.replace(tzinfo=dt.UTC)
+        return cls(name=name, architectures=frozenset(architectures), last_updated=last_updated)
 
 
 class DockerHubClient:
@@ -182,7 +194,11 @@ def _tag_map(tags: Iterable[TagInfo]) -> dict[str, TagInfo]:
 
 
 def compatible_debian_versions(
-    versions: Versions, hex_tags: Iterable[TagInfo], debian_tags: Iterable[TagInfo]
+    versions: Versions,
+    hex_tags: Iterable[TagInfo],
+    debian_tags: Iterable[TagInfo],
+    minimum_age_days: int = 0,
+    now: dt.datetime | None = None,
 ) -> list[str]:
     hex_by_name = _tag_map(hex_tags)
     debian_by_name = _tag_map(debian_tags)
@@ -198,19 +214,31 @@ def compatible_debian_versions(
         debian_tag = debian_by_name.get(debian_version)
         if not debian_tag:
             continue
-        if REQUIRED_ARCHITECTURES.issubset(hex_tag.architectures) and REQUIRED_ARCHITECTURES.issubset(
-            debian_tag.architectures
-        ):
-            compatible.append(debian_version)
+        architectures_match = REQUIRED_ARCHITECTURES.issubset(
+            hex_tag.architectures
+        ) and REQUIRED_ARCHITECTURES.issubset(debian_tag.architectures)
+        if not architectures_match:
+            continue
+        if minimum_age_days:
+            cutoff = (now or dt.datetime.now(dt.UTC)) - dt.timedelta(days=minimum_age_days)
+            if not hex_tag.last_updated or not debian_tag.last_updated:
+                continue
+            if hex_tag.last_updated > cutoff or debian_tag.last_updated > cutoff:
+                continue
+        compatible.append(debian_version)
 
     return sorted(compatible, key=lambda value: dt.datetime.strptime(value.split("-")[1], "%Y%m%d"))
 
 
-def fetch_compatible_versions(versions: Versions, client: DockerHubClient) -> list[str]:
+def fetch_compatible_versions(
+    versions: Versions, client: DockerHubClient, minimum_age_days: int = 0
+) -> list[str]:
     builder_prefix = f"{versions.elixir}-erlang-{versions.otp}-debian-{versions.debian_series}-"
     hex_tags = client.tags("hexpm/elixir", builder_prefix)
     debian_tags = client.tags("library/debian", f"{versions.debian_series}-")
-    compatible = compatible_debian_versions(versions, hex_tags, debian_tags)
+    compatible = compatible_debian_versions(
+        versions, hex_tags, debian_tags, minimum_age_days=minimum_age_days
+    )
     if not compatible:
         raise BaseImageError(
             "no compatible amd64/arm64 Debian and Hex builder tags were found for "
@@ -289,9 +317,13 @@ def check(root: pathlib.Path, client: DockerHubClient, warn_age_days: int, fail_
     return 0
 
 
-def apply(root: pathlib.Path, client: DockerHubClient, dry_run: bool) -> int:
+def apply(
+    root: pathlib.Path, client: DockerHubClient, dry_run: bool, minimum_age_days: int
+) -> int:
     versions = load_versions(root)
-    compatible = fetch_compatible_versions(versions, client)
+    compatible = fetch_compatible_versions(
+        versions, client, minimum_age_days=minimum_age_days
+    )
     latest = compatible[-1]
     if latest == versions.debian:
         print(f"Docker base snapshot is current: {versions.debian}")
@@ -303,17 +335,25 @@ def apply(root: pathlib.Path, client: DockerHubClient, dry_run: bool) -> int:
     return 0
 
 
+def nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path.cwd())
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     check_parser = subparsers.add_parser("check", help="validate configured images and report freshness")
-    check_parser.add_argument("--warn-age-days", type=int, default=45)
-    check_parser.add_argument("--fail-age-days", type=int)
+    check_parser.add_argument("--warn-age-days", type=nonnegative_int, default=45)
+    check_parser.add_argument("--fail-age-days", type=nonnegative_int)
 
     apply_parser = subparsers.add_parser("apply", help="update Dockerfiles to the latest compatible snapshot")
     apply_parser.add_argument("--dry-run", action="store_true")
+    apply_parser.add_argument("--minimum-age-days", type=nonnegative_int, default=3)
     return parser
 
 
@@ -323,7 +363,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.command == "check":
             return check(root, DockerHubClient(), args.warn_age_days, args.fail_age_days)
-        return apply(root, DockerHubClient(), args.dry_run)
+        return apply(root, DockerHubClient(), args.dry_run, args.minimum_age_days)
     except BaseImageError as error:
         print(f"error: {error}", file=sys.stderr)
         return 1

--- a/bin/image_attestations.py
+++ b/bin/image_attestations.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Verify SBOM and provenance attestations published for container images."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+
+EXPECTED_PREDICATES = frozenset(
+    {"https://slsa.dev/provenance/v1", "https://spdx.dev/Document"}
+)
+REQUIRED_PLATFORMS = frozenset({("linux", "amd64"), ("linux", "arm64")})
+
+
+class AttestationError(RuntimeError):
+    """Raised when an image does not contain the required attestations."""
+
+
+def repository_from_reference(reference: str) -> str:
+    repository = reference.split("@", maxsplit=1)[0]
+    last_slash = repository.rfind("/")
+    last_colon = repository.rfind(":")
+    if last_colon > last_slash:
+        repository = repository[:last_colon]
+    return repository
+
+
+def predicate_types(manifest: dict[str, object]) -> frozenset[str]:
+    predicates: set[str] = set()
+    for layer in manifest.get("layers") or []:
+        if not isinstance(layer, dict):
+            continue
+        annotations = layer.get("annotations") or {}
+        if not isinstance(annotations, dict):
+            continue
+        predicate = annotations.get("in-toto.io/predicate-type")
+        if isinstance(predicate, str):
+            predicates.add(predicate)
+    return frozenset(predicates)
+
+
+def validate_attestations(
+    index: dict[str, object], load_manifest: Callable[[str], dict[str, object]]
+) -> None:
+    platform_digests: dict[str, tuple[str, str]] = {}
+    attestation_digests: dict[str, list[str]] = {}
+
+    for descriptor in index.get("manifests") or []:
+        if not isinstance(descriptor, dict):
+            continue
+        digest = descriptor.get("digest")
+        if not isinstance(digest, str):
+            continue
+        platform = descriptor.get("platform") or {}
+        annotations = descriptor.get("annotations") or {}
+        if not isinstance(platform, dict) or not isinstance(annotations, dict):
+            continue
+        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+            subject = annotations.get("vnd.docker.reference.digest")
+            if isinstance(subject, str):
+                attestation_digests.setdefault(subject, []).append(digest)
+            continue
+        os_name = platform.get("os")
+        architecture = platform.get("architecture")
+        if isinstance(os_name, str) and isinstance(architecture, str):
+            platform_digests[digest] = (os_name, architecture)
+
+    available_platforms = set(platform_digests.values())
+    missing_platforms = REQUIRED_PLATFORMS - available_platforms
+    if missing_platforms:
+        rendered = ", ".join(f"{os_name}/{architecture}" for os_name, architecture in sorted(missing_platforms))
+        raise AttestationError(f"missing image platforms: {rendered}")
+
+    for subject_digest, platform in platform_digests.items():
+        if platform not in REQUIRED_PLATFORMS:
+            continue
+        predicates: set[str] = set()
+        for attestation_digest in attestation_digests.get(subject_digest, []):
+            manifest = load_manifest(attestation_digest)
+            subject = manifest.get("subject")
+            if subject is not None and (
+                not isinstance(subject, dict) or subject.get("digest") != subject_digest
+            ):
+                raise AttestationError(
+                    f"attestation {attestation_digest} has the wrong subject for {platform[0]}/{platform[1]}"
+                )
+            predicates.update(predicate_types(manifest))
+
+        missing_predicates = EXPECTED_PREDICATES - predicates
+        if missing_predicates:
+            rendered = ", ".join(sorted(missing_predicates))
+            raise AttestationError(
+                f"{platform[0]}/{platform[1]} is missing attestation predicates: {rendered}"
+            )
+
+
+def inspect_raw(reference: str) -> dict[str, object]:
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", reference],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise AttestationError(f"invalid manifest returned for {reference}")
+    return payload
+
+
+def check_image(reference: str) -> None:
+    repository = repository_from_reference(reference)
+    index = inspect_raw(reference)
+    validate_attestations(index, lambda digest: inspect_raw(f"{repository}@{digest}"))
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("images", nargs="+")
+    parser.add_argument("--attempts", type=positive_int, default=5)
+    parser.add_argument("--delay-seconds", type=nonnegative_float, default=3.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    for image in args.images:
+        for attempt in range(1, args.attempts + 1):
+            try:
+                check_image(image)
+                print(f"verified SBOM and provenance attestations: {image}")
+                break
+            except (AttestationError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as error:
+                if attempt == args.attempts:
+                    print(f"error: failed to verify {image}: {error}", file=sys.stderr)
+                    return 1
+                print(
+                    f"waiting for attestations on {image} ({attempt}/{args.attempts}): {error}",
+                    file=sys.stderr,
+                )
+                time.sleep(args.delay_seconds)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/bin/docker_base_images_test.py
+++ b/test/bin/docker_base_images_test.py
@@ -97,6 +97,40 @@ class DockerBaseImagesTest(unittest.TestCase):
             subject.compatible_debian_versions(versions, hex_tags, debian_tags),
         )
 
+    def test_compatible_versions_enforce_release_soak(self):
+        versions = subject.load_versions(self.root)
+        both = frozenset({"amd64", "arm64"})
+        now = dt.datetime(2026, 3, 10, tzinfo=dt.UTC)
+        old = now - dt.timedelta(days=4)
+        new = now - dt.timedelta(days=1)
+        hex_prefix = "1.19.5-erlang-27.3.4.6-debian-"
+        hex_tags = [
+            subject.TagInfo(f"{hex_prefix}trixie-20260202-slim", both, old),
+            subject.TagInfo(f"{hex_prefix}trixie-20260303-slim", both, new),
+        ]
+        debian_tags = [
+            subject.TagInfo("trixie-20260202-slim", both, old),
+            subject.TagInfo("trixie-20260303-slim", both, old),
+        ]
+
+        self.assertEqual(
+            ["trixie-20260202-slim"],
+            subject.compatible_debian_versions(
+                versions, hex_tags, debian_tags, minimum_age_days=3, now=now
+            ),
+        )
+
+    def test_tag_info_parses_docker_hub_timestamp(self):
+        tag = subject.TagInfo.from_api(
+            {
+                "name": "trixie-20260202-slim",
+                "images": [{"architecture": "amd64"}, {"architecture": "arm64"}],
+                "last_updated": "2026-02-03T04:05:06.123456Z",
+            }
+        )
+
+        self.assertEqual(dt.datetime(2026, 2, 3, 4, 5, 6, 123456, tzinfo=dt.UTC), tag.last_updated)
+
     def test_replace_debian_version_updates_all_dockerfiles(self):
         subject.replace_debian_version(
             self.root, "trixie-20260112-slim", "trixie-20260202-slim"

--- a/test/bin/image_attestations_test.py
+++ b/test/bin/image_attestations_test.py
@@ -1,0 +1,119 @@
+import contextlib
+import io
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "bin"))
+
+import image_attestations as subject
+
+
+class ImageAttestationsTest(unittest.TestCase):
+    def setUp(self):
+        self.index = {
+            "manifests": [
+                {
+                    "digest": "sha256:amd64",
+                    "platform": {"os": "linux", "architecture": "amd64"},
+                },
+                {
+                    "digest": "sha256:amd64-attestation",
+                    "platform": {"os": "unknown", "architecture": "unknown"},
+                    "annotations": {
+                        "vnd.docker.reference.type": "attestation-manifest",
+                        "vnd.docker.reference.digest": "sha256:amd64",
+                    },
+                },
+                {
+                    "digest": "sha256:arm64",
+                    "platform": {"os": "linux", "architecture": "arm64"},
+                },
+                {
+                    "digest": "sha256:arm64-attestation",
+                    "platform": {"os": "unknown", "architecture": "unknown"},
+                    "annotations": {
+                        "vnd.docker.reference.type": "attestation-manifest",
+                        "vnd.docker.reference.digest": "sha256:arm64",
+                    },
+                },
+            ]
+        }
+        self.manifests = {
+            "sha256:amd64-attestation": self.attestation("sha256:amd64"),
+            "sha256:arm64-attestation": self.attestation("sha256:arm64"),
+        }
+
+    def attestation(self, image_digest):
+        return {
+            "subject": {"digest": image_digest},
+            "layers": [
+                {
+                    "annotations": {
+                        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+                    }
+                },
+                {
+                    "annotations": {
+                        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+                    }
+                },
+            ],
+        }
+
+    def test_validate_attestations_accepts_sbom_and_provenance_for_both_platforms(self):
+        subject.validate_attestations(self.index, self.manifests.__getitem__)
+
+    def test_validate_attestations_rejects_missing_platform(self):
+        self.index["manifests"] = self.index["manifests"][:2]
+
+        with self.assertRaisesRegex(subject.AttestationError, "missing image platforms: linux/arm64"):
+            subject.validate_attestations(self.index, self.manifests.__getitem__)
+
+    def test_validate_attestations_rejects_missing_sbom(self):
+        self.manifests["sha256:amd64-attestation"]["layers"] = [
+            {
+                "annotations": {
+                    "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+                }
+            }
+        ]
+
+        with self.assertRaisesRegex(subject.AttestationError, "https://spdx.dev/Document"):
+            subject.validate_attestations(self.index, self.manifests.__getitem__)
+
+    def test_validate_attestations_accepts_legacy_manifest_without_subject(self):
+        del self.manifests["sha256:amd64-attestation"]["subject"]
+
+        subject.validate_attestations(self.index, self.manifests.__getitem__)
+
+    def test_validate_attestations_rejects_wrong_subject(self):
+        self.manifests["sha256:arm64-attestation"]["subject"]["digest"] = "sha256:wrong"
+
+        with self.assertRaisesRegex(subject.AttestationError, "wrong subject"):
+            subject.validate_attestations(self.index, self.manifests.__getitem__)
+
+    def test_attempts_must_be_positive(self):
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            subject.build_parser().parse_args(["--attempts", "0", "example/image:latest"])
+
+    def test_delay_must_be_nonnegative(self):
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            subject.build_parser().parse_args(
+                ["--delay-seconds", "-1", "example/image:latest"]
+            )
+
+    def test_repository_from_reference_handles_registry_ports_and_tags(self):
+        self.assertEqual(
+            "localhost:5000/logflare",
+            subject.repository_from_reference("localhost:5000/logflare:dev"),
+        )
+        self.assertEqual(
+            "supabase/logflare",
+            subject.repository_from_reference("supabase/logflare@sha256:abc"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- publish SPDX SBOM and maximum-mode SLSA provenance attestations for application, base, and runner images
- hand exact Buildx output digests between architecture builds and manifest publication instead of trusting mutable tags
- verify both predicates for amd64 and arm64 after publishing final multi-architecture tags
- verify versioned and `latest` release tags after retagging
- use immutable commit pins for every action touched by the security stack
- merge daily base/runner runs serially and from run-specific digest artifacts

## Validation

- 18 focused Python tests pass
- checker accepts BuildKit OCI and legacy attestation-manifest forms, validates subjects when present, and requires SPDX plus SLSA predicates for both architectures
- live inspection confirmed Docker Hub's current provenance descriptor format; the checker correctly rejects the existing base tag because its SBOM predicate is absent
- full production Docker image build and runtime smoke check pass
- all changed workflows pass `actionlint` except the repository's custom Blacksmith runner-label diagnostic
- production Docker workflow passed ([run 31849626334](https://github.com/Logflare/logflare/actions/runs/31849626334))

## Residual rollout note

The post-push checker intentionally fails publication if Docker Hub does not expose both attestations. Full registry verification therefore occurs on the first publishing run after merge.

## Stack

- Depends on #3835
- This is security stack PR 4 of 4
