### PR TITLE
ci: audit Hex dependencies

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -129,6 +129,8 @@ jobs:
             run: mix lint.all
           - name: Code Quality - Formatting
             run: mix test.format
+          - name: Dependency Audit
+            run: mix hex.audit
     env:
       MIX_ENV: test
       SHELL: /bin/bash


### PR DESCRIPTION
Adds mix hex.audit to the Elixir CI quality matrix so vulnerable or retired Hex dependencies fail CI. The existing lockfile currently has findings, so the new check will start red; this PR otherwise only affects the GitHub Actions workflow.