### PR TITLE
fix: redact webhook credentials comprehensively

### DIFF
--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -29,8 +29,29 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   @behaviour Logflare.Backends.Adaptor
 
-  # Sentinel value substituted for secret header values by redact_config/1.
+  # Sentinel value substituted for credentials by redact_config/1.
   @redacted_value "REDACTED"
+
+  # Header names are case-insensitive. Keep this list intentionally explicit so
+  # adding another credential-bearing header is a reviewed policy change.
+  @sensitive_header_names MapSet.new(~w(
+                            api-key
+                            apikey
+                            authorization
+                            cookie
+                            proxy-authorization
+                            webhook-secret
+                            x-access-token
+                            x-amz-security-token
+                            x-api-key
+                            x-api-token
+                            x-auth-token
+                            x-hub-signature
+                            x-hub-signature-256
+                            x-secret-key
+                            x-signature
+                            x-webhook-secret
+                          ))
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = args) do
@@ -57,6 +78,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     {existing_config, %{url: :string, headers: :map, http: :string, gzip: :boolean}}
     |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip])
     |> unredact_headers(existing_config)
+    |> unredact_url(existing_config)
     |> normalize_header_keys()
     |> Logflare.Utils.default_field_value(:http, "http2")
     |> Logflare.Utils.default_field_value(:gzip, true)
@@ -114,6 +136,20 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     end
   end
 
+  # Preserve URL credentials when a client submits the redacted URL unchanged.
+  # Comparing against the redacted stored URL prevents credentials from being
+  # copied to a different destination when the user intentionally changes it.
+  defp unredact_url(changeset, existing_config) do
+    submitted_url = Ecto.Changeset.get_change(changeset, :url)
+    existing_url = Map.get(existing_config, :url) || Map.get(existing_config, "url")
+
+    if is_binary(existing_url) and submitted_url == redact_url_userinfo(existing_url) do
+      Ecto.Changeset.put_change(changeset, :url, existing_url)
+    else
+      changeset
+    end
+  end
+
   @impl Logflare.Backends.Adaptor
   def validate_config(changeset) do
     changeset
@@ -141,20 +177,33 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   @impl Logflare.Backends.Adaptor
   def redact_config(config) do
-    Map.update(config, :headers, %{}, &redact_headers/1)
+    config
+    |> Map.update(:headers, %{}, &redact_headers/1)
+    |> Map.update(:url, nil, &redact_url_userinfo/1)
   end
+
+  defp redact_headers(nil), do: %{}
 
   defp redact_headers(headers) do
     for {key, value} <- headers, into: %{}, do: redact_header(key, value)
   end
 
   defp redact_header(key, value) do
-    if String.downcase(key) == "authorization" do
+    if MapSet.member?(@sensitive_header_names, String.downcase(to_string(key))) do
       {key, @redacted_value}
     else
       {key, value}
     end
   end
