### PR TITLE
Add BigQuery backend connection testing

### DIFF
--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -11,16 +11,17 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   require OpenTelemetry.Tracer
 
   alias Ecto.Changeset
+  alias GoogleApi.BigQuery.V2.Api.Tables
+  alias GoogleApi.BigQuery.V2.Model
   alias GoogleApi.IAM.V1.Api.Projects, as: IAMProjects
   alias GoogleApi.IAM.V1.Model.CreateServiceAccountRequest
-  alias GoogleApi.BigQuery.V2.Model
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
+  alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.Backend
   alias Logflare.Backends.DynamicPipeline
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.IngestEventQueue
-  alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.QueryError
   alias Logflare.BigQuery.SchemaTypes
   alias Logflare.Billing
@@ -45,6 +46,24 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @timeout_error_regex ~r/timed out/i
   @search_query_timeout_ms 60_000
   @endpoint_query_timeout_ms 60_000
+  @connection_test_insert_attempts 5
+  @connection_test_message "Logflare BigQuery connection test. No action required."
+  @connection_test_retry_delay_ms 200
+  @connection_test_table :_logflare_connection_test
+  @connection_test_table_ttl :timer.hours(24)
+  @connection_test_table_ttl_string Integer.to_string(@connection_test_table_ttl)
+
+  @typep connection_test_table_status :: :created | :existing | :recently_created
+
+  @type connection_test_error ::
+          :connection_error
+          | :http_client_error
+          | :http_server_error
+          | :insert_error
+          | :invalid_config
+          | :probe_table_conflict
+          | :probe_table_initializing
+          | :unknown_error
 
   @impl Logflare.Backends.Adaptor
   def start_link({source, backend} = source_backend) do
@@ -161,8 +180,289 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
     |> String.replace("-", "_")
   end
 
+  @doc """
+  Creates or reuses a persistent fixed probe table and writes a labeled event
+  through the REST ingestion path. The table's daily partitions have a 24-hour TTL.
+  """
   @impl Logflare.Backends.Adaptor
-  def test_connection(_), do: {:error, :not_implemented}
+  @spec test_connection(Backend.t()) :: :ok | {:error, connection_test_error()}
+  def test_connection(
+        %Backend{
+          id: backend_id,
+          config: %{project_id: project_id, dataset_id: dataset_id}
+        } = backend
+      )
+      when is_integer(backend_id) and is_non_empty_binary(project_id) and
+             is_non_empty_binary(dataset_id) do
+    with {:ok, table_status} <- ensure_connection_test_table(backend, project_id, dataset_id) do
+      row = connection_test_row()
+
+      project_id
+      |> insert_connection_test_row(dataset_id, row, table_status)
+      |> handle_connection_test_response(backend)
+    end
+  end
+
+  def test_connection(%Backend{}), do: {:error, :invalid_config}
+
+  @spec ensure_connection_test_table(Backend.t(), String.t(), String.t()) ::
+          {:ok, connection_test_table_status()} | {:error, connection_test_error()}
+  defp ensure_connection_test_table(backend, project_id, dataset_id) do
+    case get_connection_test_table(project_id, dataset_id) do
+      {:ok, %Model.Table{} = table} ->
+        validate_connection_test_table(table, backend, :existing)
+
+      {:error, %Tesla.Env{status: 404}} ->
+        create_connection_test_table(backend, project_id, dataset_id)
+
+      response ->
+        handle_connection_test_response(response, backend)
+    end
+  end
+
+  @spec create_connection_test_table(Backend.t(), String.t(), String.t()) ::
+          {:ok, connection_test_table_status()} | {:error, connection_test_error()}
+  defp create_connection_test_table(backend, project_id, dataset_id) do
+    case Google.BigQuery.create_table(
+           @connection_test_table,
+           dataset_id,
+           project_id,
+           @connection_test_table_ttl
+         ) do
+      {:ok, %Model.Table{}} ->
+        {:ok, :created}
+
+      {:error, %Tesla.Env{status: 409}} ->
+        case get_connection_test_table(project_id, dataset_id) do
+          {:ok, %Model.Table{} = table} ->
+            validate_connection_test_table(table, backend, :recently_created)
+
+          response ->
+            handle_connection_test_response(response, backend)
+        end
+
+      response ->
+        handle_connection_test_response(response, backend)
+    end
+  end
+
+  @spec get_connection_test_table(String.t(), String.t()) ::
+          {:ok, Model.Table.t()} | {:error, term()}
+  defp get_connection_test_table(project_id, dataset_id) do
+    GenUtils.get_conn(:ingest)
+    |> Tables.bigquery_tables_get(
+      project_id,
+      dataset_id,
+      format_table_name(@connection_test_table)
+    )
+  end
+
+  @spec validate_connection_test_table(
+          Model.Table.t(),
+          Backend.t(),
+          connection_test_table_status()
+        ) :: {:ok, connection_test_table_status()} | {:error, connection_test_error()}
+  defp validate_connection_test_table(table, backend, status) do
+    if valid_connection_test_table?(table) do
+      {:ok, status}
+    else
+      connection_test_failed(backend, :probe_table_conflict, :invalid_probe_table)
+    end
+  end
+
+  @spec valid_connection_test_table?(Model.Table.t()) :: boolean()
+  defp valid_connection_test_table?(%Model.Table{
+         type: "TABLE",
+         labels: %{
+           "managed_by" => "logflare",
+           "logflare_source" => "_logflare_connection_test"
+         },
+         requirePartitionFilter: true,
+         schema: %Model.TableSchema{fields: fields},
+         timePartitioning: %Model.TimePartitioning{
+           expirationMs: expiration_ms,
+           field: "timestamp",
+           type: "DAY"
+         }
+       })
+       when is_list(fields) and
+              expiration_ms in [@connection_test_table_ttl, @connection_test_table_ttl_string] do
+    required_fields = [
+      {"timestamp", "TIMESTAMP", "REQUIRED"},
+      {"id", "STRING", "NULLABLE"},
+      {"event_message", "STRING", "NULLABLE"}
+    ]
+
+    Enum.all?(required_fields, fn {name, type, mode} ->
+      Enum.any?(
+        fields,
+        &match?(%Model.TableFieldSchema{name: ^name, type: ^type, mode: ^mode}, &1)
+      )
+    end)
+  end
+
+  defp valid_connection_test_table?(%Model.Table{}), do: false
+
+  @spec connection_test_row() :: Model.TableDataInsertAllRequestRows.t()
+  defp connection_test_row do
+    id = Ecto.UUID.generate()
+
+    %Model.TableDataInsertAllRequestRows{
+      insertId: id,
+      json: %{
+        "event_message" => @connection_test_message,
+        "id" => id,
+        "timestamp" => DateTime.utc_now()
+      }
+    }
+  end
+
+  @spec insert_connection_test_row(
+          String.t(),
+          String.t(),
+          Model.TableDataInsertAllRequestRows.t(),
+          connection_test_table_status()
+        ) :: term()
+  defp insert_connection_test_row(project_id, dataset_id, row, table_status) do
+    retry_not_found? = table_status in [:created, :recently_created]
+    attempts = if retry_not_found?, do: @connection_test_insert_attempts, else: 1
+    do_insert_connection_test_row(project_id, dataset_id, row, attempts, retry_not_found?)
+  end
+
+  @spec do_insert_connection_test_row(
+          String.t(),
+          String.t(),
+          Model.TableDataInsertAllRequestRows.t(),
+          pos_integer(),
+          boolean()
+        ) :: term()
+  defp do_insert_connection_test_row(
+         project_id,
+         dataset_id,
+         row,
+         attempts_left,
+         retry_not_found?
+       ) do
+    response =
+      Google.BigQuery.stream_batch!(
+        %{
+          bigquery_project_id: project_id,
+          bigquery_dataset_id: dataset_id,
+          source_token: @connection_test_table
+        },
+        [row]
+      )
+
+    case response do
+      {:error, %Tesla.Env{status: 404}} when retry_not_found? and attempts_left > 1 ->
+        retry_number = @connection_test_insert_attempts - attempts_left
+        Process.sleep(@connection_test_retry_delay_ms * Integer.pow(2, retry_number))
+
+        do_insert_connection_test_row(
+          project_id,
+          dataset_id,
+          row,
+          attempts_left - 1,
+          retry_not_found?
+        )
+
+      {:error, %Tesla.Env{status: 404}} when retry_not_found? ->
+        {:error, :probe_table_initializing}
+
+      response ->
+        response
+    end
+  end
+
+  @spec handle_connection_test_response(term(), Backend.t()) ::
+          :ok | {:error, connection_test_error()}
+  defp handle_connection_test_response(
+         {:ok, %Model.TableDataInsertAllResponse{insertErrors: insert_errors}},
+         _backend
+       )
+       when insert_errors in [nil, []],
+       do: :ok
+
+  defp handle_connection_test_response(
+         {:ok, %Model.TableDataInsertAllResponse{insertErrors: insert_errors}},
+         backend
+       ) do
+    connection_test_failed(backend, :insert_error, insert_errors)
+  end
+
+  defp handle_connection_test_response(
+         {:error, %Tesla.Env{status: status, body: body}},
+         backend
+       )
+       when status in 400..499 do
+    connection_test_failed(backend, :http_client_error, %{status: status, body: body})
+  end
+
+  defp handle_connection_test_response(
+         {:error, %Tesla.Env{status: status, body: body}},
+         backend
+       )
+       when status in 500..599 do
+    connection_test_failed(backend, :http_server_error, %{status: status, body: body})
+  end
+
+  defp handle_connection_test_response(
+         {:error, %Tesla.Env{status: status, body: body}},
+         backend
+       ) do
+    connection_test_failed(backend, :unknown_error, %{status: status, body: body})
+  end
+
+  defp handle_connection_test_response({:error, error}, backend)
+       when error in [:closed, :emfile, :timeout] do
+    connection_test_failed(backend, :connection_error, error)
+  end
+
+  defp handle_connection_test_response({:error, :probe_table_initializing}, backend) do
+    connection_test_failed(backend, :probe_table_initializing, :probe_table_initializing)
+  end
+
+  defp handle_connection_test_response({:error, error}, backend) do
+    connection_test_failed(backend, :unknown_error, error)
+  end
+
+  defp handle_connection_test_response(response, backend) do
+    connection_test_failed(backend, :unknown_error, response)
+  end
+
+  @spec connection_test_failed(
+          Backend.t(),
+          connection_test_error(),
+          term()
+        ) :: {:error, connection_test_error()}
+  defp connection_test_failed(backend, reason, error) do
+    Logger.warning("BigQuery connection test failed.",
+      backend_id: backend.id,
+      user_id: backend.user_id,
+      table_name: @connection_test_table,
+      reason: reason,
+      error_string: format_connection_test_error(error)
+    )
+
+    {:error, reason}
+  end
+
+  @spec format_connection_test_error(term()) :: String.t()
+  defp format_connection_test_error(%{status: status, body: body}) do
+    inspect(%{status: status, body: body}, limit: 20, printable_limit: 2_000)
+  end
+
+  defp format_connection_test_error(errors) when is_list(errors) do
+    inspect(errors, limit: 20, printable_limit: 2_000)
+  end
+
+  defp format_connection_test_error(error) when is_atom(error), do: inspect(error)
+
+  defp format_connection_test_error(%{__struct__: module}) do
+    "unexpected #{inspect(module)}"
+  end
+
+  defp format_connection_test_error(_error), do: "unexpected response"
 
   @impl Logflare.Backends.Adaptor
   def ecto_to_sql(%Ecto.Query{} = query, _opts) do

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -11,16 +11,16 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   require OpenTelemetry.Tracer
 
   alias Ecto.Changeset
