### PR TITLE
fix(helm): probe /ready so draining pods leave the Service

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.47.2"
+appVersion: "1.50.7"

--- a/helm/README.md
+++ b/helm/README.md
@@ -330,4 +330,16 @@ Or dry-run against a real cluster:
 helm install logflare ./helm -f my-values.yaml --dry-run
 ```
 
-The container's liveness and readiness probes hit `/health` on the service port (default `4000`).
+All three probes hit the service port (default `4000`).
+
+- `livenessProbe` and `startupProbe` use `/health`, which reports node health.
+- `readinessProbe` uses `/ready`, which runs the same checks and additionally
+  fails as soon as a `SIGTERM` starts Logflare's 15 second shutdown grace
+  period, so Kubernetes drops the pod from the Service while it drains.
+- Keep `readinessProbe.periodSeconds` x `readinessProbe.failureThreshold` well
+  under that grace period, and leave liveness on `/health` so a draining pod is
+  not restarted.
+- `terminationGracePeriodSeconds` covers readiness detection, the drain, and the
+  BEAM shutdown that flushes the ingest pipelines. The kubelet `SIGKILL`s
+  whatever is still running when it expires, dropping buffered events, so the
+  chart raises it to `60` from the Kubernetes default of `30`.

--- a/helm/deployment_test.yaml
+++ b/helm/deployment_test.yaml
@@ -229,3 +229,54 @@ tests:
           path: spec.template.spec.containers[0].env[-1].value
           value: "mycluster-$(POD_TEMPLATE_HASH)"
         template: deployment.yaml
+
+  - it: should probe /ready for readiness and /health for liveness and startup
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+        template: deployment.yaml
+      # Liveness and startup stay on /health, so a draining pod is pulled from the Service
+      # instead of being restarted.
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+        template: deployment.yaml
+
+  - it: should detect readiness loss well inside the 15 second shutdown grace period
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 2
+        template: deployment.yaml
+
+  - it: should omit a probe that is set to null
+    set:
+      readinessProbe: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+        template: deployment.yaml
+
+  - it: should give the pod a termination grace period covering drain and shutdown
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+        template: deployment.yaml
+
+  - it: should fall back to the Kubernetes default grace period when set to null
+    set:
+      terminationGracePeriodSeconds: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+        template: deployment.yaml

--- a/helm/rollout_test.yaml
+++ b/helm/rollout_test.yaml
@@ -200,3 +200,33 @@ tests:
           path: spec.template.spec.containers[0].env[-1].value
           value: "mycluster-$(POD_TEMPLATE_HASH)"
         template: rollout.yaml
+
+  - it: should carry the readiness probe onto the Rollout as well
+    set:
+      rollout:
+        enabled: true
+        strategy:
+          blueGreen:
+            activeService: RELEASE-NAME-logflare
+            previewService: RELEASE-NAME-logflare-preview
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+        template: rollout.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+        template: rollout.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 2
+        template: rollout.yaml
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+        template: rollout.yaml
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+        template: rollout.yaml

--- a/helm/templates/_pod.tpl
+++ b/helm/templates/_pod.tpl
@@ -23,6 +23,9 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   serviceAccountName: {{ include "logflare.serviceAccountName" . }}
+  {{- with .Values.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ . }}
+  {{- end }}
   {{- with .Values.podSecurityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -327,6 +327,9 @@
         "readinessProbe": {
             "type": "object",
             "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
                 "httpGet": {
                     "type": "object",
                     "properties": {
@@ -337,6 +340,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "periodSeconds": {
+                    "type": "integer"
                 }
             }
         },
@@ -415,6 +421,9 @@
                     "type": "integer"
                 }
             }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
         },
         "tolerations": {
             "type": "array"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -287,10 +287,15 @@ livenessProbe:
   httpGet:
     path: /health
     port: http
+# `/ready` runs the same checks as `/health`, and additionally fails as soon as SIGTERM starts
+# the shutdown grace period, so a draining pod leaves the Service endpoints instead of taking
+# new traffic. Logflare drains for 15 seconds, so detection has to land well inside that.
 readinessProbe:
   httpGet:
-    path: /health
+    path: /ready
     port: http
+  periodSeconds: 5
+  failureThreshold: 2
 # Guards against liveness/readiness killing the pod mid-migration on first boot.
 startupProbe:
   httpGet:
@@ -298,6 +303,11 @@ startupProbe:
     port: http
   failureThreshold: 30
   periodSeconds: 10
+
+# Budget for readiness detection, then the 15 second drain, then a BEAM shutdown that flushes
+# the ingest pipelines. The kubelet SIGKILLs anything still running when this expires, which
+# drops buffered events, so the Kubernetes default of 30 leaves too little headroom.
+terminationGracePeriodSeconds: 60
 
 # Argo Rollouts support. When enabled the chart renders a Rollout in place of the
 # Deployment, plus a `<fullname>-preview` Service for the incoming version. The existing


### PR DESCRIPTION
Logflare keeps returning 200 on /health for the 15 seconds it drains after
SIGTERM, so a terminating pod stayed in the Service endpoints and took new
traffic. Point the readiness probe at the /ready endpoint added in v1.50.3,
which fails the moment shutdown begins, and tighten its timing so Kubernetes
notices inside the grace period rather than after it.

Liveness and startup stay on /health, since pointing them at /ready would
restart every pod as it starts draining. The pod also gets a 60 second
terminationGracePeriodSeconds, because the Kubernetes default of 30 leaves the
BEAM too little room to flush the ingest pipelines before the kubelet SIGKILLs
it.

Requires app v1.50.3 or later, so appVersion moves to 1.50.7.