### PR TITLE
feat(toggle): Add enabled column to backends

### DIFF
--- a/priv/repo/migrations/20260814000000_add_enabled_to_backends.exs
+++ b/priv/repo/migrations/20260814000000_add_enabled_to_backends.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddEnabledToBackends do
+  use Ecto.Migration
+
+  def change do
+    alter table(:backends) do
+      add :enabled, :boolean, default: true, null: false
+    end
+  end
+end


### PR DESCRIPTION
Initial PR 1/4(?) for [O11Y-2315](https://linear.app/supabase/issue/O11Y-2315/add-destination-level-toggle-controls).

Adds a non-null `enabled` column to backends with a constant `true` default. This expand-only migration is intended to deploy before the Ecto schema and runtime changes, while existing application versions safely ignore the column. The Supabase-supported PostgreSQL versions (13+?) would use the fast-default path, so this migration does not require a full table rewrite and should be fast.

Reference implementation: #3830.