### PR TITLE
feat: list sources for ingest credentials

### DIFF
--- a/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
+++ b/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
@@ -20,7 +20,7 @@ Access tokens can be scoped to specific functionality.
 
 ## Discovering ingest sources
 
-Use `GET /api/ingest_sources` to discover the sources available to an ingest access token. The JSON response contains only each source's `token` and `name`; send `Accept: text/csv` for RFC 4180 CSV with a `token,name` header. The endpoint accepts account-wide `ingest` and private tokens, as well as source-scoped `ingest:source:<source-id>` tokens. Deprecated `ingest:collection:<source-id>` scopes remain supported. Responses are not cached.
+Use `GET /api/ingest-sources` to discover the sources available to an ingest access token. The JSON response contains only each source's `token` and `name`; send `Accept: text/csv` for RFC 4180 CSV with a `token,name` header. The endpoint accepts account-wide `ingest` and private tokens, as well as source-scoped `ingest:source:<source-id>` tokens. Deprecated `ingest:collection:<source-id>` scopes remain supported. Responses are not cached.
 
 ## Managing Access Tokens
 

--- a/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
+++ b/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
@@ -20,7 +20,7 @@ Access tokens can be scoped to specific functionality.
 
 ## Discovering ingest sources
 
-Use `GET /api/ingest_sources` to discover the sources available to an ingest access token. The JSON response contains only each source's `token` and `name`; use `?format=csv` for RFC 4180 CSV with a `token,name` header. The endpoint accepts account-wide `ingest` and private tokens, as well as source-scoped `ingest:source:<source-id>` tokens. Deprecated `ingest:collection:<source-id>` scopes remain supported. Responses are not cached.
+Use `GET /api/ingest_sources` to discover the sources available to an ingest access token. The JSON response contains only each source's `token` and `name`; send `Accept: text/csv` for RFC 4180 CSV with a `token,name` header. The endpoint accepts account-wide `ingest` and private tokens, as well as source-scoped `ingest:source:<source-id>` tokens. Deprecated `ingest:collection:<source-id>` scopes remain supported. Responses are not cached.
 
 ## Managing Access Tokens
 

--- a/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
+++ b/docs/docs.logflare.com/docs/concepts/access-tokens/index.md
@@ -18,6 +18,10 @@ Access tokens can be scoped to specific functionality.
 
 `ingest` and `query` scopes can be scoped to specific sources and endpoints. It is recommended to use the least privileged token for the given task, especially for public ingestion.
 
