### PR TITLE
fix: preserve event chart drag selection

### DIFF
--- a/assets/js/LogEventsChart.jsx
+++ b/assets/js/LogEventsChart.jsx
@@ -259,7 +259,6 @@ const LogEventsChart = ({
   const [dragRange, setDragRange] = React.useState(null);
   const dragStartRef = React.useRef(null);
   const dragEndRef = React.useRef(null);
-  const didDragRef = React.useRef(false);
   const suppressClickRef = React.useRef(false);
 
   const triggerTimeSearch = (utcDatetime) => {
@@ -299,7 +298,11 @@ const LogEventsChart = ({
     pushEvent("datetime_update", { querystring });
   };
 
-  const shouldSuppressClick = () => didDragRef.current || suppressClickRef.current;
+  const consumeSuppressedClick = () => {
+    const suppressClick = suppressClickRef.current;
+    suppressClickRef.current = false;
+    return suppressClick;
+  };
   const pointForMouseEvent = (state, event) =>
     chartPointAtX(
       event?.clientX,
@@ -308,7 +311,7 @@ const LogEventsChart = ({
     ) || activeChartPoint(state, chartData);
 
   const handleChartClick = (state, event) => {
-    if (shouldSuppressClick()) return;
+    if (consumeSuppressedClick()) return;
     triggerTimeSearch(pointForMouseEvent(state, event)?.datetime);
   };
 
@@ -318,7 +321,6 @@ const LogEventsChart = ({
 
     dragStartRef.current = point;
     dragEndRef.current = point;
-    didDragRef.current = false;
     suppressClickRef.current = false;
     setDragRange({ start: point.label, end: point.label });
   };
@@ -330,7 +332,6 @@ const LogEventsChart = ({
     if (!point) return;
 
     dragEndRef.current = point;
-    didDragRef.current = point.label !== dragStartRef.current.label;
     setDragRange({ start: dragStartRef.current.label, end: point.label });
   };
 
@@ -346,14 +347,8 @@ const LogEventsChart = ({
     const didDrag = Boolean(start && end && start.label !== end.label);
 
     if (didDrag) {
-      didDragRef.current = true;
       suppressClickRef.current = true;
       triggerTimeRangeSearch(start.datetime, end.datetime);
-
-      requestAnimationFrame(() => {
-        didDragRef.current = false;
-        suppressClickRef.current = false;
-      });
     }
 
     resetDrag();
@@ -362,7 +357,6 @@ const LogEventsChart = ({
   const handleMouseLeave = () => {
     if (!dragStartRef.current) return;
 
-    didDragRef.current = false;
     suppressClickRef.current = false;
     resetDrag();
   };

--- a/assets/js/test/log_events_chart.integration.test.jsx
+++ b/assets/js/test/log_events_chart.integration.test.jsx
@@ -1,0 +1,138 @@
+/** @vitest-environment jsdom */
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal();
+  const { cloneElement } = await import("react");
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }) =>
+      cloneElement(children, { width: 300, height: 100 }),
+  };
+});
+
+import { LogEventsChart } from "../LogEventsChart.jsx";
+
+const chartData = [
+  { datetime: "2026-08-14T10:00:00Z", timestamp: "10:00", value: 1 },
+  { datetime: "2026-08-14T10:01:00Z", timestamp: "10:01", value: 1 },
+  { datetime: "2026-08-14T10:02:00Z", timestamp: "10:02", value: 1 },
+];
+const chartBounds = {
+  bottom: 100,
+  height: 100,
+  left: 100,
+  right: 400,
+  top: 0,
+  width: 300,
+  x: 100,
+  y: 0,
+  toJSON: () => ({}),
+};
+
+let animationFrames;
+let container;
+let nextAnimationFrameId;
+let root;
+
+const flushAnimationFrames = async () => {
+  await act(async () => {
+    const queuedFrames = [...animationFrames.values()];
+    animationFrames.clear();
+    queuedFrames.forEach((callback) => callback(performance.now()));
+  });
+};
+
+const dispatchMouseEvent = async (element, type, clientX) => {
+  await act(async () => {
+    element.dispatchEvent(
+      new MouseEvent(type, {
+        bubbles: true,
+        button: 0,
+        clientX,
+      }),
+    );
+  });
+};
+
+beforeEach(async () => {
+  animationFrames = new Map();
+  nextAnimationFrameId = 1;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+    chartBounds,
+  );
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    const frameId = nextAnimationFrameId++;
+    animationFrames.set(frameId, callback);
+    return frameId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (frameId) => {
+    animationFrames.delete(frameId);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("LogEventsChart with Recharts", () => {
+  it("keeps a drag-selected range after Recharts delivers the deferred click", async () => {
+    const pushEvent = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <LogEventsChart
+          data={chartData}
+          loading={false}
+          chart_data_shape_id="default"
+          chart_period="minute"
+          display_timezone="Etc/UTC"
+          pushEvent={pushEvent}
+        />,
+      );
+    });
+
+    const chart = container.querySelector(".recharts-wrapper");
+    expect(chart).not.toBeNull();
+
+    const rangeUpdateCalls = [
+      ["soft_pause", {}],
+      [
+        "datetime_update",
+        { querystring: "t:2026-08-14T10:00:00..2026-08-14T10:03:00" },
+      ],
+    ];
+
+    await dispatchMouseEvent(chart, "mousedown", 150);
+    await flushAnimationFrames();
+    await dispatchMouseEvent(chart, "mousemove", 350);
+    await flushAnimationFrames();
+    await dispatchMouseEvent(chart, "mouseup", 350);
+
+    expect(pushEvent).not.toHaveBeenCalled();
+
+    await flushAnimationFrames();
+    expect(pushEvent.mock.calls).toEqual(rangeUpdateCalls);
+
+    // Queue the browser's click before the next frame. In the buggy ordering,
+    // the mouseup callback's cleanup ran before Recharts delivered this click.
+    await dispatchMouseEvent(chart, "click", 350);
+    expect(pushEvent.mock.calls).toEqual(rangeUpdateCalls);
+
+    await flushAnimationFrames();
+    expect(pushEvent.mock.calls).toEqual(rangeUpdateCalls);
+  });
+});

--- a/assets/js/test/log_events_chart.test.js
+++ b/assets/js/test/log_events_chart.test.js
@@ -1,10 +1,98 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("recharts", async () => {
+  const { createElement } = await import("react");
+  const emptyComponent = () => null;
+  const mouseEventNames = [
+    "onClick",
+    "onMouseDown",
+    "onMouseLeave",
+    "onMouseMove",
+    "onMouseUp",
+  ];
+
+  return {
+    Bar: emptyComponent,
+    BarChart: ({ children, ...props }) => {
+      const deferredMouseProps = Object.fromEntries(
+        mouseEventNames
+          .filter((name) => props[name])
+          .map((name) => [
+            name,
+            (...args) => requestAnimationFrame(() => props[name](...args)),
+          ]),
+      );
+
+      return createElement(
+        "bar-chart",
+        { ...props, ...deferredMouseProps },
+        children,
+      );
+    },
+    CartesianGrid: emptyComponent,
+    ReferenceArea: emptyComponent,
+    ResponsiveContainer: ({ children }) => children,
+    Tooltip: emptyComponent,
+    XAxis: emptyComponent,
+    YAxis: emptyComponent,
+  };
+});
 
 import {
   activeDatetime,
   buildTimeRangeQuery,
   chartPointAtX,
+  LogEventsChart,
 } from "../LogEventsChart.jsx";
+
+const chartData = [
+  { datetime: "2026-08-14T10:00:00Z", timestamp: "10:00", value: 1 },
+  { datetime: "2026-08-14T10:01:00Z", timestamp: "10:01", value: 1 },
+  { datetime: "2026-08-14T10:02:00Z", timestamp: "10:02", value: 1 },
+];
+const chartBounds = { left: 100, width: 300 };
+
+const renderChart = (pushEvent, data = chartData) =>
+  TestRenderer.create(
+    React.createElement(LogEventsChart, {
+      data,
+      loading: false,
+      chart_data_shape_id: "default",
+      chart_period: "minute",
+      display_timezone: "Etc/UTC",
+      pushEvent,
+    }),
+    {
+      createNodeMock: (element) =>
+        element.type === "div"
+          ? { getBoundingClientRect: () => chartBounds }
+          : null,
+    },
+  );
+
+let animationFrames = [];
+
+const flushAnimationFrames = () => {
+  act(() => {
+    const queuedFrames = animationFrames;
+    animationFrames = [];
+    queuedFrames.forEach((callback) => callback());
+  });
+};
+
+beforeEach(() => {
+  animationFrames = [];
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    animationFrames.push(callback);
+    return animationFrames.length;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("buildTimeRangeQuery", () => {
   it("includes the complete final selected chart bucket", () => {
@@ -91,22 +179,100 @@ describe("activeDatetime", () => {
 });
 
 describe("chartPointAtX", () => {
-  const chartData = [
-    { datetime: "2026-08-14T10:00:00Z", timestamp: "10:00" },
-    { datetime: "2026-08-14T10:01:00Z", timestamp: "10:01" },
-    { datetime: "2026-08-14T10:02:00Z", timestamp: "10:02" },
-  ];
-  const bounds = { left: 100, width: 300 };
-
   it("maps the pointer position to the matching chart bucket", () => {
-    expect(chartPointAtX(250, bounds, chartData)).toEqual({
+    expect(chartPointAtX(250, chartBounds, chartData)).toEqual({
       label: "10:01",
       datetime: "2026-08-14T10:01:00Z",
     });
   });
 
   it("rejects pointer positions outside the chart", () => {
-    expect(chartPointAtX(99, bounds, chartData)).toBeNull();
-    expect(chartPointAtX(401, bounds, chartData)).toBeNull();
+    expect(chartPointAtX(99, chartBounds, chartData)).toBeNull();
+    expect(chartPointAtX(401, chartBounds, chartData)).toBeNull();
+  });
+});
+
+describe("LogEventsChart pointer selection", () => {
+  it("emits one range update and suppresses the deferred post-drag click", () => {
+    const pushEvent = vi.fn();
+    let renderer;
+
+    act(() => {
+      renderer = renderChart(pushEvent);
+    });
+    const chart = renderer.root.findByType("bar-chart");
+
+    chart.props.onMouseDown({}, { clientX: 150 });
+    flushAnimationFrames();
+    chart.props.onMouseMove({}, { clientX: 350 });
+    flushAnimationFrames();
+    chart.props.onMouseUp({}, { clientX: 350 });
+    flushAnimationFrames();
+    flushAnimationFrames();
+    chart.props.onClick({}, { clientX: 350 });
+    flushAnimationFrames();
+
+    expect(pushEvent.mock.calls).toEqual([
+      ["soft_pause", {}],
+      ["datetime_update", {
+        querystring: "t:2026-08-14T10:00:00..2026-08-14T10:03:00",
+      }],
+    ]);
+
+    pushEvent.mockClear();
+    chart.props.onMouseDown({}, { clientX: 250 });
+    flushAnimationFrames();
+    chart.props.onMouseUp({}, { clientX: 250 });
+    flushAnimationFrames();
+    chart.props.onClick({}, { clientX: 250 });
+    flushAnimationFrames();
+
+    expect(pushEvent.mock.calls).toEqual([
+      ["soft_pause", {}],
+      ["datetime_update", {
+        querystring: "t:2026-08-14T10:01:00..2026-08-14T10:02:00",
+        period: "second",
+      }],
+    ]);
+  });
+
+  it("preserves an ordinary single-bucket click", () => {
+    const pushEvent = vi.fn();
+    let renderer;
+
+    act(() => {
+      renderer = renderChart(pushEvent);
+    });
+    const chart = renderer.root.findByType("bar-chart");
+
+    chart.props.onMouseDown({}, { clientX: 250 });
+    flushAnimationFrames();
+    chart.props.onMouseUp({}, { clientX: 250 });
+    flushAnimationFrames();
+    chart.props.onClick({}, { clientX: 250 });
+    flushAnimationFrames();
+
+    expect(pushEvent.mock.calls).toEqual([
+      ["soft_pause", {}],
+      ["datetime_update", {
+        querystring: "t:2026-08-14T10:01:00..2026-08-14T10:02:00",
+        period: "second",
+      }],
+    ]);
+  });
+
+  it("ignores clicks when the chart has no active point", () => {
+    const pushEvent = vi.fn();
+    let renderer;
+
+    act(() => {
+      renderer = renderChart(pushEvent, []);
+    });
+    const chart = renderer.root.findByType("bar-chart");
+
+    chart.props.onClick({}, { clientX: 250 });
+    flushAnimationFrames();
+
+    expect(pushEvent).not.toHaveBeenCalled();
   });
 });

--- a/assets/js/test/log_events_chart.test.js
+++ b/assets/js/test/log_events_chart.test.js
@@ -3,7 +3,7 @@ import TestRenderer, { act } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("recharts", async () => {
-  const { createElement } = await import("react");
+  const { createElement, useRef } = await import("react");
   const emptyComponent = () => null;
   const mouseEventNames = [
     "onClick",
@@ -16,12 +16,24 @@ vi.mock("recharts", async () => {
   return {
     Bar: emptyComponent,
     BarChart: ({ children, ...props }) => {
+      const frameIdsByEvent = useRef(new Map());
       const deferredMouseProps = Object.fromEntries(
         mouseEventNames
           .filter((name) => props[name])
           .map((name) => [
             name,
-            (...args) => requestAnimationFrame(() => props[name](...args)),
+            (...args) => {
+              const pendingFrameId = frameIdsByEvent.current.get(name);
+              if (pendingFrameId !== undefined) {
+                cancelAnimationFrame(pendingFrameId);
+              }
+
+              const frameId = requestAnimationFrame(() => {
+                props[name](...args);
+                frameIdsByEvent.current.delete(name);
+              });
+              frameIdsByEvent.current.set(name, frameId);
+            },
           ]),
       );
 
@@ -72,21 +84,27 @@ const renderChart = (pushEvent, data = chartData) =>
     },
   );
 
-let animationFrames = [];
+let animationFrames = new Map();
+let nextAnimationFrameId = 1;
 
 const flushAnimationFrames = () => {
   act(() => {
-    const queuedFrames = animationFrames;
-    animationFrames = [];
+    const queuedFrames = [...animationFrames.values()];
+    animationFrames.clear();
     queuedFrames.forEach((callback) => callback());
   });
 };
 
 beforeEach(() => {
-  animationFrames = [];
+  animationFrames = new Map();
+  nextAnimationFrameId = 1;
   vi.stubGlobal("requestAnimationFrame", (callback) => {
-    animationFrames.push(callback);
-    return animationFrames.length;
+    const frameId = nextAnimationFrameId++;
+    animationFrames.set(frameId, callback);
+    return frameId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (frameId) => {
+    animationFrames.delete(frameId);
   });
 });
 
@@ -204,6 +222,7 @@ describe("LogEventsChart pointer selection", () => {
 
     chart.props.onMouseDown({}, { clientX: 150 });
     flushAnimationFrames();
+    chart.props.onMouseMove({}, { clientX: 250 });
     chart.props.onMouseMove({}, { clientX: 350 });
     flushAnimationFrames();
     chart.props.onMouseUp({}, { clientX: 350 });

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -36,6 +36,7 @@
         "glob": "^10.5.0",
         "playwright": "^1.60.0",
         "postcss": "^8.4.31",
+        "react-test-renderer": "^18.3.1",
         "sass": "^1.58.3",
         "tailwindcss": "^3.4.10",
         "vitest": "^3.2.4"
@@ -3124,6 +3125,20 @@
         }
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-spinners": {
       "version": "0.17.0",
       "license": "MIT",
@@ -3131,6 +3146,28 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -34,6 +34,7 @@
         "esbuild-plugin-copy": "^2.0.2",
         "esbuild-sass-plugin": "^3.3.1",
         "glob": "^10.5.0",
+        "jsdom": "^26.1.0",
         "playwright": "^1.60.0",
         "postcss": "^8.4.31",
         "react-test-renderer": "^18.3.1",
@@ -89,6 +90,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
       "license": "MIT",
@@ -101,6 +116,121 @@
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "peer": true
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -1547,6 +1677,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "dev": true,
@@ -1907,6 +2047,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
@@ -1947,6 +2101,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.29.3",
       "license": "MIT",
@@ -1973,6 +2141,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -2052,6 +2227,19 @@
       "version": "9.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2346,6 +2534,60 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "dev": true,
@@ -2459,6 +2701,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -2493,6 +2742,46 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/json-formatter-js": {
       "version": "2.3.4",
@@ -2685,6 +2974,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -2712,6 +3008,19 @@
       "version": "1.0.1",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -3009,6 +3318,16 @@
       },
       "peerDependencies": {
         "react": ">=0.14.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -3316,6 +3635,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -3351,6 +3677,13 @@
       "version": "0.4.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.84.0",
@@ -3814,6 +4147,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
@@ -4072,6 +4418,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "dev": true,
@@ -4243,6 +4596,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -4252,6 +4625,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -4625,11 +5024,72 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4746,6 +5206,45 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,6 +35,7 @@
     "esbuild-plugin-copy": "^2.0.2",
     "esbuild-sass-plugin": "^3.3.1",
     "glob": "^10.5.0",
+    "jsdom": "^26.1.0",
     "playwright": "^1.60.0",
     "postcss": "^8.4.31",
     "react-test-renderer": "^18.3.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -37,6 +37,7 @@
     "glob": "^10.5.0",
     "playwright": "^1.60.0",
     "postcss": "^8.4.31",
+    "react-test-renderer": "^18.3.1",
     "sass": "^1.58.3",
     "tailwindcss": "^3.4.10",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary

- preserve drag-selected event chart ranges until Recharts delivers the gesture's deferred click
- prevent that post-drag click from replacing the selected range with a single bucket
- add mounted regression coverage for deferred drag/click ordering, subsequent normal clicks, and empty charts

## Root cause

Recharts schedules external mouse callbacks independently with `requestAnimationFrame`. The chart cleared its click-suppression state after one animation frame, so a delayed post-drag click could arrive after suppression expired and trigger a single-bucket search.

## Manual QA

Verified against local single-tenant Logflare in managed Chromium:

- dragging across the event chart emitted exactly one `datetime_update` with `t:2026-08-17T15:25:00..2026-08-17T16:12:00`; the post-drag click did not overwrite it
- a subsequent ordinary click emitted exactly one single-bucket `datetime_update` with `t:2026-08-17T15:51:00..2026-08-17T15:52:00` and changed the period to `second`
- attached browser diagnostics passed expected-text, console, page-error, and network checks

## Verification media

The clip shows the live brush expanding across multiple buckets, the full range remaining applied after mouse-up, and a subsequent ordinary click selecting one bucket.

https://github.com/user-attachments/assets/f01e9799-24e7-435a-bede-901a99bc18a5

Follow-up to #3829.
