### PR TITLE
feat: limit ClickHouse ingestion queries to a maximum of 10 seconds

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -40,6 +40,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @resolve_interval 10_000
   @scaling_threshold 15_000
   @async_insert_busy_timeout_max_ms 3_000
+  @insert_max_execution_time_seconds 10
   @max_read_pool_size 4096
   @ch_slow_pool_checkout_ms 1_000
   @us_per_hour 3_600 * 1_000_000
@@ -742,6 +743,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   When `opts` includes `async: true`, the insert is routed through ClickHouse
   async inserts so the server coalesces sparse, late-arriving batches into
   fewer, fatter parts.
+
+  All inserts carry a server-side `max_execution_time` of
+  #{@insert_max_execution_time_seconds} seconds.
   """
   @spec insert_log_events(Backend.t(), [LogEvent.t()], TypeDetection.event_type(), keyword()) ::
           :ok | {:error, String.t()}
@@ -804,7 +808,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @spec build_insert_opts(keyword()) :: keyword()
   defp build_insert_opts(opts) do
-    if Keyword.get(opts, :async, false), do: async_insert_opts(), else: []
+    opts
+    |> Keyword.get(:async, false)
+    |> insert_settings()
+  end
+
+  @spec insert_settings(boolean()) :: keyword()
+  defp insert_settings(true), do: base_insert_opts() ++ async_insert_opts()
+  defp insert_settings(false), do: base_insert_opts()
+
+  @spec base_insert_opts() :: keyword()
+  defp base_insert_opts do
+    [max_execution_time: @insert_max_execution_time_seconds]
   end
 
   # The endpoint host an HTTP insert actually targets, for failure logging: async inserts
@@ -827,6 +842,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     [
       async_insert: 1,
       wait_for_async_insert: 1,
+      wait_for_async_insert_timeout: @insert_max_execution_time_seconds,
       async_insert_busy_timeout_max_ms: @async_insert_busy_timeout_max_ms
     ]
   end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -18,7 +18,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   @initial_delay 2_500
   @max_delay 5_000
   @pool_timeout 8_000
-  @receive_timeout 20_000
+  @receive_timeout 15_000
   @too_many_parts_marker "Code: 252."
 
   @doc """

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -987,6 +987,49 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  describe "insert settings" do
+    setup do
+      insert(:plan, name: "Free")
+      {_source, backend} = setup_clickhouse_test()
+
+      [backend: backend]
+    end
+
+    test "sync inserts set max_execution_time and no async settings", %{backend: backend} do
+      Mimic.expect(Finch, :request, fn request, _pool, _opts ->
+        params = URI.decode_query(request.query)
+
+        assert params["max_execution_time"] == "10"
+        refute Map.has_key?(params, "async_insert")
+
+        {:ok, %Finch.Response{status: 200, body: ""}}
+      end)
+
+      assert :ok = ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+    end
+
+    test "async inserts set max_execution_time alongside async settings", %{backend: backend} do
+      Mimic.expect(Finch, :request, fn request, _pool, _opts ->
+        params = URI.decode_query(request.query)
+
+        assert params["max_execution_time"] == "10"
+        assert params["async_insert"] == "1"
+        assert params["wait_for_async_insert"] == "1"
+        assert params["wait_for_async_insert_timeout"] == "10"
+
+        {:ok, %Finch.Response{status: 200, body: ""}}
+      end)
+
+      assert :ok =
+               ClickHouseAdaptor.insert_log_events_compressed(
+                 backend,
+                 :log,
+                 :zlib.gzip(""),
+                 async: true
+               )
+    end
+  end
+
   describe "insert_log_events_compressed/4 failure logging" do
     setup do
       insert(:plan, name: "Free")


### PR DESCRIPTION
Adds a 10-second limit to how long an ingest insert can occupy ClickHouse server-side using the [`max_execution_time` setting](https://clickhouse.com/docs/reference/settings/session-settings/max-execution#max_execution_time).