+## Discovering ingest sources
+
+Use `GET /api/ingest_sources` to discover the sources available to an ingest access token. The JSON response contains only each source's `token` and `name`; use `?format=csv` for RFC 4180 CSV with a `token,name` header. The endpoint accepts account-wide `ingest` and private tokens, as well as source-scoped `ingest:source:<source-id>` tokens. Deprecated `ingest:collection:<source-id>` scopes remain supported. Responses are not cached.
+
 ## Managing Access Tokens
 
 Access tokens can be created under the [Manage Access Tokens page](https://logflare.app/access-tokens).

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -61,7 +61,7 @@ defmodule Logflare.Sources do
 
   defp ingest_sources_query(user_id) do
     from(s in Source,
-      where: s.user_id == ^user_id,
+      where: s.user_id == ^user_id and s.system_source == false,
       order_by: [asc: s.name, asc: s.token],
       select: %{token: s.token, name: s.name}
     )

--- a/lib/logflare/sources.ex
+++ b/lib/logflare/sources.ex
@@ -47,6 +47,26 @@ defmodule Logflare.Sources do
     |> Enum.map(&put_retention_days/1)
   end
 
+  @spec list_ingest_sources_by_user(pos_integer(), :all | [pos_integer()]) :: [map()]
+  def list_ingest_sources_by_user(user_id, :all) do
+    ingest_sources_query(user_id)
+    |> Repo.all()
+  end
+
+  def list_ingest_sources_by_user(user_id, source_ids) when is_list(source_ids) do
+    ingest_sources_query(user_id)
+    |> where([s], s.id in ^source_ids)
+    |> Repo.all()
+  end
+
+  defp ingest_sources_query(user_id) do
+    from(s in Source,
+      where: s.user_id == ^user_id,
+      order_by: [asc: s.name, asc: s.token],
+      select: %{token: s.token, name: s.name}
+    )
+  end
+
   @spec list_system_sources_by_user(User.t()) :: [Source.t()]
   def list_system_sources_by_user(%User{id: user_id}), do: list_system_sources_by_user(user_id)
 

--- a/lib/logflare_web/controllers/api/ingest_source_controller.ex
+++ b/lib/logflare_web/controllers/api/ingest_source_controller.ex
@@ -1,0 +1,90 @@
+defmodule LogflareWeb.Api.IngestSourceController do
+  use LogflareWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Logflare.Sources
+  alias LogflareWeb.Api.FallbackController
+  alias LogflareWeb.OpenApi.BadRequest
+  alias LogflareWeb.OpenApi.List
+  alias LogflareWeb.OpenApi.Unauthorized
+  alias LogflareWeb.OpenApiSchemas.IngestSource
+  alias OpenApiSpex.MediaType
+  alias OpenApiSpex.Response
+  alias OpenApiSpex.Schema
+
+  action_fallback(FallbackController)
+
+  tags(["ingest"])
+
+  operation(:index,
+    summary: "List sources available for ingestion",
+    parameters: [
+      format: [
+        in: :query,
+        description: "Response format",
+        schema: %Schema{type: :string, enum: ["csv"]}
+      ]
+    ],
+    responses: %{
+      200 => %Response{
+        description: "Available ingest sources",
+        content: %{
+          "application/json" => %MediaType{schema: List.schema(IngestSource)},
+          "text/csv" => %MediaType{schema: %Schema{type: :string}}
+        }
+      },
+      400 => BadRequest.response(),
+      401 => Unauthorized.response()
+    }
+  )
+
+  def index(%{assigns: %{user: user, access_token: access_token}} = conn, params) do
+    with {:ok, source_ids} <- authorized_source_ids(access_token) do
+      sources = Sources.list_ingest_sources_by_user(user.id, source_ids)
+
+      conn = put_resp_header(conn, "cache-control", "no-store")
+
+      case Map.get(params, "format") do
+        nil -> json(conn, sources)
+        "csv" -> send_resp(conn |> put_resp_content_type("text/csv"), 200, csv(sources))
+        _ -> {:error, "Unsupported format. Supported formats: csv"}
+      end
+    end
+  end
+
+  defp authorized_source_ids(nil), do: {:ok, :all}
+
+  defp authorized_source_ids(%{scopes: scopes}) do
+    scopes = String.split(scopes || "")
+
+    if scopes == [] or "public" in scopes or "private" in scopes or "ingest" in scopes do
+      {:ok, :all}
+    else
+      source_ids =
+        for scope <- scopes,
+            [_, id] <- [Regex.run(~r/^ingest:(?:source|collection):(\d+)$/, scope)],
+            do: String.to_integer(id)
+
+      if source_ids == [], do: {:error, :unauthorized}, else: {:ok, source_ids}
+    end
+  end
+
+  defp csv(sources) do
+    [
+      "token,name\r\n"
+      | Enum.map(sources, fn %{token: token, name: name} ->
+          [csv_field(token), ",", csv_field(name), "\r\n"]
+        end)
+    ]
+  end
+
+  defp csv_field(value) do
+    value = to_string(value)
+
+    if String.contains?(value, [",", "\"", "\r", "\n"]) do
+      ["\"", String.replace(value, "\"", "\"\""), "\""]
+    else
+      value
+    end
+  end
+end

--- a/lib/logflare_web/controllers/api/ingest_source_controller.ex
+++ b/lib/logflare_web/controllers/api/ingest_source_controller.ex
@@ -35,12 +35,9 @@ defmodule LogflareWeb.Api.IngestSourceController do
     with {:ok, source_ids} <- authorized_source_ids(access_token) do
       sources = Sources.list_ingest_sources_by_user(user.id, source_ids)
 
-      conn = put_resp_header(conn, "cache-control", "no-store")
-
-      case get_format(conn) do
-        "json" -> json(conn, sources)
-        "csv" -> render(conn, :index, sources: sources)
-      end
+      conn
+      |> put_resp_header("cache-control", "no-store")
+      |> render(:index, sources: sources)
     end
   end
 

--- a/lib/logflare_web/controllers/api/ingest_source_controller.ex
+++ b/lib/logflare_web/controllers/api/ingest_source_controller.ex
@@ -29,7 +29,9 @@ defmodule LogflareWeb.Api.IngestSourceController do
     }
   )
 