-  alias GoogleApi.BigQuery.V2.Model
   alias GoogleApi.IAM.V1.Api.Projects, as: IAMProjects
   alias GoogleApi.IAM.V1.Model.CreateServiceAccountRequest
+  alias GoogleApi.BigQuery.V2.Model
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
-  alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.Backend
   alias Logflare.Backends.DynamicPipeline
   alias Logflare.Backends.Ecto.SqlUtils
   alias Logflare.Backends.IngestEventQueue
+  alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.QueryError
   alias Logflare.BigQuery.SchemaTypes
   alias Logflare.Billing

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -11,7 +11,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   require OpenTelemetry.Tracer
 
   alias Ecto.Changeset
-  alias GoogleApi.BigQuery.V2.Api.Tables
   alias GoogleApi.BigQuery.V2.Model
   alias GoogleApi.IAM.V1.Api.Projects, as: IAMProjects
   alias GoogleApi.IAM.V1.Model.CreateServiceAccountRequest
@@ -32,7 +31,9 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   alias Logflare.Google.BigQuery.GCPConfig
   alias Logflare.Google.BigQuery.GenUtils
   alias Logflare.Google.CloudResourceManager
+  alias Logflare.Rules
   alias Logflare.Sources
+  alias Logflare.Sources.Source
   alias Logflare.Sources.Source.BigQuery.Pipeline
   alias Logflare.Sources.Source.BigQuery.Schema
   alias Logflare.User
@@ -46,14 +47,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   @timeout_error_regex ~r/timed out/i
   @search_query_timeout_ms 60_000
   @endpoint_query_timeout_ms 60_000
-  @connection_test_insert_attempts 5
   @connection_test_message "Logflare BigQuery connection test. No action required."
-  @connection_test_retry_delay_ms 200
-  @connection_test_table :_logflare_connection_test
-  @connection_test_table_ttl :timer.hours(24)
-  @connection_test_table_ttl_string Integer.to_string(@connection_test_table_ttl)
-
-  @typep connection_test_table_status :: :created | :existing | :recently_created
 
   @type connection_test_error ::
           :connection_error
