### PR TITLE
fix: SQL formatting errors in Events view

### DIFF
--- a/lib/logflare_web/components/query_components.ex
+++ b/lib/logflare_web/components/query_components.ex
@@ -152,10 +152,10 @@ defmodule LogflareWeb.QueryComponents do
 
   defp prepare_table_name(sql) do
     Regex.replace(
-      ~r/`([^`]+)`\.([^\s]+)/,
+      ~r/`([^`]+)`\.`?([^`.\s]+)`?\.`?([^`\s]+)`?/,
       sql,
-      fn _, project, rest ->
-        "`#{project}.#{rest}`"
+      fn _, project, dataset, table ->
+        "`#{project}.#{dataset}.#{table}`"
       end
     )
   end

--- a/lib/logflare_web/utils.ex
+++ b/lib/logflare_web/utils.ex
@@ -132,32 +132,35 @@ defmodule LogflareWeb.Utils do
   end
 
   @spec sql_params_to_sql(String.t(), list()) :: String.t()
-  def sql_params_to_sql(sql, params) when is_binary(sql) and is_list(params) do
-    Enum.reduce(params, sql, fn param, acc_sql ->
-      type = Map.get(param.parameterType, :type)
-      value = Map.get(param.parameterValue, :value)
+  def sql_params_to_sql(sql, []) when is_binary(sql), do: sql
 
-      replacement =
-        case type do
-          "STRING" ->
-            escaped = value |> String.replace("\\", "\\\\") |> String.replace("'", "''")
-            "'#{escaped}'"
+  def sql_params_to_sql(sql, [param | params]) when is_binary(sql) do
+    type = Map.get(param.parameterType, :type)
+    value = Map.get(param.parameterValue, :value)
 
-          num when num in ["INTEGER", "FLOAT"] ->
-            inspect(value)
+    replacement =
+      case type do
+        "STRING" ->
+          escaped = value |> String.replace("\\", "\\\\") |> String.replace("'", "''")
+          "'#{escaped}'"
 
-          "BOOL" ->
-            to_string(value)
+        num when num in ["INTEGER", "FLOAT"] ->
+          inspect(value)
 
-          _ ->
-            escaped =
-              value |> to_string() |> String.replace("\\", "\\\\") |> String.replace("'", "''")
+        "BOOL" ->
+          to_string(value)
 
-            "'#{escaped}'"
-        end
+        _ ->
+          escaped =
+            value |> to_string() |> String.replace("\\", "\\\\") |> String.replace("'", "''")
 
-      String.replace(acc_sql, "?", replacement, global: false)
-    end)
+          "'#{escaped}'"
+      end
+
+    case String.split(sql, "?", parts: 2) do
+      [before, after_sql] -> before <> replacement <> sql_params_to_sql(after_sql, params)
+      [_] -> sql
+    end
   end
 
   @spec replace_table_with_source_name(String.t(), %{

--- a/test/logflare_web/components/query_components_test.exs
+++ b/test/logflare_web/components/query_components_test.exs
@@ -91,20 +91,24 @@ defmodule LogflareWeb.QueryComponentsTest do
       assert html =~ "3.14"
     end
 
-    test "ensures table names surrounded by backticks" do
+    test "formats BigQuery table names with backticks" do
+      expected_table_name =
+        "`logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6`"
+
       [
-        "SELECT t0.timestamp, t0.id FROM `logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6` AS t0",
-        "SELECT t0.timestamp, t0.id FROM `logflare-dev-464423`.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6 AS t0"
+        "`logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6`",
+        "`logflare-dev-464423`.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6",
+        "`logflare-dev-464423`.`1_dev`.`9db56741_41ca_4fe8_8c05_051a76a4c5d6`",
+        "`logflare-dev-464423`.1_dev.`9db56741_41ca_4fe8_8c05_051a76a4c5d6`"
       ]
-      |> Enum.each(fn sql_string ->
+      |> Enum.each(fn table_name ->
         html =
           render_component(&QueryComponents.formatted_sql/1, %{
-            sql_string: sql_string,
+            sql_string: "SELECT t0.timestamp, t0.id FROM #{table_name} AS t0",
             params: []
           })
 
-        assert html =~
-                 "`logflare-dev-464423.1_dev.9db56741_41ca_4fe8_8c05_051a76a4c5d6`"
+        assert html =~ expected_table_name
       end)
     end
   end

--- a/test/logflare_web/utils_test.exs
+++ b/test/logflare_web/utils_test.exs
@@ -141,6 +141,21 @@ defmodule LogflareWeb.UtilsTest do
                "SELECT * FROM t WHERE t.col = 'simple_value'"
     end
 
+    test "preserves question marks within substituted string parameters" do
+      sql = "SELECT * FROM t WHERE request.search = ? AND response.status_code = ?"
+
+      params = [
+        %{
+          parameterType: %{type: "STRING"},
+          parameterValue: %{value: "?grant_type=id_token"}
+        },
+        %{parameterType: %{type: "INTEGER"}, parameterValue: %{value: 400}}
+      ]
+
+      assert Utils.sql_params_to_sql(sql, params) ==
+               "SELECT * FROM t WHERE request.search = '?grant_type=id_token' AND response.status_code = 400"
+    end
+
     test "renders BOOL parameters as unquoted literals" do
       sql = "SELECT * FROM t WHERE t.col = ?"
 


### PR DESCRIPTION
* Handle partially quoted BigQuery table names. Tables names are now quoted as one quoted value 
  * `` `abc`.1_dev.`123` `` becomes  `` `abc.1_dev.123` `` 
* Prevent `?` in SQL params from replacing later values when escaping SQL.
  * A query with a `?` in the param value would be escaped repeatedly. 

<img width="4519" height="1415" alt="CleanShot 2026-08-20 at 12 05 20@2x" src="https://github.com/user-attachments/assets/883464d4-dc4b-4dbd-8cf5-6131236acb0d" />

Fixes O11Y-2366