-  def index(%{assigns: %{user: user, access_token: access_token}} = conn, _params) do
+  def index(%{assigns: %{user: user}} = conn, _params) do
+    access_token = Map.get(conn.assigns, :access_token)
+
     with {:ok, source_ids} <- authorized_source_ids(access_token) do
       sources = Sources.list_ingest_sources_by_user(user.id, source_ids)
 

--- a/lib/logflare_web/controllers/api/ingest_source_controller.ex
+++ b/lib/logflare_web/controllers/api/ingest_source_controller.ex
@@ -39,7 +39,7 @@ defmodule LogflareWeb.Api.IngestSourceController do
 
       case get_format(conn) do
         "json" -> json(conn, sources)
-        "csv" -> send_resp(conn |> put_resp_content_type("text/csv"), 200, csv(sources))
+        "csv" -> render(conn, :index, sources: sources)
       end
     end
   end
@@ -58,25 +58,6 @@ defmodule LogflareWeb.Api.IngestSourceController do
             do: String.to_integer(id)
 
       if source_ids == [], do: {:error, :unauthorized}, else: {:ok, source_ids}
-    end
-  end
-
-  defp csv(sources) do
-    [
-      "token,name\r\n"
-      | Enum.map(sources, fn %{token: token, name: name} ->
-          [csv_field(token), ",", csv_field(name), "\r\n"]
-        end)
-    ]
-  end
-
-  defp csv_field(value) do
-    value = to_string(value)
-
-    if String.contains?(value, [",", "\"", "\r", "\n"]) do
-      ["\"", String.replace(value, "\"", "\"\""), "\""]
-    else
-      value
     end
   end
 end

--- a/lib/logflare_web/controllers/api/ingest_source_controller.ex
+++ b/lib/logflare_web/controllers/api/ingest_source_controller.ex
@@ -4,7 +4,6 @@ defmodule LogflareWeb.Api.IngestSourceController do
 
   alias Logflare.Sources
   alias LogflareWeb.Api.FallbackController
-  alias LogflareWeb.OpenApi.BadRequest
   alias LogflareWeb.OpenApi.List
   alias LogflareWeb.OpenApi.Unauthorized
   alias LogflareWeb.OpenApiSchemas.IngestSource
@@ -18,13 +17,6 @@ defmodule LogflareWeb.Api.IngestSourceController do
 
   operation(:index,
     summary: "List sources available for ingestion",
-    parameters: [
-      format: [
-        in: :query,
-        description: "Response format",
-        schema: %Schema{type: :string, enum: ["csv"]}
-      ]
-    ],
     responses: %{
       200 => %Response{
         description: "Available ingest sources",
@@ -33,21 +25,19 @@ defmodule LogflareWeb.Api.IngestSourceController do
           "text/csv" => %MediaType{schema: %Schema{type: :string}}
         }
       },
-      400 => BadRequest.response(),
       401 => Unauthorized.response()
     }
   )
 