@@ -61,8 +55,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
           | :http_server_error
           | :insert_error
           | :invalid_config
-          | :probe_table_conflict
-          | :probe_table_initializing
+          | :source_required
           | :unknown_error
 
   @impl Logflare.Backends.Adaptor
@@ -181,127 +174,71 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   end
 
   @doc """
-  Creates or reuses a persistent fixed probe table and writes a labeled event
-  through the REST ingestion path. The table's daily partitions have a 24-hour TTL.
+  Writes a labeled event through the REST ingestion path to an attached source's table.
+
+  Direct source attachments are preferred over rule sources.
   """
   @impl Logflare.Backends.Adaptor
   @spec test_connection(Backend.t()) :: :ok | {:error, connection_test_error()}
   def test_connection(
         %Backend{
           id: backend_id,
+          user_id: user_id,
           config: %{project_id: project_id, dataset_id: dataset_id}
         } = backend
       )
-      when is_integer(backend_id) and is_non_empty_binary(project_id) and
+      when is_integer(backend_id) and is_integer(user_id) and is_non_empty_binary(project_id) and
              is_non_empty_binary(dataset_id) do
-    with {:ok, table_status} <- ensure_connection_test_table(backend, project_id, dataset_id) do
-      row = connection_test_row()
-
-      project_id
-      |> insert_connection_test_row(dataset_id, row, table_status)
-      |> handle_connection_test_response(backend)
+    with {:ok, %Source{token: source_token}} <- connection_test_source(backend) do
+      Google.BigQuery.stream_batch!(
+        %{
+          bigquery_project_id: project_id,
+          bigquery_dataset_id: dataset_id,
+          source_token: source_token
+        },
+        [connection_test_row()]
+      )
+      |> handle_connection_test_response(backend, source_token)
     end
   end
 
   def test_connection(%Backend{}), do: {:error, :invalid_config}
 
-  @spec ensure_connection_test_table(Backend.t(), String.t(), String.t()) ::
-          {:ok, connection_test_table_status()} | {:error, connection_test_error()}
-  defp ensure_connection_test_table(backend, project_id, dataset_id) do
-    case get_connection_test_table(project_id, dataset_id) do
-      {:ok, %Model.Table{} = table} ->
-        validate_connection_test_table(table, backend, :existing)
+  @spec connection_test_source(Backend.t()) :: {:ok, Source.t()} | {:error, :source_required}
+  defp connection_test_source(%Backend{id: backend_id, user_id: user_id}) do
+    direct_source =
+      [backend_id: backend_id, user_id: user_id]
+      |> Sources.list_sources()
+      |> Enum.min_by(& &1.id, fn -> nil end)
 
-      {:error, %Tesla.Env{status: 404}} ->
-        create_connection_test_table(backend, project_id, dataset_id)
+    case direct_source do
+      %Source{} = source ->
+        {:ok, source}
 
-      response ->
-        handle_connection_test_response(response, backend)
+      nil ->
+        connection_test_rule_source(backend_id, user_id)
     end
   end
 
-  @spec create_connection_test_table(Backend.t(), String.t(), String.t()) ::
-          {:ok, connection_test_table_status()} | {:error, connection_test_error()}
-  defp create_connection_test_table(backend, project_id, dataset_id) do
-    case Google.BigQuery.create_table(
-           @connection_test_table,
-           dataset_id,
-           project_id,
-           @connection_test_table_ttl
-         ) do
-      {:ok, %Model.Table{}} ->
-        {:ok, :created}
+  @spec connection_test_rule_source(pos_integer(), pos_integer()) ::
+          {:ok, Source.t()} | {:error, :source_required}
+  defp connection_test_rule_source(backend_id, user_id) do
+    rule =
+      user_id
+      |> Rules.list_rules_by_user_id(backend_id)
+      |> Enum.min_by(& &1.source_id, fn -> nil end)
 
-      {:error, %Tesla.Env{status: 409}} ->
-        case get_connection_test_table(project_id, dataset_id) do
-          {:ok, %Model.Table{} = table} ->
-            validate_connection_test_table(table, backend, :recently_created)
-
-          response ->
-            handle_connection_test_response(response, backend)
+    case rule do
+      %{source_id: source_id} ->
+        case Sources.fetch_source_by(id: source_id, user_id: user_id) do
+          {:ok, %Source{} = source} -> {:ok, source}
+          {:error, :not_found} -> {:error, :source_required}
         end
 
-      response ->
-        handle_connection_test_response(response, backend)
+      nil ->
+        {:error, :source_required}
     end
   end
-
-  @spec get_connection_test_table(String.t(), String.t()) ::
-          {:ok, Model.Table.t()} | {:error, term()}
-  defp get_connection_test_table(project_id, dataset_id) do
-    GenUtils.get_conn(:ingest)
-    |> Tables.bigquery_tables_get(
-      project_id,
-      dataset_id,
-      format_table_name(@connection_test_table)
-    )
-  end
-
-  @spec validate_connection_test_table(
-          Model.Table.t(),
-          Backend.t(),
-          connection_test_table_status()
-        ) :: {:ok, connection_test_table_status()} | {:error, connection_test_error()}
-  defp validate_connection_test_table(table, backend, status) do
-    if valid_connection_test_table?(table) do
-      {:ok, status}
-    else
-      connection_test_failed(backend, :probe_table_conflict, :invalid_probe_table)
-    end
-  end
-
-  @spec valid_connection_test_table?(Model.Table.t()) :: boolean()
-  defp valid_connection_test_table?(%Model.Table{
-         type: "TABLE",
-         labels: %{
-           "managed_by" => "logflare",
-           "logflare_source" => "_logflare_connection_test"
-         },
-         requirePartitionFilter: true,
-         schema: %Model.TableSchema{fields: fields},
-         timePartitioning: %Model.TimePartitioning{
-           expirationMs: expiration_ms,
-           field: "timestamp",
-           type: "DAY"
-         }
-       })
-       when is_list(fields) and
-              expiration_ms in [@connection_test_table_ttl, @connection_test_table_ttl_string] do
-    required_fields = [
-      {"timestamp", "TIMESTAMP", "REQUIRED"},
-      {"id", "STRING", "NULLABLE"},
-      {"event_message", "STRING", "NULLABLE"}
-    ]
-
-    Enum.all?(required_fields, fn {name, type, mode} ->
-      Enum.any?(
-        fields,
-        &match?(%Model.TableFieldSchema{name: ^name, type: ^type, mode: ^mode}, &1)
-      )
-    end)
-  end
-
-  defp valid_connection_test_table?(%Model.Table{}), do: false
 
   @spec connection_test_row() :: Model.TableDataInsertAllRequestRows.t()
   defp connection_test_row do
@@ -317,129 +254,80 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
     }
   end
 
