### PR TITLE
fix: regex generates invalid postgres chart query

### DIFF
--- a/lib/logflare/logs/search_operations.ex
+++ b/lib/logflare/logs/search_operations.ex
@@ -670,7 +670,7 @@ defmodule Logflare.Logs.SearchOperations do
       :postgres ->
         query =
           query
-          |> Lql.apply_filter_rules(non_chart_filters)
+          |> Lql.apply_filter_rules(non_chart_filters, dialect: so.backend_type)
           |> PostgresTransformer.transform_chart_rule(
             chart_rule.aggregate,
             chart_rule.path,

--- a/test/e2e/features/logs_search_test.exs
+++ b/test/e2e/features/logs_search_test.exs
@@ -76,7 +76,7 @@ defmodule E2e.Features.LogsSearchTest do
       |> visit(~p"/auth/login/single_tenant")
       |> assert_path(~p"/dashboard")
       |> visit(
-        ~p"/sources/#{source.id}/search?#{%{querystring: ~s|event_message:~\"^#{pagination_message}-\"|}}"
+        ~p"/sources/#{source.id}/search?#{%{querystring: ~s|event_message:~\"^#{pagination_message}-\"|, tailing?: false}}"
       )
       |> assert_has("#logs-list li[data-event-id]", count: 100)
       |> click("#load-more-events-top")

--- a/test/logflare/logs/search_operations_test.exs
+++ b/test/logflare/logs/search_operations_test.exs
@@ -235,6 +235,7 @@ defmodule Logflare.Logs.SearchOperationsTest do
         @postgres_search_attrs
         |> Map.merge(%{source: source, type: :aggregates})
         |> SO.new()
+        |> Map.put(:chart_rules, [%ChartRule{}])
 
       [base_so: base_so]
     end
@@ -271,6 +272,22 @@ defmodule Logflare.Logs.SearchOperationsTest do
       so = SearchOperations.apply_numeric_aggs(so)
 
       assert length(so.query.wheres) == 1
+    end
+
+    test "uses postgres regex syntax for event message filters", %{base_so: base_so} do
+      regex_filter = %FilterRule{path: "event_message", operator: :"~", value: "(?i)error"}
+
+      so = %{
+        base_so
+        | lql_meta_and_msg_filters: [regex_filter],
+          query: from("test_table")
+      }
+
+      so = SearchOperations.apply_numeric_aggs(so)
+      {:ok, {sql, _params}} = PostgresAdaptor.ecto_to_sql(so.query, [])
+
+      assert sql =~ ~s|t0."event_message" ~ $1|
+      refute sql =~ "REGEXP_CONTAINS"
     end
 
     test "generates expected SQL for all aggregate types", %{base_so: base_so} do


### PR DESCRIPTION
Fixes an invalid chart query when a Postgres backend is queried with a regex. 

A query with a regex emitted the BigQuery dialect `REGEXP_CONTAINS(event_message, '(?i)error')` but PostgreSQL requires `event_message ~ '(?i)error'`.

Updated an E2E test that was inadvertently relying on this crash to pass.

<img width="5710" height="2170" alt="CleanShot 2026-08-27 at 14 55 54@2x" src="https://github.com/user-attachments/assets/cee622d0-e9d3-4636-bfe1-7fb6662b9345" />