-  def index(%{assigns: %{user: user, access_token: access_token}} = conn, params) do
+  def index(%{assigns: %{user: user, access_token: access_token}} = conn, _params) do
     with {:ok, source_ids} <- authorized_source_ids(access_token) do
       sources = Sources.list_ingest_sources_by_user(user.id, source_ids)
 
       conn = put_resp_header(conn, "cache-control", "no-store")
 
-      case Map.get(params, "format") do
-        nil -> json(conn, sources)
+      case get_format(conn) do
+        "json" -> json(conn, sources)
         "csv" -> send_resp(conn |> put_resp_content_type("text/csv"), 200, csv(sources))
-        _ -> {:error, "Unsupported format. Supported formats: csv"}
       end
     end
   end

--- a/lib/logflare_web/open_api_schemas.ex
+++ b/lib/logflare_web/open_api_schemas.ex
@@ -115,6 +115,15 @@ defmodule LogflareWeb.OpenApiSchemas do
     use LogflareWeb.OpenApi, properties: @properties, required: []
   end
 
+  defmodule IngestSource do
+    @properties %{
+      token: %Schema{type: :string},
+      name: %Schema{type: :string}
+    }
+
+    use LogflareWeb.OpenApi, properties: @properties, required: [:token, :name]
+  end
+
   defmodule Source do
     @properties %{
       name: %Schema{type: :string},

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -510,7 +510,7 @@ defmodule LogflareWeb.Router do
   scope "/api", LogflareWeb do
     pipe_through([:ingest_source_discovery_auth])
 
-    get("/ingest_sources", Api.IngestSourceController, :index)
+    get("/ingest-sources", Api.IngestSourceController, :index)
   end
 
   scope "/api/partner", LogflareWeb do

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -151,7 +151,7 @@ defmodule LogflareWeb.Router do
     plug(Plug.RequestId)
     plug(OpenApiSpex.Plug.PutApiSpec, module: LogflareWeb.ApiSpec)
     plug(LogflareWeb.Plugs.VerifyApiAccess, require_token: true)
-    plug(:accepts, ["json"])
+    plug(:accepts, ["json", "csv"])
     plug(LogflareWeb.Plugs.SetHeaders)
   end
 

--- a/lib/logflare_web/router.ex
+++ b/lib/logflare_web/router.ex
@@ -147,6 +147,14 @@ defmodule LogflareWeb.Router do
     plug(LogflareWeb.Plugs.VerifyApiAccess, scopes: ~w(private))
   end
 
+  pipeline :ingest_source_discovery_auth do
+    plug(Plug.RequestId)
+    plug(OpenApiSpex.Plug.PutApiSpec, module: LogflareWeb.ApiSpec)
+    plug(LogflareWeb.Plugs.VerifyApiAccess, require_token: true)
+    plug(:accepts, ["json"])
+    plug(LogflareWeb.Plugs.SetHeaders)
+  end
+
   pipeline :require_auth do
     plug(LogflareWeb.Plugs.RequireAuth)
   end
@@ -497,6 +505,12 @@ defmodule LogflareWeb.Router do
     get "/key-values", Api.KeyValueController, :index
     post "/key-values", Api.KeyValueController, :create
     delete "/key-values", Api.KeyValueController, :delete
+  end
+
+  scope "/api", LogflareWeb do
+    pipe_through([:ingest_source_discovery_auth])
+
+    get("/ingest_sources", Api.IngestSourceController, :index)
   end
 
   scope "/api/partner", LogflareWeb do

--- a/lib/logflare_web/views/api/ingest_source_view.ex
+++ b/lib/logflare_web/views/api/ingest_source_view.ex
@@ -1,0 +1,22 @@
+defmodule LogflareWeb.Api.IngestSourceView do
+  use LogflareWeb, :view
+
+  def render("index.csv", %{sources: sources}) do
+    [
+      "token,name\r\n"
+      | Enum.map(sources, fn %{token: token, name: name} ->
+          [csv_field(token), ",", csv_field(name), "\r\n"]
+        end)
+    ]
+  end
+
+  defp csv_field(value) do
+    value = to_string(value)
+
+    if String.contains?(value, [",", "\"", "\r", "\n"]) do
+      ["\"", String.replace(value, "\"", "\"\""), "\""]
+    else
+      value
+    end
+  end
+end

--- a/lib/logflare_web/views/api/ingest_source_view.ex
+++ b/lib/logflare_web/views/api/ingest_source_view.ex
@@ -1,6 +1,8 @@
 defmodule LogflareWeb.Api.IngestSourceView do
   use LogflareWeb, :view
 
+  def render("index.json", %{sources: sources}), do: sources
+
   def render("index.csv", %{sources: sources}) do
     [
       "token,name\r\n"

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -86,6 +86,26 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
                |> json_response(200)
     end
 
+    test "excludes system sources from JSON and CSV discovery", %{conn: conn, user: user} do
+      system_source = insert(:source, user: user, name: "system.logs", system_source: true)
+
+      response =
+        conn
+        |> add_access_token(user, "ingest")
+        |> get("/api/ingest_sources")
+        |> json_response(200)
+
+      refute Enum.any?(response, &(&1["token"] == to_string(system_source.token)))
+
+      csv_conn =
+        build_conn()
+        |> add_access_token(user, "ingest:source:#{system_source.id}")
+        |> put_req_header("accept", "text/csv")
+        |> get("/api/ingest_sources?format=csv")
+
+      assert response(csv_conn, 200) == "token,name\r\n"
+    end
+
     test "preserves deprecated empty and public ingest-compatible access token scopes", %{
       conn: conn,
       user: user

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -153,6 +153,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       csv_conn =
         conn
         |> add_access_token(user, "ingest")
+        |> put_req_header("accept", "text/csv")
         |> get("/api/ingest_sources?format=csv")
 
       assert response(csv_conn, 200) =~ "\"comma, \"\"quote\"\"\nline\""

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -25,7 +25,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       json_conn =
         conn
         |> add_access_token(user, "ingest")
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
 
       assert json_response(json_conn, 200) == [
                %{"token" => to_string(source_a.token), "name" => source_a.name},
@@ -46,7 +46,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         assert 2 ==
                  conn
                  |> credential.()
-                 |> get("/api/ingest_sources")
+                 |> get("/api/ingest-sources")
                  |> json_response(200)
                  |> length()
       end
@@ -65,7 +65,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
           user,
           "ingest:source:#{source_a.id} ingest:collection:#{source_b.id} ingest:source:#{other_source.id}"
         )
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
         |> json_response(200)
 
       assert response == [
@@ -82,7 +82,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       assert [] =
                conn
                |> add_access_token(user, "ingest:source:#{other_source.id}")
-               |> get("/api/ingest_sources")
+               |> get("/api/ingest-sources")
                |> json_response(200)
     end
 
@@ -92,7 +92,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       response =
         conn
         |> add_access_token(user, "ingest")
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
         |> json_response(200)
 
       refute Enum.any?(response, &(&1["token"] == to_string(system_source.token)))
@@ -101,7 +101,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         build_conn()
         |> add_access_token(user, "ingest:source:#{system_source.id}")
         |> put_req_header("accept", "text/csv")
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
 
       assert response(csv_conn, 200) == "token,name\r\n"
     end
@@ -114,7 +114,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         assert 2 ==
                  conn
                  |> add_access_token(user, scopes)
-                 |> get("/api/ingest_sources")
+                 |> get("/api/ingest-sources")
                  |> json_response(200)
                  |> length()
       end
@@ -127,14 +127,14 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       query_token = Logflare.Auth.create_access_token(user, %{scopes: "query"}) |> elem(1)
 
       for request <- [
-            fn conn -> get(conn, "/api/ingest_sources") end,
+            fn conn -> get(conn, "/api/ingest-sources") end,
             fn conn ->
               conn
               |> put_req_header("authorization", "Bearer invalid")
-              |> get("/api/ingest_sources")
+              |> get("/api/ingest-sources")
             end,
-            fn conn -> conn |> add_access_token(user, "query") |> get("/api/ingest_sources") end,
-            fn conn -> get(conn, "/api/ingest_sources?api_key=#{query_token.token}") end
+            fn conn -> conn |> add_access_token(user, "query") |> get("/api/ingest-sources") end,
+            fn conn -> get(conn, "/api/ingest-sources?api_key=#{query_token.token}") end
           ] do
         assert %{"error" => "Unauthorized"} = conn |> request.() |> json_response(401)
       end
@@ -146,14 +146,14 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       assert [] =
                conn
                |> add_access_token(user, "ingest")
-               |> get("/api/ingest_sources")
+               |> get("/api/ingest-sources")
                |> json_response(200)
 
       csv_conn =
         build_conn()
         |> add_access_token(user, "ingest")
         |> put_req_header("accept", "text/csv")
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
 
       assert response(csv_conn, 200) == "token,name\r\n"
       assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]
@@ -175,7 +175,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         conn
         |> add_access_token(user, "ingest")
         |> put_req_header("accept", "text/csv")
-        |> get("/api/ingest_sources")
+        |> get("/api/ingest-sources")
 
       assert response(csv_conn, 200) =~ "\"comma, \"\"quote\"\"\nline\""
       assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -1,0 +1,171 @@
+defmodule LogflareWeb.Api.IngestSourceControllerTest do
+  use LogflareWeb.ConnCase
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Logflare.Sources.Source
+
+  setup do
+    user = insert(:user)
+    other_user = insert(:user)
+    source_a = insert(:source, user: user, name: "Alpha")
+    source_b = insert(:source, user: user, name: "Bravo")
+    other_source = insert(:source, user: other_user, name: "Other")
+
+    {:ok, user: user, source_a: source_a, source_b: source_b, other_source: other_source}
+  end
+
+  describe "index/2" do
+    test "lists only token and name for account-wide ingest credentials in stable order", %{
+      conn: conn,
+      user: user,
+      source_a: source_a,
+      source_b: source_b
+    } do
+      json_conn =
+        conn
+        |> add_access_token(user, "ingest")
+        |> get("/api/ingest_sources")
+
+      assert json_response(json_conn, 200) == [
+               %{"token" => to_string(source_a.token), "name" => source_a.name},
+               %{"token" => to_string(source_b.token), "name" => source_b.name}
+             ]
+
+      assert get_resp_header(json_conn, "cache-control") == ["no-store"]
+    end
+
+    test "lists all owned sources for private and legacy API key credentials", %{
+      conn: conn,
+      user: user
+    } do
+      for credential <- [
+            fn conn -> add_access_token(conn, user, "private") end,
+            fn conn -> put_req_header(conn, "x-api-key", user.api_key) end
+          ] do
+        assert 2 ==
+                 conn
+                 |> credential.()
+                 |> get("/api/ingest_sources")
+                 |> json_response(200)
+                 |> length()
+      end
+    end
+
+    test "limits source and deprecated collection credentials to their owned sources", %{
+      conn: conn,
+      user: user,
+      source_a: source_a,
+      source_b: source_b,
+      other_source: other_source
+    } do
+      response =
+        conn
+        |> add_access_token(
+          user,
+          "ingest:source:#{source_a.id} ingest:collection:#{source_b.id} ingest:source:#{other_source.id}"
+        )
+        |> get("/api/ingest_sources")
+        |> json_response(200)
+
+      assert response == [
+               %{"token" => to_string(source_a.token), "name" => source_a.name},
+               %{"token" => to_string(source_b.token), "name" => source_b.name}
+             ]
+    end
+
+    test "returns an empty list for a scope that names another user's source", %{
+      conn: conn,
+      user: user,
+      other_source: other_source
+    } do
+      assert [] =
+               conn
+               |> add_access_token(user, "ingest:source:#{other_source.id}")
+               |> get("/api/ingest_sources")
+               |> json_response(200)
+    end
+
+    test "preserves deprecated empty and public ingest-compatible access token scopes", %{
+      conn: conn,
+      user: user
+    } do
+      for scopes <- ["", "public"] do
+        assert 2 ==
+                 conn
+                 |> add_access_token(user, scopes)
+                 |> get("/api/ingest_sources")
+                 |> json_response(200)
+                 |> length()
+      end
+    end
+
+    test "rejects missing, invalid, query-only, and query-only parameter credentials", %{
+      conn: conn,
+      user: user
+    } do
+      query_token = Logflare.Auth.create_access_token(user, %{scopes: "query"}) |> elem(1)
+
+      for request <- [
+            fn conn -> get(conn, "/api/ingest_sources") end,
+            fn conn ->
+              conn
+              |> put_req_header("authorization", "Bearer invalid")
+              |> get("/api/ingest_sources")
+            end,
+            fn conn -> conn |> add_access_token(user, "query") |> get("/api/ingest_sources") end,
+            fn conn -> get(conn, "/api/ingest_sources?api_key=#{query_token.token}") end
+          ] do
+        assert %{"error" => "Unauthorized"} = conn |> request.() |> json_response(401)
+      end
+    end
+
+    test "returns empty JSON and header-only CSV results", %{conn: conn} do
+      user = insert(:user)
+
+      assert [] =
+               conn
+               |> add_access_token(user, "ingest")
+               |> get("/api/ingest_sources")
+               |> json_response(200)
+
+      csv_conn =
+        build_conn()
+        |> add_access_token(user, "ingest")
+        |> get("/api/ingest_sources?format=csv")
+
+      assert response(csv_conn, 200) == "token,name\r\n"
+      assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]
+    end
+
+    test "returns RFC 4180 CSV with no-store caching", %{
+      conn: conn,
+      user: user,
+      source_a: source_a
+    } do
+      name = "comma, \"quote\"\nline"
+
+      Logflare.Repo.update_all(
+        from(source in Source, where: source.id == ^source_a.id),
+        set: [name: name]
+      )
+
+      csv_conn =
+        conn
+        |> add_access_token(user, "ingest")
+        |> get("/api/ingest_sources?format=csv")
+
+      assert response(csv_conn, 200) =~ "\"comma, \"\"quote\"\"\nline\""
+      assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]
+      assert get_resp_header(csv_conn, "cache-control") == ["no-store"]
+    end
+
+    test "returns a documented bad request for an unsupported format", %{conn: conn, user: user} do
+      assert %{"error" => "Unsupported format. Supported formats: csv"} =
+               conn
+               |> add_access_token(user, "ingest")
+               |> get("/api/ingest_sources?format=xml")
+               |> json_response(400)
+    end
+  end
+end

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -101,7 +101,7 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         build_conn()
         |> add_access_token(user, "ingest:source:#{system_source.id}")
         |> put_req_header("accept", "text/csv")
-        |> get("/api/ingest_sources?format=csv")
+        |> get("/api/ingest_sources")
 
       assert response(csv_conn, 200) == "token,name\r\n"
     end
@@ -152,7 +152,8 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       csv_conn =
         build_conn()
         |> add_access_token(user, "ingest")
-        |> get("/api/ingest_sources?format=csv")
+        |> put_req_header("accept", "text/csv")
+        |> get("/api/ingest_sources")
 
       assert response(csv_conn, 200) == "token,name\r\n"
       assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]