-  @spec insert_connection_test_row(
-          String.t(),
-          String.t(),
-          Model.TableDataInsertAllRequestRows.t(),
-          connection_test_table_status()
-        ) :: term()
-  defp insert_connection_test_row(project_id, dataset_id, row, table_status) do
-    retry_not_found? = table_status in [:created, :recently_created]
-    attempts = if retry_not_found?, do: @connection_test_insert_attempts, else: 1
-    do_insert_connection_test_row(project_id, dataset_id, row, attempts, retry_not_found?)
-  end
-
-  @spec do_insert_connection_test_row(
-          String.t(),
-          String.t(),
-          Model.TableDataInsertAllRequestRows.t(),
-          pos_integer(),
-          boolean()
-        ) :: term()
-  defp do_insert_connection_test_row(
-         project_id,
-         dataset_id,
-         row,
-         attempts_left,
-         retry_not_found?
-       ) do
-    response =
-      Google.BigQuery.stream_batch!(
-        %{
-          bigquery_project_id: project_id,
-          bigquery_dataset_id: dataset_id,
-          source_token: @connection_test_table
-        },
-        [row]
-      )
-
-    case response do
-      {:error, %Tesla.Env{status: 404}} when retry_not_found? and attempts_left > 1 ->
-        retry_number = @connection_test_insert_attempts - attempts_left
-        Process.sleep(@connection_test_retry_delay_ms * Integer.pow(2, retry_number))
-
-        do_insert_connection_test_row(
-          project_id,
-          dataset_id,
-          row,
-          attempts_left - 1,
-          retry_not_found?
-        )
-
-      {:error, %Tesla.Env{status: 404}} when retry_not_found? ->
-        {:error, :probe_table_initializing}
-
-      response ->
-        response
-    end
-  end
-
-  @spec handle_connection_test_response(term(), Backend.t()) ::
+  @spec handle_connection_test_response(term(), Backend.t(), atom()) ::
           :ok | {:error, connection_test_error()}
   defp handle_connection_test_response(
          {:ok, %Model.TableDataInsertAllResponse{insertErrors: insert_errors}},
-         _backend
+         _backend,
+         _source_token
        )
        when insert_errors in [nil, []],
        do: :ok
 
   defp handle_connection_test_response(
          {:ok, %Model.TableDataInsertAllResponse{insertErrors: insert_errors}},
-         backend
+         backend,
+         source_token
        ) do
-    connection_test_failed(backend, :insert_error, insert_errors)
+    connection_test_failed(backend, source_token, :insert_error, insert_errors)
   end
 
   defp handle_connection_test_response(
          {:error, %Tesla.Env{status: status, body: body}},
-         backend
+         backend,
+         source_token
        )
        when status in 400..499 do
-    connection_test_failed(backend, :http_client_error, %{status: status, body: body})
+    connection_test_failed(backend, source_token, :http_client_error, %{
+      status: status,
+      body: body
+    })
   end
 
   defp handle_connection_test_response(
          {:error, %Tesla.Env{status: status, body: body}},
-         backend
+         backend,
+         source_token
        )
        when status in 500..599 do
-    connection_test_failed(backend, :http_server_error, %{status: status, body: body})
+    connection_test_failed(backend, source_token, :http_server_error, %{
+      status: status,
+      body: body
+    })
   end
 
   defp handle_connection_test_response(
          {:error, %Tesla.Env{status: status, body: body}},
-         backend
+         backend,
+         source_token
        ) do
-    connection_test_failed(backend, :unknown_error, %{status: status, body: body})
+    connection_test_failed(backend, source_token, :unknown_error, %{status: status, body: body})
   end
 
-  defp handle_connection_test_response({:error, error}, backend)
+  defp handle_connection_test_response({:error, error}, backend, source_token)
        when error in [:closed, :emfile, :timeout] do
-    connection_test_failed(backend, :connection_error, error)
+    connection_test_failed(backend, source_token, :connection_error, error)
   end
 
-  defp handle_connection_test_response({:error, :probe_table_initializing}, backend) do
-    connection_test_failed(backend, :probe_table_initializing, :probe_table_initializing)
+  defp handle_connection_test_response({:error, error}, backend, source_token) do
+    connection_test_failed(backend, source_token, :unknown_error, error)
   end
 
-  defp handle_connection_test_response({:error, error}, backend) do
-    connection_test_failed(backend, :unknown_error, error)
-  end
-
-  defp handle_connection_test_response(response, backend) do
-    connection_test_failed(backend, :unknown_error, response)
+  defp handle_connection_test_response(response, backend, source_token) do
+    connection_test_failed(backend, source_token, :unknown_error, response)
   end
 
   @spec connection_test_failed(
           Backend.t(),
+          atom(),
           connection_test_error(),
           term()
         ) :: {:error, connection_test_error()}
-  defp connection_test_failed(backend, reason, error) do
+  defp connection_test_failed(backend, source_token, reason, error) do
     Logger.warning("BigQuery connection test failed.",
       backend_id: backend.id,
       user_id: backend.user_id,
-      table_name: @connection_test_table,
+      table_name: format_table_name(source_token),
       reason: reason,
       error_string: format_connection_test_error(error)
     )

--- a/lib/logflare_web/live/backends/components.ex
+++ b/lib/logflare_web/live/backends/components.ex
@@ -33,6 +33,11 @@ defmodule LogflareWeb.Backends.Components do
     LogflareWeb.QueryErrorHelpers.query_error_message(query_error)
   end
 
+  defp status_error_message(reason)
+       when reason in [:source_required, {:error, :source_required}] do
+    "Attach a source or add a drain rule before testing this connection."
+  end
+
   defp status_error_message(_reason) do
     LogflareWeb.QueryErrorHelpers.generic_query_error_message()
   end

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -5,10 +5,20 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
   import Ecto.Query
 
   alias GoogleApi.BigQuery.V2.Api.Jobs, as: BqJobs
-  alias Logflare.Backends.Backend
+  alias GoogleApi.BigQuery.V2.Api.Tabledata, as: BqTabledata
+  alias GoogleApi.BigQuery.V2.Api.Tables, as: BqTables
+  alias GoogleApi.BigQuery.V2.Model
+  alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.Backends.Adaptor.QueryResult
+  alias Logflare.Backends.Backend
   alias Logflare.Backends.QueryError
+  alias Logflare.Google
+
+  @connection_test_message "Logflare BigQuery connection test. No action required."
+  @connection_test_table :_logflare_connection_test
+  @connection_test_table_name Atom.to_string(@connection_test_table)
+  @connection_test_table_ttl :timer.hours(24)
 
   # Characters illegal in a BigQuery dataset identifier: SQL delimiters,
   # identifier-quoting characters, whitespace, and shell metacharacters.
@@ -20,6 +30,29 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
             suffix <- string(:alphanumeric) do
       prefix <> <<bad_char>> <> suffix
     end
