### PR TITLE
fix: make pointer queue removals atomic

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -410,14 +410,11 @@ defmodule Logflare.Backends.IngestEventQueue do
     do: do_get_tid({sid, bid}, pid)
 
   defp do_get_tid(key, pid) do
-    :ets.match(@ets_table_mapper, {key, pid, :"$1"}, 1)
-    |> case do
-      {[[tid]], _cont} ->
-        if :ets.info(tid, :name) != :undefined, do: tid
-
-      _ ->
-        nil
-    end
+    @ets_table_mapper
+    |> :ets.match({key, pid, :"$1"})
+    |> Enum.find_value(fn [tid] ->
+      if :ets.info(tid, :name) != :undefined, do: tid
+    end)
   end
 
   @doc """
@@ -905,9 +902,7 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending_pointers(_, 0), do: {:ok, [], nil}
 
   def pop_pending_pointers(sid_bid_pid, n) when is_integer(n) do
-    ms = [
-      {{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$1"]}
-    ]
+    ms = [{{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$1"]}]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
   end
@@ -961,28 +956,42 @@ defmodule Logflare.Backends.IngestEventQueue do
       )
       when event_type in [:log, :metric, :trace] and is_integer(day_bucket) and
              is_integer(n) and n > 0 do
-    ms = [
-      {{:"$1", :_, :_, :_, :_, event_type, day_bucket}, [], [:"$1"]}
-    ]
+    ms = [{{:"$1", :_, :_, :_, :_, event_type, day_bucket}, [], [:"$1"]}]
 
     pop_selected_pointers(sid_bid_pid, n, ms)
   end
 
   defp pop_selected_pointers(sid_bid_pid, n, ms) do
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         {selected_ids, _cont} <- :ets.select(tid, ms, n) do
-      {:ok, take_selected_pointers(selected_ids, tid, []), tid}
+         {:ok, ids} <- select_pointer_ids(tid, ms, n) do
+      case ids do
+        [] -> {:ok, [], nil}
+        ids -> pointer_claim_result(claim_pointers(tid, ids), tid)
+      end
     else
       nil -> {:error, :not_initialized}
-      :"$end_of_table" -> {:ok, [], nil}
+      {:error, :not_initialized} = error -> error
     end
   end
 
-  defp take_selected_pointers([], _tid, pointers), do: :lists.reverse(pointers)
+  defp select_pointer_ids(tid, ms, n) do
+    case :ets.select(tid, ms, n) do
+      {ids, _cont} -> {:ok, ids}
+      :"$end_of_table" -> {:ok, []}
+    end
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      {:error, :not_initialized}
+  end
 
-  defp take_selected_pointers([id | selected_ids], tid, pointers) do
-    case :ets.take(tid, id) do
-      [{^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket}] ->
+  defp claim_pointers(tid, ids), do: claim_pointers(ids, tid, [])
+
+  defp claim_pointers([], _tid, pointers), do: {:lists.reverse(pointers), false}
+
+  defp claim_pointers([id | ids], tid, pointers) do
+    case take_pointer_row(tid, id) do
+      {:ok, {^id, gen_tid, gen_event_id, size, retries, event_type, day_bucket}} ->
         pointer = %LogEventPointer{
           id: id,
           tid: gen_tid,
@@ -994,11 +1003,29 @@ defmodule Logflare.Backends.IngestEventQueue do
           day_bucket: day_bucket
         }
 
-        take_selected_pointers(selected_ids, tid, [pointer | pointers])
+        claim_pointers(ids, tid, [pointer | pointers])
 
-      [] ->
-        take_selected_pointers(selected_ids, tid, pointers)
+      :missing ->
+        claim_pointers(ids, tid, pointers)
+
+      :stale ->
+        {:lists.reverse(pointers), true}
     end
+  end
+
+  defp pointer_claim_result({[], true}, _tid), do: {:error, :not_initialized}
+  defp pointer_claim_result({pointers, _stale?}, tid), do: {:ok, pointers, tid}
+
+  @spec take_pointer_row(:ets.tid(), term()) :: {:ok, tuple()} | :missing | :stale
+  defp take_pointer_row(tid, id) do
+    case :ets.take(tid, id) do
+      [row] -> {:ok, row}
+      [] -> :missing
+    end
+  rescue
+    ArgumentError ->
+      emit_stale_ets_table_telemetry()
+      :stale
   end
 
   @doc """
