### PR TITLE
feat: pass in different spool queues for different instance groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ deploy.staging.main:
 
 	gcloud builds submit . \
 		--config=./cloudbuild/staging/deploy.yaml \
-		--substitutions=_IMAGE_TAG=$(SHA_IMAGE_TAG),_INSTANCE_GROUP=instance-group-staging-main-saturated,_INSTANCE_TYPE=c2d-highcpu-16 \
+		--substitutions=_IMAGE_TAG=$(SHA_IMAGE_TAG),_INSTANCE_GROUP=instance-group-staging-main-saturated,_INSTANCE_TYPE=c2d-highcpu-16,_SPOOL_CLUSTER=main-saturated \
 		--region=us-central1 \
 		--gcs-log-dir="gs://logflare-staging_cloudbuild-logs/logs"
 
@@ -381,7 +381,7 @@ deploy.prod.versioned:
 	@echo "Creating prod instance templates..."
 	gcloud builds submit . \
 		--config=./cloudbuild/prod/pre-deploy.yaml \
-		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION),_CLUSTER=prod-a,_LOGFLARE_ALERTS_ENABLED=true \
+		--substitutions=_IMAGE_TAG=$(VERSION),_NORMALIZED_IMAGE_TAG=$(NORMALIZED_VERSION),_CLUSTER=prod-a,_LOGFLARE_ALERTS_ENABLED=true,_SPOOL_MODE=disable \
 		--region=europe-west3 \
 		--gcs-log-dir="gs://logflare-prod_cloudbuild-logs/logs"
 	gcloud builds submit . \

--- a/cloudbuild/prod/pre-deploy.yaml
+++ b/cloudbuild/prod/pre-deploy.yaml
@@ -13,11 +13,33 @@ steps:
           printf '%s\n' 'LOGFLARE_PUBSUB_POOL_SIZE=32'
           printf 'LOGFLARE_METADATA_CLUSTER=%s\n' "$$2"
           printf 'LOGFLARE_ALERTS_ENABLED=%s\n' "$$3"
+          # SPOOL_PUBSUB_TOPIC/SPOOL_QUEUE_NAME point at this cluster's own
+          # Pub/Sub topic + subscription (provisioned via
+          # o11y-team-tools/logflare-gcp/scripts/provision-prod-spool.sh), so
+          # draining a cluster during a blue/green traffic switchover only
+          # drains its own queue instead of one shared across every prod
+          # cluster. Producer/consumer aren't split apart yet (SPOOL_MODE
+          # still comes from the baked-in prod secrets, same for every
+          # cluster, unless overridden below) — this only isolates the
+          # queues.
+          printf 'SPOOL_PUBSUB_TOPIC=%s\n' "$$4"
+          printf 'SPOOL_QUEUE_NAME=%s\n' "$$5"
+          # Per-cluster SPOOL_MODE override — empty (the default) means
+          # inherit whatever's baked into the prod secrets (.prod.env's
+          # SPOOL_MODE, "both" today). Used to turn the spool off for
+          # clusters that don't serve ingest traffic (e.g. prod-a, see
+          # deploy/config/clusters.yaml in o11y-team-tools/logflare-gcp).
+          if [ -n "$$6" ]; then
+            printf 'SPOOL_MODE=%s\n' "$$6"
+          fi
         } > gce-container.env
       - --
       - ${_COOKIE}
       - ${_CLUSTER}
       - ${_LOGFLARE_ALERTS_ENABLED}
+      - ${_SPOOL_PUBSUB_TOPIC}
+      - ${_SPOOL_QUEUE_NAME}
+      - ${_SPOOL_MODE}
   # create instance template
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
@@ -50,6 +72,15 @@ substitutions:
   _TEMPLATE_NAME: logflare-prod-${_NORMALIZED_IMAGE_TAG}-${_CLUSTER}
   _CONTAINER_IMAGE: gcr.io/logflare-232118/logflare_app:${_IMAGE_TAG}
   _LOGFLARE_ALERTS_ENABLED: "false"