+  end
+
+  defp connection_test_table do
+    %Model.Table{
+      labels: %{
+        "managed_by" => "logflare",
+        "logflare_source" => @connection_test_table_name
+      },
+      requirePartitionFilter: true,
+      schema: %Model.TableSchema{
+        fields: [
+          %Model.TableFieldSchema{name: "timestamp", type: "TIMESTAMP", mode: "REQUIRED"},
+          %Model.TableFieldSchema{name: "id", type: "STRING", mode: "NULLABLE"},
+          %Model.TableFieldSchema{name: "event_message", type: "STRING", mode: "NULLABLE"}
+        ]
+      },
+      timePartitioning: %Model.TimePartitioning{
+        expirationMs: Integer.to_string(@connection_test_table_ttl),
+        field: "timestamp",
+        type: "DAY"
+      },
+      type: "TABLE"
+    }
   end
 
   describe "validate_config/1" do
@@ -57,6 +90,310 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
     test "allows nil dataset_id and project_id" do
       changeset = BigQueryAdaptor.cast_config(%{})
       assert BigQueryAdaptor.validate_config(changeset).valid?
+    end
+  end
+
+  describe "test_connection/1" do
+    setup do
+      insert(:plan)
+      user = insert(:user)
+
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          config: %{project_id: "test-project", dataset_id: "test_dataset"}
+        )
+
+      [backend: Backends.get_backend(backend.id)]
+    end
+
+    test "creates a fixed probe table and writes one labeled event through REST", %{
+      backend: backend
+    } do
+      BqTables
+      |> expect(:bigquery_tables_get, fn _conn,
+                                         "test-project",
+                                         "test_dataset",
+                                         @connection_test_table_name ->
+        {:error, %Tesla.Env{status: 404}}
+      end)
+
+      BqTables
+      |> expect(:bigquery_tables_insert, fn _conn, project_id, dataset_id, opts ->
+        assert project_id == "test-project"
+        assert dataset_id == "test_dataset"
+
+        assert %Model.Table{
+                 tableReference: %Model.TableReference{
+                   projectId: "test-project",
+                   datasetId: "test_dataset",
+                   tableId: @connection_test_table_name
+                 },
+                 labels: %{
+                   "managed_by" => "logflare",
+                   "logflare_source" => @connection_test_table_name
+                 },
+                 requirePartitionFilter: true,
+                 schema: %Model.TableSchema{fields: fields},
+                 timePartitioning: %Model.TimePartitioning{
+                   field: "timestamp",
+                   type: "DAY",
+                   expirationMs: @connection_test_table_ttl
+                 }
+               } = table = opts[:body]
+
+        assert Enum.map(fields, &{&1.name, &1.type, &1.mode}) == [
+                 {"timestamp", "TIMESTAMP", "REQUIRED"},
+                 {"id", "STRING", "NULLABLE"},
+                 {"event_message", "STRING", "NULLABLE"}
+               ]
+
+        {:ok, table}
+      end)
+
+      BqTabledata
+      |> expect(:bigquery_tabledata_insert_all, fn _conn,
+                                                   project_id,
+                                                   dataset_id,
+                                                   table_name,
+                                                   opts ->
+        assert project_id == "test-project"
+        assert dataset_id == "test_dataset"
+        assert table_name == @connection_test_table_name
+
+        assert %Model.TableDataInsertAllRequest{
+                 ignoreUnknownValues: true,
+                 skipInvalidRows: true,
+                 rows: [%Model.TableDataInsertAllRequestRows{} = row]
+               } = opts[:body]
+
+        assert row.insertId == row.json["id"]
+        assert is_binary(row.insertId)
+        assert %DateTime{} = row.json["timestamp"]
+        assert row.json["event_message"] == @connection_test_message
+
+        {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      assert :ok = BigQueryAdaptor.test_connection(backend)
+    end
+
+    test "reuses the probe table when it already exists", %{backend: backend} do
+      BqTables
+      |> expect(:bigquery_tables_get, fn _conn,
+                                         "test-project",
+                                         "test_dataset",
+                                         @connection_test_table_name ->
+        {:ok, connection_test_table()}
+      end)
+
+      Mimic.reject(Google.BigQuery, :create_table, 4)
+
+      BqTabledata
+      |> expect(:bigquery_tabledata_insert_all, fn _conn,
+                                                   _project_id,
+                                                   _dataset_id,
+                                                   table_name,
+                                                   _opts ->
+        assert table_name == @connection_test_table_name
+        {:ok, %Model.TableDataInsertAllResponse{insertErrors: []}}
+      end)
+
+      assert :ok = BigQueryAdaptor.test_connection(backend)
+    end
+
+    test "retries a not-found insert after creating the probe table", %{backend: backend} do
+      BqTables
+      |> expect(:bigquery_tables_get, fn _conn,
+                                         "test-project",
+                                         "test_dataset",
+                                         @connection_test_table_name ->
+        {:error, %Tesla.Env{status: 404}}
+      end)
+
+      Google.BigQuery
+      |> expect(:create_table, fn @connection_test_table,
+                                  "test_dataset",
+                                  "test-project",
+                                  @connection_test_table_ttl ->
+        {:ok, connection_test_table()}
+      end)
+
+      test_pid = self()
+
+      Google.BigQuery
+      |> expect(:stream_batch!, 2, fn _context, [row] ->
+        send(test_pid, {:insert_attempt, row.insertId})
+        attempt = Process.get(:connection_test_insert_attempt, 0)
+        Process.put(:connection_test_insert_attempt, attempt + 1)
+
+        if attempt == 0 do
+          {:error, %Tesla.Env{status: 404}}
+        else
+          {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
+        end
+      end)
+
+      assert :ok = BigQueryAdaptor.test_connection(backend)
+      assert_receive {:insert_attempt, insert_id}
+      assert_receive {:insert_attempt, ^insert_id}
+    end
+
+    test "handles another request creating the probe table concurrently", %{backend: backend} do
+      BqTables
+      |> expect(:bigquery_tables_get, 2, fn _conn,
+                                            "test-project",
+                                            "test_dataset",
+                                            @connection_test_table_name ->
+        attempt = Process.get(:connection_test_table_get_attempt, 0)
+        Process.put(:connection_test_table_get_attempt, attempt + 1)
+
+        if attempt == 0 do
+          {:error, %Tesla.Env{status: 404}}
+        else
+          {:ok, connection_test_table()}
+        end
+      end)
+
+      Google.BigQuery
+      |> expect(:create_table, fn @connection_test_table,
+                                  "test_dataset",
+                                  "test-project",
+                                  @connection_test_table_ttl ->
+        {:error, %Tesla.Env{status: 409}}
+      end)
+
+      Google.BigQuery
+      |> expect(:stream_batch!, 2, fn _context, [row] ->
+        attempt = Process.get(:concurrent_connection_test_insert_attempt, 0)
+        Process.put(:concurrent_connection_test_insert_attempt, attempt + 1)
+
+        if attempt == 0 do
+          Process.put(:concurrent_connection_test_insert_id, row.insertId)
+          {:error, %Tesla.Env{status: 404}}
+        else
+          assert Process.get(:concurrent_connection_test_insert_id) == row.insertId
+          {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
+        end
+      end)
+
+      assert :ok = BigQueryAdaptor.test_connection(backend)
+    end
+
+    test "rejects an unrelated table using the probe table name", %{backend: backend} do
+      BqTables
+      |> expect(:bigquery_tables_get, fn _conn,
+                                         "test-project",
+                                         "test_dataset",
+                                         @connection_test_table_name ->
+        {:ok, %Model.Table{type: "VIEW"}}
+      end)
+
+      Mimic.reject(Google.BigQuery, :create_table, 4)
+      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
+
+      assert {:error, :probe_table_conflict} = BigQueryAdaptor.test_connection(backend)
+    end
+
+    test "returns an atom for insert failures", %{backend: backend} do
+      BqTables
+      |> stub(:bigquery_tables_get, fn _conn,
+                                       "test-project",
+                                       "test_dataset",
+                                       @connection_test_table_name ->
+        {:ok, connection_test_table()}
+      end)
+
+      responses = [
+        {{:ok, %Model.TableDataInsertAllResponse{insertErrors: [%{index: 0}]}}, :insert_error},
+        {{:error, %Tesla.Env{status: 404, body: %{"error" => "not found"}}}, :http_client_error},
+        {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
+        {{:error, %Tesla.Env{status: 503, body: %{"error" => "unavailable"}}},
+         :http_server_error},
+        {{:error, :timeout}, :connection_error},
+        {{:error, :unexpected}, :unknown_error},
+        {{:ok, :unexpected}, :unknown_error}
+      ]
+
+      for {response, expected_reason} <- responses do
+        Google.BigQuery
+        |> expect(:stream_batch!, fn _context, [_row] -> response end)
+
+        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
+      end
+    end
+
+    test "returns an atom when the probe table cannot be read", %{backend: backend} do
+      Mimic.reject(Google.BigQuery, :create_table, 4)
+      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
+
+      responses = [
+        {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
+        {{:error, %Tesla.Env{status: 503, body: %{"error" => "unavailable"}}},
+         :http_server_error},
+        {{:error, :timeout}, :connection_error},
+        {{:ok, :unexpected}, :unknown_error}
+      ]
+
+      for {response, expected_reason} <- responses do
+        BqTables
+        |> expect(:bigquery_tables_get, fn _conn,
+                                           "test-project",
+                                           "test_dataset",
+                                           @connection_test_table_name ->
+          response
+        end)
+
+        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
+      end
+    end
+
+    test "returns an atom when the probe table cannot be created", %{backend: backend} do
+      BqTables
+      |> stub(:bigquery_tables_get, fn _conn,
+                                       "test-project",
+                                       "test_dataset",
+                                       @connection_test_table_name ->
+        {:error, %Tesla.Env{status: 404}}
+      end)
+
+      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
+
+      responses = [
+        {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
+        {{:error, %Tesla.Env{status: 503, body: %{"error" => "unavailable"}}},
+         :http_server_error},
+        {{:error, :timeout}, :connection_error},
+        {{:ok, :unexpected}, :unknown_error}
+      ]
+
+      for {response, expected_reason} <- responses do
+        Google.BigQuery
+        |> expect(:create_table, fn @connection_test_table,
+                                    "test_dataset",
+                                    "test-project",
+                                    @connection_test_table_ttl ->
+          response
+        end)
+
+        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
+      end
+    end
+
+    test "rejects incomplete configuration without making a request", %{backend: backend} do
+      Mimic.reject(BqTables, :bigquery_tables_get, 5)
+      Mimic.reject(Google.BigQuery, :create_table, 4)
+      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
+
+      for config <- [
+            %{},
+            %{project_id: "", dataset_id: "test_dataset"},
+            %{project_id: "test-project", dataset_id: nil}
+          ] do
+        assert {:error, :invalid_config} =
+                 BigQueryAdaptor.test_connection(%{backend | config: config})
+      end
     end
   end
 

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -8,11 +8,11 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
   alias GoogleApi.BigQuery.V2.Api.Tabledata, as: BqTabledata
   alias GoogleApi.BigQuery.V2.Api.Tables, as: BqTables
   alias GoogleApi.BigQuery.V2.Model
+  alias Logflare.Backends.Backend
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
   alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
   alias Logflare.Backends.Adaptor.QueryResult
-  alias Logflare.Backends.Backend
   alias Logflare.Backends.QueryError
   alias Logflare.Google
 

--- a/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/bigquery_adaptor_test.exs
@@ -10,15 +10,13 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
   alias GoogleApi.BigQuery.V2.Model
   alias Logflare.Backends
   alias Logflare.Backends.Adaptor.BigQueryAdaptor
+  alias Logflare.Backends.Adaptor.BigQueryAdaptor.GoogleApiClient
   alias Logflare.Backends.Adaptor.QueryResult
   alias Logflare.Backends.Backend
   alias Logflare.Backends.QueryError
   alias Logflare.Google
 
   @connection_test_message "Logflare BigQuery connection test. No action required."
-  @connection_test_table :_logflare_connection_test
-  @connection_test_table_name Atom.to_string(@connection_test_table)
-  @connection_test_table_ttl :timer.hours(24)
 
   # Characters illegal in a BigQuery dataset identifier: SQL delimiters,
   # identifier-quoting characters, whitespace, and shell metacharacters.
@@ -30,29 +28,6 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
             suffix <- string(:alphanumeric) do
       prefix <> <<bad_char>> <> suffix
     end
-  end
-
-  defp connection_test_table do
-    %Model.Table{
-      labels: %{
-        "managed_by" => "logflare",
-        "logflare_source" => @connection_test_table_name
-      },
-      requirePartitionFilter: true,
-      schema: %Model.TableSchema{
-        fields: [
-          %Model.TableFieldSchema{name: "timestamp", type: "TIMESTAMP", mode: "REQUIRED"},
-          %Model.TableFieldSchema{name: "id", type: "STRING", mode: "NULLABLE"},
-          %Model.TableFieldSchema{name: "event_message", type: "STRING", mode: "NULLABLE"}
-        ]
-      },
-      timePartitioning: %Model.TimePartitioning{
-        expirationMs: Integer.to_string(@connection_test_table_ttl),
-        field: "timestamp",
-        type: "DAY"
-      },
-      type: "TABLE"
-    }
   end
 
   describe "validate_config/1" do
@@ -97,60 +72,26 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
     setup do
       insert(:plan)
       user = insert(:user)
+      source = insert(:source, user: user, bq_storage_write_api: true)
 
       backend =
         insert(:backend,
           type: :bigquery,
           user: user,
+          sources: [source],
           config: %{project_id: "test-project", dataset_id: "test_dataset"}
         )
 
-      [backend: Backends.get_backend(backend.id)]
+      [backend: Backends.get_backend(backend.id), source: source, user: user]
     end
 
-    test "creates a fixed probe table and writes one labeled event through REST", %{
-      backend: backend
+    test "writes one labeled event to the attached source table through REST", %{
+      backend: backend,
+      source: source
     } do
-      BqTables
-      |> expect(:bigquery_tables_get, fn _conn,
-                                         "test-project",
-                                         "test_dataset",
-                                         @connection_test_table_name ->
-        {:error, %Tesla.Env{status: 404}}
-      end)
-
-      BqTables
-      |> expect(:bigquery_tables_insert, fn _conn, project_id, dataset_id, opts ->
-        assert project_id == "test-project"
-        assert dataset_id == "test_dataset"
-
-        assert %Model.Table{
-                 tableReference: %Model.TableReference{
-                   projectId: "test-project",
-                   datasetId: "test_dataset",
-                   tableId: @connection_test_table_name
-                 },
-                 labels: %{
-                   "managed_by" => "logflare",
-                   "logflare_source" => @connection_test_table_name
-                 },
-                 requirePartitionFilter: true,
-                 schema: %Model.TableSchema{fields: fields},
-                 timePartitioning: %Model.TimePartitioning{
-                   field: "timestamp",
-                   type: "DAY",
-                   expirationMs: @connection_test_table_ttl
-                 }
-               } = table = opts[:body]
-
-        assert Enum.map(fields, &{&1.name, &1.type, &1.mode}) == [
-                 {"timestamp", "TIMESTAMP", "REQUIRED"},
-                 {"id", "STRING", "NULLABLE"},
-                 {"event_message", "STRING", "NULLABLE"}
-               ]
-
-        {:ok, table}
-      end)
+      Mimic.reject(BqTables, :bigquery_tables_get, 4)
+      Mimic.reject(Google.BigQuery, :create_table, 4)
+      Mimic.reject(GoogleApiClient, :append_rows, 3)
 
       BqTabledata
       |> expect(:bigquery_tabledata_insert_all, fn _conn,
@@ -160,7 +101,7 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
                                                    opts ->
         assert project_id == "test-project"
         assert dataset_id == "test_dataset"
-        assert table_name == @connection_test_table_name
+        assert table_name == BigQueryAdaptor.format_table_name(source.token)
 
         assert %Model.TableDataInsertAllRequest{
                  ignoreUnknownValues: true,
@@ -179,133 +120,118 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
       assert :ok = BigQueryAdaptor.test_connection(backend)
     end
 
-    test "reuses the probe table when it already exists", %{backend: backend} do
-      BqTables
-      |> expect(:bigquery_tables_get, fn _conn,
-                                         "test-project",
-                                         "test_dataset",
-                                         @connection_test_table_name ->
-        {:ok, connection_test_table()}
+    test "uses a rule source when no source is attached directly", %{user: user} do
+      source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          config: %{project_id: "rule-project", dataset_id: "rule_dataset"}
+        )
+
+      insert(:rule, backend: backend, source: source)
+
+      Google.BigQuery
+      |> expect(:stream_batch!, fn context, [_row] ->
+        assert context == %{
+                 bigquery_project_id: "rule-project",
+                 bigquery_dataset_id: "rule_dataset",
+                 source_token: source.token
+               }
+
+        {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
       end)
 
-      Mimic.reject(Google.BigQuery, :create_table, 4)
-
-      BqTabledata
-      |> expect(:bigquery_tabledata_insert_all, fn _conn,
-                                                   _project_id,
-                                                   _dataset_id,
-                                                   table_name,
-                                                   _opts ->
-        assert table_name == @connection_test_table_name
-        {:ok, %Model.TableDataInsertAllResponse{insertErrors: []}}
-      end)
-
-      assert :ok = BigQueryAdaptor.test_connection(backend)
+      assert :ok = BigQueryAdaptor.test_connection(Backends.get_backend(backend.id))
     end
 
-    test "retries a not-found insert after creating the probe table", %{backend: backend} do
-      BqTables
-      |> expect(:bigquery_tables_get, fn _conn,
-                                         "test-project",
-                                         "test_dataset",
-                                         @connection_test_table_name ->
-        {:error, %Tesla.Env{status: 404}}
-      end)
+    test "prefers a direct source over an older rule source", %{user: user} do
+      rule_source = insert(:source, user: user)
+      direct_source = insert(:source, user: user)
+
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          sources: [direct_source],
+          config: %{project_id: "test-project", dataset_id: "test_dataset"}
+        )
+
+      insert(:rule, backend: backend, source: rule_source)
 
       Google.BigQuery
-      |> expect(:create_table, fn @connection_test_table,
-                                  "test_dataset",
-                                  "test-project",
-                                  @connection_test_table_ttl ->
-        {:ok, connection_test_table()}
+      |> expect(:stream_batch!, fn %{source_token: source_token}, [_row] ->
+        assert source_token == direct_source.token
+        {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
       end)
 
-      test_pid = self()
-
-      Google.BigQuery
-      |> expect(:stream_batch!, 2, fn _context, [row] ->
-        send(test_pid, {:insert_attempt, row.insertId})
-        attempt = Process.get(:connection_test_insert_attempt, 0)
-        Process.put(:connection_test_insert_attempt, attempt + 1)
-
-        if attempt == 0 do
-          {:error, %Tesla.Env{status: 404}}
-        else
-          {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
-        end
-      end)
-
-      assert :ok = BigQueryAdaptor.test_connection(backend)
-      assert_receive {:insert_attempt, insert_id}
-      assert_receive {:insert_attempt, ^insert_id}
+      assert rule_source.id < direct_source.id
+      assert :ok = BigQueryAdaptor.test_connection(Backends.get_backend(backend.id))
     end
 
-    test "handles another request creating the probe table concurrently", %{backend: backend} do
-      BqTables
-      |> expect(:bigquery_tables_get, 2, fn _conn,
-                                            "test-project",
-                                            "test_dataset",
-                                            @connection_test_table_name ->
-        attempt = Process.get(:connection_test_table_get_attempt, 0)
-        Process.put(:connection_test_table_get_attempt, attempt + 1)
+    test "selects the oldest directly attached source deterministically", %{user: user} do
+      first_source = insert(:source, user: user)
+      second_source = insert(:source, user: user)
 
-        if attempt == 0 do
-          {:error, %Tesla.Env{status: 404}}
-        else
-          {:ok, connection_test_table()}
-        end
-      end)
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          sources: [second_source, first_source],
+          config: %{project_id: "test-project", dataset_id: "test_dataset"}
+        )
 
       Google.BigQuery
-      |> expect(:create_table, fn @connection_test_table,
-                                  "test_dataset",
-                                  "test-project",
-                                  @connection_test_table_ttl ->
-        {:error, %Tesla.Env{status: 409}}
+      |> expect(:stream_batch!, fn %{source_token: source_token}, [_row] ->
+        assert source_token == first_source.token
+        {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
       end)
 
-      Google.BigQuery
-      |> expect(:stream_batch!, 2, fn _context, [row] ->
-        attempt = Process.get(:concurrent_connection_test_insert_attempt, 0)
-        Process.put(:concurrent_connection_test_insert_attempt, attempt + 1)
-
-        if attempt == 0 do
-          Process.put(:concurrent_connection_test_insert_id, row.insertId)
-          {:error, %Tesla.Env{status: 404}}
-        else
-          assert Process.get(:concurrent_connection_test_insert_id) == row.insertId
-          {:ok, %Model.TableDataInsertAllResponse{insertErrors: nil}}
-        end
-      end)
-
-      assert :ok = BigQueryAdaptor.test_connection(backend)
+      assert first_source.id < second_source.id
+      assert :ok = BigQueryAdaptor.test_connection(Backends.get_backend(backend.id))
     end
 
-    test "rejects an unrelated table using the probe table name", %{backend: backend} do
-      BqTables
-      |> expect(:bigquery_tables_get, fn _conn,
-                                         "test-project",
-                                         "test_dataset",
-                                         @connection_test_table_name ->
-        {:ok, %Model.Table{type: "VIEW"}}
-      end)
+    test "requires an attached direct or rule source", %{user: user} do
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          config: %{project_id: "test-project", dataset_id: "test_dataset"}
+        )
 
+      Mimic.reject(BqTables, :bigquery_tables_get, 4)
       Mimic.reject(Google.BigQuery, :create_table, 4)
       Mimic.reject(Google.BigQuery, :stream_batch!, 2)
 
-      assert {:error, :probe_table_conflict} = BigQueryAdaptor.test_connection(backend)
+      assert {:error, :source_required} =
+               BigQueryAdaptor.test_connection(Backends.get_backend(backend.id))
     end
 
-    test "returns an atom for insert failures", %{backend: backend} do
-      BqTables
-      |> stub(:bigquery_tables_get, fn _conn,
-                                       "test-project",
-                                       "test_dataset",
-                                       @connection_test_table_name ->
-        {:ok, connection_test_table()}
-      end)
+    test "ignores source associations owned by another user", %{user: user} do
+      other_user = insert(:user)
+      direct_source = insert(:source, user: other_user)
+      rule_source = insert(:source, user: other_user)
 
+      backend =
+        insert(:backend,
+          type: :bigquery,
+          user: user,
+          sources: [direct_source],
+          config: %{project_id: "test-project", dataset_id: "test_dataset"}
+        )
+
+      insert(:rule, backend: backend, source: rule_source)
+
+      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
+
+      assert {:error, :source_required} =
+               BigQueryAdaptor.test_connection(Backends.get_backend(backend.id))
+    end
+
+    test "normalizes REST insert responses to atom reasons", %{backend: backend} do
       responses = [
+        {{:ok, %Model.TableDataInsertAllResponse{insertErrors: []}}, :ok},
         {{:ok, %Model.TableDataInsertAllResponse{insertErrors: [%{index: 0}]}}, :insert_error},
         {{:error, %Tesla.Env{status: 404, body: %{"error" => "not found"}}}, :http_client_error},
         {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
@@ -320,69 +246,13 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptorTest do
         Google.BigQuery
         |> expect(:stream_batch!, fn _context, [_row] -> response end)
 
-        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
-      end
-    end
-
-    test "returns an atom when the probe table cannot be read", %{backend: backend} do
-      Mimic.reject(Google.BigQuery, :create_table, 4)
-      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
-
-      responses = [
-        {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
-        {{:error, %Tesla.Env{status: 503, body: %{"error" => "unavailable"}}},
-         :http_server_error},
-        {{:error, :timeout}, :connection_error},
-        {{:ok, :unexpected}, :unknown_error}
-      ]
-
-      for {response, expected_reason} <- responses do
-        BqTables
-        |> expect(:bigquery_tables_get, fn _conn,
-                                           "test-project",
-                                           "test_dataset",
-                                           @connection_test_table_name ->
-          response
-        end)
-
-        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
-      end
-    end
-
-    test "returns an atom when the probe table cannot be created", %{backend: backend} do
-      BqTables
-      |> stub(:bigquery_tables_get, fn _conn,
-                                       "test-project",
-                                       "test_dataset",
-                                       @connection_test_table_name ->
-        {:error, %Tesla.Env{status: 404}}
-      end)
-
-      Mimic.reject(Google.BigQuery, :stream_batch!, 2)
-
-      responses = [
-        {{:error, %Tesla.Env{status: 403, body: %{"error" => "forbidden"}}}, :http_client_error},
-        {{:error, %Tesla.Env{status: 503, body: %{"error" => "unavailable"}}},
-         :http_server_error},
-        {{:error, :timeout}, :connection_error},
-        {{:ok, :unexpected}, :unknown_error}
-      ]
-
-      for {response, expected_reason} <- responses do
-        Google.BigQuery
-        |> expect(:create_table, fn @connection_test_table,
-                                    "test_dataset",
-                                    "test-project",
-                                    @connection_test_table_ttl ->
-          response
-        end)
-
-        assert {:error, ^expected_reason} = BigQueryAdaptor.test_connection(backend)
+        expected = if expected_reason == :ok, do: :ok, else: {:error, expected_reason}
+        assert BigQueryAdaptor.test_connection(backend) == expected
       end
     end
 
     test "rejects incomplete configuration without making a request", %{backend: backend} do
-      Mimic.reject(BqTables, :bigquery_tables_get, 5)
+      Mimic.reject(BqTables, :bigquery_tables_get, 4)
       Mimic.reject(Google.BigQuery, :create_table, 4)
       Mimic.reject(Google.BigQuery, :stream_batch!, 2)
 

--- a/test/logflare_web/live/backends/components_test.exs
+++ b/test/logflare_web/live/backends/components_test.exs
@@ -37,6 +37,15 @@ defmodule LogflareWeb.Backends.ComponentsTest do
       refute html =~ "fa-check"
     end
 
+    test "explains that BigQuery connection tests require a source" do
+      result = AsyncResult.failed(AsyncResult.loading(), :source_required)
+      html = render_component(&Components.status_indicator/1, %{status: result})
+
+      assert html =~ "fa-times"
+      assert html =~ "Attach a source or add a drain rule before testing this connection."
+      refute html =~ "Backend error!"
+    end
+
     test "renders a check icon when the async result is ok" do
       result = AsyncResult.ok(AsyncResult.loading(), :connected)
       html = render_component(&Components.status_indicator/1, %{status: result})


### PR DESCRIPTION
Implements [O11Y-1947](https://linear.app/supabase/issue/O11Y-1947/bigquery-adaptor-connection-testing) with a REST-based BigQuery connection test that deterministically selects an attached source—preferring a direct attachment and falling back to a rule source—and inserts one labeled probe event into its existing table.

The probe requires a same-owner source association, performs no dataset or table DDL, and returns source_required before making a BigQuery request when none exists.

REST responses are normalized to atom-only sanitized errors, and the LiveView explains how to satisfy the source prerequisite.

It intentionally does not wait for Storage Write gRPC support.

Tests: the BigQuery adaptor file passes with 35 tests and one property, the backend component file passes with 5 tests, and Dialyzer, formatting, diff checks, and targeted strict Credo pass.