### PR TITLE
perf(clickhouse): encode RowBinary rows in processors

### DIFF
--- a/bench/clickhouse_processor_rowbinary.exs
+++ b/bench/clickhouse_processor_rowbinary.exs
@@ -1,5 +1,6 @@
 # Fixed-work benchmark for moving fused ClickHouse mapping/RowBinary production
-# from Broadway batch processors into processors.
+# from Broadway batch processors into processors. It excludes Broadway message
+# handling, generation replacement, HTTP, and ClickHouse execution.
 #
 # Examples:
 #

--- a/bench/clickhouse_processor_rowbinary.exs
+++ b/bench/clickhouse_processor_rowbinary.exs
@@ -1,0 +1,185 @@
+# Fixed-work benchmark for moving fused ClickHouse mapping/RowBinary production
+# from Broadway batch processors into processors.
+#
+# Examples:
+#
+#   MIX_ENV=test SCENARIO=baseline EVENT_TYPE=log BATCH_SIZE=10000 BATCHES=20 \
+#     mix run --no-start bench/clickhouse_processor_rowbinary.exs
+#
+#   MIX_ENV=test SCENARIO=processor CONCURRENCY=6 EVENT_TYPE=log \
+#     BATCH_SIZE=10000 BATCHES=20 \
+#     mix run --no-start bench/clickhouse_processor_rowbinary.exs
+#
+# Scenarios:
+#   baseline  ETS lookup -> fused mapper/RowBinary -> streaming gzip, serially
+#   processor ETS lookup -> fused mapper/RowBinary in parallel processor chunks,
+#             then streaming gzip serially
+#   encode    processor-side lookup and fused mapper/RowBinary only
+#   compress  gzip already-encoded rows only
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+defmodule Logflare.Bench.ClickHouseProcessorRowBinary do
+  @moduledoc false
+
+  alias Logflare.Backends.IngestEventQueue
+  alias Logflare.LogEvent
+  alias Logflare.Mapper
+  alias Logflare.Mapper.OutputContext
+
+  @spec encode_rows(
+          [{term(), :ets.tid()}],
+          reference(),
+          binary(),
+          pos_integer(),
+          pos_integer()
+        ) :: [binary()]
+  def encode_rows(id_tid_pairs, compiled, mapping_config_id, concurrency, processor_chunk_size) do
+    id_tid_pairs
+    |> Enum.chunk_every(processor_chunk_size)
+    |> Task.async_stream(
+      fn chunk -> Enum.map(chunk, &encode_pointer(&1, compiled, mapping_config_id)) end,
+      max_concurrency: concurrency,
+      ordered: true,
+      timeout: :infinity
+    )
+    |> Enum.flat_map(fn {:ok, rows} -> rows end)
+  end
+
+  @spec encode_rows_serial([{term(), :ets.tid()}], reference(), binary()) :: [binary()]
+  def encode_rows_serial(id_tid_pairs, compiled, mapping_config_id) do
+    Enum.map(id_tid_pairs, &encode_pointer(&1, compiled, mapping_config_id))
+  end
+
+  @spec compress_rows([binary()]) :: binary()
+  def compress_rows(rows) do
+    gzip_stream(fn z -> Enum.map(rows, &:zlib.deflate(z, &1)) end)
+  end
+
+  @spec baseline([{term(), :ets.tid()}], reference(), binary()) :: binary()
+  def baseline(id_tid_pairs, compiled, mapping_config_id) do
+    gzip_stream(fn z ->
+      Enum.map(id_tid_pairs, fn pair ->
+        :zlib.deflate(z, encode_pointer(pair, compiled, mapping_config_id))
+      end)
+    end)
+  end
+
+  defp encode_pointer({id, tid}, compiled, mapping_config_id) do
+    %LogEvent{} = event = IngestEventQueue.lookup_event(tid, id)
+    output_context = OutputContext.clickhouse_row_binary(event, mapping_config_id)
+    Mapper.map(event.body, compiled, output_context: output_context)
+  end
+
+  defp gzip_stream(fun) do
+    z = :zlib.open()
+
+    try do
+      :zlib.deflateInit(z, :default, :deflated, 31, 8, :default)
+      chunks = fun.(z)
+      IO.iodata_to_binary([chunks, :zlib.deflate(z, "", :finish)])
+    after
+      :zlib.deflateEnd(z)
+      :zlib.close(z)
+    end
+  end
+end
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+alias Logflare.Bench.ClickHouseProcessorRowBinary, as: Bench
+
+scenario = System.get_env("SCENARIO", "processor") |> String.to_existing_atom()
+type = System.get_env("EVENT_TYPE", "log") |> String.to_existing_atom()
+batch_size = System.get_env("BATCH_SIZE", "10000") |> String.to_integer()
+batches = System.get_env("BATCHES", "20") |> String.to_integer()
+warmup_batches = System.get_env("WARMUP_BATCHES", "2") |> String.to_integer()
+concurrency = System.get_env("CONCURRENCY", "6") |> String.to_integer()
+processor_chunk_size = System.get_env("PROCESSOR_CHUNK_SIZE", "1000") |> String.to_integer()
+
+{compiled, config_id} = Data.compiled_output(type)
+mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+events = Data.batch(type, batch_size, :realistic)
+tid = Data.setup_processing_ets(events)
+id_tid_pairs = Enum.map(events, &{&1.id, tid})
+encoded_rows = Bench.encode_rows_serial(id_tid_pairs, compiled, mapping_config_id)
+
+baseline = Bench.baseline(id_tid_pairs, compiled, mapping_config_id)
+candidate = Bench.compress_rows(encoded_rows)
+
+if baseline != candidate do
+  raise "processor-side output differs from the batch-side baseline"
+end
+
+run =
+  case scenario do
+    :baseline ->
+      fn -> Bench.baseline(id_tid_pairs, compiled, mapping_config_id) end
+
+    :processor ->
+      fn ->
+        id_tid_pairs
+        |> Bench.encode_rows(compiled, mapping_config_id, concurrency, processor_chunk_size)
+        |> Bench.compress_rows()
+      end
+
+    :encode ->
+      fn ->
+        Bench.encode_rows(
+          id_tid_pairs,
+          compiled,
+          mapping_config_id,
+          concurrency,
+          processor_chunk_size
+        )
+      end
+
+    :compress ->
+      fn -> Bench.compress_rows(encoded_rows) end
+  end
+
+if warmup_batches > 0 do
+  for _ <- 1..warmup_batches, do: run.()
+end
+
+:erlang.garbage_collect()
+:erlang.statistics(:runtime)
+:erlang.statistics(:wall_clock)
+:erlang.statistics(:reductions)
+
+{elapsed_us, result_bytes} =
+  :timer.tc(fn ->
+    Enum.reduce(1..batches, 0, fn _, total ->
+      result = run.()
+      bytes = if is_binary(result), do: byte_size(result), else: Enum.sum_by(result, &byte_size/1)
+      total + bytes
+    end)
+  end)
+
+{_, runtime_ms} = :erlang.statistics(:runtime)
+{_, wall_ms} = :erlang.statistics(:wall_clock)
+{_, reductions} = :erlang.statistics(:reductions)
+rows = batch_size * batches
+
+IO.puts("scenario=#{scenario}")
+IO.puts("event_type=#{type}")
+IO.puts("schedulers_online=#{System.schedulers_online()}")
+IO.puts("concurrency=#{concurrency}")
+IO.puts("processor_chunk_size=#{processor_chunk_size}")
+IO.puts("batch_size=#{batch_size}")
+IO.puts("batches=#{batches}")
+IO.puts("rows=#{rows}")
+
+IO.puts(
+  "rowbinary_bytes_per_row=#{Float.round(Enum.sum_by(encoded_rows, &byte_size/1) / batch_size, 2)}"
+)
+
+IO.puts("result_bytes_total=#{result_bytes}")
+IO.puts("elapsed_us=#{elapsed_us}")
+IO.puts("runtime_ms=#{runtime_ms}")
+IO.puts("wall_ms=#{wall_ms}")
+IO.puts("reductions=#{reductions}")
+IO.puts("rows_per_wall_second=#{Float.round(rows / (elapsed_us / 1_000_000), 2)}")
+IO.puts("wall_us_per_row=#{Float.round(elapsed_us / rows, 4)}")
+IO.puts("runtime_us_per_row=#{Float.round(runtime_ms * 1000 / rows, 4)}")
+IO.puts("reductions_per_row=#{Float.round(reductions / rows, 2)}")

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -74,7 +74,10 @@ Maximum RSS changed by less than 1% because the benchmark includes the bounded t
 handoff where an event copy and its new binary coexist. After handoff, ETS memory falls
 sharply while binary memory rises; total VM memory is lower.
 
-Reducing batch-processor concurrency also lowers the count-based in-flight ceiling from
-3.84 million to 480,000 rows per backend. Together with the lower steady-state memory
-above, this supports deferring byte-based control while retaining it as useful future
+Batch-processor concurrency is decoupled from the count-based in-flight ceiling. Four
+workers bound concurrent gzip/HTTP inserts, while the producer retains the previous
+64-batch capacity of 3.84 million rows per backend. During downstream stalls, encoded
+partial and completed batches can accumulate in Broadway's `:ch` batcher up to that
+cap; additional backlog remains in `IngestEventQueue`. The lower steady-state memory
+above supports retaining this capacity while byte-based control remains useful future
 hardening.

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -1,8 +1,11 @@
 # ClickHouse processor-side RowBinary benchmark
 
-This benchmark compares the fused-mapper baseline, where each batch processor
-resolves and encodes every row serially after a batch triggers, with processor-side
-encoding followed by batch-only gzip work.
+This fixed-work benchmark compares the fused-mapper baseline, where each batch
+processor resolves and encodes every row serially after a batch triggers, with
+processor-side encoding followed by batch-only gzip work. It measures ETS lookup,
+mapping, RowBinary encoding, and compression; it does not include Broadway message
+handling, generation-value replacement, HTTP, or ClickHouse execution. Treat the
+results as directional local-path measurements rather than production throughput.
 
 ## Environment
 
@@ -19,8 +22,9 @@ Commands use `MIX_ENV=test mix run --no-start` with:
 
 The phase comparison uses `BATCH_SIZE=60000`, `BATCHES=3`, `WARMUP_BATCHES=1`,
 `CONCURRENCY=6`, and `PROCESSOR_CHUNK_SIZE=1000` for each event type and the `baseline`,
-`processor`, `encode`, and `compress` scenarios. The concurrency sweep holds those
-settings constant while testing `CONCURRENCY=4,6,8,12`. Memory runs use
+`processor`, `encode`, and `compress` scenarios. Each table entry is one three-batch
+observation rather than a repeated distribution with variance. The concurrency sweep
+holds those settings constant while testing `CONCURRENCY=4,6,8,12`. Memory runs use
 `BATCH_SIZE=60000` and compare `SCENARIO=event` with `SCENARIO=encoded` in separate OS
 processes under `/usr/bin/time -v`.
 
@@ -37,10 +41,12 @@ a warmup batch.
 | trace | 120,384 | 135,506 | 136,458 | **138,754** |
 
 Six processors remain the balanced setting on the six-scheduler benchmark host. At
-runtime, processor concurrency is `max(System.schedulers_online() - 4, 6)`, reserving
-nominal capacity for the four fixed gzip/HTTP batch processors. This resolves to 6
-processors on 6 schedulers, 8 on 12, and 28 on 32. Concurrency remains per backend
-pipeline, so deployments with multiple active ClickHouse backends multiply that count.
+runtime, processor concurrency is `max(System.schedulers_online() - 4, 6)`. This
+subtracts four on larger hosts but intentionally keeps a six-processor floor, so hosts
+with fewer than ten schedulers remain oversubscribed once the four gzip/HTTP batch
+processors are included. The formula resolves to 6 processors on 6 schedulers, 8 on 12,
+and 28 on 32. Concurrency remains per backend pipeline, so deployments with multiple
+active ClickHouse backends multiply that count.
 
 Twelve processors on the six-scheduler host gain only about 2% for logs and traces while
 losing about 2% for metrics, illustrating the cost of oversubscribing the available
@@ -48,12 +54,12 @@ schedulers. The existing `max_demand: 1_000` remains suitable: six-processor enc
 plus gzip completes 60,000 rows in roughly 0.35–0.58 seconds, comfortably below the
 5-second batch timeout.
 
-## End-to-end comparison with current main
+## Local-path comparison with historical main
 
