### PR TITLE
feat: add ndjson payload format option to webhook backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ flake.nix
 flake.lock
 
 /tmp
+
+.plans/

--- a/docs/docs.logflare.com/docs/backends/webhook.mdx
+++ b/docs/docs.logflare.com/docs/backends/webhook.mdx
@@ -12,8 +12,19 @@ The following values are required when creating a webhook backend:
 
 - `url`: (`string`, required) a valid HTTP(S) endpoint.
 
+Optional values:
+
+- `format`: (`string`, optional) the payload encoding, either `json` (default) or `ndjson`.
+- `gzip`: (`boolean`, optional, default `true`) compress the request body with gzip. The request sets the `content-encoding: gzip` header. Disable this when the receiver does not decompress request bodies.
+
 ### Request 
 The request made will be a `POST`.
+
+### Payload format
+
+With `format` set to `json`, each batch is sent as a JSON array of events.
+
+With `format` set to `ndjson`, each batch is sent as newline-delimited JSON, one event per line. The request uses the `application/x-ndjson` content type. A user-configured `content-type` header takes precedence.
 
 ### Batching
 

--- a/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
+++ b/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
@@ -36,11 +36,16 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
     Tesla.put_header(%{env | headers: headers}, "content-type", @content_type)
   end
 
-  defp encode([%LogEvent{} | _] = events) do
+  @doc """
+  Encodes `Logflare.LogEvent`s as newline-delimited JSON iodata, one event body
+  per line. Any other term passes through unchanged.
+  """
+  @spec encode([LogEvent.t()] | term()) :: iodata() | term()
+  def encode([%LogEvent{} | _] = events) do
     events
     |> Enum.map(fn %LogEvent{body: body} -> Jason.encode_to_iodata!(body) end)
     |> Enum.intersperse("\n")
   end
 
-  defp encode(term), do: term
+  def encode(term), do: term
 end

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -34,6 +34,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Backend
   alias Logflare.Backends.Adaptor.HttpBased.Headers
+  alias Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter
   alias Logflare.LogEvent
   alias Logflare.Utils
   alias Logflare.Utils.SSRF
@@ -201,25 +202,43 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   @impl Logflare.Backends.Adaptor
   @spec transform_config(Backend.t()) :: map()
-  def transform_config(%Backend{config: config}) do
-    if Map.get(config, :format) == "ndjson" do
-      headers =
-        (Map.get(config, :headers) || %{})
-        |> Map.put_new("content-type", "application/x-ndjson")
+  def transform_config(%Backend{config: %{format: "ndjson"} = config}) do
+    config
+    |> Map.put(:format_batch, &encode_ndjson/1)
+    |> Map.put(:headers, ndjson_headers(config))
+  end
 
-      config
-      |> Map.put(:format_batch, &encode_ndjson/1)
-      |> Map.put(:headers, headers)
-    else
-      config
+  def transform_config(%Backend{config: config}), do: config
+
+  # Normalizes the stored header names before adding the content type. Header names
+  # are case-insensitive, and config written before Headers.normalize_keys/1 (or
+  # through a partial update that never casts :headers) can still hold "Content-Type".
+  # Without the normalization both keys ship as separate headers.
+  @spec ndjson_headers(map()) :: map()
+  defp ndjson_headers(config) do
+    (Map.get(config, :headers) || %{})
+    |> Headers.normalize_keys()
+    |> Map.put_new("content-type", "application/x-ndjson")
+  end
+
+  @doc """
+  Builds the request body for a batch of log events.
+
+  Uses the config's `:format_batch` function when one is set, and otherwise falls
+  back to the list of event bodies.
+  """
+  @spec format_payload(map(), [LogEvent.t()]) :: term()
+  def format_payload(config, events) do
+    case Map.get(config, :format_batch) do
+      nil -> Enum.map(events, & &1.body)
+      format_batch -> format_batch.(events)
     end
   end
 
   @spec encode_ndjson([LogEvent.t()]) :: binary()
   defp encode_ndjson(events) do
     events
-    |> Enum.map(fn %LogEvent{body: body} -> Jason.encode_to_iodata!(body) end)
-    |> Enum.intersperse("\n")
+    |> NdjsonFormatter.encode()
     |> IO.iodata_to_binary()
   end
 
@@ -265,13 +284,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   def test_connection(%Backend{} = backend) do
     config = transform_config(backend)
 
