### PR TITLE
fix: encode LQL timestamp equality filters

### DIFF
--- a/lib/logflare/lql/encoder.ex
+++ b/lib/logflare/lql/encoder.ex
@@ -90,6 +90,9 @@ defmodule Logflare.Lql.Encoder do
     "t:#{to_datetime_with_range(lv, rv)}"
   end
 
+  defp to_fragment(%FilterRule{path: "timestamp", operator: :=, value: v}),
+    do: "t:#{format_filter_value(v)}"
+
   defp to_fragment(%FilterRule{path: "timestamp", operator: op, value: %Date{} = v}),
     do: "t:#{op}#{v}"
 

--- a/test/logflare/lql/encoder_test.exs
+++ b/test/logflare/lql/encoder_test.exs
@@ -121,6 +121,12 @@ defmodule Logflare.Lql.EncoderTest do
       assert result == "t:>=2026-03-17T12:47:02.123"
     end
 
+    test "equality date timestamp can be parsed after encoding" do
+      assert {:ok, lql_rules} = Parser.parse("t:2026-08-19")
+
+      assert "t:2026-08-19" = Encoder.to_querystring(lql_rules)
+    end
+
     test "encodes quoted string filter" do
       lql_rules = [
         %FilterRule{


### PR DESCRIPTION
Fixes an LQL encoder issue with `t:` filter rules. A rule such as `t:2025-08-25` is accepted by the parser but `Encoder.to_querystring` encodes it to `t:=2025-08-25`, causing an error.


## Demo
### Before

https://github.com/user-attachments/assets/eb7f3a50-438d-48db-8136-9c9bc64aa3db

### After (no error message)


https://github.com/user-attachments/assets/0b1d3176-6ceb-4abb-b315-e594bdc116f6