+  # This cluster's dedicated spool topic/subscription (see
+  # o11y-team-tools/logflare-gcp/scripts/provision-prod-spool.sh). Overriding
+  # _CLUSTER — as the Makefile does per prod-a..g / canary build — re-derives
+  # both automatically.
+  _SPOOL_PUBSUB_TOPIC: projects/logflare-232118/topics/logflare-spool-${_CLUSTER}
+  _SPOOL_QUEUE_NAME: projects/logflare-232118/subscriptions/logflare-spool-${_CLUSTER}-sub
+  # Empty by default (inherit SPOOL_MODE from the baked-in prod secrets).
+  # Set to producer/consumer/both/disable to override for this cluster.
+  _SPOOL_MODE: ""
 timeout: 1800s
 options:
   dynamicSubstitutions: true

--- a/cloudbuild/staging/deploy.yaml
+++ b/cloudbuild/staging/deploy.yaml
@@ -10,10 +10,20 @@ steps:
           printf '%s\n' 'LOGFLARE_GRPC_PORT=50051'
           printf 'RELEASE_COOKIE=%s\n' "$$1"
           printf 'LOGFLARE_METADATA_CLUSTER=%s\n' "$$2"
+          # SPOOL_PUBSUB_TOPIC/SPOOL_QUEUE_NAME point at this cluster's own
+          # Pub/Sub topic + subscription (provisioned via
+          # o11y-team-tools/logflare-gcp/scripts/provision-staging-spool.sh),
+          # keyed on _SPOOL_CLUSTER rather than _CLUSTER so main and
+          # main-saturated — which intentionally share _CLUSTER/_COOKIE to
+          # join the same BEAM cluster — still get separate spool queues.
+          printf 'SPOOL_PUBSUB_TOPIC=%s\n' "$$3"
+          printf 'SPOOL_QUEUE_NAME=%s\n' "$$4"
         } > gce-container.env
       - --
       - ${_COOKIE}
       - ${_CLUSTER}
+      - ${_SPOOL_PUBSUB_TOPIC}
+      - ${_SPOOL_QUEUE_NAME}
   # create instance template - dedicated
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
@@ -62,9 +72,17 @@ substitutions:
   _CLUSTER: main
   _COOKIE: default-${_CLUSTER}
   _NORMALIZED_IMAGE_TAG: ${_IMAGE_TAG}
-  # test clusters (main) override instance type in makefile 
+  # test clusters (main) override instance type in makefile
   _INSTANCE_TYPE: c2d-highcpu-4
   _INSTANCE_GROUP: instance-group-staging-${_CLUSTER}
+  # This deploy's own spool identity. Defaults to _CLUSTER (covers main and
+  # versioned automatically) — the main-saturated build in the Makefile
+  # overrides this explicitly to "main-saturated" without touching _CLUSTER,
+  # since main/main-saturated must keep sharing _CLUSTER/_COOKIE to join the
+  # same BEAM cluster.
+  _SPOOL_CLUSTER: ${_CLUSTER}
+  _SPOOL_PUBSUB_TOPIC: projects/logflare-staging/topics/logflare-spool-staging-${_SPOOL_CLUSTER}
+  _SPOOL_QUEUE_NAME: projects/logflare-staging/subscriptions/logflare-spool-staging-${_SPOOL_CLUSTER}-sub
   _IMAGE_TAG: $SHORT_SHA
   _TEMPLATE_NAME: logflare-staging-${_CLUSTER}-cluster-${_NORMALIZED_IMAGE_TAG}
   _TEMPLATE_NAME_SPOT: ${_TEMPLATE_NAME}-spot

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -554,11 +554,12 @@ spool_mode_override =
     p when p in [nil, ""] ->
       []
 
-    mode when mode in ["producer", "consumer", "both"] ->
+    mode when mode in ["producer", "consumer", "both", "disable"] ->
       [mode: String.to_atom(mode)]
 
     other ->
-      raise ArgumentError, "Invalid SPOOL_MODE=#{other}. Must be producer, consumer, or both."
+      raise ArgumentError,
+            "Invalid SPOOL_MODE=#{other}. Must be producer, consumer, both, or disable."
   end
 
 spool_provider_override =


### PR DESCRIPTION
Point each instance group to its own spool queue. This is to allow traffic draining during prod deploys so the draining cluster will fully consume its own queue rather than continue to consume from the shared topic.