-Current `main` at `ee61fab1` was measured in a separate clean workspace on the same
-host using the same fixtures and fixed-work settings. Its production-equivalent path is
-ETS lookup, `Mapper.map/3`, Elixir RowBinary encoding, and streaming gzip. Compressed
-output byte counts matched both stacked scenarios exactly.
+Historical `main` at `ee61fab1` was measured in a separate clean workspace on the same
+host using the same fixtures and fixed-work settings. Its measured local path is ETS
+lookup, `Mapper.map/3`, Elixir RowBinary encoding, and streaming gzip. Compressed output
+byte counts matched both stacked scenarios exactly.
 
 | Event type | Current main | Fused batch-side (#3759) | Processor-side (#3837) | #3837 elapsed change vs main |
 | --- | ---: | ---: | ---: | ---: |
@@ -61,8 +67,9 @@ output byte counts matched both stacked scenarios exactly.
 | metric | 37,309 rows/s | 49,452 rows/s | 102,807 rows/s | -64% |
 | trace | 38,807 rows/s | 66,893 rows/s | 137,989 rows/s | -72% |
 
-The combined stack therefore shortens the measured local path by 55–72% versus current
-main. The next section isolates #3837's incremental effect on top of the fused mapper.
+The combined stack therefore shortens this measured local path by 55–72% versus the
+historical revision. The next section isolates #3837's incremental effect on top of the
+fused mapper; it does not estimate end-to-end ingest throughput.
 
 ## Incremental batch critical path
 
@@ -109,6 +116,7 @@ Batch-processor concurrency is decoupled from the count-based in-flight ceiling.
 workers bound concurrent gzip/HTTP inserts, while the producer retains the previous
 64-batch capacity of 3.84 million rows per backend. During downstream stalls, encoded
 partial and completed batches can accumulate in Broadway's `:ch` batcher up to that
-cap; additional backlog remains in `IngestEventQueue`. The lower steady-state memory
-above supports retaining this capacity while byte-based control remains useful future
+cap; additional backlog remains in `IngestEventQueue`. The one-batch steady-state
+measurement above does not establish memory safety at the count ceiling. It supports
+the relative representation change, while byte-based control remains useful future
 hardening.

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -17,38 +17,47 @@ Commands use `MIX_ENV=test mix run --no-start` with:
 - `bench/clickhouse_processor_rowbinary.exs`
 - `bench/clickhouse_processor_rowbinary_memory.exs`
 
+The phase comparison uses `BATCH_SIZE=60000`, `BATCHES=3`, `WARMUP_BATCHES=1`,
+`CONCURRENCY=6`, and `PROCESSOR_CHUNK_SIZE=1000` for each event type and the `baseline`,
+`processor`, `encode`, and `compress` scenarios. The concurrency sweep holds those
+settings constant while testing `CONCURRENCY=4,6,8,12`. Memory runs use
+`BATCH_SIZE=60000` and compare `SCENARIO=event` with `SCENARIO=encoded` in separate OS
+processes under `/usr/bin/time -v`.
+
 ## Processor concurrency
 
 The processor scenario uses Broadway-shaped chunks of at most 1,000 rows. Results are
-rows per wall-clock second; each result covers two measured 60,000-row batches after a
-warmup batch.
+rows per wall-clock second; each result covers three measured 60,000-row batches after
+a warmup batch.
 
 | Event type | 4 processors | 6 processors | 8 processors | 12 processors |
 | --- | ---: | ---: | ---: | ---: |
-| log | 160,738 | **177,639** | 172,985 | 172,124 |
-| metric | 102,026 | 109,377 | **110,139** | 106,113 |
-| trace | 122,252 | 137,700 | 136,841 | **140,546** |
+| log | 158,534 | 170,951 | 171,329 | **174,227** |
+| metric | 99,290 | **107,397** | 106,749 | 105,733 |
+| trace | 120,384 | 135,506 | 136,458 | **138,754** |
 
-Six processors are the balanced setting on six schedulers. Higher concurrency has no
-consistent benefit across event types and increases scheduler competition with gzip.
-The existing `max_demand: 1_000` also remains suitable: serial fused encoding measured
-about 9–19 ms per 1,000 production-shaped rows, comfortably below the 5-second batch
-timeout.
+Six processors remain the balanced setting on six schedulers. Twelve processors gain
+only about 2% for logs and traces while losing about 2% for metrics, at the cost of
+additional scheduler competition with gzip. The existing `max_demand: 1_000` also
+remains suitable: six-processor encoding plus gzip completes 60,000 rows in roughly
+0.35–0.58 seconds, comfortably below the 5-second batch timeout.
 
 ## Batch critical path
 
 | Event type | Batch-side encode + gzip | Processor encode, then gzip | Gzip only |
 | --- | ---: | ---: | ---: |
-| log | 63,330 rows/s | 177,639 rows/s | 200,831 rows/s |
-| metric | 51,659 rows/s | 109,377 rows/s | 179,262 rows/s |
-| trace | 69,281 rows/s | 137,700 rows/s | 218,439 rows/s |
+| log | 78,693 rows/s | 168,077 rows/s | 230,489 rows/s |
+| metric | 49,452 rows/s | 102,807 rows/s | 178,773 rows/s |
+| trace | 66,893 rows/s | 137,989 rows/s | 219,139 rows/s |
 
 Processor-side encoding shortens the local 60,000-row encode/compress critical path by
-roughly 50–64%. It does not remove CPU work; it overlaps and parallelizes fused encoding
-before the batch trigger. Gzip remains serial per batch.
+roughly 51–53%. Encoding-only throughput with six processors is 379k log, 230k metric,
+and 334k trace rows/s; gzip-only throughput shows that serial compression becomes the
+remaining local bottleneck. The change does not remove CPU work—it overlaps and
+parallelizes fused encoding before the batch trigger.
 
 Batch-processor concurrency is reduced from 32 to 4. The local benchmark shows that one
-gzip worker can process roughly 179k–218k rows/s, so additional workers primarily cover
+gzip worker can process roughly 179k–230k rows/s, so additional workers primarily cover
 HTTP latency rather than CPU throughput. Production insert timeouts provide the missing
 downstream evidence: 32 workers let one backend issue 32 simultaneous HTTP/1 inserts,
 occupy most of the shared primary Finch pool, exceed the async pool's connection count,
@@ -66,11 +75,11 @@ The ETS value and Broadway message share the same reference-counted RowBinary pa
 
 | Event type | Full-event state | Encoded-row state | Change |
 | --- | ---: | ---: | ---: |
-| log | 328.9 MB | 230.7 MB | -29.9% |
-| metric | 471.6 MB | 275.0 MB | -41.7% |
-| trace | 403.4 MB | 249.6 MB | -38.1% |
+| log | 328.2 MB | 229.3 MB | -30.1% |
+| metric | 472.4 MB | 275.0 MB | -41.8% |
+| trace | 402.8 MB | 249.6 MB | -38.0% |
 
-Maximum RSS changed by less than 1% because the benchmark includes the bounded transient
+Maximum RSS changed by at most 1.6% because the benchmark includes the bounded transient
 handoff where an event copy and its new binary coexist. After handoff, ETS memory falls
 sharply while binary memory rises; total VM memory is lower.
 

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -42,9 +42,25 @@ additional scheduler competition with gzip. The existing `max_demand: 1_000` als
 remains suitable: six-processor encoding plus gzip completes 60,000 rows in roughly
 0.35–0.58 seconds, comfortably below the 5-second batch timeout.
 
-## Batch critical path
+## End-to-end comparison with current main
 
-| Event type | Batch-side encode + gzip | Processor encode, then gzip | Gzip only |
+Current `main` at `ee61fab1` was measured in a separate clean workspace on the same
+host using the same fixtures and fixed-work settings. Its production-equivalent path is
+ETS lookup, `Mapper.map/3`, Elixir RowBinary encoding, and streaming gzip. Compressed
+output byte counts matched both stacked scenarios exactly.
+
+| Event type | Current main | Fused batch-side (#3759) | Processor-side (#3837) | #3837 elapsed change vs main |
+| --- | ---: | ---: | ---: | ---: |
+| log | 75,520 rows/s | 78,693 rows/s | 168,077 rows/s | -55% |
+| metric | 37,309 rows/s | 49,452 rows/s | 102,807 rows/s | -64% |
+| trace | 38,807 rows/s | 66,893 rows/s | 137,989 rows/s | -72% |
+
+The combined stack therefore shortens the measured local path by 55–72% versus current
+main. The next section isolates #3837's incremental effect on top of the fused mapper.
+
+## Incremental batch critical path
+
+| Event type | Fused batch-side (#3759) | Processor-side (#3837) | Gzip only |
 | --- | ---: | ---: | ---: |
 | log | 78,693 rows/s | 168,077 rows/s | 230,489 rows/s |
 | metric | 49,452 rows/s | 102,807 rows/s | 178,773 rows/s |

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -1,0 +1,80 @@
+# ClickHouse processor-side RowBinary benchmark
+
+This benchmark compares the fused-mapper baseline, where each batch processor
+resolves and encodes every row serially after a batch triggers, with processor-side
+encoding followed by batch-only gzip work.
+
+## Environment
+
+- Linux aarch64
+- 6 online BEAM schedulers
+- production-shaped synthetic log, metric, and trace events
+- 60,000-row batches
+- fused mapper output validated byte-for-byte against the baseline
+
+Commands use `MIX_ENV=test mix run --no-start` with:
+
+- `bench/clickhouse_processor_rowbinary.exs`
+- `bench/clickhouse_processor_rowbinary_memory.exs`
+
+## Processor concurrency
+
+The processor scenario uses Broadway-shaped chunks of at most 1,000 rows. Results are
+rows per wall-clock second; each result covers two measured 60,000-row batches after a
+warmup batch.
+
+| Event type | 4 processors | 6 processors | 8 processors | 12 processors |
+| --- | ---: | ---: | ---: | ---: |
+| log | 160,738 | **177,639** | 172,985 | 172,124 |
+| metric | 102,026 | 109,377 | **110,139** | 106,113 |
+| trace | 122,252 | 137,700 | 136,841 | **140,546** |
+
+Six processors are the balanced setting on six schedulers. Higher concurrency has no
+consistent benefit across event types and increases scheduler competition with gzip.
+The existing `max_demand: 1_000` also remains suitable: serial fused encoding measured
+about 9–19 ms per 1,000 production-shaped rows, comfortably below the 5-second batch
+timeout.
+
+## Batch critical path
+
+| Event type | Batch-side encode + gzip | Processor encode, then gzip | Gzip only |
+| --- | ---: | ---: | ---: |
+| log | 63,330 rows/s | 177,639 rows/s | 200,831 rows/s |
+| metric | 51,659 rows/s | 109,377 rows/s | 179,262 rows/s |
+| trace | 69,281 rows/s | 137,700 rows/s | 218,439 rows/s |
+
+Processor-side encoding shortens the local 60,000-row encode/compress critical path by
+roughly 50–64%. It does not remove CPU work; it overlaps and parallelizes fused encoding
+before the batch trigger. Gzip remains serial per batch.
+
+Batch-processor concurrency is reduced from 32 to 4. The local benchmark shows that one
+gzip worker can process roughly 179k–218k rows/s, so additional workers primarily cover
+HTTP latency rather than CPU throughput. Production insert timeouts provide the missing
+downstream evidence: 32 workers let one backend issue 32 simultaneous HTTP/1 inserts,
+occupy most of the shared primary Finch pool, exceed the async pool's connection count,
+and amplify retries when ClickHouse slows. Four workers retain bounded HTTP overlap
+without allowing one backend to monopolize the connection pools.
+
+## Memory
+
+Steady-state VM memory was measured after garbage collection while holding either:
+
+1. claimed pointers plus full `LogEvent`s in the generation store, or
+2. processor messages plus `EncodedRow`s replacing those generation values.
+
+The ETS value and Broadway message share the same reference-counted RowBinary payload.
+
+| Event type | Full-event state | Encoded-row state | Change |
+| --- | ---: | ---: | ---: |
+| log | 328.9 MB | 230.7 MB | -29.9% |
+| metric | 471.6 MB | 275.0 MB | -41.7% |
+| trace | 403.4 MB | 249.6 MB | -38.1% |
+
+Maximum RSS changed by less than 1% because the benchmark includes the bounded transient
+handoff where an event copy and its new binary coexist. After handoff, ETS memory falls
+sharply while binary memory rises; total VM memory is lower.
+
+Reducing batch-processor concurrency also lowers the count-based in-flight ceiling from
+3.84 million to 480,000 rows per backend. Together with the lower steady-state memory
+above, this supports deferring byte-based control while retaining it as useful future
+hardening.

--- a/bench/clickhouse_processor_rowbinary.md
+++ b/bench/clickhouse_processor_rowbinary.md
@@ -36,11 +36,17 @@ a warmup batch.
 | metric | 99,290 | **107,397** | 106,749 | 105,733 |
 | trace | 120,384 | 135,506 | 136,458 | **138,754** |
 
-Six processors remain the balanced setting on six schedulers. Twelve processors gain
-only about 2% for logs and traces while losing about 2% for metrics, at the cost of
-additional scheduler competition with gzip. The existing `max_demand: 1_000` also
-remains suitable: six-processor encoding plus gzip completes 60,000 rows in roughly
-0.35–0.58 seconds, comfortably below the 5-second batch timeout.
+Six processors remain the balanced setting on the six-scheduler benchmark host. At
+runtime, processor concurrency is `max(System.schedulers_online() - 4, 6)`, reserving
+nominal capacity for the four fixed gzip/HTTP batch processors. This resolves to 6
+processors on 6 schedulers, 8 on 12, and 28 on 32. Concurrency remains per backend
+pipeline, so deployments with multiple active ClickHouse backends multiply that count.
+
+Twelve processors on the six-scheduler host gain only about 2% for logs and traces while
+losing about 2% for metrics, illustrating the cost of oversubscribing the available
+schedulers. The existing `max_demand: 1_000` remains suitable: six-processor encoding
+plus gzip completes 60,000 rows in roughly 0.35–0.58 seconds, comfortably below the
+5-second batch timeout.
 
 ## End-to-end comparison with current main
 

--- a/bench/clickhouse_processor_rowbinary_memory.exs
+++ b/bench/clickhouse_processor_rowbinary_memory.exs
@@ -1,0 +1,111 @@
+# Compares the steady-state and peak VM memory of claimed ClickHouse events backed
+# by full LogEvents versus processor-produced RowBinary messages whose generation
+# rows have been replaced with the same reference-counted binaries.
+#
+# Run each scenario in a separate OS process, preferably under /usr/bin/time -v:
+#
+#   MIX_ENV=test SCENARIO=event BATCH_SIZE=60000 \
+#     mix run --no-start bench/clickhouse_processor_rowbinary_memory.exs
+#   MIX_ENV=test SCENARIO=encoded BATCH_SIZE=60000 CONCURRENCY=6 \
+#     mix run --no-start bench/clickhouse_processor_rowbinary_memory.exs
+
+Code.require_file("support/clickhouse_pipeline_bench_data.exs", __DIR__)
+
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.Backends.IngestEventQueue
+alias Logflare.Backends.IngestEventQueue.LogEventPointer
+alias Logflare.Bench.ClickHousePipelineData, as: Data
+alias Logflare.LogEvent
+alias Logflare.Mapper
+alias Logflare.Mapper.OutputContext
+
+scenario = System.get_env("SCENARIO", "event") |> String.to_existing_atom()
+type = System.get_env("EVENT_TYPE", "log") |> String.to_existing_atom()
+batch_size = System.get_env("BATCH_SIZE", "60000") |> String.to_integer()
+concurrency = System.get_env("CONCURRENCY", "6") |> String.to_integer()
+processor_chunk_size = System.get_env("PROCESSOR_CHUNK_SIZE", "1000") |> String.to_integer()
+
+build_generation = fn ->
+  events = Data.batch(type, batch_size, :realistic)
+  tid = Data.setup_processing_ets(events)
+
+  pointers =
+    Enum.map(events, fn event ->
+      %LogEventPointer{
+        id: event.id,
+        tid: tid,
+        gen_event_id: event.id,
+        queue_tid: tid,
+        size: :erlang.external_size(event.body),
+        retries: 0,
+        event_type: event.event_type,
+        day_bucket: event.day_bucket
+      }
+    end)
+
+  {tid, pointers}
+end
+
+{tid, pointers} = build_generation.()
+:erlang.garbage_collect()
+
+held =
+  case scenario do
+    :event ->
+      pointers
+
+    :encoded ->
+      {compiled, config_id} = Data.compiled_output(type)
+      mapping_config_id = Ingester.encode_mapping_config_id(config_id)
+
+      pointers
+      |> Enum.chunk_every(processor_chunk_size)
+      |> Task.async_stream(
+        fn chunk ->
+          Enum.map(chunk, fn pointer ->
+            %LogEvent{} =
+              event =
+              IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id)
+
+            output_context = OutputContext.clickhouse_row_binary(event, mapping_config_id)
+
+            encoded = %EncodedRow{
+              pointer: pointer,
+              row: Mapper.map(event.body, compiled, output_context: output_context)
+            }
+
+            :ok =
+              IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded)
+
+            encoded
+          end)
+        end,
+        max_concurrency: concurrency,
+        ordered: true,
+        timeout: :infinity
+      )
+      |> Enum.flat_map(fn {:ok, rows} -> rows end)
+  end
+
+:erlang.garbage_collect()
+Process.sleep(100)
+
+memory = :erlang.memory()
+
+held_payload_bytes =
+  Enum.sum_by(held, fn
+    %EncodedRow{row: row} -> byte_size(row)
+    %LogEventPointer{size: size} -> size
+  end)
+
+IO.puts("scenario=#{scenario}")
+IO.puts("event_type=#{type}")
+IO.puts("batch_size=#{batch_size}")
+IO.puts("concurrency=#{concurrency}")
+IO.puts("generation_words=#{:ets.info(tid, :memory)}")
+IO.puts("held_payload_bytes=#{held_payload_bytes}")
+
+for key <- [:total, :processes_used, :binary, :ets] do
+  IO.puts("#{key}_bytes=#{Keyword.fetch!(memory, key)}")
+end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/encoded_row.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/encoded_row.ex
@@ -1,0 +1,20 @@
+defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow do
+  @moduledoc """
+  A ClickHouse RowBinary row and the queue pointer that owns it.
+
+  The processor replaces the full `LogEvent` in the generation store with this
+  representation after fused mapping and encoding. The large row binary is shared
+  between ETS and Broadway messages by reference, and retries update and reinsert
+  only the lightweight pointer without mapping or encoding the event again.
+  """
+
+  alias Logflare.Backends.IngestEventQueue.LogEventPointer
+
+  @enforce_keys [:pointer, :row]
+  defstruct [:pointer, :row]
+
+  @type t :: %__MODULE__{
+          pointer: LogEventPointer.t(),
+          row: binary()
+        }
+end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/encoded_row.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/encoded_row.ex
@@ -2,10 +2,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow do
   @moduledoc """
   A ClickHouse RowBinary row and the queue pointer that owns it.
 
-  The processor replaces the full `LogEvent` in the generation store with this
-  representation after fused mapping and encoding. The large row binary is shared
-  between ETS and Broadway messages by reference, and retries update and reinsert
-  only the lightweight pointer without mapping or encoding the event again.
+  After fused mapping and encoding, the processor stores this representation in the
+  generation table while that table remains live. The Broadway message independently
+  retains the row across concurrent generation eviction. Normally the large binary is
+  shared by reference between ETS and the message, and retries update only the pointer
+  without mapping or encoding the event again.
   """
 
   alias Logflare.Backends.IngestEventQueue.LogEventPointer

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -62,6 +62,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @spec processor_concurrency() :: pos_integer()
   def processor_concurrency, do: processor_concurrency(System.schedulers_online())
 
+  # This concurrency is allocated per backend pipeline, so the total processor count
+  # grows with active ClickHouse backends. Revisit a global cap or admission budget
+  # before enabling ClickHouse log drains broadly.
   @doc false
   @spec processor_concurrency(pos_integer()) :: pos_integer()
   def processor_concurrency(schedulers_online)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -542,55 +542,40 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec requeue_payload(pos_integer(), EncodedRow.t() | LogEventPointer.t()) :: requeue_result()
   defp requeue_payload(backend_id, %EncodedRow{pointer: pointer} = encoded) do
-    pointer = %{pointer | retries: pointer.retries + 1}
-    encoded = %{encoded | pointer: pointer}
-
-    case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
-      :ok -> reinsert_retry_pointer(backend_id, pointer)
-      {:error, :not_found} -> :lookup_miss
-    end
+    transfer_retry_payload(backend_id, pointer, encoded)
   end
 
   defp requeue_payload(backend_id, %LogEventPointer{} = pointer) do
     case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
-      nil ->
-        :lookup_miss
-
-      _event_or_encoded_row ->
-        pointer = %{pointer | retries: pointer.retries + 1}
-        reinsert_retry_pointer(backend_id, pointer)
+      nil -> :lookup_miss
+      event_or_encoded_row -> transfer_retry_payload(backend_id, pointer, event_or_encoded_row)
     end
   end
 
-  @spec reinsert_retry_pointer(pos_integer(), LogEventPointer.t()) :: requeue_result()
-  defp reinsert_retry_pointer(backend_id, pointer) do
-    result =
-      case IngestEventQueue.reinsert_pointer(pointer) do
-        :ok ->
-          :ok
+  @spec transfer_retry_payload(pos_integer(), LogEventPointer.t(), EncodedRow.t() | LogEvent.t()) ::
+          requeue_result()
+  defp transfer_retry_payload(backend_id, pointer, payload) do
+    pointer = %{pointer | retries: pointer.retries + 1}
 
-        {:error, :already_exists} = error ->
-          error
-
-        {:error, :not_initialized} ->
-          IngestEventQueue.reinsert_pointer({:consolidated, backend_id}, pointer)
-      end
-
-    case result do
-      :ok ->
-        :requeued
-
-      {:error, :already_exists} ->
-        :deduplicated
-
-      {:error, :not_initialized} ->
-        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
-        :queue_unavailable
-    end
+    {:consolidated, backend_id}
+    |> IngestEventQueue.requeue_payload(pointer, fn new_pointer ->
+      retry_payload_with_pointer(payload, new_pointer)
+    end)
+    |> requeue_transfer_result()
   end
+
+  defp retry_payload_with_pointer(%EncodedRow{} = encoded, pointer),
+    do: %{encoded | pointer: pointer}
+
+  defp retry_payload_with_pointer(%LogEvent{} = event, pointer),
+    do: %{event | retries: pointer.retries}
+
+  defp requeue_transfer_result({:ok, _pointer}), do: :requeued
+  defp requeue_transfer_result({:error, :already_exists}), do: :deduplicated
+  defp requeue_transfer_result({:error, :not_initialized}), do: :queue_unavailable
 
   # A lookup miss means GenerationJanitor dropped the backing generation before the
-  # retry could resolve or replace its event. Bounded and rare in practice, but worth
+  # retry could resolve its event. Bounded and rare in practice, but worth
   # surfacing since it's otherwise invisible.
   @spec emit_requeue_lookup_miss_telemetry(pos_integer(), non_neg_integer()) :: :ok
   defp emit_requeue_lookup_miss_telemetry(_backend_id, 0), do: :ok

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -11,9 +11,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   Uses ID-passing: the producer emits `LogEventPointer`s (id + routing metadata)
   while full events live in a separate generation store (see
-  `Logflare.Backends.IngestEventQueue`). Processors resolve and replace each full event
-  with a fused mapper-produced `EncodedRow`; batch processors only stream those
-  reference-counted RowBinary rows through gzip and insert the compressed payload.
+  `Logflare.Backends.IngestEventQueue`). Processors resolve each full event and produce
+  an `EncodedRow`, replacing the generation value while that generation remains live.
+  The processor message retains its encoded bytes across concurrent generation eviction;
+  batch processors only stream those RowBinary rows through gzip and insert the payload.
   """
 
   @behaviour Broadway.Acknowledger
@@ -63,8 +64,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   def processor_concurrency, do: processor_concurrency(System.schedulers_online())
 
   # This concurrency is allocated per backend pipeline, so the total processor count
-  # grows with active ClickHouse backends. Revisit a global cap or admission budget
-  # before enabling ClickHouse log drains broadly.
+  # grows with active ClickHouse backends. The six-processor floor also intentionally
+  # oversubscribes hosts with fewer than ten schedulers. Revisit a global cap or
+  # admission budget before enabling ClickHouse log drains broadly.
   @doc false
   @spec processor_concurrency(pos_integer()) :: pos_integer()
   def processor_concurrency(schedulers_online)
@@ -241,7 +243,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       {acknowledger, ack_ref, Map.put(ack_data, :missing_generation_event_type, event_type)}
 
     message
-    |> then(&%{&1 | acknowledger: acknowledger})
+    |> Map.replace!(:acknowledger, acknowledger)
     |> Message.failed(:not_found)
   end
 
@@ -603,7 +605,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   defp emit_requeue_deduplicated_telemetry(backend_id, deduplicated_count) do
     Logger.warning(
-      "Deduplicated #{deduplicated_count} ClickHouse event(s) during retry requeue: a newer same-ID pointer remains queued",
+      "Deduplicated #{deduplicated_count} ClickHouse event(s) during retry requeue: an existing same-ID pointer has a resolvable payload",
       backend_id: backend_id
     )
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -51,10 +51,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   # monopolize the shared Finch pools and amplify ClickHouse timeouts under backlog.
   @batcher_concurrency 4
   @max_retries 1
-  # Two full batches across every batch processor, used as a generous safety valve
-  # rather than a fine-grained flow-control knob — see
+  # Keep buffer capacity independent of concurrent gzip/HTTP inserts. This preserves
+  # the previous 64-batch ceiling while four batch processors bound downstream load.
+  # It remains a generous safety valve rather than fine-grained flow control — see
   # BufferProducer.capped_fetch_amount/2.
-  @max_in_flight 2 * @batch_size * @batcher_concurrency
+  @max_in_flight_batches 64
+  @max_in_flight @batch_size * @max_in_flight_batches
 
   @doc false
   @spec max_retries() :: non_neg_integer()

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -181,7 +181,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         _processor_name,
         %Message{data: %LogEventPointer{event_type: event_type, day_bucket: day_bucket} = pointer} =
           message,
-        %{backend_id: backend_id, mapper_configs: mapper_configs}
+        %{mapper_configs: mapper_configs}
       )
       when is_event_type(event_type) do
     message =
@@ -199,22 +199,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         case Mapper.map_result(event.body, compiled, output_context: output_context) do
           {:ok, row} ->
             encoded = %EncodedRow{pointer: pointer, row: row}
-            replace_event_with_encoded_row(message, encoded, backend_id, event_type)
+            replace_event_with_encoded_row(message, encoded)
 
           {:error, reason} ->
             Message.failed(message, reason)
         end
 
       %EncodedRow{} = encoded ->
-        replace_event_with_encoded_row(
-          message,
-          %{encoded | pointer: pointer},
-          backend_id,
-          event_type
-        )
+        replace_event_with_encoded_row(message, %{encoded | pointer: pointer})
 
       nil ->
-        fail_missing_message(message, backend_id, event_type)
+        fail_missing_message(message, event_type)
     end
   end
 
@@ -222,29 +217,32 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     Message.failed(message, :not_found)
   end
 
-  @spec replace_event_with_encoded_row(
-          Message.t(),
-          EncodedRow.t(),
-          pos_integer(),
-          TypeDetection.event_type()
-        ) :: Message.t()
-  defp replace_event_with_encoded_row(
-         message,
-         %EncodedRow{pointer: pointer} = encoded,
-         backend_id,
-         event_type
-       ) do
+  @spec replace_event_with_encoded_row(Message.t(), EncodedRow.t()) :: Message.t()
+  defp replace_event_with_encoded_row(message, %EncodedRow{pointer: pointer} = encoded) do
     encoded_message = %{message | data: encoded}
 
     case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
-      :ok -> encoded_message
-      {:error, :not_found} -> fail_missing_message(message, backend_id, event_type)
+      :ok ->
+        encoded_message
+
+      {:error, :not_found} ->
+        # The processor owns the encoded bytes once lookup succeeds. Generation eviction
+        # may race this best-effort replacement, but must not discard a row that can still
+        # be inserted or transferred into a fresh generation on retry.
+        encoded_message
     end
   end
 
-  defp fail_missing_message(message, backend_id, event_type) do
-    emit_missing_ids_telemetry(backend_id, event_type, 1)
-    Message.failed(message, :not_found)
+  defp fail_missing_message(
+         %Message{acknowledger: {acknowledger, ack_ref, ack_data}} = message,
+         event_type
+       ) do
+    acknowledger =
+      {acknowledger, ack_ref, Map.put(ack_data, :missing_generation_event_type, event_type)}
+
+    message
+    |> then(&%{&1 | acknowledger: acknowledger})
+    |> Message.failed(:not_found)
   end
 
   @spec handle_batch(
@@ -272,6 +270,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @spec ack(ack_ref :: term(), successful :: [Message.t()], failed :: [Message.t()]) :: :ok
   def ack(_ack_ref, successful, failed) do
     decrement_in_flight(successful, failed)
+    emit_missing_ids_telemetry(failed)
 
     Enum.each(successful, fn message ->
       pointer = message_pointer(message)
@@ -350,7 +349,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     } do
       {good, rejected, good_count, compressed} = stream_compress(messages, event_type)
 
-      emit_missing_ids_telemetry(rejected, backend, event_type)
       finalize_insert(backend, event_type, compressed, good_count, good, rejected)
     end
   end
@@ -408,19 +406,37 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     {good, [message | rejected], good_count, chunks}
   end
 
-  @spec emit_missing_ids_telemetry([Message.t()], Backend.t(), TypeDetection.event_type()) :: :ok
-  defp emit_missing_ids_telemetry(rejected, %Backend{} = backend, event_type) do
-    count = Enum.count(rejected, &match?(%Message{status: {:failed, :not_found}}, &1))
-    emit_missing_ids_telemetry(backend.id, event_type, count)
+  @spec emit_missing_ids_telemetry([Message.t()]) :: :ok
+  defp emit_missing_ids_telemetry(messages) do
+    messages
+    |> Enum.reduce(%{}, fn
+      %Message{
+        acknowledger:
+          {_, _,
+           %{
+             backend_id: backend_id,
+             missing_generation_event_type: event_type
+           }}
+      },
+      counts
+      when is_event_type(event_type) ->
+        Map.update(counts, {backend_id, event_type}, 1, &(&1 + 1))
+
+      _message, counts ->
+        counts
+    end)
+    |> Enum.each(fn {{backend_id, event_type}, count} ->
+      emit_missing_ids_telemetry(backend_id, event_type, count)
+    end)
+
+    :ok
   end
 
   @spec emit_missing_ids_telemetry(
           pos_integer(),
           TypeDetection.event_type(),
-          non_neg_integer()
+          pos_integer()
         ) :: :ok
-  defp emit_missing_ids_telemetry(_backend_id, _event_type, 0), do: :ok
-
   defp emit_missing_ids_telemetry(backend_id, event_type, count) do
     :telemetry.execute(
       [:logflare, :ingest_event_queue, :missing_ids],

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -10,10 +10,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   insert targets a single ClickHouse partition.
 
   Uses ID-passing: the producer emits `LogEventPointer`s (id + routing metadata)
-  while the full events live in a separate generation store (see
-  `Logflare.Backends.IngestEventQueue`). Each batcher resolves the pointer to its event
-  lazily and streams it through zlib deflate to build a gzip-compressed RowBinary
-  payload without holding the full batch in process memory.
+  while full events live in a separate generation store (see
+  `Logflare.Backends.IngestEventQueue`). Processors resolve and replace each full event
+  with a fused mapper-produced `EncodedRow`; batch processors only stream those
+  reference-counted RowBinary rows through gzip and insert the compressed payload.
   """
 
   @behaviour Broadway.Acknowledger
