### PR TITLE
fix(ssrf): Fix IPv6 URL rewriting in SSRF middleware

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
+++ b/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
@@ -29,13 +29,15 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtection do
   end
 
   @spec host_header(URI.t()) :: String.t()
-  defp host_header(%URI{authority: authority, userinfo: userinfo}) when is_binary(authority) do
-    # URI.host omits IPv6 brackets and the explicit port, so preserve the URI authority while
-    # removing userinfo, which must not be included in the Host header.
-    if userinfo do
-      String.replace_prefix(authority, "#{userinfo}@", "")
+  defp host_header(%URI{host: host, port: port, scheme: scheme})
+       when is_binary(host) and is_binary(scheme) do
+    # URI.host stores IPv6 without brackets and excludes the port, so add both when required.
+    host = if String.contains?(host, ":"), do: "[#{host}]", else: host
+
+    if is_integer(port) and port != URI.default_port(scheme) do
+      "#{host}:#{port}"
     else
-      authority
+      host
     end
   end
 end

--- a/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
+++ b/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
@@ -15,7 +15,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtection do
         # hostname (required by HTTP/1.1 and virtual hosting).
         ip_host = SSRF.url_host(addr)
         rewritten = URI.to_string(%{uri | host: ip_host, authority: nil})
-        headers = List.keystore(env.headers, "host", 0, {"host", uri.host})
+        headers = List.keystore(env.headers, "host", 0, {"host", host_header(uri)})
         Tesla.run(%{env | url: rewritten, headers: headers}, next)
 
       {:ok, _addr} ->
@@ -25,6 +25,17 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtection do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @spec host_header(URI.t()) :: String.t()
+  defp host_header(%URI{authority: authority, userinfo: userinfo}) when is_binary(authority) do
+    # URI.host omits IPv6 brackets and the explicit port, so preserve the URI authority while
+    # removing userinfo, which must not be included in the Host header.
+    if userinfo do
+      String.replace_prefix(authority, "#{userinfo}@", "")
+    else
+      authority
     end
   end
 end

--- a/lib/logflare/utils/ssrf.ex
+++ b/lib/logflare/utils/ssrf.ex
@@ -68,11 +68,9 @@ defmodule Logflare.Utils.SSRF do
 
   def safe_resolve(_), do: {:error, "invalid host"}
 
-  @doc "Formats an IP address tuple as a URL host component (IPv6 wrapped in brackets)."
+  # URI hosts store IPv6 addresses without brackets; URI.to_string/1 adds them when serializing.
+  @doc "Formats an IP address tuple for use as a `URI.host` value."
   @spec url_host(:inet.ip_address()) :: String.t()
-  def url_host(addr) when tuple_size(addr) == 8,
-    do: "[#{addr |> :inet.ntoa() |> List.to_string()}]"
-
   def url_host(addr), do: addr |> :inet.ntoa() |> List.to_string()
 
   defp resolve_hostname(charlist) do

--- a/test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs
+++ b/test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs
@@ -32,6 +32,13 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtectionTest do
       assert env.url == "http://1.2.3.4/path"
       assert {"host", "1.2.3.4"} in env.headers
     end
+
+    test "rewrites public IPv6 without double brackets and preserves bracketed Host header" do
+      {:ok, env} = call("http://[2001:4860:4860::8888]:8088/path")
+
+      assert env.url == "http://[2001:4860:4860::8888]:8088/path"
+      assert {"host", "[2001:4860:4860::8888]:8088"} in env.headers
+    end
   end
 
   describe "call/3 with HTTPS URLs" do

--- a/test/logflare/utils/ssrf_test.exs
+++ b/test/logflare/utils/ssrf_test.exs
@@ -92,11 +92,11 @@ defmodule Logflare.Utils.SSRFTest do
       assert SSRF.url_host({1, 2, 3, 4}) == "1.2.3.4"
     end
 
-    test "formats IPv6 with brackets" do
-      assert SSRF.url_host({0, 0, 0, 0, 0, 0, 0, 1}) == "[::1]"
+    test "formats IPv6 without brackets for URI.host" do
+      assert SSRF.url_host({0, 0, 0, 0, 0, 0, 0, 1}) == "::1"
 
       assert SSRF.url_host({0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888}) ==
-               "[2001:4860:4860::8888]"
+               "2001:4860:4860::8888"
     end
   end
 end


### PR DESCRIPTION
Ensure resolved IPv6 addresses remain unbracketed in URI.host so URI serialization does not produce malformed double brackets. Preserve the original bracketed authority and explicit port for the HTTP Host header while excluding userinfo. Add regression coverage for complete public IPv6 rewrites and update url_host/1 expectations. Tests: mix test test/logflare/utils/ssrf_test.exs test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs (17 tests, 0 failures).