-    body =
-      case Map.get(config, :format_batch) do
-        nil -> []
-        format_batch -> format_batch.([])
-      end
-
-    test_connection(%{backend | config: config}, body)
+    test_connection(%{backend | config: config}, format_payload(config, []))
   end
 
   @doc """
@@ -413,6 +426,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     use Broadway
     alias Broadway.Message
     alias Logflare.Backends.BufferProducer
+    alias Logflare.Backends.Adaptor.WebhookAdaptor
     alias Logflare.Backends.Adaptor.WebhookAdaptor.Client
 
     @batch_timeout if Application.compile_env(:logflare, :env) == :test, do: 10, else: 1_000
@@ -476,14 +490,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       %{metadata: backend_metadata} = backend = Backends.Cache.get_backend(context.backend_id)
       config = Backends.Adaptor.get_backend_config(backend)
 
-      # convert this to a custom format if needed
-      payload =
-        if format_batch = Map.get(config, :format_batch) do
-          events = for %{data: le} <- messages, do: le
-          format_batch.(events)
-        else
-          for %{data: le} <- messages, do: le.body
-        end
+      events = for %{data: le} <- messages, do: le
+      payload = WebhookAdaptor.format_payload(config, events)
 
       process_data(payload, config, backend_metadata, context)
       messages

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -11,6 +11,17 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   If you want to manually select a specific Finch pool, you can use the `:pool_name` option and provide the module name.
 
 
+  ### Payload format
+
+  The `:format` option selects the batch payload encoding:
+
+  - `"json"` (default) - the batch is sent as a JSON array of event bodies.
+  - `"ndjson"` - the batch is sent as newline-delimited JSON, one event body per
+    line, with the `application/x-ndjson` content type. A user-configured
+    `content-type` header takes precedence.
+
+  Adaptors that set `:format_batch` bypass this option.
+
   ### Dynamic URL handling with URL Override
 
   This adaptor performs a merge on config that will prevent you from leveraging a dynamically generated URL configuration at runtime.
@@ -23,6 +34,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   alias Logflare.Backends.Adaptor
   alias Logflare.Backends.Backend
   alias Logflare.Backends.Adaptor.HttpBased.Headers
+  alias Logflare.LogEvent
   alias Logflare.Utils
   alias Logflare.Utils.SSRF
 
@@ -32,6 +44,8 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   # Sentinel value substituted for credentials by redact_config/1.
   @redacted_value "REDACTED"
+
+  @formats ["json", "ndjson"]
 
   # Header names are case-insensitive. Keep this list intentionally explicit so
   # adding another credential-bearing header is a reviewed policy change.
@@ -76,13 +90,15 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
 
   @impl Logflare.Backends.Adaptor
   def cast_config(params, existing_config \\ %{}) do
-    {existing_config, %{url: :string, headers: :map, http: :string, gzip: :boolean}}
-    |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip])
+    {existing_config,
+     %{url: :string, headers: :map, http: :string, gzip: :boolean, format: :string}}
+    |> Ecto.Changeset.cast(params, [:url, :headers, :http, :gzip, :format])
     |> unredact_headers(existing_config)
     |> unredact_url(existing_config)
     |> normalize_header_keys()
     |> Logflare.Utils.default_field_value(:http, "http2")
     |> Logflare.Utils.default_field_value(:gzip, true)
+    |> Logflare.Utils.default_field_value(:format, "json")
   end
 
   # Canonicalizes submitted header names to lower case so the stored config cannot
@@ -157,6 +173,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     |> Ecto.Changeset.validate_required([:url])
     |> Ecto.Changeset.validate_format(:url, ~r/https?\:\/\/.+/)
     |> Ecto.Changeset.validate_inclusion(:http, ["http1", "http2"])
+    |> Ecto.Changeset.validate_inclusion(:format, @formats)
     |> validate_no_ssrf()
   end
 
@@ -176,6 +193,36 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     end
   end
 
+  @doc """
+  Payload formats this adaptor supports.
+  """
+  @spec formats() :: [String.t()]
+  def formats, do: @formats
+
+  @impl Logflare.Backends.Adaptor
+  @spec transform_config(Backend.t()) :: map()
+  def transform_config(%Backend{config: config}) do
+    if Map.get(config, :format) == "ndjson" do
+      headers =
+        (Map.get(config, :headers) || %{})
+        |> Map.put_new("content-type", "application/x-ndjson")
+
+      config
+      |> Map.put(:format_batch, &encode_ndjson/1)
+      |> Map.put(:headers, headers)
+    else
+      config
+    end
+  end
+
+  @spec encode_ndjson([LogEvent.t()]) :: binary()
+  defp encode_ndjson(events) do
+    events
+    |> Enum.map(fn %LogEvent{body: body} -> Jason.encode_to_iodata!(body) end)
+    |> Enum.intersperse("\n")
+    |> IO.iodata_to_binary()
+  end
+
   @impl Logflare.Backends.Adaptor
   def redact_config(config) do
     config
@@ -186,7 +233,7 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   @impl Logflare.Backends.Adaptor
   def sanitize_config_for_display(config) do
     config
-    |> Adaptor.mask_config_values(except: [:url, :http, :gzip])
+    |> Adaptor.mask_config_values(except: [:url, :http, :gzip, :format])
     |> Map.update(:url, nil, &redact_url_userinfo/1)
   end
 
@@ -216,7 +263,15 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   @impl Logflare.Backends.Adaptor
   @spec test_connection(Backend.t()) :: :ok | {:error, term()}
   def test_connection(%Backend{} = backend) do
-    test_connection(backend, [])
+    config = transform_config(backend)
+
+    body =
+      case Map.get(config, :format_batch) do
+        nil -> []
+        format_batch -> format_batch.([])
+      end
+
+    test_connection(%{backend | config: config}, body)
   end
 
   @doc """

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -57,6 +57,16 @@
             <% end %>
             {text_input(f_config, :url, class: "form-control")}
           </div>
