### PR TITLE
fix: remove rechart outline

### DIFF
--- a/assets/css/source_log_search.scss
+++ b/assets/css/source_log_search.scss
@@ -1,5 +1,9 @@
 @import "named_variables";
 
+#log-events-chart-container .recharts-surface {
+  outline: none;
+}
+
 #logs-list-container {
   min-height: 47.75vh;
 }

--- a/test/e2e/features/backends_test.exs
+++ b/test/e2e/features/backends_test.exs
@@ -114,7 +114,10 @@ defmodule E2e.Features.BackendsTest do
       backend: backend,
       conn: conn
     } do
-      session = visit(conn, ~p"/backends/#{backend.id}/edit")
+      session =
+        conn
+        |> visit(~p"/backends/#{backend.id}/edit")
+        |> assert_has("[data-phx-main].phx-connected")
 
       unwrap(session, fn %{frame_id: frame_id} ->
         Frame.fill(frame_id,


### PR DESCRIPTION
* removes chart focus outline introduced by recharts (Follow up to #3872)
* wait for LiveView to connect in E2E backends test to fix flaky CI test.

<img width="5676" height="710" alt="CleanShot 2026-08-27 at 10 12 56@2x" src="https://github.com/user-attachments/assets/1e3894db-35b0-4f5e-a819-9290e5c68773" />
