### PR TITLE
fix: EndpointsLive handles invalid description

### DIFF
--- a/priv/repo/migrations/20260827222658_alter_endpoint_query_description_to_text.exs
+++ b/priv/repo/migrations/20260827222658_alter_endpoint_query_description_to_text.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AlterEndpointQueryDescriptionToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:endpoint_queries) do
+      modify :description, :text, from: :string
+    end
+  end
+end

--- a/test/logflare_web/live_views/endpoints_live_test.exs
+++ b/test/logflare_web/live_views/endpoints_live_test.exs
@@ -260,6 +260,33 @@ defmodule LogflareWeb.EndpointsLiveTest do
     assert render(view) =~ "some description"
   end
 
+  test "new endpoint displays validation messages", %{conn: conn} do
+    {:ok, view, _html} = live_with_redirect(conn, "/endpoints/new")
+
+    params = %{
+      name: "",
+      query: "",
+      max_limit: 0,
+      language: "bq_sql"
+    }
+
+    html =
+      view
+      |> element("form#endpoint")
+      |> render_submit(%{endpoint: params})
+
+    assert has_element?(view, "#endpoint_name + .help-block", "can't be blank")
+    assert has_element?(view, "#endpoint_query_editor > .help-block", "can't be blank")
+    assert html =~ "must be greater than 0"
+
+    html =
+      view
+      |> element("form#endpoint")
+      |> render_submit(%{endpoint: %{params | max_limit: 10_001}})
+
+    assert html =~ "must be less than 10001"
+  end
+
   test "new endpoint with redact_pii enabled", %{conn: conn} do
     {:ok, view, _html} = live_with_redirect(conn, "/endpoints/new")
     assert view |> has_element?("form#endpoint")


### PR DESCRIPTION
Fixes a bug where the EndpointsLive would crash when an endpoint is created with a description exceeding the maximum character length.

* Adds migration for `endpoint_queries.description` to text
* Add form validation test coverage to Endpoints new

<img width="3262" height="2446" alt="CleanShot 2026-08-27 at 13 34 05@2x" src="https://github.com/user-attachments/assets/899e5bb1-9d20-4229-ad6b-a4aa4dc1431c" />