@@ -174,19 +175,11 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
         conn
         |> add_access_token(user, "ingest")
         |> put_req_header("accept", "text/csv")
-        |> get("/api/ingest_sources?format=csv")
+        |> get("/api/ingest_sources")
 
       assert response(csv_conn, 200) =~ "\"comma, \"\"quote\"\"\nline\""
       assert get_resp_header(csv_conn, "content-type") == ["text/csv; charset=utf-8"]
       assert get_resp_header(csv_conn, "cache-control") == ["no-store"]
-    end
-
-    test "returns a documented bad request for an unsupported format", %{conn: conn, user: user} do
-      assert %{"error" => "Unsupported format. Supported formats: csv"} =
-               conn
-               |> add_access_token(user, "ingest")
-               |> get("/api/ingest_sources?format=xml")
-               |> json_response(400)
     end
   end
 end

--- a/test/logflare_web/controllers/api/ingest_source_controller_test.exs
+++ b/test/logflare_web/controllers/api/ingest_source_controller_test.exs
@@ -52,6 +52,23 @@ defmodule LogflareWeb.Api.IngestSourceControllerTest do
       end
     end
 
+    test "lists owned sources for partner impersonation", %{conn: conn} do
+      partner = insert(:partner)
+      user = insert(:user, partner: partner)
+      source = insert(:source, user: user, name: "Partner source")
+
+      response =
+        conn
+        |> put_req_header("x-lf-partner-user", user.token)
+        |> add_partner_access_token(partner)
+        |> get("/api/ingest-sources")
+        |> json_response(200)
+
+      assert response == [
+               %{"token" => to_string(source.token), "name" => source.name}
+             ]
+    end
+
     test "limits source and deprecated collection credentials to their owned sources", %{
       conn: conn,
       user: user,

--- a/test/logflare_web/views/api/ingest_source_view_test.exs
+++ b/test/logflare_web/views/api/ingest_source_view_test.exs
@@ -1,0 +1,25 @@
+defmodule LogflareWeb.Api.IngestSourceViewTest do
+  use ExUnit.Case, async: true
+
+  alias LogflareWeb.Api.IngestSourceView
+
+  test "renders JSON sources unchanged" do
+    sources = [%{token: :source_a, name: "Alpha"}]
+
+    assert IngestSourceView.render("index.json", %{sources: sources}) == sources
+  end
+
+  test "renders exact RFC 4180 CSV output" do
+    sources = [
+      %{token: :source_a, name: "Alpha"},
+      %{token: :source_b, name: "comma, \"quote\"\nline"}
+    ]
+
+    csv =
+      IngestSourceView.render("index.csv", %{sources: sources})
+      |> IO.iodata_to_binary()
+
+    assert csv ==
+             "token,name\r\nsource_a,Alpha\r\nsource_b,\"comma, \"\"quote\"\"\nline\"\r\n"
+  end
+end


### PR DESCRIPTION
## Summary

- add `GET /api/ingest-sources` for minimal source token/name discovery
- authorize account-wide, legacy, private, and resource-scoped ingest credentials, plus existing partner impersonation, while preserving ownership isolation
- support ordered JSON and RFC 4180 CSV responses selected through HTTP `Accept` negotiation, and document the endpoint in OpenAPI and access-token docs

## Why a dedicated endpoint

The existing `GET /api/sources` route is a management API protected by private scope. It returns the full source representation and performs dashboard-oriented backend and metrics preloads. Allowing ingest credentials onto that route would either expose management fields or make its response shape depend on the credential type, complicating the existing API contract and increasing regression risk for management clients.

A dedicated endpoint keeps `GET /api/sources` unchanged while providing ingest credentials with a small, stable `token`/`name` contract. It also permits a lightweight authentication and query path that applies source-scoped filtering without the management preloads or the single-source ingestion pipeline.

## Alternative implementation

See #3869 for the alternative implementation that reuses `GET /api/sources` and varies its response by credential type. The two PRs are intended for direct comparison; only one approach should merge.