@@ -27,6 +27,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingConfigStore
   alias Logflare.Backends.Backend
@@ -39,17 +40,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   alias Logflare.Mapper.OutputContext
   alias Logflare.Utils
 
+  @event_types [:log, :metric, :trace]
   @producer_concurrency 1
   @processor_concurrency 6
   @processor_min_demand 100
   @processor_max_demand 1_000
   @batch_size 60_000
   @batch_timeout 5_000
-  @batcher_concurrency 32
+  # Bound each backend to four concurrent gzip/HTTP inserts. Higher concurrency can
+  # monopolize the shared Finch pools and amplify ClickHouse timeouts under backlog.
+  @batcher_concurrency 4
   @max_retries 1
-  # Two full batches across every batcher, used as a generous safety valve rather
-  # than a fine-grained flow-control knob — see BufferProducer.capped_fetch_amount/2.
-  # It should only cap genuinely runaway backlog during healthy operation.
+  # Two full batches across every batch processor, used as a generous safety valve
+  # rather than a fine-grained flow-control knob — see
+  # BufferProducer.capped_fetch_amount/2.
   @max_in_flight 2 * @batch_size * @batcher_concurrency
 
   @doc false
@@ -111,8 +115,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           batch_timeout: @batch_timeout
         ]
       ],
-      context: %{backend_id: backend.id}
+      context: processor_context(backend.id)
     )
+  end
+
+  @doc false
+  @spec processor_context(pos_integer()) :: map()
+  def processor_context(backend_id) do
+    mapper_configs =
+      Map.new(@event_types, fn event_type ->
+        {:ok, compiled, config_id} = MappingConfigStore.get_compiled(event_type)
+
+        {event_type,
+         %{
+           compiled: compiled,
+           mapping_config_id: Ingester.encode_mapping_config_id(config_id)
+         }}
+      end)
+
+    %{backend_id: backend_id, mapper_configs: mapper_configs}
   end
 
   @spec process_name(via_tuple :: {:via, module(), {module(), term()}}, base_name :: term()) ::
@@ -141,17 +162,52 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           Message.t()
   def handle_message(
         _processor_name,
-        %Message{data: %LogEventPointer{event_type: event_type, day_bucket: day_bucket}} = message,
-        _context
+        %Message{data: %LogEventPointer{event_type: event_type, day_bucket: day_bucket} = pointer} =
+          message,
+        %{mapper_configs: mapper_configs}
       )
       when is_event_type(event_type) do
-    message
-    |> Message.put_batcher(:ch)
-    |> Message.put_batch_key({event_type, day_bucket})
+    message =
+      message
+      |> Message.put_batcher(:ch)
+      |> Message.put_batch_key({event_type, day_bucket})
+
+    case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
+      %LogEvent{} = event ->
+        %{compiled: compiled, mapping_config_id: mapping_config_id} =
+          Map.fetch!(mapper_configs, event_type)
+
+        output_context = OutputContext.clickhouse_row_binary(event, mapping_config_id)
+
+        case Mapper.map_result(event.body, compiled, output_context: output_context) do
+          {:ok, row} ->
+            encoded = %EncodedRow{pointer: pointer, row: row}
+            replace_event_with_encoded_row(message, encoded)
+
+          {:error, reason} ->
+            Message.failed(message, reason)
+        end
+
+      %EncodedRow{} = encoded ->
+        replace_event_with_encoded_row(message, %{encoded | pointer: pointer})
+
+      nil ->
+        Message.failed(message, :not_found)
+    end
   end
 
   def handle_message(_processor_name, message, _context) do
     Message.failed(message, :not_found)