+
+  defp redact_url_userinfo(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{userinfo: nil} -> url
+      uri -> URI.to_string(%{uri | userinfo: @redacted_value})
+    end
+  end
+
+  defp redact_url_userinfo(url), do: url
 
   @impl Logflare.Backends.Adaptor
   @spec test_connection(Backend.t()) :: :ok | {:error, term()}

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -10,7 +10,26 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   alias Logflare.Backends.SourceSup
   alias Logflare.SystemMetrics.AllLogsLogged
   alias Tesla.Middleware.JSON
+
   @subject Logflare.Backends.Adaptor.WebhookAdaptor
+  @sensitive_header_names ~w(
+    api-key
+    apikey
+    authorization
+    cookie
+    proxy-authorization
+    webhook-secret
+    x-access-token
+    x-amz-security-token
+    x-api-key
+    x-api-token
+    x-auth-token
+    x-hub-signature
+    x-hub-signature-256
+    x-secret-key
+    x-signature
+    x-webhook-secret
+  )
 
   setup do
     insert(:plan)
@@ -404,21 +423,47 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
   end
 
   describe "redact_config/1" do
-    test "redacts Authorization header" do
+    test "redacts every maintained sensitive header while preserving other headers" do
+      sensitive_headers = Map.new(@sensitive_header_names, &{&1, "leaked-secret"})
+
       config = %{
-        headers: %{
-          "Authorization" => "Bearer secret-token-123",
-          "Content-Type" => "application/json"
-        }
+        headers:
+          Map.merge(sensitive_headers, %{
+            "Content-Type" => "application/json",
+            "X-Custom" => "visible-value"
+          })
       }
 
-      assert %{headers: %{"Authorization" => "REDACTED", "Content-Type" => "application/json"}} =
+      assert %{headers: redacted_headers} = @subject.redact_config(config)
+
+      assert Map.take(redacted_headers, @sensitive_header_names) ==
+               Map.new(@sensitive_header_names, &{&1, "REDACTED"})
+
+      assert redacted_headers["Content-Type"] == "application/json"
+      assert redacted_headers["X-Custom"] == "visible-value"
+    end
+
+    test "redacts sensitive headers case-insensitively" do
+      config = %{headers: %{"Authorization" => "Basic dXNlcjpwYXNz", "X-API-KEY" => "secret"}}
+
+      assert %{headers: %{"Authorization" => "REDACTED", "X-API-KEY" => "REDACTED"}} =
                @subject.redact_config(config)
     end
 
-    test "redacts authorization header case-insensitive" do
-      config = %{headers: %{"authorization" => "Basic dXNlcjpwYXNz"}}
-      assert %{headers: %{"authorization" => "REDACTED"}} = @subject.redact_config(config)
+    test "redacts URL userinfo" do
+      config = %{url: "https://user:leaked-secret@example.com/hooks"}
+
+      assert %{url: "https://REDACTED@example.com/hooks"} = @subject.redact_config(config)
+    end
+
+    test "preserves a URL without userinfo" do
+      config = %{url: "https://example.com/hooks"}
+      assert %{url: "https://example.com/hooks", headers: %{}} = @subject.redact_config(config)
+    end
+
+    test "normalizes nil headers when serializing legacy config" do
+      config = %{url: "https://example.com/hooks", headers: nil}
+      assert %{url: "https://example.com/hooks", headers: %{}} = @subject.redact_config(config)
     end
   end
 
@@ -518,6 +563,26 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       changeset = @subject.cast_config(params, %{url: "https://example.com", headers: %{}})
 
       assert Ecto.Changeset.get_field(changeset, :headers) == %{}
+    end
+  end
+
+  describe "cast_config/2 URL redaction round-trip" do
+    test "restores stored URL credentials when the redacted URL is submitted unchanged" do
+      existing = %{url: "https://user:leaked-secret@example.com/hooks"}
+      params = %{url: "https://REDACTED@example.com/hooks"}
+
+      changeset = @subject.cast_config(params, existing)
+
+      assert Ecto.Changeset.get_field(changeset, :url) == existing.url
+    end
+
+    test "does not copy stored credentials when the destination changes" do
+      existing = %{url: "https://user:leaked-secret@example.com/hooks"}
+      params = %{url: "https://REDACTED@other.example.com/hooks"}
+
+      changeset = @subject.cast_config(params, existing)
+
+      assert Ecto.Changeset.get_field(changeset, :url) == params.url
     end
   end
 

--- a/test/logflare_web/controllers/api/backend_controller_test.exs
+++ b/test/logflare_web/controllers/api/backend_controller_test.exs
@@ -114,19 +114,92 @@ defmodule LogflareWeb.Api.BackendControllerTest do
         refute Jason.encode!(backend["config"]) =~ "leaked-secret"
       end
     end
+
+    test "redacts persisted webhook header and URL credentials in the raw response", %{
+      conn: conn,
+      user: user
+    } do
+      %_{id: id} =
+        insert(:backend,
+          type: :webhook,
+          user: user,
+          config: %{
+            url: "https://user:url-leaked-secret@example.com/hooks",
+            headers: %{
+              "Content-Type" => "application/json",
+              "X-Webhook-Secret" => "header-leaked-secret"
+            }
+          }
+        )
+
+      conn =
+        conn
+        |> add_access_token(user, "private")
+        |> get(~p"/api/backends")
+
+      refute conn.resp_body =~ "url-leaked-secret"
+      refute conn.resp_body =~ "header-leaked-secret"
+
+      response = json_response(conn, 200)
+      assert %{"id" => ^id} = backend = Enum.find(response, &(&1["id"] == id))
+
+      assert %{
+               "url" => "https://REDACTED@example.com/hooks",
+               "headers" => %{
+                 "content-type" => "application/json",
+                 "x-webhook-secret" => "REDACTED"
+               }
+             } = backend["config"]
+    end
   end
 
   describe "show/2" do
-    test "returns single backend for given user", %{conn: conn, user: user} do
-      backend = insert(:backend, user: user)
+    test "returns a backend without webhook credentials in the raw response", %{
+      conn: conn,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          type: :webhook,
+          user: user,
+          config: %{
+            url: "https://user:url-leaked-secret@example.com/hooks",
+            headers: %{"X-Auth-Token" => "header-leaked-secret"}
+          }
+        )
 
-      response =
+      conn =
         conn
         |> add_access_token(user, "private")
         |> get("/api/backends/#{backend.token}")
-        |> json_response(200)
 
-      assert response["id"] == backend.id
+      refute conn.resp_body =~ "url-leaked-secret"
+      refute conn.resp_body =~ "header-leaked-secret"
+
+      assert %{
+               "id" => backend_id,
+               "config" => %{
+                 "url" => "https://REDACTED@example.com/hooks",
+                 "headers" => %{"x-auth-token" => "REDACTED"}
+               }
+             } = json_response(conn, 200)
+
+      assert backend_id == backend.id
+    end
+
+    test "serializes a persisted webhook with nil headers", %{conn: conn, user: user} do
+      backend =
+        insert(:backend,
+          type: :webhook,
+          user: user,
+          config: %{url: "https://example.com/hooks", headers: nil}
+        )
+
+      assert %{"config" => %{"headers" => %{}}} =
+               conn
+               |> add_access_token(user, "private")
+               |> get("/api/backends/#{backend.token}")
+               |> json_response(200)
     end
 
     test "returns not found if doesn't own the source", %{conn: conn} do
@@ -507,6 +580,43 @@ defmodule LogflareWeb.Api.BackendControllerTest do
       assert response["config"]["url"] == "http://example.com"
       assert response["config"]["gzip"] == false
       assert response["config"]["http"] == "http1"
+    end
+
+    test "redacted webhook config round-trip preserves stored credentials", %{
+      conn: conn,
+      user: user
+    } do
+      original_url = "https://user:url-secret@example.com/hooks"
+      original_header = "header-secret"
+
+      backend =
+        insert(:backend,
+          type: :webhook,
+          user: user,
+          config: %{
+            url: original_url,
+            headers: %{"X-Webhook-Secret" => original_header}
+          }
+        )
+
+      redacted_config =
+        conn
+        |> add_access_token(user, "private")
+        |> get("/api/backends/#{backend.token}")
+        |> json_response(200)
+        |> Map.fetch!("config")
+
+      conn
+      |> add_access_token(user, "private")
+      |> patch("/api/backends/#{backend.token}", %{config: redacted_config})
+      |> response(204)
+
+      stored_config = Logflare.Backends.get_backend(backend.id).config_encrypted
+      stored_url = Map.get(stored_config, :url) || Map.get(stored_config, "url")
+      stored_headers = Map.get(stored_config, :headers) || Map.get(stored_config, "headers")
+
+      assert stored_url == original_url
+      assert Map.get(stored_headers, "x-webhook-secret") == original_header
     end
   end
 

--- a/test/logflare_web/controllers/api/source_controller_test.exs
+++ b/test/logflare_web/controllers/api/source_controller_test.exs
@@ -364,6 +364,45 @@ defmodule LogflareWeb.Api.SourceControllerTest do
         refute Jason.encode!(backend["config"]) =~ "leaked-secret"
       end
     end
+
+    test "redacts persisted webhook credentials in the raw source response", %{
+      conn: conn,
+      user: user,
+      sources: [source | _]
+    } do
+      insert(:backend,
+        type: :webhook,
+        user: user,
+        sources: [source],
+        default_ingest?: true,
+        config: %{
+          url: "https://user:url-leaked-secret@example.com/hooks",
+          headers: %{
+            "Content-Type" => "application/json",
+            "X-Secret-Key" => "header-leaked-secret"
+          }
+        }
+      )
+
+      conn =
+        conn
+        |> add_access_token(user, "private")
+        |> get("/api/sources")
+
+      refute conn.resp_body =~ "url-leaked-secret"
+      refute conn.resp_body =~ "header-leaked-secret"
+
+      response = json_response(conn, 200)
+      assert %{"backends" => [backend]} = Enum.find(response, &(&1["id"] == source.id))
+
+      assert %{
+               "url" => "https://REDACTED@example.com/hooks",
+               "headers" => %{
+                 "Content-Type" => "application/json",
+                 "X-Secret-Key" => "REDACTED"
+               }
+             } = backend["config"]
+    end
   end
 
   describe "add_backend/2" do


### PR DESCRIPTION
## Summary

- redact a hand-maintained, case-insensitive list of credential-bearing webhook headers
- redact URL userinfo while safely restoring unchanged credentials on config updates
- assert secrets are absent from raw backend/source API responses and verify exact redacted output
- preserve stored URL and header credentials across a GET-to-PATCH round trip
- handle legacy webhook configs with `headers: nil`

Follow-up to #3844.