@@ -1035,26 +1062,43 @@ defmodule Logflare.Backends.IngestEventQueue do
   def pop_pending(_, 0), do: {:ok, []}
 
   def pop_pending(sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
+    ms = [{{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$1"]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         size when is_integer(size) <- :ets.info(tid, :size),
-         {selected, _cont} <- :ets.select(tid, ms, min(n, max(size, 1))) do
-      events =
-        selected
-        |> Enum.map(&resolve_and_delete_pending(tid, &1))
-        |> Enum.reject(&is_nil/1)
+         {:ok, ids} <- select_pointer_ids(tid, ms, n) do
+      {events, claimed, stale?} = claim_events(ids, tid, [], 0)
 
-      {:ok, events}
+      if stale? and claimed == 0 do
+        {:error, :not_initialized}
+      else
+        {:ok, events}
+      end
     else
       nil -> {:error, :not_initialized}
-      :"$end_of_table" -> {:ok, []}
+      {:error, :not_initialized} = error -> error
     end
   end
 
-  defp resolve_and_delete_pending(tid, {id, gen_tid, gen_event_id}) do
-    :ets.delete(tid, id)
+  defp claim_events([], _tid, events, claimed),
+    do: {:lists.reverse(events), claimed, false}
 
+  defp claim_events([id | ids], tid, events, claimed) do
+    case take_pointer_row(tid, id) do
+      {:ok, {^id, gen_tid, gen_event_id, _, _, _, _}} ->
+        case take_pointer_event({gen_tid, gen_event_id}) do
+          nil -> claim_events(ids, tid, events, claimed + 1)
+          event -> claim_events(ids, tid, [event | events], claimed + 1)
+        end
+
+      :missing ->
+        claim_events(ids, tid, events, claimed)
+
+      :stale ->
+        {:lists.reverse(events), claimed, true}
+    end
+  end
+
+  defp take_pointer_event({gen_tid, gen_event_id}) do
     case :ets.take(gen_tid, gen_event_id) do
       [{^gen_event_id, event}] -> event
       [] -> nil
@@ -1272,13 +1316,13 @@ defmodule Logflare.Backends.IngestEventQueue do
   """
   @spec drop_pending(source_backend_pid(), non_neg_integer()) :: :ok
 
+  def drop_pending({_, _}, 0), do: :ok
+
   def drop_pending({_, _} = sid_bid, n) when is_integer(n) do
     traverse_queues(sid_bid, fn objs, acc ->
       num =
         for {sid_bid_pid, _tid} <- objs, reduce: 0 do
-          acc ->
-            {:ok, num} = drop_pending(sid_bid_pid, n)
-            acc + num
+          acc -> add_dropped_count(sid_bid_pid, n, acc)
         end
 
       num + acc
@@ -1287,22 +1331,48 @@ defmodule Logflare.Backends.IngestEventQueue do
     :ok
   end
 
+  defp add_dropped_count(sid_bid_pid, n, acc) do
+    case drop_pending(sid_bid_pid, n) do
+      {:ok, num} -> acc + num
+      {:error, :not_initialized} -> acc
+    end
+  end
+
   @spec drop_pending(source_backend_pid() | consolidated_table_key(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:error, :not_initialized}
+  def drop_pending({_, _, _}, 0), do: {:ok, 0}
+
   def drop_pending({_, _, _} = sid_bid_pid, n) when is_integer(n) do
-    ms = [{{:"$1", :"$2", :"$3", :_, :_, :_, :_}, [], [{{:"$1", :"$2", :"$3"}}]}]
+    ms = [{{:"$1", :_, :_, :_, :_, :_, :_}, [], [:"$1"]}]
 
     with tid when tid != nil <- get_tid(sid_bid_pid),
-         {taken, _cont} <- :ets.select(tid, ms, n) do
-      for {id, gen_tid, gen_event_id} <- taken do
-        :ets.delete(tid, id)
-        delete_id(gen_tid, gen_event_id)
-      end
+         {:ok, ids} <- select_pointer_ids(tid, ms, n) do
+      {dropped, stale?} = drop_claimed(ids, tid, 0)
 
-      {:ok, Enum.count(taken)}
+      if stale? and dropped == 0 do
+        {:error, :not_initialized}
+      else
+        {:ok, dropped}
+      end
     else
       nil -> {:error, :not_initialized}
-      :"$end_of_table" -> {:ok, 0}
+      {:error, :not_initialized} = error -> error
+    end
+  end
+
+  defp drop_claimed([], _tid, dropped), do: {dropped, false}
+
+  defp drop_claimed([id | ids], tid, dropped) do
+    case take_pointer_row(tid, id) do
+      {:ok, {^id, gen_tid, gen_event_id, _, _, _, _}} ->
+        delete_id(gen_tid, gen_event_id)
+        drop_claimed(ids, tid, dropped + 1)
+
+      :missing ->
+        drop_claimed(ids, tid, dropped)
+
+      :stale ->
+        {dropped, true}
     end
   end
 

--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -1331,13 +1331,6 @@ defmodule Logflare.Backends.IngestEventQueue do
     :ok
   end
 
-  defp add_dropped_count(sid_bid_pid, n, acc) do
-    case drop_pending(sid_bid_pid, n) do
-      {:ok, num} -> acc + num
-      {:error, :not_initialized} -> acc
-    end
-  end
-
   @spec drop_pending(source_backend_pid() | consolidated_table_key(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:error, :not_initialized}
   def drop_pending({_, _, _}, 0), do: {:ok, 0}
@@ -1357,6 +1350,13 @@ defmodule Logflare.Backends.IngestEventQueue do
     else
       nil -> {:error, :not_initialized}
       {:error, :not_initialized} = error -> error
+    end
+  end
+
+  defp add_dropped_count(sid_bid_pid, n, acc) do
+    case drop_pending(sid_bid_pid, n) do
+      {:ok, num} -> acc + num
+      {:error, :not_initialized} -> acc
     end
   end
 

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -464,6 +464,52 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert %LogEvent{} = IngestEventQueue.lookup_event(gen_tid, remaining_gen_event_id)
     end
 
+    @tag :race
+    test "drop_pending/2 never deletes events claimed by pointer consumers", %{
+      source: source,
+      source_backend_pid: sbp
+    } do
+      count = 2_000
+      events = for _ <- 1..count, do: build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(sbp, events)
+
+      barrier = :atomics.new(2, signed: false)
+
+      tasks =
+        for kind <- List.duplicate(:claim, 4) ++ List.duplicate(:drop, 4) do
+          Task.async(fn ->
+            :atomics.add_get(barrier, 1, 1)
+            await_counter(barrier, 2, 1)
+
+            case kind do
+              :claim ->
+                {:ok, pointers, _tid} = IngestEventQueue.pop_pending_pointers(sbp, count)
+                {:claimed, pointers}
+
+              :drop ->
+                {:ok, dropped} = IngestEventQueue.drop_pending(sbp, count)
+                {:dropped, dropped}
+            end
+          end)
+        end
+
+      await_counter(barrier, 1, length(tasks))
+      :atomics.put(barrier, 2, 1)
+      results = Task.await_many(tasks, 10_000)
+
+      pointers = for {:claimed, pointers} <- results, pointer <- pointers, do: pointer
+      dropped = for({:dropped, count} <- results, do: count) |> Enum.sum()
+      pointer_ids = Enum.map(pointers, & &1.id)
+
+      assert length(pointer_ids) == length(Enum.uniq(pointer_ids))
+      assert length(pointers) + dropped == count
+
+      for pointer <- pointers do
+        assert %LogEvent{} =
+                 IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id)
+      end
+    end
+
     test "truncate all events in a queue", %{source: source, source_backend_pid: sbp} do
       batch =
         for _ <- 1..500 do
@@ -1327,6 +1373,53 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert IngestEventQueue.get_table_size(key) == 0
     end
 
+    @tag :race
+    test "resolved and ID-passing consumers never claim the same event", %{
+      key: key,
+      source: source
+    } do
+      count = 2_000
+      events = for _ <- 1..count, do: build(:log_event, source: source)
+      assert :ok = IngestEventQueue.add_to_table(key, events)
+
+      barrier = :atomics.new(2, signed: false)
+
+      tasks =
+        for kind <- List.duplicate(:pointer, 4) ++ List.duplicate(:event, 4) do
+          Task.async(fn ->
+            :atomics.add_get(barrier, 1, 1)
+            await_counter(barrier, 2, 1)
+
+            case kind do
+              :pointer ->
+                {:ok, pointers, _tid} = IngestEventQueue.pop_pending_pointers(key, count)
+                {:pointers, pointers}
+
+              :event ->
+                {:ok, claimed_events} = IngestEventQueue.pop_pending(key, count)
+                {:events, claimed_events}
+            end
+          end)
+        end
+
+      await_counter(barrier, 1, length(tasks))
+      :atomics.put(barrier, 2, 1)
+      results = Task.await_many(tasks, 10_000)
+
+      pointers = for {:pointers, pointers} <- results, pointer <- pointers, do: pointer
+      claimed_events = for {:events, events} <- results, event <- events, do: event
+      pointer_ids = MapSet.new(pointers, & &1.id)
+      event_ids = MapSet.new(claimed_events, & &1.id)
+
+      assert MapSet.disjoint?(pointer_ids, event_ids)
+      assert MapSet.size(pointer_ids) + MapSet.size(event_ids) == count
+
+      for pointer <- pointers do
+        assert %LogEvent{} =
+                 IngestEventQueue.lookup_event(pointer.tid, pointer.gen_event_id)
+      end
+    end
+
     test "skips a pointer whose generation was already dropped instead of crashing", %{
       key: key,
       source: source
@@ -1876,6 +1969,13 @@ defmodule Logflare.Backends.IngestEventQueueTest do
         # use extended_statistics to view units of work done
         formatters: [{Benchee.Formatters.Console, extended_statistics: true}]
       )
+    end
+  end
+
+  defp await_counter(counter, index, target) do
+    if :atomics.get(counter, index) < target do
+      :erlang.yield()
+      await_counter(counter, index, target)
     end
   end
 end


### PR DESCRIPTION
## Summary

- gate every destructive pointer-queue operation on an atomic `:ets.take/2`
- use the row returned by the winning claim for ID-passing, resolved-event, and queue-janitor paths
- preserve completed claims and counts when a pointer table becomes stale mid-operation
- skip stale mapper entries without masking a live replacement table
- cover mixed-consumer and load-shedding races with barrier-synchronized tests

## Why

`:ets.select/3` returns candidate snapshots, not ownership. Previously, `pop_pending/2` and `drop_pending/2` could act on a selected pointer after another consumer had already claimed it. That could delete the generation-store event behind an acknowledged pointer or allow resolved and ID-passing consumers to act on the same event.

This PR makes the atomic pointer claim the ownership gate for every destructive path.

## Semantics

- Missing candidates are skipped because another consumer won them.
- A successful claim uses the row returned by `:ets.take/2`, not the earlier selection snapshot.
- If a pointer table becomes stale after earlier claims succeed, those completed claims are returned or counted.
- An initially stale table returns `{:error, :not_initialized}` and emits stale-table telemetry.
- Destroying a pointer table still destroys its unclaimed rows; this change prevents secondary crashes and stale-snapshot deletion but cannot recover rows already destroyed with their owner table.

## Performance

Same-host public-API Benchee comparison against `main` at `0b3d20f`, using OTP 27 with six schedulers. Queue rows were rebuilt outside each timed invocation; timings used a 1-second warmup and 2-second measurement window.

| Operation | Batch | `main` median | PR median | Change |
| --- | ---: | ---: | ---: | ---: |
| `pop_pending_pointers/2` | 100 | 9.334 µs | 8.791 µs | 5.8% faster |
| `pop_pending_pointers/2` | 1,000 | 126.375 µs | 113.084 µs | 10.5% faster |
| `drop_pending/2` | 100 | 13.542 µs | 12.250 µs | 9.5% faster |
| `drop_pending/2` | 1,000 | 137.313 µs | 113.542 µs | 17.3% faster |
| `pop_pending/2` | 100 | 21.333 µs | 21.292 µs | unchanged |
| `pop_pending/2` | 1,000 | 258.000 µs | 265.377 µs | 2.9% slower |

Pointer claims use ID-only selection and tail-recursive accumulation. Resolved-event claims and queue drops consume atomically taken rows directly instead of constructing `LogEventPointer` structs.

For 1,000 `get_tid/1` calls, the PR was 13.2% faster with no stale duplicate and 17.7% faster with one. An artificial 100-stale-entry case was 23.6% slower because the stale-safe lookup materializes every exact-key match; mapper cleanup bounds this uncommon case.