### PR TITLE
fix: Require hostname in read replica URIs and improve error handling

### DIFF
--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -110,27 +110,25 @@ defmodule Logflare.Repo.Replicas do
   end
 
   defp parse_uri_with_host(entry, uri) do
-    try do
-      config =
-        case uri.path do
-          v when v not in [nil, "", "/"] ->
-            entry
-            |> Ecto.Repo.Supervisor.parse_url()
+    config =
+      case uri.path do
+        v when v not in [nil, "", "/"] ->
+          entry
+          |> Ecto.Repo.Supervisor.parse_url()
 
-          _ ->
-            # no database set - use a placeholder to satisfy Ecto's URL parser,
-            # then drop it so the primary's database is inherited instead
-            URI.to_string(%{uri | path: "/placeholder"})
-            |> Ecto.Repo.Supervisor.parse_url()
-            |> Keyword.delete(:database)
-        end
-        |> Keyword.delete(:scheme)
-        |> maybe_put_socket_options()
+        _ ->
+          # no database set - use a placeholder to satisfy Ecto's URL parser,
+          # then drop it so the primary's database is inherited instead
+          URI.to_string(%{uri | path: "/placeholder"})
+          |> Ecto.Repo.Supervisor.parse_url()
+          |> Keyword.delete(:database)
+      end
+      |> Keyword.delete(:scheme)
+      |> maybe_put_socket_options()
 
-      {:ok, {build_key(config), config}}
-    rescue
-      e in Ecto.InvalidURLError -> {:error, redact(e.message, uri.userinfo)}
-    end
+    {:ok, {build_key(config), config}}
+  rescue
+    e in Ecto.InvalidURLError -> {:error, redact(e.message, uri.userinfo)}
   end
 
   defp maybe_put_socket_options(config) do
@@ -145,12 +143,7 @@ defmodule Logflare.Repo.Replicas do
   end
 
   defp redact(entry) do
-    if String.contains?(entry, "://") do
-      uri = URI.parse(entry)
-      URI.to_string(%{uri | userinfo: if(uri.userinfo, do: "REDACTED")})
-    else
-      entry
-    end
+    Regex.replace(~r{^([a-z][a-z0-9+.-]*://)[^/@]*@}i, entry, "\\1")
   end
 
   defp redact(message, nil), do: message

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -7,11 +7,12 @@ defmodule Logflare.Repo.Replicas do
   `Registry`. If no replicas are configured, the supervisor is skipped entirely.
 
   Each `LOGFLARE_READ_REPLICAS` entry is either a bare hostname or a Postgres URI
-  (`postgres://user:pass@host:port/database?ssl=true&pool_size=5`). In both
-  cases, only the parts explicitly given override the primary `Logflare.Repo`
-  config - anything not specified (host, port, database, credentials, ssl, ...) is
-  inherited from the primary's `DB_*` settings, without ever baking the primary's
-  actual values into the parsed result. URIs are parsed and validated entirely by
+  (`postgres://user:pass@host:port/database?ssl=true&pool_size=5`). A URI entry
+  must always include a hostname; only the remaining parts explicitly given
+  (port, database, credentials, ssl, ...) override the primary `Logflare.Repo`
+  config, and anything not specified is inherited from the primary's `DB_*`
+  settings, without ever baking the primary's actual values into the parsed
+  result. URIs are parsed and validated entirely by
   `Ecto.Repo.Supervisor.parse_url/1`.
 
   Replica pools are identified by a key derived from the entry (host/port/database
@@ -101,6 +102,14 @@ defmodule Logflare.Repo.Replicas do
   defp parse_uri(entry) do
     uri = URI.parse(entry)
 
+    if uri.host in [nil, ""] do
+      {:error, "hostname is required"}
+    else
+      parse_uri_with_host(entry, uri)
+    end
+  end
+
+  defp parse_uri_with_host(entry, uri) do
     try do
       config =
         case uri.path do

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -143,7 +143,7 @@ defmodule Logflare.Repo.Replicas do
   end
 
   defp redact(entry) do
-    Regex.replace(~r{^([a-z][a-z0-9+.-]*://)[^/@]*@}i, entry, "\\1")
+    Regex.replace(~r{^([a-z][a-z0-9+.-]*://)[^/]*@}i, entry, "\\1")
   end
 
   defp redact(message, nil), do: message

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -116,7 +116,7 @@ defmodule Logflare.RepoTest do
             "postgres:///db",
             "postgres://u:pass@/db"
           ] do
-        assert {:error, _reason} = Replicas.parse(entry), "expected #{entry} to be rejected"
+        assert {:error, _reason} = Replicas.parse(entry)
       end
     end
 

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -110,18 +110,23 @@ defmodule Logflare.RepoTest do
       refute key1 == key2
     end
 
-    test "an omitted host inherits the primary's, without baking it into the parsed config" do
-      assert {:ok, {key, config}} = Replicas.parse("postgres:///db")
-      refute Keyword.has_key?(config, :hostname)
-      assert key =~ ~r{^-\d+$}
-    end
-
     test "rejects invalid entries" do
       for entry <- [
-            "postgres://host?pool_size=abc"
+            "postgres://host?pool_size=abc",
+            "postgres:///db",
+            "postgres://u:pass@/db"
           ] do
         assert {:error, _reason} = Replicas.parse(entry), "expected #{entry} to be rejected"
       end
+    end
+
+    test "does not leak credentials when a hostless URI is rejected" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Replicas.parse!("postgres://u:supersecret@/db")
+        end
+
+      refute Exception.message(error) =~ "supersecret"
     end
 
     test "parse!/1 raises without leaking credentials" do

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -129,6 +129,16 @@ defmodule Logflare.RepoTest do
       refute Exception.message(error) =~ "supersecret"
     end
 
+    test "does not leak credentials when a hostless URI has an unescaped @ in the password" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Replicas.parse!("postgres://u:super@secret@/db")
+        end
+
+      refute Exception.message(error) =~ "super"
+      refute Exception.message(error) =~ "secret"
+    end
+
     test "parse!/1 raises without leaking credentials" do
       error =
         assert_raise ArgumentError, fn ->


### PR DESCRIPTION
Require hostname to be provided, addressing comments in #3883 