+  end
+
+  @spec replace_event_with_encoded_row(Message.t(), EncodedRow.t()) :: Message.t()
+  defp replace_event_with_encoded_row(message, %EncodedRow{pointer: pointer} = encoded) do
+    encoded_message = %{message | data: encoded}
+
+    case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
+      :ok -> encoded_message
+      {:error, :not_found} -> Message.failed(message, :not_found)
+    end
   end
 
   @spec handle_batch(
@@ -173,14 +229,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
     backend = Backends.Cache.get_backend(backend_id)
 
-    encode_and_insert(backend, messages, event_type, batch_info, day_bucket)
+    compress_and_insert(backend, messages, event_type, batch_info, day_bucket)
   end
 
   @spec ack(ack_ref :: term(), successful :: [Message.t()], failed :: [Message.t()]) :: :ok
   def ack(_ack_ref, successful, failed) do
     decrement_in_flight(successful, failed)
 
-    Enum.each(successful, fn %{data: %LogEventPointer{} = pointer} ->
+    Enum.each(successful, fn message ->
+      pointer = message_pointer(message)
       IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
 
@@ -237,14 +294,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     )
   end
 
-  @spec encode_and_insert(
+  @spec compress_and_insert(
           Backend.t(),
           [Message.t()],
           TypeDetection.event_type(),
           Broadway.BatchInfo.t(),
           integer()
         ) :: [Message.t()]
-  defp encode_and_insert(backend, messages, event_type, batch_info, day_bucket) do
+  defp compress_and_insert(backend, messages, event_type, batch_info, day_bucket) do
     OpenTelemetry.Tracer.with_span :clickhouse_pipeline, %{
       attributes: %{
         backend_id: backend.id,
@@ -254,32 +311,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         day_bucket: day_bucket
       }
     } do
-      with {:ok, compiled, config_id} <- MappingConfigStore.get_compiled(event_type) do
-        {good, rejected, good_count, compressed} =
-          stream_compress(messages, event_type, compiled, config_id)
+      {good, rejected, good_count, compressed} = stream_compress(messages, event_type)
 
-        emit_missing_ids_telemetry(rejected, backend, event_type)
-        finalize_insert(backend, event_type, compressed, good_count, good, rejected)
-      else
-        {:error, reason} -> Enum.map(messages, &Message.failed(&1, reason))
-      end
+      emit_missing_ids_telemetry(rejected, backend, event_type)
+      finalize_insert(backend, event_type, compressed, good_count, good, rejected)
     end
   end
 
-  # Maps and encodes each event in one NIF call, then streams the RowBinary row
-  # into gzip so the full uncompressed batch is never materialized.
-  @spec stream_compress([Message.t()], TypeDetection.event_type(), reference(), String.t()) ::
+  # RowBinary production is complete before batching. This stage owns only the one
+  # gzip stream that requires a complete batch.
+  @spec stream_compress([Message.t()], TypeDetection.event_type()) ::
           {[Message.t()], [Message.t()], non_neg_integer(), binary()}
-  defp stream_compress(messages, event_type, compiled, config_id) do
+  defp stream_compress(messages, event_type) do
     z = :zlib.open()
 
     try do
       :zlib.deflateInit(z, :default, :deflated, 31, 8, :default)
-      mapping_config_id = Ingester.encode_mapping_config_id(config_id)
 
       {good, rejected, good_count, chunks} =
         Enum.reduce(messages, {[], [], 0, []}, fn message, acc ->
-          encode_message(z, event_type, compiled, mapping_config_id, message, acc)
+          compress_message(z, event_type, message, acc)
         end)
 
       final_chunk = :zlib.deflate(z, "", :finish)
@@ -290,49 +341,34 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     end
   end
 
-  @spec encode_message(
+  @spec compress_message(
           term(),
           TypeDetection.event_type(),
-          reference(),
-          binary(),
           Message.t(),
           {[Message.t()], [Message.t()], non_neg_integer(), iodata()}
         ) :: {[Message.t()], [Message.t()], non_neg_integer(), iodata()}
-  defp encode_message(
+  defp compress_message(
          z,
          event_type,
-         compiled,
-         mapping_config_id,
-         %{data: %LogEventPointer{event_type: event_type} = pointer} = message,
+         %{
+           data: %EncodedRow{
+             pointer: %LogEventPointer{event_type: event_type},
+             row: row
+           }
+         } = message,
          {good, rejected, good_count, chunks}
        ) do
-    case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
-      %LogEvent{} = event ->
-        output_context = OutputContext.clickhouse_row_binary(event, mapping_config_id)
-
-        case Mapper.map_result(event.body, compiled, output_context: output_context) do
-          {:ok, row} ->
-            row_chunk = :zlib.deflate(z, row)
-            {[message | good], rejected, good_count + 1, [row_chunk | chunks]}
-
-          {:error, reason} ->
-            {good, [Message.failed(message, reason) | rejected], good_count, chunks}
-        end
-
-      nil ->
-        {good, [Message.failed(message, :not_found) | rejected], good_count, chunks}
-    end
+    row_chunk = :zlib.deflate(z, row)
+    {[message | good], rejected, good_count + 1, [row_chunk | chunks]}
   end
 
-  defp encode_message(
+  defp compress_message(
          _z,
          _event_type,
-         _compiled,
-         _mapping_config_id,
          message,
          {good, rejected, good_count, chunks}
        ) do
-    {good, [Message.failed(message, :not_found) | rejected], good_count, chunks}
+    {good, [message | rejected], good_count, chunks}
   end
 
   @spec emit_missing_ids_telemetry([Message.t()], Backend.t(), TypeDetection.event_type()) :: :ok
@@ -358,7 +394,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           [Message.t()],
           [Message.t()]
         ) :: [Message.t()]
-  defp finalize_insert(_backend, _event_type, _compressed, _good_count, [] = _good, rejected) do
+  defp finalize_insert(
+         _backend,
+         _event_type,
+         _compressed,
+         _good_count,
+         [] = _good,
+         rejected
+       ) do
     # No rows encoded, so skip the empty ClickHouse insert. Rejected messages
     # already carry their mapping failure or missing-event reason.
     rejected
@@ -407,17 +450,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @spec maybe_requeue_failed(backend_id :: pos_integer(), messages :: [Message.t()]) :: :ok
   defp maybe_requeue_failed(backend_id, messages) do
+    payloads = Enum.map(messages, & &1.data)
+
     {retriable, exhausted} =
-      messages
-      |> Enum.map(fn %{data: %LogEventPointer{} = pointer} -> pointer end)
-      |> Enum.split_with(&(&1.retries < @max_retries))
+      Enum.split_with(payloads, &(message_pointer(&1).retries < @max_retries))
 
     drop_failed(exhausted, backend_id, "exhausted #{@max_retries} retries")
 
     requeue_or_shed(backend_id, retriable)
   end
 
-  @spec requeue_or_shed(backend_id :: pos_integer(), retriable :: [LogEventPointer.t()]) :: :ok
+  @spec requeue_or_shed(
+          backend_id :: pos_integer(),
+          retriable :: [EncodedRow.t() | LogEventPointer.t()]
+        ) :: :ok
   defp requeue_or_shed(_backend_id, []), do: :ok
 
   defp requeue_or_shed(backend_id, retriable) do
@@ -430,26 +476,46 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     end
   end
 
-  @spec requeue_retriable(backend_id :: pos_integer(), retriable :: [LogEventPointer.t()]) :: :ok
+  @spec requeue_retriable(
+          backend_id :: pos_integer(),
+          retriable :: [EncodedRow.t() | LogEventPointer.t()]
+        ) :: :ok
   defp requeue_retriable(backend_id, retriable) do
     Logger.info(
       "Requeuing #{length(retriable)} ClickHouse events for retry",
       backend_id: backend_id
     )
 
-    events =
-      for pointer <- retriable,
-          event = IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id),
-          not is_nil(event) do
-        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
-        %{event | retries: pointer.retries + 1}
-      end
-
-    emit_requeue_lookup_miss_telemetry(backend_id, length(retriable) - length(events))
-
-    if events != [], do: IngestEventQueue.add_to_table({:consolidated, backend_id}, events)
+    requeued = Enum.count(retriable, &requeue_payload/1)
+    emit_requeue_lookup_miss_telemetry(backend_id, length(retriable) - requeued)
 
     :ok
+  end
+
+  @spec requeue_payload(EncodedRow.t() | LogEventPointer.t()) :: boolean()
+  defp requeue_payload(%EncodedRow{pointer: pointer} = encoded) do
+    pointer = %{pointer | retries: pointer.retries + 1}
+    encoded = %{encoded | pointer: pointer}
+
+    case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
+      :ok ->
+        IngestEventQueue.reinsert_pointer(pointer)
+        true
+
+      {:error, :not_found} ->
+        false
+    end
+  end
+
+  defp requeue_payload(%LogEventPointer{} = pointer) do
+    case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
+      nil ->
+        false
+
+      _event_or_encoded_row ->
+        IngestEventQueue.reinsert_pointer(%{pointer | retries: pointer.retries + 1})
+        true
+    end
   end
 
   # A miss here means the pointer's generation was already dropped by
@@ -473,20 +539,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   end
 
   @spec drop_failed(
-          pointers :: [LogEventPointer.t()],
+          payloads :: [EncodedRow.t() | LogEventPointer.t()],
           backend_id :: pos_integer(),
           reason :: String.t()
         ) :: :ok
   defp drop_failed([], _backend_id, _reason), do: :ok
 
-  defp drop_failed(pointers, backend_id, reason) do
+  defp drop_failed(payloads, backend_id, reason) do
     Logger.warning(
-      "Dropping #{length(pointers)} ClickHouse events: #{reason}",
+      "Dropping #{length(payloads)} ClickHouse events: #{reason}",
       backend_id: backend_id
     )
 
-    Enum.each(pointers, fn pointer ->
+    Enum.each(payloads, fn payload ->
+      pointer = message_pointer(payload)
       IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
   end
+
+  @spec message_pointer(Message.t() | EncodedRow.t() | LogEventPointer.t()) :: LogEventPointer.t()
+  defp message_pointer(%Message{data: data}), do: message_pointer(data)
+  defp message_pointer(%EncodedRow{pointer: pointer}), do: pointer
+  defp message_pointer(%LogEventPointer{} = pointer), do: pointer
 end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -134,13 +134,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
           batch_timeout: @batch_timeout
         ]
       ],
-      context: processor_context(backend.id)
+      context: build_processor_context(backend.id)
     )
   end
 
   @doc false
-  @spec processor_context(pos_integer()) :: map()
-  def processor_context(backend_id) do
+  @spec build_processor_context(pos_integer()) :: map()
+  def build_processor_context(backend_id) do
     mapper_configs =
       Map.new(@event_types, fn event_type ->
         {:ok, compiled, config_id} = MappingConfigStore.get_compiled(event_type)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -42,7 +42,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
   @event_types [:log, :metric, :trace]
   @producer_concurrency 1
-  @processor_concurrency 6
+  @min_processor_concurrency 6
   @processor_min_demand 100
   @processor_max_demand 1_000
   @batch_size 60_000
@@ -57,6 +57,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   # BufferProducer.capped_fetch_amount/2.
   @max_in_flight_batches 64
   @max_in_flight @batch_size * @max_in_flight_batches
+
+  @doc false
+  @spec processor_concurrency() :: pos_integer()
+  def processor_concurrency, do: processor_concurrency(System.schedulers_online())
+
+  @doc false
+  @spec processor_concurrency(pos_integer()) :: pos_integer()
+  def processor_concurrency(schedulers_online)
+      when is_integer(schedulers_online) and schedulers_online > 0 do
+    max(schedulers_online - @batcher_concurrency, @min_processor_concurrency)
+  end
 
   @doc false
   @spec max_retries() :: non_neg_integer()
@@ -85,6 +96,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   def start_link(args) do
     {name, args} = Keyword.pop(args, :name)
     backend = Keyword.fetch!(args, :backend)
+    processor_concurrency = processor_concurrency()
 
     Broadway.start_link(__MODULE__,
       name: name,
@@ -105,7 +117,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       ],
       processors: [
         default: [
-          concurrency: @processor_concurrency,
+          concurrency: processor_concurrency,
           min_demand: @processor_min_demand,
           max_demand: @processor_max_demand
         ]

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -178,7 +178,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         _processor_name,
         %Message{data: %LogEventPointer{event_type: event_type, day_bucket: day_bucket} = pointer} =
           message,
-        %{mapper_configs: mapper_configs}
+        %{backend_id: backend_id, mapper_configs: mapper_configs}
       )
       when is_event_type(event_type) do
     message =
@@ -196,17 +196,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         case Mapper.map_result(event.body, compiled, output_context: output_context) do
           {:ok, row} ->
             encoded = %EncodedRow{pointer: pointer, row: row}
-            replace_event_with_encoded_row(message, encoded)
+            replace_event_with_encoded_row(message, encoded, backend_id, event_type)
 
           {:error, reason} ->
             Message.failed(message, reason)
         end
 
       %EncodedRow{} = encoded ->
-        replace_event_with_encoded_row(message, %{encoded | pointer: pointer})
+        replace_event_with_encoded_row(
+          message,
+          %{encoded | pointer: pointer},
+          backend_id,
+          event_type
+        )
 
       nil ->
-        Message.failed(message, :not_found)
+        fail_missing_message(message, backend_id, event_type)
     end
   end
 
@@ -214,14 +219,29 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     Message.failed(message, :not_found)
   end
 
-  @spec replace_event_with_encoded_row(Message.t(), EncodedRow.t()) :: Message.t()
-  defp replace_event_with_encoded_row(message, %EncodedRow{pointer: pointer} = encoded) do
+  @spec replace_event_with_encoded_row(
+          Message.t(),
+          EncodedRow.t(),
+          pos_integer(),
+          TypeDetection.event_type()
+        ) :: Message.t()
+  defp replace_event_with_encoded_row(
+         message,
+         %EncodedRow{pointer: pointer} = encoded,
+         backend_id,
+         event_type
+       ) do
     encoded_message = %{message | data: encoded}
 
     case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
       :ok -> encoded_message
-      {:error, :not_found} -> Message.failed(message, :not_found)
+      {:error, :not_found} -> fail_missing_message(message, backend_id, event_type)
     end
+  end
+
+  defp fail_missing_message(message, backend_id, event_type) do
+    emit_missing_ids_telemetry(backend_id, event_type, 1)
+    Message.failed(message, :not_found)
   end
 
   @spec handle_batch(
@@ -386,18 +406,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   end
 
   @spec emit_missing_ids_telemetry([Message.t()], Backend.t(), TypeDetection.event_type()) :: :ok
-  defp emit_missing_ids_telemetry(rejected, backend, event_type) do
-    case Enum.count(rejected, &match?(%Message{status: {:failed, :not_found}}, &1)) do
-      0 ->
-        :ok
+  defp emit_missing_ids_telemetry(rejected, %Backend{} = backend, event_type) do
+    count = Enum.count(rejected, &match?(%Message{status: {:failed, :not_found}}, &1))
+    emit_missing_ids_telemetry(backend.id, event_type, count)
+  end
 
-      count ->
-        :telemetry.execute(
-          [:logflare, :ingest_event_queue, :missing_ids],
-          %{count: count},
-          %{backend_type: :clickhouse, backend_id: backend.id, event_type: event_type}
-        )
-    end
+  @spec emit_missing_ids_telemetry(
+          pos_integer(),
+          TypeDetection.event_type(),
+          non_neg_integer()
+        ) :: :ok
+  defp emit_missing_ids_telemetry(_backend_id, _event_type, 0), do: :ok
+
+  defp emit_missing_ids_telemetry(backend_id, event_type, count) do
+    :telemetry.execute(
+      [:logflare, :ingest_event_queue, :missing_ids],
+      %{count: count},
+      %{backend_type: :clickhouse, backend_id: backend_id, event_type: event_type}
+    )
   end
 
   @spec finalize_insert(
@@ -490,6 +516,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     end
   end
 
+  @typep requeue_result :: :requeued | :deduplicated | :lookup_miss | :queue_unavailable
+
   @spec requeue_retriable(
           backend_id :: pos_integer(),
           retriable :: [EncodedRow.t() | LogEventPointer.t()]
@@ -500,42 +528,70 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       backend_id: backend_id
     )
 
-    requeued = Enum.count(retriable, &requeue_payload/1)
-    emit_requeue_lookup_miss_telemetry(backend_id, length(retriable) - requeued)
+    result_counts = Enum.frequencies_by(retriable, &requeue_payload(backend_id, &1))
+
+    emit_requeue_lookup_miss_telemetry(backend_id, Map.get(result_counts, :lookup_miss, 0))
+
+    emit_requeue_queue_unavailable_telemetry(
+      backend_id,
+      Map.get(result_counts, :queue_unavailable, 0)
+    )
 
     :ok
   end
 
-  @spec requeue_payload(EncodedRow.t() | LogEventPointer.t()) :: boolean()
-  defp requeue_payload(%EncodedRow{pointer: pointer} = encoded) do
+  @spec requeue_payload(pos_integer(), EncodedRow.t() | LogEventPointer.t()) :: requeue_result()
+  defp requeue_payload(backend_id, %EncodedRow{pointer: pointer} = encoded) do
     pointer = %{pointer | retries: pointer.retries + 1}
     encoded = %{encoded | pointer: pointer}
 
     case IngestEventQueue.replace_event(pointer.tid, pointer.gen_event_id, encoded) do
-      :ok ->
-        IngestEventQueue.reinsert_pointer(pointer)
-        true
-
-      {:error, :not_found} ->
-        false
+      :ok -> reinsert_retry_pointer(backend_id, pointer)
+      {:error, :not_found} -> :lookup_miss
     end
   end
 
-  defp requeue_payload(%LogEventPointer{} = pointer) do
+  defp requeue_payload(backend_id, %LogEventPointer{} = pointer) do
     case IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) do
       nil ->
-        false
+        :lookup_miss
 
       _event_or_encoded_row ->
-        IngestEventQueue.reinsert_pointer(%{pointer | retries: pointer.retries + 1})
-        true
+        pointer = %{pointer | retries: pointer.retries + 1}
+        reinsert_retry_pointer(backend_id, pointer)
     end
   end
 
-  # A miss here means the pointer's generation was already dropped by
-  # GenerationJanitor before the retry could look it up — the event is silently
-  # lost rather than requeued. Bounded and rare in practice, but worth surfacing
-  # since it's otherwise invisible.
+  @spec reinsert_retry_pointer(pos_integer(), LogEventPointer.t()) :: requeue_result()
+  defp reinsert_retry_pointer(backend_id, pointer) do
+    result =
+      case IngestEventQueue.reinsert_pointer(pointer) do
+        :ok ->
+          :ok
+
+        {:error, :already_exists} = error ->
+          error
+
+        {:error, :not_initialized} ->
+          IngestEventQueue.reinsert_pointer({:consolidated, backend_id}, pointer)
+      end
+
+    case result do
+      :ok ->
+        :requeued
+
+      {:error, :already_exists} ->
+        :deduplicated
+
+      {:error, :not_initialized} ->
+        IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
+        :queue_unavailable
+    end
+  end
+
+  # A lookup miss means GenerationJanitor dropped the backing generation before the
+  # retry could resolve or replace its event. Bounded and rare in practice, but worth
+  # surfacing since it's otherwise invisible.
   @spec emit_requeue_lookup_miss_telemetry(pos_integer(), non_neg_integer()) :: :ok
   defp emit_requeue_lookup_miss_telemetry(_backend_id, 0), do: :ok
 
@@ -549,6 +605,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       [:logflare, :ingest_event_queue, :requeue_lookup_miss],
       %{count: missing_count},
       %{backend_id: backend_id}
+    )
+  end
+
+  @spec emit_requeue_queue_unavailable_telemetry(pos_integer(), non_neg_integer()) :: :ok
+  defp emit_requeue_queue_unavailable_telemetry(_backend_id, 0), do: :ok
+
+  defp emit_requeue_queue_unavailable_telemetry(backend_id, dropped_count) do
+    Logger.warning(
+      "Dropped #{dropped_count} ClickHouse event(s) during retry requeue: no queue remained available",
+      backend_id: backend_id
+    )
+
+    :telemetry.execute(
+      [:logflare, :ingest_event_queue, :not_initialized, :dropped],
+      %{count: dropped_count},
+      %{backend_type: :clickhouse, backend_id: backend_id}
     )
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -530,6 +530,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
 
     result_counts = Enum.frequencies_by(retriable, &requeue_payload(backend_id, &1))
 
+    emit_requeue_deduplicated_telemetry(
+      backend_id,
+      Map.get(result_counts, :deduplicated, 0)
+    )
+
     emit_requeue_lookup_miss_telemetry(backend_id, Map.get(result_counts, :lookup_miss, 0))
 
     emit_requeue_queue_unavailable_telemetry(
@@ -573,6 +578,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   defp requeue_transfer_result({:ok, _pointer}), do: :requeued
   defp requeue_transfer_result({:error, :already_exists}), do: :deduplicated
   defp requeue_transfer_result({:error, :not_initialized}), do: :queue_unavailable
+
+  @spec emit_requeue_deduplicated_telemetry(pos_integer(), non_neg_integer()) :: :ok
+  defp emit_requeue_deduplicated_telemetry(_backend_id, 0), do: :ok
+
+  defp emit_requeue_deduplicated_telemetry(backend_id, deduplicated_count) do
+    Logger.warning(
+      "Deduplicated #{deduplicated_count} ClickHouse event(s) during retry requeue: a newer same-ID pointer remains queued",
+      backend_id: backend_id
+    )
+
+    :telemetry.execute(
+      [:logflare, :ingest_event_queue, :requeue_deduplicated],
+      %{count: deduplicated_count},
+      %{backend_type: :clickhouse, backend_id: backend_id}
+    )
+  end
 
   # A lookup miss means GenerationJanitor dropped the backing generation before the
   # retry could resolve its event. Bounded and rare in practice, but worth

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1211,30 +1211,6 @@ defmodule Logflare.Backends.IngestEventQueue do
       {:error, :not_initialized}
   end
 
-  @doc """
-  Routes a claimed pointer to an available queue without overwriting an existing ID.
-
-  Active producer queues are tried from least to most pending, followed by the startup
-  queue. A candidate that disappears during routing is skipped. The backing generation
-  row is not copied; the routed pointer continues to reference it directly.
-  """
-  @spec insert_new_pointer(
-          queues_key() | consolidated_queues_key() | spool_producer_queues_key(),
-          LogEventPointer.t()
-        ) :: :ok | {:error, :already_exists | :not_initialized}
-  def insert_new_pointer(queues_key, %LogEventPointer{} = pointer) do
-    queues_key
-    |> list_queues_with_tids()
-    |> Enum.sort_by(&reinsert_queue_priority/1)
-    |> Enum.reduce_while({:error, :not_initialized}, fn {_table_key, queue_tid}, _acc ->
-      case insert_new_pointer(%{pointer | queue_tid: queue_tid}) do
-        :ok -> {:halt, :ok}
-        {:error, :already_exists} = error -> {:halt, error}
-        {:error, :not_initialized} -> {:cont, {:error, :not_initialized}}
-      end
-    end)
-  end
-
   defp pointer_row(pointer) do
     {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
      pointer.event_type, pointer.day_bucket}

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -7,9 +7,11 @@ defmodule Logflare.Backends.IngestEventQueue do
   Every queue uses the same storage model: a small per-pipeline "pointer" table (this
   module's main tables, one per `{sid,bid,pid}` / `{:consolidated,bid,pid}` /
   `{:spool_producer,nil,pid}`) holding lightweight pointer rows, plus a shared,
-  generationally-rotated event store per `queues_key` holding the actual `LogEvent`
-  bodies (see `current_generation_tid/1`, `new_generations/1`,
-  `Logflare.Backends.IngestEventQueue.GenerationJanitor`). `add_to_table/3` always
+  generationally-rotated event store per `queues_key` initially holding the actual
+  `LogEvent` bodies (see `current_generation_tid/1`, `new_generations/1`,
+  `Logflare.Backends.IngestEventQueue.GenerationJanitor`). A consumer may replace a
+  claimed value with a backend-specific encoded representation while retaining the
+  same pointer for retries. `add_to_table/3` always
   writes both; which read function a caller uses decides whether it gets back
   lightweight pointers (`pop_pending_pointers/2` — ID-passing pipelines: ClickHouse,
   BigQuery, spool) or fully-resolved `LogEvent` structs (`pop_pending/2` — every other
@@ -275,7 +277,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   @doc """
-  Looks up a single event directly in a generation table.
+  Looks up a single event or its encoded replacement directly in a generation table.
 
   `tid` here is a generation's tid (e.g. a claimed `LogEventPointer.tid`) — a direct
   `:ets.lookup_element/4`, no separate id-to-table resolution needed. Returns `nil` on a miss,
@@ -283,13 +285,30 @@ defmodule Logflare.Backends.IngestEventQueue do
   `drop_generation/2`) — callers should treat that the same as any other lookup miss,
   not as an error.
   """
-  @spec lookup_event(:ets.tid(), term()) :: LogEvent.t() | nil
+  @spec lookup_event(:ets.tid(), term()) :: term() | nil
   def lookup_event(tid, id) do
     :ets.lookup_element(tid, id, 2, nil)
   rescue
     ArgumentError ->
       emit_stale_ets_table_telemetry()
       nil
+  end
+
+  @doc """
+  Replaces an existing generation-store value without recreating a row that was
+  concurrently removed or whose generation was dropped.
+  """
+  @spec replace_event(:ets.tid(), term(), term()) :: :ok | {:error, :not_found}
+  def replace_event(tid, id, replacement) do
+    if :ets.update_element(tid, id, {2, replacement}) do
+      :ok
+    else
+      {:error, :not_found}
+    end
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      {:error, :not_found}
   end
 
   # --- recent-events cache ---
@@ -1102,7 +1121,7 @@ defmodule Logflare.Backends.IngestEventQueue do
     ms = [{{:_, :"$1"}, [], [:"$1"]}]
 
     case :ets.select(tid, ms, n) do
-      {events, _cont} -> events
+      {events, _cont} -> Enum.filter(events, &match?(%LogEvent{}, &1))
       :"$end_of_table" -> []
     end
   rescue

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1095,7 +1095,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
     case insert_generation_payload(gen_tid, gen_event_id, payload) do
       :ok ->
-        case reinsert_pointer(new_pointer) do
+        case insert_new_pointer(new_pointer) do
           :ok ->
             {:ok, new_pointer}
 
@@ -1135,18 +1135,32 @@ defmodule Logflare.Backends.IngestEventQueue do
   itself alive by claiming this in the first place. Bump `pointer.retries` before
   calling this if the caller is retrying after a failure.
 
-  Returns `{:error, :not_initialized}` if `queue_tid` has since gone stale because its
-  owning producer died, allowing callers that retain the event payload to reroute it.
-  Returns `{:error, :already_exists}` rather than overwriting a newer same-ID pointer.
+  This preserves the historical overwrite behavior required by startup seeding and
+  spool retries: if the destination already contains the same event ID, this claimed
+  pointer replaces it instead of being silently stranded. Call `insert_new_pointer/1`
+  when an existing pointer must remain authoritative.
   """
-  @spec reinsert_pointer(LogEventPointer.t()) ::
-          :ok | {:error, :already_exists | :not_initialized}
+  @spec reinsert_pointer(LogEventPointer.t()) :: :ok
   def reinsert_pointer(%LogEventPointer{} = pointer) do
-    row =
-      {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
-       pointer.event_type, pointer.day_bucket}
+    :ets.insert(pointer.queue_tid, pointer_row(pointer))
+    :ok
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      :ok
+  end
 
-    if :ets.insert_new(pointer.queue_tid, row) do
+  @doc """
+  Inserts a claimed pointer only when the destination does not already contain its ID.
+
+  Returns `{:error, :not_initialized}` if `queue_tid` has since gone stale, allowing a
+  caller that retains the payload to try another queue. Returns
+  `{:error, :already_exists}` without overwriting the authoritative same-ID pointer.
+  """
+  @spec insert_new_pointer(LogEventPointer.t()) ::
+          :ok | {:error, :already_exists | :not_initialized}
+  def insert_new_pointer(%LogEventPointer{} = pointer) do
+    if :ets.insert_new(pointer.queue_tid, pointer_row(pointer)) do
       :ok
     else
       {:error, :already_exists}
@@ -1158,27 +1172,32 @@ defmodule Logflare.Backends.IngestEventQueue do
   end
 
   @doc """
-  Routes a previously-claimed pointer to an available queue for `queues_key`.
+  Routes a claimed pointer to an available queue without overwriting an existing ID.
 
   Active producer queues are tried from least to most pending, followed by the startup
   queue. A candidate that disappears during routing is skipped. The backing generation
   row is not copied; the routed pointer continues to reference it directly.
   """
-  @spec reinsert_pointer(
+  @spec insert_new_pointer(
           queues_key() | consolidated_queues_key() | spool_producer_queues_key(),
           LogEventPointer.t()
         ) :: :ok | {:error, :already_exists | :not_initialized}
-  def reinsert_pointer(queues_key, %LogEventPointer{} = pointer) do
+  def insert_new_pointer(queues_key, %LogEventPointer{} = pointer) do
     queues_key
     |> list_queues_with_tids()
     |> Enum.sort_by(&reinsert_queue_priority/1)
     |> Enum.reduce_while({:error, :not_initialized}, fn {_table_key, queue_tid}, _acc ->
-      case reinsert_pointer(%{pointer | queue_tid: queue_tid}) do
+      case insert_new_pointer(%{pointer | queue_tid: queue_tid}) do
         :ok -> {:halt, :ok}
         {:error, :already_exists} = error -> {:halt, error}
         {:error, :not_initialized} -> {:cont, {:error, :not_initialized}}
       end
     end)
+  end
+
+  defp pointer_row(pointer) do
+    {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
+     pointer.event_type, pointer.day_bucket}
   end
 
   defp reinsert_queue_priority({{_, _, pid}, tid}) do

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1026,21 +1026,58 @@ defmodule Logflare.Backends.IngestEventQueue do
   itself alive by claiming this in the first place. Bump `pointer.retries` before
   calling this if the caller is retrying after a failure.
 
-  If `queue_tid` has since gone stale (its owning producer died), the retry is dropped —
-  same stale-table telemetry/rescue pattern used everywhere else in this module.
+  Returns `{:error, :not_initialized}` if `queue_tid` has since gone stale because its
+  owning producer died, allowing callers that retain the event payload to reroute it.
+  Returns `{:error, :already_exists}` rather than overwriting a newer same-ID pointer.
   """
-  @spec reinsert_pointer(LogEventPointer.t()) :: :ok
+  @spec reinsert_pointer(LogEventPointer.t()) ::
+          :ok | {:error, :already_exists | :not_initialized}
   def reinsert_pointer(%LogEventPointer{} = pointer) do
     row =
       {pointer.id, pointer.tid, pointer.gen_event_id, pointer.size, pointer.retries,
        pointer.event_type, pointer.day_bucket}
 
-    :ets.insert(pointer.queue_tid, row)
-    :ok
+    if :ets.insert_new(pointer.queue_tid, row) do
+      :ok
+    else
+      {:error, :already_exists}
+    end
   rescue
     ArgumentError ->
       emit_stale_ets_table_telemetry()
-      :ok
+      {:error, :not_initialized}
+  end
+
+  @doc """
+  Routes a previously-claimed pointer to an available queue for `queues_key`.
+
+  Active producer queues are tried from least to most pending, followed by the startup
+  queue. A candidate that disappears during routing is skipped. The backing generation
+  row is not copied; the routed pointer continues to reference it directly.
+  """
+  @spec reinsert_pointer(
+          queues_key() | consolidated_queues_key() | spool_producer_queues_key(),
+          LogEventPointer.t()
+        ) :: :ok | {:error, :already_exists | :not_initialized}
+  def reinsert_pointer(queues_key, %LogEventPointer{} = pointer) do
+    queues_key
+    |> list_queues_with_tids()
+    |> Enum.sort_by(&reinsert_queue_priority/1)
+    |> Enum.reduce_while({:error, :not_initialized}, fn {_table_key, queue_tid}, _acc ->
+      case reinsert_pointer(%{pointer | queue_tid: queue_tid}) do
+        :ok -> {:halt, :ok}
+        {:error, :already_exists} = error -> {:halt, error}
+        {:error, :not_initialized} -> {:cont, {:error, :not_initialized}}
+      end
+    end)
+  end
+
+  defp reinsert_queue_priority({{_, _, pid}, tid}) do
+    case :ets.info(tid, :size) do
+      size when is_integer(size) and is_nil(pid) -> {1, size}
+      size when is_integer(size) -> {0, size}
+      _ -> {2, 0}
+    end
   end
 
   @doc """

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -33,6 +33,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   @ets_recent_events :ingest_event_queue_recent_events
   @max_queue_size 30_000
   @consolidated_max_queue_size 120_000
+  @requeue_pointer_collision_retries 2
   @pointer_batch_key_match_spec (for event_type <- [:log, :metric, :trace] do
                                    {{:_, :_, :_, :_, :_, event_type, :"$1"},
                                     [{:is_integer, :"$1"}], [{{event_type, :"$1"}}]}
@@ -1026,10 +1027,12 @@ defmodule Logflare.Backends.IngestEventQueue do
   The payload is staged before its pointer, so a consumer cannot claim a pointer whose
   backing value is missing. The original queue is tried first, followed by the other
   live queues for `queues_key`. A stale destination rolls back only the staged row and
-  tries the next queue. Once a new pointer is published, or a newer same-ID pointer wins,
-  the old generation row is deleted because the caller's claim no longer owns it. If no
-  queue remains, both rows are removed and `{:error, :not_initialized}` reports that the
-  caller must account for the payload as dropped.
+  tries the next queue. Once a new pointer is published, or a newer same-ID pointer with
+  a resolvable payload wins, the old generation row is deleted because the caller's
+  claim no longer owns it. A dangling same-ID pointer is replaced instead of causing the
+  valid retry payload to be discarded. If no queue remains, both rows are removed and
+  `{:error, :not_initialized}` reports that the caller must account for the payload as
+  dropped.
 
   `payload_builder` receives the final pointer so payloads that embed their pointer can
   store the new generation and destination queue identifiers consistently.
@@ -1095,7 +1098,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
     case insert_generation_payload(gen_tid, gen_event_id, payload) do
       :ok ->
-        case insert_new_pointer(new_pointer) do
+        case publish_requeued_pointer(new_pointer, @requeue_pointer_collision_retries) do
           :ok ->
             {:ok, new_pointer}
 
@@ -1123,6 +1126,43 @@ defmodule Logflare.Backends.IngestEventQueue do
   defp insert_generation_payload(gen_tid, gen_event_id, payload) do
     :ets.insert(gen_tid, {gen_event_id, payload})
     :ok
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      {:error, :not_initialized}
+  end
+
+  defp publish_requeued_pointer(pointer, collision_retries) do
+    case insert_new_pointer(pointer) do
+      {:error, :already_exists} when collision_retries > 0 ->
+        case remove_dangling_pointer(pointer.queue_tid, pointer.id) do
+          :retry -> publish_requeued_pointer(pointer, collision_retries - 1)
+          :resolvable -> {:error, :already_exists}
+          {:error, :not_initialized} = error -> error
+        end
+
+      result ->
+        result
+    end
+  end
+
+  defp remove_dangling_pointer(queue_tid, id) do
+    case :ets.lookup(queue_tid, id) do
+      [{^id, gen_tid, gen_event_id, _, _, _, _} = row] ->
+        case lookup_event(gen_tid, gen_event_id) do
+          nil ->
+            # Delete only the row inspected above. If another writer replaced it, this
+            # is a no-op and the bounded publication retry re-evaluates that winner.
+            :ets.delete_object(queue_tid, row)
+            :retry
+
+          _payload ->
+            :resolvable
+        end
+
+      [] ->
+        :retry
+    end
   rescue
     ArgumentError ->
       emit_stale_ets_table_telemetry()

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -10,9 +10,9 @@ defmodule Logflare.Backends.IngestEventQueue do
   generationally-rotated event store per `queues_key` initially holding the actual
   `LogEvent` bodies (see `current_generation_tid/1`, `new_generations/1`,
   `Logflare.Backends.IngestEventQueue.GenerationJanitor`). A consumer may replace a
-  claimed value with a backend-specific encoded representation while retaining the
-  same pointer for retries. `add_to_table/3` always
-  writes both; which read function a caller uses decides whether it gets back
+  claimed value with a backend-specific encoded representation, then transfer that
+  value into the current generation when retrying. `add_to_table/3` always writes both;
+  which read function a caller uses decides whether it gets back
   lightweight pointers (`pop_pending_pointers/2` — ID-passing pipelines: ClickHouse,
   BigQuery, spool) or fully-resolved `LogEvent` structs (`pop_pending/2` — every other
   adaptor).
@@ -1018,6 +1018,115 @@ defmodule Logflare.Backends.IngestEventQueue do
       [] ->
         take_selected_pointers(selected_ids, tid, pointers)
     end
+  end
+
+  @doc """
+  Transfers a claimed payload into the current generation and publishes its new pointer.
+
+  The payload is staged before its pointer, so a consumer cannot claim a pointer whose
+  backing value is missing. The original queue is tried first, followed by the other
+  live queues for `queues_key`. A stale destination rolls back only the staged row and
+  tries the next queue. Once a new pointer is published, or a newer same-ID pointer wins,
+  the old generation row is deleted because the caller's claim no longer owns it. If no
+  queue remains, both rows are removed and `{:error, :not_initialized}` reports that the
+  caller must account for the payload as dropped.
+
+  `payload_builder` receives the final pointer so payloads that embed their pointer can
+  store the new generation and destination queue identifiers consistently.
+  """
+  @spec requeue_payload(
+          queues_key() | consolidated_queues_key() | spool_producer_queues_key(),
+          LogEventPointer.t(),
+          (LogEventPointer.t() -> term())
+        ) ::
+          {:ok, LogEventPointer.t()} | {:error, :already_exists | :not_initialized}
+  def requeue_payload(queues_key, %LogEventPointer{} = pointer, payload_builder)
+      when is_function(payload_builder, 1) do
+    candidate_tids =
+      queues_key
+      |> list_queues_with_tids()
+      |> Enum.sort_by(&reinsert_queue_priority/1)
+      |> Enum.map(&elem(&1, 1))
+      |> then(&Enum.uniq([pointer.queue_tid | &1]))
+
+    result =
+      requeue_payload_to_candidate(candidate_tids, queues_key, pointer, payload_builder)
+
+    delete_id(pointer.tid, pointer.gen_event_id)
+    result
+  end
+
+  defp requeue_payload_to_candidate([], _queues_key, _pointer, _payload_builder),
+    do: {:error, :not_initialized}
+
+  defp requeue_payload_to_candidate(
+         [queue_tid | candidate_tids],
+         queues_key,
+         pointer,
+         payload_builder
+       ) do
+    case stage_and_publish_requeued_payload(queues_key, queue_tid, pointer, payload_builder, 1) do
+      {:error, :not_initialized} ->
+        requeue_payload_to_candidate(candidate_tids, queues_key, pointer, payload_builder)
+
+      result ->
+        result
+    end
+  end
+
+  defp stage_and_publish_requeued_payload(
+         queues_key,
+         queue_tid,
+         pointer,
+         payload_builder,
+         generation_retries
+       ) do
+    gen_tid = current_generation_tid(queues_key)
+    gen_event_id = make_ref()
+
+    new_pointer = %{
+      pointer
+      | tid: gen_tid,
+        gen_event_id: gen_event_id,
+        queue_tid: queue_tid
+    }
+
+    payload = payload_builder.(new_pointer)
+
+    case insert_generation_payload(gen_tid, gen_event_id, payload) do
+      :ok ->
+        case reinsert_pointer(new_pointer) do
+          :ok ->
+            {:ok, new_pointer}
+
+          {:error, reason} = error when reason in [:already_exists, :not_initialized] ->
+            delete_id(gen_tid, gen_event_id)
+            error
+        end
+
+      {:error, :not_initialized} when generation_retries > 0 ->
+        :ok = new_generations([queues_key])
+
+        stage_and_publish_requeued_payload(
+          queues_key,
+          queue_tid,
+          pointer,
+          payload_builder,
+          generation_retries - 1
+        )
+
+      {:error, :not_initialized} = error ->
+        error
+    end
+  end
+
+  defp insert_generation_payload(gen_tid, gen_event_id, payload) do
+    :ets.insert(gen_tid, {gen_event_id, payload})
+    :ok
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      {:error, :not_initialized}
   end
 
   @doc """

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1027,8 +1027,8 @@ defmodule Logflare.Backends.IngestEventQueue do
   The payload is staged before its pointer, so a consumer cannot claim a pointer whose
   backing value is missing. The original queue is tried first, followed by the other
   live queues for `queues_key`. A stale destination rolls back only the staged row and
-  tries the next queue. Once a new pointer is published, or a newer same-ID pointer with
-  a resolvable payload wins, the old generation row is deleted because the caller's
+  tries the next queue. Once a new pointer is published, or an existing same-ID pointer
+  with a resolvable payload wins, the old generation row is deleted because the caller's
   claim no longer owns it. A dangling same-ID pointer is replaced instead of causing the
   valid retry payload to be discarded. If no queue remains, both rows are removed and
   `{:error, :not_initialized}` reports that the caller must account for the payload as
@@ -1195,7 +1195,7 @@ defmodule Logflare.Backends.IngestEventQueue do
 
   Returns `{:error, :not_initialized}` if `queue_tid` has since gone stale, allowing a
   caller that retains the payload to try another queue. Returns
-  `{:error, :already_exists}` without overwriting the authoritative same-ID pointer.
+  `{:error, :already_exists}` without overwriting the existing same-ID pointer.
   """
   @spec insert_new_pointer(LogEventPointer.t()) ::
           :ok | {:error, :already_exists | :not_initialized}

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -438,7 +438,7 @@ defmodule Logflare.Telemetry do
         measurement: :count,
         tags: [:backend_type],
         description:
-          "Count of claimed retry payloads discarded because a newer same-ID pointer already existed"
+          "Count of claimed retry payloads discarded because an existing same-ID pointer had a resolvable payload"
       )
     ]
 

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -403,7 +403,7 @@ defmodule Logflare.Telemetry do
       sum("logflare.ingest_event_queue.missing_ids.count",
         event_name: [:logflare, :ingest_event_queue, :missing_ids],
         tags: [:backend_type],
-        description: "Count of event IDs not found in ETS during handle_batch fetch"
+        description: "Count of event IDs not found during pipeline generation-store resolution"
       ),
       sum("logflare.ingest_event_queue.not_initialized.dropped.count",
         event_name: [:logflare, :ingest_event_queue, :not_initialized, :dropped],

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -432,6 +432,13 @@ defmodule Logflare.Telemetry do
         measurement: :count,
         description:
           "Count of retriable events whose generation-store row was already gone by requeue lookup time"
+      ),
+      sum("logflare.ingest_event_queue.requeue_deduplicated.count",
+        event_name: [:logflare, :ingest_event_queue, :requeue_deduplicated],
+        measurement: :count,
+        tags: [:backend_type],
+        description:
+          "Count of claimed retry payloads discarded because a newer same-ID pointer already existed"
       )
     ]
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -6,6 +6,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   alias Broadway.Message
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
   alias Logflare.Backends.IngestEventQueue
@@ -34,7 +35,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
     end)
 
-    context = %{backend_id: backend.id}
+    context = Pipeline.processor_context(backend.id)
 
     [
       source: source,
@@ -60,7 +61,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   defp lookup_by_event_id(tid, event_id) do
     tid
     |> :ets.tab2list()
-    |> Enum.find_value(fn {_gen_event_id, event} -> if event.id == event_id, do: event end)
+    |> Enum.find_value(fn
+      {_gen_event_id, %EncodedRow{pointer: %{id: ^event_id}} = encoded} -> encoded
+      {_gen_event_id, %{id: ^event_id} = event} -> event
+      _row -> nil
+    end)
   end
 
   # Builds a LogEventPointer for `event`, resolvable via `gen_tid` (see
@@ -79,20 +84,45 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     }
   end
 
+  defp queued_pointer(queue_tid, event_id) do
+    case :ets.lookup(queue_tid, event_id) do
+      [{^event_id, gen_tid, gen_event_id, size, retries, event_type, day_bucket}] ->
+        %LogEventPointer{
+          id: event_id,
+          tid: gen_tid,
+          gen_event_id: gen_event_id,
+          queue_tid: queue_tid,
+          size: size,
+          retries: retries,
+          event_type: event_type,
+          day_bucket: day_bucket
+        }
+
+      [] ->
+        nil
+    end
+  end
+
   # Builds a message in the format produced by handle_message/3, for use in
   # handle_batch/4 and ack/3 tests.
   defp batch_message(event, gen_tid, backend_id, queue_tid \\ nil, in_flight_ref \\ nil) do
-    %Message{
+    message = %Message{
       data: pointer_for(event, gen_tid, queue_tid),
       acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id, in_flight_ref: in_flight_ref}}
     }
+
+    Pipeline.handle_message(:default, message, Pipeline.processor_context(backend_id))
   end
 
   # handle_batch/4 is not required to preserve input order (Broadway partitions and
   # re-reverses its return by status internally), so compare message sets by id
   # rather than list order.
   defp assert_same_messages(result, expected) do
-    sort_key = fn %{data: %LogEventPointer{id: id}} -> id end
+    sort_key = fn
+      %{data: %EncodedRow{pointer: %{id: id}}} -> id
+      %{data: %LogEventPointer{id: id}} -> id
+    end
+
     assert Enum.sort_by(result, sort_key) == Enum.sort_by(expected, sort_key)
   end
 
@@ -152,8 +182,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_message(:default, message, context)
 
-      assert %Message{batcher: :ch, batch_key: {:log, day_bucket}} = result
-      assert result.data == pointer
+      assert %Message{
+               batcher: :ch,
+               batch_key: {:log, day_bucket},
+               data: %EncodedRow{pointer: ^pointer, row: row}
+             } = result
+
+      assert is_binary(row)
+
+      assert %EncodedRow{pointer: ^pointer, row: ^row} =
+               IngestEventQueue.lookup_event(gen_tid, event.id)
+
       assert day_bucket == event.day_bucket
     end
 
@@ -204,7 +243,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   end
 
   describe "handle_batch/4" do
-    test "extracts events from the generation store and inserts into ClickHouse", %{
+    test "compresses processor-encoded rows and inserts into ClickHouse", %{
       context: context,
       source: source,
       backend: backend
@@ -254,7 +293,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       end)
     end
 
-    test "encodes rows independently while preserving missing events", %{
+    test "compresses encoded rows while preserving missing messages", %{
       context: context,
       source: source,
       backend: backend
@@ -373,9 +412,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       event1 = build(:log_event, source: source, message: "gone 1")
       event2 = build(:log_event, source: source, message: "gone 2")
 
-      # Empty generation table: rows were claimed via pop_pending_pointers/2 but their
-      # generation rotated out (or was otherwise dropped) before batch time, so
-      # encode_message finds nothing.
+      # Empty generation table: processors fail these messages before they can enter a
+      # real batch. Passing them directly here also proves the batch callback skips an
+      # empty RowBinary insert defensively.
       gen_tid = setup_generation_events([])
 
       messages = [
@@ -1142,30 +1181,42 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
   if Pipeline.max_retries() > 0 do
     describe "ack/3 retry behavior" do
-      test "re-queues failed messages when the pointer's retries are under limit", %{
+      test "re-queues the encoded row without mapping it again", %{
         source: source,
         backend: backend
       } do
         event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
         gen_tid = setup_generation_events([event])
+        queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
 
-        failed_message = %Message{
-          data: pointer_for(event, gen_tid),
-          acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
-          status: {:failed, "connection error"}
-        }
+        failed_message =
+          event
+          |> batch_message(gen_tid, backend.id, queue_tid)
+          |> Message.failed("connection error")
+
+        assert %EncodedRow{row: original_row} = failed_message.data
 
         Pipeline.ack(:ack_ref, [], [failed_message])
 
-        # old copy deleted from the generation it failed in ...
-        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+        assert %EncodedRow{pointer: %{retries: 1}, row: ^original_row} =
+                 IngestEventQueue.lookup_event(gen_tid, event.id)
 
-        # ... and re-added to the current generation with incremented retries
-        current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-        assert %{retries: 1} = lookup_by_event_id(current_gen_tid, event.id)
+        assert %LogEventPointer{retries: 1} = retry_pointer = queued_pointer(queue_tid, event.id)
+
+        retry_message = %Message{
+          data: retry_pointer,
+          acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+        }
+
+        assert %Message{data: %EncodedRow{row: ^original_row}} =
+                 Pipeline.handle_message(
+                   :default,
+                   retry_message,
+                   Pipeline.processor_context(backend.id)
+                 )
       end
 
-      test "increments retry count on each re-queue", %{
+      test "increments retry count on each encoded-row requeue", %{
         source: source,
         backend: backend
       } do
@@ -1176,23 +1227,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
           build(:log_event, source: source, message: "Test") |> Map.put(:retries, initial_retries)
 
         gen_tid = setup_generation_events([event])
+        queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
 
-        failed_message = %Message{
-          data: pointer_for(event, gen_tid),
-          acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
-          status: {:failed, "connection error"}
-        }
+        failed_message =
+          event
+          |> batch_message(gen_tid, backend.id, queue_tid)
+          |> Message.failed("connection error")
 
         Pipeline.ack(:ack_ref, [], [failed_message])
 
-        current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-
         assert %{retries: ^initial_retries} = event
-        assert %{retries: retries} = lookup_by_event_id(current_gen_tid, event.id)
+        assert %EncodedRow{pointer: %{retries: retries}} = lookup_by_event_id(gen_tid, event.id)
         assert retries == initial_retries + 1
+        assert %LogEventPointer{retries: ^retries} = queued_pointer(queue_tid, event.id)
       end
 
-      test "handles mixed retriable and exhausted messages", %{
+      test "handles mixed retriable and exhausted encoded rows", %{
         source: source,
         backend: backend
       } do
@@ -1206,37 +1256,29 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
           |> Map.put(:retries, max_retries)
 
         gen_tid = setup_generation_events([retriable_event, exhausted_event])
+        retriable_queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
+        exhausted_queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
 
         failed_messages = [
-          %Message{
-            data: pointer_for(retriable_event, gen_tid),
-            acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
-            status: {:failed, "error"}
-          },
-          %Message{
-            data: pointer_for(exhausted_event, gen_tid),
-            acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
-            status: {:failed, "error"}
-          }
+          retriable_event
+          |> batch_message(gen_tid, backend.id, retriable_queue_tid)
+          |> Message.failed("error"),
+          exhausted_event
+          |> batch_message(gen_tid, backend.id, exhausted_queue_tid)
+          |> Message.failed("error")
         ]
 
-        log =
-          capture_log(fn ->
-            Pipeline.ack(:ack_ref, [], failed_messages)
-          end)
+        log = capture_log(fn -> Pipeline.ack(:ack_ref, [], failed_messages) end)
 
         assert log =~ "Dropping 1 ClickHouse events: exhausted #{max_retries} retries"
-
-        # exhausted event's event row is deleted from the generation store, never re-added
         assert IngestEventQueue.lookup_event(gen_tid, exhausted_event.id) == nil
+        assert queued_pointer(exhausted_queue_tid, exhausted_event.id) == nil
 
-        current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-        assert lookup_by_event_id(current_gen_tid, exhausted_event.id) == nil
+        assert %EncodedRow{pointer: %{retries: 1}} =
+                 IngestEventQueue.lookup_event(gen_tid, retriable_event.id)
 
-        # retriable event's old copy is deleted too, but re-added to the current
-        # generation with incremented retries
-        assert IngestEventQueue.lookup_event(gen_tid, retriable_event.id) == nil
-        assert %{retries: 1} = lookup_by_event_id(current_gen_tid, retriable_event.id)
+        assert %LogEventPointer{retries: 1} =
+                 queued_pointer(retriable_queue_tid, retriable_event.id)
       end
 
       test "emits telemetry and logs a warning when a retriable event's generation is already gone",
@@ -1524,7 +1566,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
     end
 
-    test "requeues retriable messages when the breaker is closed", %{
+    test "requeues encoded rows when the breaker is closed", %{
       source: source,
       backend: backend
     } do
@@ -1532,19 +1574,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
       gen_tid = setup_generation_events([event])
+      queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
 
-      failed_message = %Message{
-        data: pointer_for(event, gen_tid),
-        acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
-        status: {:failed, "boom"}
-      }
+      failed_message =
+        event
+        |> batch_message(gen_tid, backend.id, queue_tid)
+        |> Message.failed("boom")
 
       Pipeline.ack(:ack_ref, [], [failed_message])
 
-      assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+      assert %EncodedRow{pointer: %{retries: 1}} =
+               IngestEventQueue.lookup_event(gen_tid, event.id)
 
-      current_gen_tid = IngestEventQueue.current_generation_tid({:consolidated, backend.id})
-      assert %{retries: 1} = lookup_by_event_id(current_gen_tid, event.id)
+      assert %LogEventPointer{retries: 1} = queued_pointer(queue_tid, event.id)
     end
   end
 end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -120,13 +120,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   # re-reverses its return by status internally), so compare message sets by id
   # rather than list order.
   defp assert_same_messages(result, expected) do
-    sort_key = fn
-      %{data: %EncodedRow{pointer: %{id: id}}} -> id
-      %{data: %LogEventPointer{id: id}} -> id
-    end
-
-    assert Enum.sort_by(result, sort_key) == Enum.sort_by(expected, sort_key)
+    assert Enum.sort_by(result, &message_id/1) == Enum.sort_by(expected, &message_id/1)
   end
+
+  defp message_id(%Message{data: %EncodedRow{pointer: %{id: id}}}), do: id
+  defp message_id(%Message{data: %LogEventPointer{id: id}}), do: id
 
   describe "child_spec/1" do
     test "returns proper child specification" do
@@ -220,6 +218,32 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                IngestEventQueue.lookup_event(gen_tid, event.id)
 
       assert day_bucket == event.day_bucket
+    end
+
+    test "emits missing-id telemetry when the processor cannot resolve an event", %{
+      context: context,
+      backend: backend
+    } do
+      event = build(:log_event)
+      gen_tid = setup_generation_events([])
+      pointer = pointer_for(event, gen_tid)
+
+      message = %Message{
+        data: pointer,
+        acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+      }
+
+      telemetry_event = [:logflare, :ingest_event_queue, :missing_ids]
+      ref = :telemetry_test.attach_event_handlers(self(), [telemetry_event])
+      on_exit(fn -> :telemetry.detach(ref) end)
+
+      assert %Message{status: {:failed, :not_found}} =
+               Pipeline.handle_message(:default, message, context)
+
+      assert_receive {^telemetry_event, ^ref, %{count: 1}, metadata}
+      assert metadata.backend_type == :clickhouse
+      assert metadata.backend_id == backend.id
+      assert metadata.event_type == :log
     end
 
     test "keys metric events by `{:metric, day_bucket}`", %{context: context, backend: backend} do
@@ -392,10 +416,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
-      statuses =
-        Map.new(result, fn %Message{data: %LogEventPointer{id: id}, status: status} ->
-          {id, status}
-        end)
+      statuses = Map.new(result, fn message -> {message_id(message), message.status} end)
 
       assert statuses[valid_event.id] == :ok
       assert statuses[invalid_event.id] == {:failed, "invalid event UUID"}
@@ -1242,6 +1263,77 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                  )
       end
 
+      test "reroutes an encoded retry when its claiming producer queue is stale", %{
+        source: source
+      } do
+        retry_backend_id = System.unique_integer([:positive])
+        target_key = {:consolidated, retry_backend_id, self()}
+        assert {:ok, target_tid} = IngestEventQueue.upsert_tid(target_key)
+
+        stale_queue_tid = :ets.new(:test_pipeline_stale_retry_queue, [:set, :public])
+        :ets.delete(stale_queue_tid)
+
+        event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+        gen_tid = setup_generation_events([event])
+        pointer = pointer_for(event, gen_tid, stale_queue_tid)
+        original_row = <<1, 2, 3>>
+        encoded = %EncodedRow{pointer: pointer, row: original_row}
+        assert :ok = IngestEventQueue.replace_event(gen_tid, event.id, encoded)
+
+        failed_message = %Message{
+          data: encoded,
+          acknowledger: {Pipeline, :ack_id, %{backend_id: retry_backend_id}},
+          status: {:failed, "connection error"}
+        }
+
+        Mimic.stub(CircuitBreaker, :check, fn ^retry_backend_id -> :ok end)
+
+        assert :ok = Pipeline.ack(:ack_ref, [], [failed_message])
+
+        assert %LogEventPointer{retries: 1, queue_tid: ^target_tid} =
+                 queued_pointer(target_tid, event.id)
+
+        assert %EncodedRow{pointer: %{retries: 1}, row: ^original_row} =
+                 IngestEventQueue.lookup_event(gen_tid, event.id)
+      end
+
+      test "reports a queue-unavailable drop separately from a generation lookup miss", %{
+        source: source
+      } do
+        retry_backend_id = System.unique_integer([:positive])
+        stale_queue_tid = :ets.new(:test_pipeline_stale_retry_queue, [:set, :public])
+        :ets.delete(stale_queue_tid)
+
+        event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+        gen_tid = setup_generation_events([event])
+        pointer = pointer_for(event, gen_tid, stale_queue_tid)
+        encoded = %EncodedRow{pointer: pointer, row: <<1, 2, 3>>}
+        assert :ok = IngestEventQueue.replace_event(gen_tid, event.id, encoded)
+
+        failed_message = %Message{
+          data: encoded,
+          acknowledger: {Pipeline, :ack_id, %{backend_id: retry_backend_id}},
+          status: {:failed, "connection error"}
+        }
+
+        dropped_event = [:logflare, :ingest_event_queue, :not_initialized, :dropped]
+        lookup_miss_event = [:logflare, :ingest_event_queue, :requeue_lookup_miss]
+
+        ref =
+          :telemetry_test.attach_event_handlers(self(), [dropped_event, lookup_miss_event])
+
+        on_exit(fn -> :telemetry.detach(ref) end)
+        Mimic.stub(CircuitBreaker, :check, fn ^retry_backend_id -> :ok end)
+
+        assert :ok = Pipeline.ack(:ack_ref, [], [failed_message])
+
+        assert_receive {^dropped_event, ^ref, %{count: 1}, metadata}
+        assert metadata.backend_type == :clickhouse
+        assert metadata.backend_id == retry_backend_id
+        refute_receive {^lookup_miss_event, ^ref, _, _}
+        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+      end
+
       test "increments retry count on each encoded-row requeue", %{
         source: source,
         backend: backend
@@ -1405,10 +1497,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
-      statuses =
-        Map.new(result, fn %Message{data: %LogEventPointer{id: id}, status: status} ->
-          {id, status}
-        end)
+      statuses = Map.new(result, fn message -> {message_id(message), message.status} end)
 
       assert statuses[valid_event.id] == {:failed, "Connection timeout"}
       assert statuses[invalid_event.id] == {:failed, "invalid event UUID"}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1338,6 +1338,42 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                ) == authoritative_event
       end
 
+      test "replaces a dangling same-ID pointer instead of deduplicating the retry", %{
+        source: source,
+        backend: backend
+      } do
+        event = build(:log_event, source: source, message: "claimed") |> Map.put(:retries, 0)
+        old_gen_tid = setup_generation_events([event])
+        queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
+
+        failed_message =
+          event
+          |> batch_message(old_gen_tid, backend.id, queue_tid)
+          |> Message.failed("connection error")
+
+        assert %EncodedRow{row: original_row} = failed_message.data
+
+        stale_gen_tid = setup_generation_events([])
+        dangling_pointer = pointer_for(event, stale_gen_tid, queue_tid)
+        :ets.delete(stale_gen_tid)
+        assert :ok = IngestEventQueue.reinsert_pointer(dangling_pointer)
+
+        telemetry_event = [:logflare, :ingest_event_queue, :requeue_deduplicated]
+        ref = :telemetry_test.attach_event_handlers(self(), [telemetry_event])
+        on_exit(fn -> :telemetry.detach(ref) end)
+
+        assert :ok = Pipeline.ack(:ack_ref, [], [failed_message])
+
+        assert %LogEventPointer{retries: 1} = retry_pointer = queued_pointer(queue_tid, event.id)
+        refute retry_pointer.tid == stale_gen_tid
+        refute retry_pointer.gen_event_id == dangling_pointer.gen_event_id
+
+        assert %EncodedRow{pointer: ^retry_pointer, row: ^original_row} =
+                 IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
+
+        refute_receive {^telemetry_event, ^ref, _, _}
+      end
+
       test "moves an unencoded retry into the current generation", %{
         source: source,
         backend: backend

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1243,6 +1243,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
         assert %EncodedRow{row: original_row} = failed_message.data
 
+        telemetry_event = [:logflare, :ingest_event_queue, :requeue_deduplicated]
+        ref = :telemetry_test.attach_event_handlers(self(), [telemetry_event])
+        on_exit(fn -> :telemetry.detach(ref) end)
+
         Pipeline.ack(:ack_ref, [], [failed_message])
 
         assert %LogEventPointer{retries: 1} = retry_pointer = queued_pointer(queue_tid, event.id)
@@ -1267,6 +1271,46 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                    retry_message,
                    Pipeline.processor_context(backend.id)
                  )
+
+        refute_receive {^telemetry_event, ^ref, _, _}
+      end
+
+      test "reports and cleans up an encoded retry deduplicated by a newer pointer", %{
+        source: source,
+        backend: backend
+      } do
+        event = build(:log_event, source: source, message: "claimed") |> Map.put(:retries, 0)
+        old_gen_tid = setup_generation_events([event])
+        queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
+
+        failed_message =
+          event
+          |> batch_message(old_gen_tid, backend.id, queue_tid)
+          |> Message.failed("connection error")
+
+        authoritative_event = %{event | body: Map.put(event.body, "event_message", "newer")}
+        authoritative_gen_tid = setup_generation_events([authoritative_event])
+        authoritative_pointer = pointer_for(authoritative_event, authoritative_gen_tid, queue_tid)
+        assert :ok = IngestEventQueue.reinsert_pointer(authoritative_pointer)
+
+        telemetry_event = [:logflare, :ingest_event_queue, :requeue_deduplicated]
+        ref = :telemetry_test.attach_event_handlers(self(), [telemetry_event])
+        on_exit(fn -> :telemetry.detach(ref) end)
+
+        log = capture_log(fn -> Pipeline.ack(:ack_ref, [], [failed_message]) end)
+
+        assert log =~ "Deduplicated 1 ClickHouse event(s) during retry requeue"
+
+        assert_receive {^telemetry_event, ^ref, %{count: 1}, metadata}
+        assert metadata == %{backend_type: :clickhouse, backend_id: backend.id}
+
+        assert IngestEventQueue.lookup_event(old_gen_tid, event.id) == nil
+        assert queued_pointer(queue_tid, event.id) == authoritative_pointer
+
+        assert IngestEventQueue.lookup_event(
+                 authoritative_pointer.tid,
+                 authoritative_pointer.gen_event_id
+               ) == authoritative_event
       end
 
       test "moves an unencoded retry into the current generation", %{

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1245,10 +1245,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
         Pipeline.ack(:ack_ref, [], [failed_message])
 
-        assert %EncodedRow{pointer: %{retries: 1}, row: ^original_row} =
-                 IngestEventQueue.lookup_event(gen_tid, event.id)
-
         assert %LogEventPointer{retries: 1} = retry_pointer = queued_pointer(queue_tid, event.id)
+        refute retry_pointer.tid == gen_tid
+        refute retry_pointer.gen_event_id == event.id
+        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+        assert %EncodedRow{pointer: ^retry_pointer, row: ^original_row} =
+                 IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
+
+        # The retry no longer depends on the old generation remaining alive.
+        :ets.delete(gen_tid)
 
         retry_message = %Message{
           data: retry_pointer,
@@ -1260,6 +1266,37 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                    :default,
                    retry_message,
                    Pipeline.processor_context(backend.id)
+                 )
+      end
+
+      test "moves an unencoded retry into the current generation", %{
+        source: source,
+        backend: backend
+      } do
+        event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+        old_gen_tid = setup_generation_events([event])
+        queue_tid = :ets.new(:test_pipeline_retry_queue, [:set, :public])
+        queues_key = {:consolidated, backend.id}
+        assert :ok = IngestEventQueue.new_generations([queues_key])
+        current_gen_tid = IngestEventQueue.current_generation_tid(queues_key)
+
+        failed_message = %Message{
+          data: pointer_for(event, old_gen_tid, queue_tid),
+          acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}},
+          status: {:failed, "connection error"}
+        }
+
+        assert :ok = Pipeline.ack(:ack_ref, [], [failed_message])
+
+        assert %LogEventPointer{tid: ^current_gen_tid, retries: 1} =
+                 retry_pointer = queued_pointer(queue_tid, event.id)
+
+        assert IngestEventQueue.lookup_event(old_gen_tid, event.id) == nil
+
+        assert %Logflare.LogEvent{retries: 1} =
+                 IngestEventQueue.lookup_event(
+                   retry_pointer.tid,
+                   retry_pointer.gen_event_id
                  )
       end
 
@@ -1291,10 +1328,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         assert :ok = Pipeline.ack(:ack_ref, [], [failed_message])
 
         assert %LogEventPointer{retries: 1, queue_tid: ^target_tid} =
-                 queued_pointer(target_tid, event.id)
+                 retry_pointer = queued_pointer(target_tid, event.id)
 
-        assert %EncodedRow{pointer: %{retries: 1}, row: ^original_row} =
-                 IngestEventQueue.lookup_event(gen_tid, event.id)
+        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+        assert %EncodedRow{pointer: ^retry_pointer, row: ^original_row} =
+                 IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
       end
 
       test "reports a queue-unavailable drop separately from a generation lookup miss", %{
@@ -1355,9 +1394,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         Pipeline.ack(:ack_ref, [], [failed_message])
 
         assert %{retries: ^initial_retries} = event
-        assert %EncodedRow{pointer: %{retries: retries}} = lookup_by_event_id(gen_tid, event.id)
+
+        assert %LogEventPointer{retries: retries} =
+                 retry_pointer =
+                 queued_pointer(queue_tid, event.id)
+
         assert retries == initial_retries + 1
-        assert %LogEventPointer{retries: ^retries} = queued_pointer(queue_tid, event.id)
+        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+        assert %EncodedRow{pointer: ^retry_pointer} =
+                 lookup_by_event_id(retry_pointer.tid, event.id)
       end
 
       test "handles mixed retriable and exhausted encoded rows", %{
@@ -1392,11 +1438,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         assert IngestEventQueue.lookup_event(gen_tid, exhausted_event.id) == nil
         assert queued_pointer(exhausted_queue_tid, exhausted_event.id) == nil
 
-        assert %EncodedRow{pointer: %{retries: 1}} =
-                 IngestEventQueue.lookup_event(gen_tid, retriable_event.id)
-
         assert %LogEventPointer{retries: 1} =
+                 retry_pointer =
                  queued_pointer(retriable_queue_tid, retriable_event.id)
+
+        assert IngestEventQueue.lookup_event(gen_tid, retriable_event.id) == nil
+
+        assert %EncodedRow{pointer: ^retry_pointer} =
+                 IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
       end
 
       test "emits telemetry and logs a warning when a retriable event's generation is already gone",
@@ -1698,10 +1747,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       Pipeline.ack(:ack_ref, [], [failed_message])
 
-      assert %EncodedRow{pointer: %{retries: 1}} =
-               IngestEventQueue.lookup_event(gen_tid, event.id)
+      assert %LogEventPointer{retries: 1} = retry_pointer = queued_pointer(queue_tid, event.id)
+      assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
 
-      assert %LogEventPointer{retries: 1} = queued_pointer(queue_tid, event.id)
+      assert %EncodedRow{pointer: ^retry_pointer} =
+               IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
     end
   end
 end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -4,11 +4,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
   import ExUnit.CaptureLog
 
   alias Broadway.Message
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreaker
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.EncodedRow
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline
+  alias Logflare.Backends.DynamicPipeline
   alias Logflare.Backends.IngestEventQueue
   alias Logflare.Backends.IngestEventQueue.LogEventPointer
   alias Logflare.Mapper
@@ -132,6 +134,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert spec.id == Pipeline
       assert spec.start == {Pipeline, :start_link, [:some_arg]}
+    end
+
+    test "scales processors with schedulers while reserving four batch processors" do
+      assert Pipeline.processor_concurrency(1) == 6
+      assert Pipeline.processor_concurrency(6) == 6
+      assert Pipeline.processor_concurrency(12) == 8
+      assert Pipeline.processor_concurrency(32) == 28
+    end
+
+    test "starts Broadway with runtime-derived processor concurrency", %{backend: backend} do
+      dynamic_pipeline_name = Backends.via_backend(backend, Pipeline)
+      assert [pipeline_name] = DynamicPipeline.list_pipelines(dynamic_pipeline_name)
+
+      topology = Broadway.topology(pipeline_name)
+      assert [processor] = topology[:processors]
+      assert [batcher] = topology[:batchers]
+
+      assert processor.concurrency == Pipeline.processor_concurrency()
+      assert batcher.concurrency == 4
     end
 
     test "retains 64 batches of in-flight capacity independently of insert concurrency" do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -233,9 +233,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
       }
 
-      Mimic.expect(IngestEventQueue, :replace_event, fn ^gen_tid,
-                                                        id,
-                                                        %EncodedRow{} ->
+      Mimic.expect(IngestEventQueue, :replace_event, fn ^gen_tid, id, %EncodedRow{} ->
         assert id == event.id
         :ets.delete(gen_tid)
         {:error, :not_found}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -133,6 +133,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert spec.id == Pipeline
       assert spec.start == {Pipeline, :start_link, [:some_arg]}
     end
+
+    test "retains 64 batches of in-flight capacity independently of insert concurrency" do
+      assert Pipeline.max_in_flight() == 64 * Pipeline.max_batch_size()
+      assert Pipeline.max_in_flight() == 3_840_000
+    end
   end
 
   describe "process_name/2" do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -220,12 +220,12 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert day_bucket == event.day_bucket
     end
 
-    test "emits missing-id telemetry when the processor cannot resolve an event", %{
+    test "keeps an encoded row when its generation disappears after lookup", %{
       context: context,
       backend: backend
     } do
       event = build(:log_event)
-      gen_tid = setup_generation_events([])
+      gen_tid = setup_generation_events([event])
       pointer = pointer_for(event, gen_tid)
 
       message = %Message{
@@ -233,17 +233,51 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
       }
 
+      Mimic.expect(IngestEventQueue, :replace_event, fn ^gen_tid,
+                                                        id,
+                                                        %EncodedRow{} ->
+        assert id == event.id
+        :ets.delete(gen_tid)
+        {:error, :not_found}
+      end)
+
+      assert %Message{
+               status: :ok,
+               data: %EncodedRow{pointer: ^pointer, row: row}
+             } = Pipeline.handle_message(:default, message, context)
+
+      assert is_binary(row)
+    end
+
+    test "aggregates missing-id telemetry when processors cannot resolve events", %{
+      context: context,
+      backend: backend
+    } do
+      events = build_list(3, :log_event)
+      gen_tid = setup_generation_events([])
+
+      failed_messages =
+        Enum.map(events, fn event ->
+          message = %Message{
+            data: pointer_for(event, gen_tid),
+            acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+          }
+
+          assert %Message{status: {:failed, :not_found}} =
+                   Pipeline.handle_message(:default, message, context)
+        end)
+
       telemetry_event = [:logflare, :ingest_event_queue, :missing_ids]
       ref = :telemetry_test.attach_event_handlers(self(), [telemetry_event])
       on_exit(fn -> :telemetry.detach(ref) end)
 
-      assert %Message{status: {:failed, :not_found}} =
-               Pipeline.handle_message(:default, message, context)
+      capture_log(fn -> assert :ok = Pipeline.ack(:ack_ref, [], failed_messages) end)
 
-      assert_receive {^telemetry_event, ^ref, %{count: 1}, metadata}
+      assert_receive {^telemetry_event, ^ref, %{count: 3}, metadata}
       assert metadata.backend_type == :clickhouse
       assert metadata.backend_id == backend.id
       assert metadata.event_type == :log
+      refute_receive {^telemetry_event, ^ref, _, _}
     end
 
     test "keys metric events by `{:metric, day_bucket}`", %{context: context, backend: backend} do
@@ -383,12 +417,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       end)
     end
 
-    test "isolates mapping failures while inserting valid rows and tracking only missing events",
-         %{
-           context: context,
-           source: source,
-           backend: backend
-         } do
+    test "isolates mapping failures while inserting valid rows", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
       valid_event = build(:log_event, source: source, message: "valid row")
 
       invalid_event =
@@ -411,9 +444,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         trigger: :flush
       }
 
-      telemetry_event = [:logflare, :ingest_event_queue, :missing_ids]
-      TestUtils.attach_forwarder(telemetry_event)
-
       result = Pipeline.handle_batch(:ch, messages, batch_info, context)
 
       statuses = Map.new(result, fn message -> {message_id(message), message.status} end)
@@ -421,11 +451,6 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert statuses[valid_event.id] == :ok
       assert statuses[invalid_event.id] == {:failed, "invalid event UUID"}
       assert statuses[missing_event.id] == {:failed, :not_found}
-
-      assert_receive {:telemetry_event, ^telemetry_event, %{count: 1},
-                      %{backend_id: backend_id, event_type: :log}}
-
-      assert backend_id == backend.id
 
       table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -37,7 +37,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
     end)
 
-    context = Pipeline.processor_context(backend.id)
+    context = Pipeline.build_processor_context(backend.id)
 
     [
       source: source,
@@ -113,7 +113,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       acknowledger: {Pipeline, :ack_id, %{backend_id: backend_id, in_flight_ref: in_flight_ref}}
     }
 
-    Pipeline.handle_message(:default, message, Pipeline.processor_context(backend_id))
+    Pipeline.handle_message(:default, message, Pipeline.build_processor_context(backend_id))
   end
 
   # handle_batch/4 is not required to preserve input order (Broadway partitions and
@@ -1292,7 +1292,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                  Pipeline.handle_message(
                    :default,
                    retry_message,
-                   Pipeline.processor_context(backend.id)
+                   Pipeline.build_processor_context(backend.id)
                  )
 
         refute_receive {^telemetry_event, ^ref, _, _}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1298,6 +1298,58 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         refute_receive {^telemetry_event, ^ref, _, _}
       end
 
+      test "drops an encoded row when its published retry also fails", %{
+        source: source,
+        backend: backend,
+        context: context
+      } do
+        event = build(:log_event, source: source, message: "Test") |> Map.put(:retries, 0)
+        gen_tid = setup_generation_events([event])
+        retry_key = {:consolidated, backend.id, self()}
+        assert {:ok, queue_tid} = IngestEventQueue.upsert_tid(retry_key)
+
+        first_failure =
+          event
+          |> batch_message(gen_tid, backend.id, queue_tid)
+          |> Message.failed("first connection error")
+
+        assert %EncodedRow{row: original_row} = first_failure.data
+        assert :ok = Pipeline.ack(:ack_ref, [], [first_failure])
+
+        assert {:ok, [retry_pointer], ^queue_tid} =
+                 IngestEventQueue.pop_pending_pointers(retry_key, 1)
+
+        assert retry_pointer.retries == Pipeline.max_retries()
+
+        retry_message = %Message{
+          data: retry_pointer,
+          acknowledger: {Pipeline, :ack_id, %{backend_id: backend.id}}
+        }
+
+        assert %Message{data: %EncodedRow{row: ^original_row}} =
+                 processed_retry =
+                 Pipeline.handle_message(:default, retry_message, context)
+
+        log =
+          capture_log(fn ->
+            assert :ok =
+                     Pipeline.ack(
+                       :ack_ref,
+                       [],
+                       [Message.failed(processed_retry, "second connection error")]
+                     )
+          end)
+
+        assert log =~ "Dropping 1 ClickHouse events: exhausted #{Pipeline.max_retries()} retries"
+        assert IngestEventQueue.total_pending(retry_key) == 0
+        assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+        assert IngestEventQueue.lookup_event(
+                 retry_pointer.tid,
+                 retry_pointer.gen_event_id
+               ) == nil
+      end
+
       test "reports and cleans up an encoded retry deduplicated by a newer pointer", %{
         source: source,
         backend: backend

--- a/test/logflare/backends/consolidated_sup_test.exs
+++ b/test/logflare/backends/consolidated_sup_test.exs
@@ -1,6 +1,7 @@
 defmodule Logflare.Backends.ConsolidatedSupTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor
   alias Logflare.Backends.ConsolidatedSup
   alias Logflare.Backends.IngestEventQueue
 
@@ -92,19 +93,24 @@ defmodule Logflare.Backends.ConsolidatedSupTest do
       [source: source, backend: backend]
     end
 
-    test "pipeline processes events from consolidated queue", %{
+    test "pipeline processes and inserts events from the consolidated queue", %{
       source: source,
       backend: backend
     } do
+      assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
       assert {:ok, _pid} = ConsolidatedSup.start_pipeline(backend)
 
       events = for _ <- 1..5, do: build(:log_event, source: source)
       IngestEventQueue.add_to_table({:consolidated, backend.id}, events)
 
-      TestUtils.retry_assert(fn ->
-        pending_counts = IngestEventQueue.list_pending_counts({:consolidated, backend.id})
-        total_pending = Enum.reduce(pending_counts, 0, fn {_key, count}, acc -> acc + count end)
-        assert total_pending < 5
+      table_name = ClickHouseAdaptor.clickhouse_ingest_table_name(backend, :log)
+
+      TestUtils.retry_assert([duration: 10_000], fn ->
+        assert {:ok, {[%{"count" => 5}], _bytes}} =
+                 ClickHouseAdaptor.execute_ch_query(
+                   backend,
+                   "SELECT count(*) AS count FROM #{table_name}"
+                 )
       end)
     end
   end

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -1038,30 +1038,6 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert {:error, :not_initialized} = IngestEventQueue.insert_new_pointer(pointer)
     end
 
-    test "routes a pointer away from a stale queue", %{source: source, sbp: {sid, bid, _pid}} do
-      stale_tid = :ets.new(:stale_reinsert_queue, [:public, :set])
-      :ets.delete(stale_tid)
-
-      target_key = {sid, bid, self()}
-      target_tid = IngestEventQueue.get_tid(target_key)
-      event = build(:log_event, source: source)
-
-      pointer = %LogEventPointer{
-        id: event.id,
-        tid: make_ref(),
-        gen_event_id: make_ref(),
-        queue_tid: stale_tid,
-        size: 1,
-        retries: 1,
-        event_type: event.event_type,
-        day_bucket: event.day_bucket
-      }
-
-      assert :ok = IngestEventQueue.insert_new_pointer({sid, bid}, pointer)
-      assert [{event_id, _, _, _, 1, _, _}] = :ets.lookup(target_tid, event.id)
-      assert event_id == event.id
-    end
-
     test "does not overwrite a newer pointer with the same event id", %{source: source, sbp: sbp} do
       event = build(:log_event, source: source)
       assert :ok = IngestEventQueue.add_to_table(sbp, [event])

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -870,7 +870,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert reclaimed.retries == 1
     end
 
-    test "is a silent no-op when the queue table is stale" do
+    test "reports when the queue table is stale" do
       tid = :ets.new(:stale_reinsert_queue, [:public, :set])
       :ets.delete(tid)
 
@@ -885,7 +885,52 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         day_bucket: 0
       }
 
-      assert :ok = IngestEventQueue.reinsert_pointer(pointer)
+      assert {:error, :not_initialized} = IngestEventQueue.reinsert_pointer(pointer)
+    end
+
+    test "routes a pointer away from a stale queue", %{source: source, sbp: {sid, bid, _pid}} do
+      stale_tid = :ets.new(:stale_reinsert_queue, [:public, :set])
+      :ets.delete(stale_tid)
+
+      target_key = {sid, bid, self()}
+      target_tid = IngestEventQueue.get_tid(target_key)
+      event = build(:log_event, source: source)
+
+      pointer = %LogEventPointer{
+        id: event.id,
+        tid: make_ref(),
+        gen_event_id: make_ref(),
+        queue_tid: stale_tid,
+        size: 1,
+        retries: 1,
+        event_type: event.event_type,
+        day_bucket: event.day_bucket
+      }
+
+      assert :ok = IngestEventQueue.reinsert_pointer({sid, bid}, pointer)
+      assert [{event_id, _, _, _, 1, _, _}] = :ets.lookup(target_tid, event.id)
+      assert event_id == event.id
+    end
+
+    test "does not overwrite a newer pointer with the same event id", %{source: source, sbp: sbp} do
+      event = build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+      queue_tid = IngestEventQueue.get_tid(sbp)
+      [existing] = :ets.lookup(queue_tid, event.id)
+
+      retry = %LogEventPointer{
+        id: event.id,
+        tid: make_ref(),
+        gen_event_id: make_ref(),
+        queue_tid: queue_tid,
+        size: 1,
+        retries: 1,
+        event_type: event.event_type,
+        day_bucket: event.day_bucket
+      }
+
+      assert {:error, :already_exists} = IngestEventQueue.reinsert_pointer(retry)
+      assert :ets.lookup(queue_tid, event.id) == [existing]
     end
   end
 

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -870,6 +870,71 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert reclaimed.retries == 1
     end
 
+    test "transfers a retry payload into the current generation before publishing its pointer", %{
+      source: source,
+      sbp: {sid, bid, _pid} = sbp
+    } do
+      event = build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
+
+      old_gen_tid = pointer.tid
+      old_gen_event_id = pointer.gen_event_id
+      queues_key = {sid, bid}
+      assert :ok = IngestEventQueue.new_generations([queues_key])
+      current_gen_tid = IngestEventQueue.current_generation_tid(queues_key)
+      retry_pointer = %{pointer | retries: pointer.retries + 1}
+
+      assert {:ok, %LogEventPointer{tid: ^current_gen_tid} = published_pointer} =
+               IngestEventQueue.requeue_payload(queues_key, retry_pointer, fn new_pointer ->
+                 {:retried, new_pointer}
+               end)
+
+      assert IngestEventQueue.lookup_event(old_gen_tid, old_gen_event_id) == nil
+
+      assert {:retried, ^published_pointer} =
+               IngestEventQueue.lookup_event(
+                 published_pointer.tid,
+                 published_pointer.gen_event_id
+               )
+
+      assert {:ok, [^published_pointer], _tid} =
+               IngestEventQueue.pop_pending_pointers(sbp, 1)
+    end
+
+    test "cleans up the claimed and staged payloads when a newer pointer already exists", %{
+      source: source,
+      sbp: {sid, bid, _pid} = sbp
+    } do
+      event = build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
+
+      duplicate = %{event | body: Map.put(event.body, "event_message", "newer")}
+      assert :ok = IngestEventQueue.add_to_table(sbp, [duplicate])
+      queue_tid = IngestEventQueue.get_tid(sbp)
+      [existing_pointer_row] = :ets.lookup(queue_tid, event.id)
+
+      {_, existing_gen_tid, existing_gen_event_id, _, _, _, _} = existing_pointer_row
+      queues_key = {sid, bid}
+      assert :ok = IngestEventQueue.new_generations([queues_key])
+      staged_gen_tid = IngestEventQueue.current_generation_tid(queues_key)
+
+      assert {:error, :already_exists} =
+               IngestEventQueue.requeue_payload(
+                 queues_key,
+                 %{pointer | retries: pointer.retries + 1},
+                 fn new_pointer -> {:retried, new_pointer} end
+               )
+
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
+      assert :ets.info(staged_gen_tid, :size) == 0
+      assert :ets.lookup(queue_tid, event.id) == [existing_pointer_row]
+
+      assert IngestEventQueue.lookup_event(existing_gen_tid, existing_gen_event_id) ==
+               duplicate
+    end
+
     test "reports when the queue table is stale" do
       tid = :ets.new(:stale_reinsert_queue, [:public, :set])
       :ets.delete(tid)

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -41,6 +41,26 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     assert nil == IngestEventQueue.get_tid({source.id, backend.id, pid})
   end
 
+  describe "replace_event/3" do
+    test "replaces an existing generation value" do
+      tid = :ets.new(:replace_event_test, [:set, :public])
+      :ets.insert(tid, {:id, :original})
+
+      assert :ok = IngestEventQueue.replace_event(tid, :id, :replacement)
+      assert IngestEventQueue.lookup_event(tid, :id) == :replacement
+    end
+
+    test "does not recreate a missing or stale generation row" do
+      tid = :ets.new(:replace_event_test, [:set, :public])
+
+      assert {:error, :not_found} = IngestEventQueue.replace_event(tid, :id, :replacement)
+      assert IngestEventQueue.lookup_event(tid, :id) == nil
+
+      :ets.delete(tid)
+      assert {:error, :not_found} = IngestEventQueue.replace_event(tid, :id, :replacement)
+    end
+  end
+
   describe "with user, source, backend" do
     setup do
       user = insert(:user)

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -945,6 +945,50 @@ defmodule Logflare.Backends.IngestEventQueueTest do
                duplicate
     end
 
+    test "replaces a same-ID pointer whose generation payload is gone", %{
+      source: source,
+      sbp: {sid, bid, _pid} = sbp
+    } do
+      event = build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
+
+      stale_gen_tid = :ets.new(:stale_retry_generation, [:set, :public])
+      stale_gen_event_id = make_ref()
+
+      dangling_pointer = %{
+        pointer
+        | tid: stale_gen_tid,
+          gen_event_id: stale_gen_event_id,
+          retries: 99
+      }
+
+      :ets.delete(stale_gen_tid)
+      assert :ok = IngestEventQueue.reinsert_pointer(dangling_pointer)
+
+      assert {:ok, %LogEventPointer{} = published_pointer} =
+               IngestEventQueue.requeue_payload(
+                 {sid, bid},
+                 %{pointer | retries: pointer.retries + 1},
+                 fn new_pointer -> {:retried, new_pointer} end
+               )
+
+      refute published_pointer.tid == stale_gen_tid
+      refute published_pointer.gen_event_id == stale_gen_event_id
+      assert published_pointer.retries == 1
+
+      assert {:ok, [^published_pointer], _tid} =
+               IngestEventQueue.pop_pending_pointers(sbp, 1)
+
+      assert {:retried, ^published_pointer} =
+               IngestEventQueue.lookup_event(
+                 published_pointer.tid,
+                 published_pointer.gen_event_id
+               )
+
+      assert IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id) == nil
+    end
+
     test "reports when the queue table is stale" do
       tid = :ets.new(:stale_reinsert_queue, [:public, :set])
       :ets.delete(tid)

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -843,7 +843,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
     end
   end
 
-  describe "reinsert_pointer/1" do
+  describe "pointer reinsertion" do
     setup do
       user = insert(:user)
       source = insert(:source, user: user)
@@ -862,11 +862,21 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
       assert IngestEventQueue.total_pending(sbp) == 0
 
+      colliding_pointer = %{
+        pointer
+        | tid: make_ref(),
+          gen_event_id: make_ref(),
+          retries: 99
+      }
+
+      assert :ok = IngestEventQueue.insert_new_pointer(colliding_pointer)
       assert :ok = IngestEventQueue.reinsert_pointer(%{pointer | retries: pointer.retries + 1})
       assert IngestEventQueue.total_pending(sbp) == 1
 
       assert {:ok, [reclaimed], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
       assert reclaimed.id == le.id
+      assert reclaimed.tid == pointer.tid
+      assert reclaimed.gen_event_id == pointer.gen_event_id
       assert reclaimed.retries == 1
     end
 
@@ -950,7 +960,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         day_bucket: 0
       }
 
-      assert {:error, :not_initialized} = IngestEventQueue.reinsert_pointer(pointer)
+      assert {:error, :not_initialized} = IngestEventQueue.insert_new_pointer(pointer)
     end
 
     test "routes a pointer away from a stale queue", %{source: source, sbp: {sid, bid, _pid}} do
@@ -972,7 +982,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         day_bucket: event.day_bucket
       }
 
-      assert :ok = IngestEventQueue.reinsert_pointer({sid, bid}, pointer)
+      assert :ok = IngestEventQueue.insert_new_pointer({sid, bid}, pointer)
       assert [{event_id, _, _, _, 1, _, _}] = :ets.lookup(target_tid, event.id)
       assert event_id == event.id
     end
@@ -994,7 +1004,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         day_bucket: event.day_bucket
       }
 
-      assert {:error, :already_exists} = IngestEventQueue.reinsert_pointer(retry)
+      assert {:error, :already_exists} = IngestEventQueue.insert_new_pointer(retry)
       assert :ets.lookup(queue_tid, event.id) == [existing]
     end
   end

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -912,6 +912,37 @@ defmodule Logflare.Backends.IngestEventQueueTest do
                IngestEventQueue.pop_pending_pointers(sbp, 1)
     end
 
+    test "recovers when the current generation disappears before retry payload staging", %{
+      source: source,
+      sbp: {sid, bid, _pid} = sbp
+    } do
+      event = build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, [event])
+      assert {:ok, [pointer], _tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
+
+      stale_gen_tid = pointer.tid
+      assert :ok = IngestEventQueue.drop_generation({sid, bid}, stale_gen_tid)
+
+      assert {:ok, %LogEventPointer{} = published_pointer} =
+               IngestEventQueue.requeue_payload(
+                 {sid, bid},
+                 %{pointer | retries: pointer.retries + 1},
+                 fn new_pointer -> {:retried, new_pointer} end
+               )
+
+      refute published_pointer.tid == stale_gen_tid
+      assert published_pointer.tid == IngestEventQueue.current_generation_tid({sid, bid})
+
+      assert {:retried, ^published_pointer} =
+               IngestEventQueue.lookup_event(
+                 published_pointer.tid,
+                 published_pointer.gen_event_id
+               )
+
+      assert {:ok, [^published_pointer], _tid} =
+               IngestEventQueue.pop_pending_pointers(sbp, 1)
+    end
+
     test "cleans up the claimed and staged payloads when a newer pointer already exists", %{
       source: source,
       sbp: {sid, bid, _pid} = sbp

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -22,6 +22,13 @@ defmodule Logflare.TelemetryTest do
   @drop_stale_metric_name [:logflare, :logs, :ingest_logs, :drop_stale]
   @drop_stale_metric_string "logflare.logs.ingest_logs.drop_stale"
 
+  @requeue_deduplicated_metric_name [
+    :logflare,
+    :ingest_event_queue,
+    :requeue_deduplicated,
+    :count
+  ]
+
   describe "metrics/0" do
     test "returns only well-formed Telemetry.Metrics definitions" do
       metrics = Telemetry.metrics()
@@ -58,6 +65,14 @@ defmodule Logflare.TelemetryTest do
           ] do
         assert expected in names, "expected #{inspect(expected)} to be a defined metric"
       end
+    end
+
+    test "defines retry deduplication as a low-cardinality event count" do
+      [metric] = requeue_deduplicated_metrics()
+
+      assert metric.event_name == [:logflare, :ingest_event_queue, :requeue_deduplicated]
+      assert metric.measurement == :count
+      assert metric.tags == [:backend_type]
     end
 
     test "defines ClickHouse batch distribution and throughput metrics" do
@@ -422,5 +437,9 @@ defmodule Logflare.TelemetryTest do
 
   defp drop_stale_metrics do
     Enum.filter(Telemetry.metrics(), &(&1.name == @drop_stale_metric_name))
+  end
+
+  defp requeue_deduplicated_metrics do
+    Enum.filter(Telemetry.metrics(), &(&1.name == @requeue_deduplicated_metric_name))
   end
 end


### PR DESCRIPTION
## Summary

- move fused mapping and ClickHouse RowBinary encoding from the batch callback into runtime-scaled Broadway processors
- replace claimed generation-store events with shared `EncodedRow` values so retries reuse encoded bytes without remapping
- leave batch processors responsible only for gzip and insertion, reducing concurrent inserts from 32 to 4
- independently retain the previous 64-batch, 3.84-million-message per-backend in-flight capacity
- add repeatable throughput, concurrency, phase-decomposition, and memory benchmarks

## Stack

This PR is stacked on #3759 (`perf/mapper-rowbinary-fusion`). Review it against that branch; it contains only processor-side changes.

## Performance

Linux aarch64, OTP 27, six online schedulers, production-shaped 60,000-row batches. Throughput results cover three measured batches after one warmup and validate byte-identical output first.

### End-to-end comparison with current main

Current `main` at `ee61fab1` was measured in a separate clean workspace on the same host. It uses the production-equivalent ETS lookup → `Mapper.map/3` → Elixir RowBinary → streaming gzip path. The same fixtures and fixed-work settings were used, and compressed output byte counts matched exactly.

| Event type | Current main | Fused batch-side (#3759) | Processor-side (#3837) | #3837 elapsed change vs main |
|---|---:|---:|---:|---:|
| Log | 75,520 rows/s | 78,693 rows/s | 168,077 rows/s | -55% |
| Metric | 37,309 rows/s | 49,452 rows/s | 102,807 rows/s | -64% |
| Trace | 38,807 rows/s | 66,893 rows/s | 137,989 rows/s | -72% |

### Incremental effect of #3837 on #3759

| Event type | Fused batch-side (#3759) | Processor-side (#3837) | Change | Gzip only |
|---|---:|---:|---:|---:|
| Log | 78,693 rows/s | 168,077 rows/s | -53% elapsed | 230,489 rows/s |
| Metric | 49,452 rows/s | 102,807 rows/s | -52% elapsed | 178,773 rows/s |
| Trace | 66,893 rows/s | 137,989 rows/s | -52% elapsed | 219,139 rows/s |

Six-processor encoding-only throughput was 379k log, 230k metric, and 334k trace rows/s. Gzip is therefore the remaining serial local bottleneck.

### Processor concurrency

| Event type | 4 processors | 6 processors | 8 processors | 12 processors |
|---|---:|---:|---:|---:|
| Log | 158,534 | 170,951 | 171,329 | 174,227 |
| Metric | 99,290 | 107,397 | 106,749 | 105,733 |
| Trace | 120,384 | 135,506 | 136,458 | 138,754 |

Six processors remain the balanced setting on the six-scheduler benchmark host. Production concurrency is calculated at pipeline startup as `max(System.schedulers_online() - 4, 6)`, leaving nominal capacity for four fixed gzip/HTTP batch processors. This gives 6 processors on 6 schedulers, 8 on 12, and 28 on 32. Concurrency remains per backend pipeline, so multiple active ClickHouse backends multiply the count.

### Steady-state VM memory

| Event type | Full-event state | Encoded-row state | Change |
|---|---:|---:|---:|
| Log | 328.2 MB | 229.3 MB | -30.1% |
| Metric | 472.4 MB | 275.0 MB | -41.8% |
| Trace | 402.8 MB | 249.6 MB | -38.0% |

The ETS value and Broadway message share the same reference-counted RowBinary payload. Maximum RSS remained within 1.6% because the benchmark also observes the transient event-to-binary handoff.

Four batch processors bound concurrent gzip/HTTP inserts. During downstream stalls, encoded partial and completed batches can accumulate in Broadway's `:ch` batcher up to the independent 3.84-million-message cap; additional backlog remains in `IngestEventQueue`.

Detailed commands and results are recorded in `bench/clickhouse_processor_rowbinary.md`.

## Validation

- pipeline, `IngestEventQueue`, and consolidated supervisor: 146 tests, 0 failures, 3 excluded
- formatter check passed
- processor output matched the batch-side baseline byte-for-byte for every benchmark run