+          <div class="form-group">
+            {label(f_config, :format, "Payload format")}
+            {select(f_config, :format, Logflare.Backends.Adaptor.WebhookAdaptor.formats(),
+              class: "form-control form-control-margin",
+              id: "webhook-format"
+            )}
+            <small class="form-text text-muted">
+              Encoding of each batch. <code>json</code> sends a JSON array. <code>ndjson</code> sends newline-delimited JSON, one event per line.
+            </small>
+          </div>
         <% "postgres" -> %>
           <div class="form-group">
             <%= label f_config, :url do %>

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -95,6 +95,80 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "ndjson ingestion" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user)
+      [source: source]
+    end
+
+    test "sends a newline-delimited binary body with the ndjson content-type", %{source: source} do
+      insert(:backend,
+        type: :webhook,
+        sources: [source],
+        config: %{http: "http1", url: "https://example.com", format: "ndjson"}
+      )
+
+      start_supervised!({SourceSup, source})
+
+      this = self()
+      ref = make_ref()
+
+      @subject.Client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:body], req[:headers]})
+        %Tesla.Env{}
+      end)
+
+      les = for _ <- 1..2, do: build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs(les, source)
+      assert_receive {^ref, body, headers}, 2000
+
+      assert is_binary(body)
+
+      decoded =
+        body
+        |> String.split("\n")
+        |> Enum.map(&Jason.decode!/1)
+
+      assert length(decoded) == 2
+      assert Enum.all?(decoded, &is_map/1)
+      assert headers["content-type"] == "application/x-ndjson"
+    end
+
+    test "keeps a user-configured content-type", %{source: source} do
+      insert(:backend,
+        type: :webhook,
+        sources: [source],
+        config: %{
+          http: "http1",
+          url: "https://example.com",
+          format: "ndjson",
+          headers: %{"content-type" => "text/plain"}
+        }
+      )
+
+      start_supervised!({SourceSup, source})
+
+      this = self()
+      ref = make_ref()
+
+      @subject.Client
+      |> expect(:send, fn req ->
+        send(this, {ref, req[:headers]})
+        %Tesla.Env{}
+      end)
+
+      le = build(:log_event, source: source)
+
+      assert {:ok, _} = Backends.ingest_logs([le], source)
+      assert_receive {^ref, headers}, 2000
+
+      assert headers["content-type"] == "text/plain"
+    end
+  end
+
   describe "test_connection/1" do
     setup do
       user = insert(:user)
@@ -116,6 +190,26 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
         assert req[:url] == "https://example.com"
         assert req[:body] == []
         assert req[:headers] == %{"x-key" => "v"}
