### PR TITLE
fix(ssrf): Handle empty DNS responses in SSRF resolver

### DIFF
--- a/lib/logflare/utils/ssrf.ex
+++ b/lib/logflare/utils/ssrf.ex
@@ -85,11 +85,12 @@ defmodule Logflare.Utils.SSRF do
   end
 
   defp resolve_hostname(charlist, family) do
-    with {:ok, addrs} <- :inet.getaddrs(charlist, family),
+    with {:ok, [addr | _] = addrs} <- :inet.getaddrs(charlist, family),
          {:private, false} <- {:private, Enum.any?(addrs, &private_ip?/1)} do
-      {:ok, List.first(addrs)}
+      {:ok, addr}
     else
       {:private, true} -> {:error, @private_ip_error}
+      {:ok, []} -> :unresolved
       {:error, _} -> :unresolved
     end
   end


### PR DESCRIPTION
Treat `{:ok, []}` DNS responses as unresolved instead of returning `{:ok, nil}`. This preserves the `safe_resolve/1` typespec and allows fallback from IPv4 to IPv6 resolution. Tests: `mix test test/logflare/utils/ssrf_test.exs`.