### PR TITLE
fix(ssrf): deduplicate SSRF Host headers

### DIFF
--- a/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
+++ b/lib/logflare/backends/adaptor/http_based/ssrf_protection.ex
@@ -2,6 +2,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtection do
   @moduledoc false
   @behaviour Tesla.Middleware
 
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
   alias Logflare.Utils.SSRF
 
   @impl Tesla.Middleware
@@ -15,7 +16,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtection do
         # hostname (required by HTTP/1.1 and virtual hosting).
         ip_host = SSRF.url_host(addr)
         rewritten = URI.to_string(%{uri | host: ip_host, authority: nil})
-        headers = List.keystore(env.headers, "host", 0, {"host", uri.host})
+        headers = [{"host", uri.host} | Headers.drop_reserved(env.headers, ["host"])]
         Tesla.run(%{env | url: rewritten, headers: headers}, next)
 
       {:ok, _addr} ->

--- a/test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs
+++ b/test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs
@@ -6,8 +6,10 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtectionTest do
 
   defp ok_next(env), do: {:ok, env}
 
-  defp call(url),
-    do: SSRFProtection.call(%Tesla.Env{url: url, headers: []}, [{:fn, &ok_next/1}], [])
+  defp call(url, opts \\ []) do
+    env = struct!(Tesla.Env, Keyword.put(opts, :url, url))
+    SSRFProtection.call(env, [{:fn, &ok_next/1}], [])
+  end
 
   describe "call/3 with HTTP URLs" do
     test "blocks private IPv4 at request time" do
@@ -31,6 +33,24 @@ defmodule Logflare.Backends.Adaptor.HttpBased.SSRFProtectionTest do
 
       assert env.url == "http://1.2.3.4/path"
       assert {"host", "1.2.3.4"} in env.headers
+    end
+
+    test "replaces all existing Host headers case-insensitively" do
+      {:ok, env} =
+        call("http://1.2.3.4/path",
+          headers: [
+            {"Host", "other.example"},
+            {"hOsT", "duplicate.example"},
+            {"host", "third.example"},
+            {"authorization", "Bearer token"}
+          ]
+        )
+
+      host_headers =
+        Enum.filter(env.headers, fn {key, _value} -> String.downcase(key) == "host" end)
+
+      assert host_headers == [{"host", "1.2.3.4"}]
+      assert {"authorization", "Bearer token"} in env.headers
     end
   end
 


### PR DESCRIPTION
## Summary

- Remove every case-insensitive `Host` variant in the HTTP SSRF middleware before adding the canonical header for the original URL.
- `SSRFProtection` is currently wired through `WebhookAdaptor.Client`, but normal Webhook config casting already lowercases header keys, so ordinary webhook configs are unlikely to be affected; legacy/direct calls and wrapper paths such as `LokiAdaptor` or maybe future call-sites could potentially bypass that normalization.
- Add regression coverage for duplicate mixed-case Host headers while preserving unrelated headers.

## Testing

- `mix test test/logflare/backends/adaptor/http_based/ssrf_protection_test.exs`