+        {:ok, %Tesla.Env{status: 200, body: ""}}
+      end)
+
+      assert :ok = @subject.test_connection(backend)
+    end
+
+    test "sends an ndjson probe for an ndjson backend" do
+      user = insert(:user)
+
+      backend =
+        insert(:backend,
+          type: :webhook,
+          user: user,
+          config: %{http: "http1", url: "https://example.com", format: "ndjson"}
+        )
+
+      @subject.Client
+      |> expect(:send, fn req ->
+        assert req[:body] == ""
+        assert req[:headers]["content-type"] == "application/x-ndjson"
         {:ok, %Tesla.Env{status: 200, body: ""}}
       end)
 
@@ -419,6 +513,32 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
              Adaptor.cast_and_validate_config(@subject, %{
                url: "http://example.com",
                http: "http2"
+             })
+  end
+
+  test "cast_and_validate_config/1 for format" do
+    assert %Ecto.Changeset{
+             valid?: true,
+             changes: %{
+               format: "json"
+             }
+           } = Adaptor.cast_and_validate_config(@subject, %{url: "http://example.com"})
+
+    assert %Ecto.Changeset{
+             valid?: true,
+             changes: %{
+               format: "ndjson"
+             }
+           } =
+             Adaptor.cast_and_validate_config(@subject, %{
+               url: "http://example.com",
+               format: "ndjson"
+             })
+
+    assert %Ecto.Changeset{valid?: false} =
+             Adaptor.cast_and_validate_config(@subject, %{
+               url: "http://example.com",
+               format: "xml"
              })
   end
 

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -169,6 +169,41 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
     end
   end
 
+  describe "transform_config/1" do
+    test "collapses a case-variant content-type header for the ndjson format" do
+      backend =
+        build(:backend,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            format: "ndjson",
+            headers: %{"Content-Type" => "text/plain"}
+          }
+        )
+
+      assert %{headers: headers} = @subject.transform_config(backend)
+      assert headers == %{"content-type" => "text/plain"}
+    end
+
+    test "adds the ndjson content-type when the config has no headers" do
+      backend =
+        build(:backend,
+          type: :webhook,
+          config: %{url: "https://example.com", format: "ndjson"}
+        )
+
+      assert %{headers: headers} = @subject.transform_config(backend)
+      assert headers == %{"content-type" => "application/x-ndjson"}
+    end
+
+    test "leaves a json format config untouched" do
+      config = %{url: "https://example.com", format: "json", headers: %{"X-Api" => "abc"}}
+      backend = build(:backend, type: :webhook, config: config)
+
+      assert @subject.transform_config(backend) == config
+    end
+  end
+
   describe "test_connection/1" do
     setup do
       user = insert(:user)


### PR DESCRIPTION
## Human summary
- adds ndjson option to send ndjson payloads for webhook backends
- testing a connection tests the correct config
- gitignores my .plans folder

(custom header fields, the header-wipe fix, and the compression toggle moved to the stacked PR #3894)

## Summary

The webhook backend gains a `format` config option:

- `json` (default) — the current behavior, a JSON array of event bodies.
- `ndjson` — newline-delimited JSON, one event body per line, sent with the `application/x-ndjson` content type. A user-configured `content-type` header takes precedence.

## Design

The option is implemented through `transform_config/1`, the existing mechanism for payload shape and derived headers (the same pattern LokiAdaptor uses). When `format` is `ndjson`, `transform_config/1` sets `format_batch` and injects the content-type header. Because of this:

- The shared Broadway Pipeline is unchanged.
- `test_connection/1` resolves config the same way, so the connection test sends a format-correct probe (empty ndjson body with the `application/x-ndjson` header) instead of a JSON-array probe.
- Wrapper adaptors (Datadog, Elastic, Loki, and others) never cast `format`, so their behavior does not change.

The form's payload format select is sourced from `WebhookAdaptor.formats/0`, shared with `validate_config/1`. The webhook backend docs describe the `format` and `gzip` config options.

## Testing

`mix test test/logflare/backends/adaptor/webhook_adaptor_test.exs` — 8 doctests, 40 tests, 0 failures. New tests cover config cast/validation, the NDJSON body shape and content type through the full pipeline, precedence of a user-configured `content-type` header, and the ndjson connection probe.

Stacked follow-up: #3894 adds the custom header inputs, the header-wipe fix, the gzip checkbox, and poison-event drop-and-log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)