### PR TITLE
feat: add custom header inputs to the webhook backend form

### DIFF
--- a/docs/docs.logflare.com/docs/backends/webhook.mdx
+++ b/docs/docs.logflare.com/docs/backends/webhook.mdx
@@ -15,6 +15,7 @@ The following values are required when creating a webhook backend:
 Optional values:
 
 - `format`: (`string`, optional) the payload encoding, either `json` (default) or `ndjson`.
+- `headers`: (`map`, optional) headers sent with each request. For a bearer token, set the `authorization` header to `Bearer <token>`.
 - `gzip`: (`boolean`, optional, default `true`) compress the request body with gzip. The request sets the `content-encoding: gzip` header. Disable this when the receiver does not decompress request bodies.
 
 ### Request 

--- a/lib/logflare/backends/adaptor/google_secops_adaptor.ex
+++ b/lib/logflare/backends/adaptor/google_secops_adaptor.ex
@@ -92,10 +92,11 @@ defmodule Logflare.Backends.Adaptor.GoogleSecOpsAdaptor do
   end
 
   @impl HttpBased.Client
-  def client_opts(%Backend{config: config}) do
+  def client_opts(%Backend{config: config} = backend) do
     [
       url: endpoint_url(config),
       formatter: HttpBased.NdjsonFormatter,
+      formatter_opts: [metadata: [backend_id: backend.id]],
       json: false,
       headers: %{
         "x-goog-api-key" => config.api_key,

--- a/lib/logflare/backends/adaptor/http_based/client.ex
+++ b/lib/logflare/backends/adaptor/http_based/client.ex
@@ -30,6 +30,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
           | {:headers, %{String.t() => String.t()} | Tesla.Env.headers()}
           | {:basic_auth, [username: binary(), password: binary()]}
           | {:formatter, Tesla.Client.middleware()}
+          | {:formatter_opts, keyword()}
           | {:pool_name, atom()}
           | {:http2, boolean()}
 
@@ -55,6 +56,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
     Formatters that set request headers should export `reserved_headers/0` so
     user-supplied copies are removed. In particular, a formatter that owns
     `content-type` should return `["content-type"]`.
+  * `:formatter_opts` - Options passed to the formatter middleware. Omitted when unset,
+    so a formatter that takes no options stays a bare module.
   * `:pool_name` - An override for the name of the Finch pool to use for requests.
   * `:http2` - Whether to use HTTP/2. Defaults to `true`.
   """
@@ -70,7 +73,7 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
         opts[:token] && {Tesla.Middleware.BearerAuth, token: opts[:token]},
         opts[:basic_auth] && {Tesla.Middleware.BasicAuth, opts[:basic_auth]},
         headers_middleware(headers),
-        Keyword.get(opts, :formatter, LogEventTransformer),
+        formatter_middleware(opts),
         Keyword.get(opts, :json, true) && Tesla.Middleware.JSON,
         opts[:gzip] && {Tesla.Middleware.CompressRequest, format: "gzip"},
         EgressTracer
@@ -78,6 +81,16 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Client do
       |> Enum.filter(& &1),
       adapter_config(Keyword.get(opts, :http2, true), opts[:pool_name])
     )
+  end
+
+  @spec formatter_middleware(opts()) :: module() | {module(), keyword()}
+  defp formatter_middleware(opts) do
+    formatter = Keyword.get(opts, :formatter, LogEventTransformer)
+
+    case Keyword.get(opts, :formatter_opts) do
+      nil -> formatter
+      formatter_opts -> {formatter, formatter_opts}
+    end
   end
 
   # Header names the middleware will set, so they must be dropped from

--- a/lib/logflare/backends/adaptor/http_based/headers.ex
+++ b/lib/logflare/backends/adaptor/http_based/headers.ex
@@ -42,6 +42,13 @@ defmodule Logflare.Backends.Adaptor.HttpBased.Headers do
   """
   @spec normalize_keys(map()) :: map()
   def normalize_keys(headers) when is_map(headers) do
-    Map.new(headers, fn {key, value} -> {String.downcase(to_string(key)), value} end)
+    Map.new(headers, fn {key, value} -> {normalize_key(key), value} end)
   end
+
+  @doc """
+  Canonicalizes a single header name to lower case, so a lookup matches a map
+  built by `normalize_keys/1`.
+  """
+  @spec normalize_key(term()) :: String.t()
+  def normalize_key(key), do: key |> to_string() |> String.downcase()
 end

--- a/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
+++ b/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
@@ -15,11 +15,19 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
   @content_type "application/json"
 
   @impl Tesla.Middleware
-  def call(env, next, _opts) do
-    env
-    |> put_content_type_header()
-    |> Tesla.put_body(encode(env.body))
-    |> Tesla.run(next)
+  def call(env, next, opts) do
+    metadata = Keyword.get(opts || [], :metadata, [])
+
+    case encode(env.body, metadata) do
+      [] when env.body != [] ->
+        {:error, :all_events_dropped}
+
+      body ->
+        env
+        |> put_content_type_header()
+        |> Tesla.put_body(body)
+        |> Tesla.run(next)
+    end
   end
 
   @doc """
@@ -43,10 +51,12 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
   per line. Any other term passes through unchanged.
 
   An event whose body cannot be JSON-encoded is dropped. The count of dropped
-  events is logged per batch.
+  events is logged per batch, with `metadata` attached to the log entry.
   """
-  @spec encode([LogEvent.t()] | term()) :: iodata() | term()
-  def encode([%LogEvent{} | _] = events) do
+  @spec encode([LogEvent.t()] | term(), keyword()) :: iodata() | term()
+  def encode(events, metadata \\ [])
+
+  def encode([%LogEvent{} | _] = events, metadata) do
     {encoded, dropped_count} =
       Enum.reduce(events, {[], 0}, fn %LogEvent{body: body}, {acc, dropped_count} ->
         case Jason.encode_to_iodata(body) do
@@ -57,7 +67,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
 
     if dropped_count > 0 do
       Logger.warning(
-        "Dropped #{dropped_count} log events from an NDJSON batch: JSON encoding failed"
+        "Dropped #{dropped_count} log events from an NDJSON batch: JSON encoding failed",
+        metadata
       )
     end
 
@@ -66,5 +77,5 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
     |> Enum.intersperse("\n")
   end
 
-  def encode(term), do: term
+  def encode(term, _metadata), do: term
 end

--- a/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
+++ b/lib/logflare/backends/adaptor/http_based/ndjson_formatter.ex
@@ -6,6 +6,8 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
   `Logflare.Backends.Adaptor.HttpBased.Client.new/1` options.
   """
 
+  require Logger
+
   alias Logflare.LogEvent
 
   @behaviour Tesla.Middleware
@@ -39,11 +41,28 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter do
   @doc """
   Encodes `Logflare.LogEvent`s as newline-delimited JSON iodata, one event body
   per line. Any other term passes through unchanged.
+
+  An event whose body cannot be JSON-encoded is dropped. The count of dropped
+  events is logged per batch.
   """
   @spec encode([LogEvent.t()] | term()) :: iodata() | term()
   def encode([%LogEvent{} | _] = events) do
-    events
-    |> Enum.map(fn %LogEvent{body: body} -> Jason.encode_to_iodata!(body) end)
+    {encoded, dropped_count} =
+      Enum.reduce(events, {[], 0}, fn %LogEvent{body: body}, {acc, dropped_count} ->
+        case Jason.encode_to_iodata(body) do
+          {:ok, iodata} -> {[iodata | acc], dropped_count}
+          {:error, _reason} -> {acc, dropped_count + 1}
+        end
+      end)
+
+    if dropped_count > 0 do
+      Logger.warning(
+        "Dropped #{dropped_count} log events from an NDJSON batch: JSON encoding failed"
+      )
+    end
+
+    encoded
+    |> Enum.reverse()
     |> Enum.intersperse("\n")
   end
 

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -200,11 +200,19 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   @spec formats() :: [String.t()]
   def formats, do: @formats
 
+  @doc """
+  Sentinel rendered in place of a stored header value, so a decrypted secret never
+  reaches the browser. `unredact_headers/2` restores the stored value when the
+  sentinel is submitted back under an unchanged key.
+  """
+  @spec redacted_value() :: String.t()
+  def redacted_value, do: @redacted_value
+
   @impl Logflare.Backends.Adaptor
   @spec transform_config(Backend.t()) :: map()
-  def transform_config(%Backend{config: %{format: "ndjson"} = config}) do
+  def transform_config(%Backend{config: %{format: "ndjson"} = config} = backend) do
     config
-    |> Map.put(:format_batch, &encode_ndjson/1)
+    |> Map.put(:format_batch, &encode_ndjson(&1, backend_id: backend.id))
     |> Map.put(:headers, ndjson_headers(config))
   end
 
@@ -235,10 +243,10 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
     end
   end
 
-  @spec encode_ndjson([LogEvent.t()]) :: binary()
-  defp encode_ndjson(events) do
+  @spec encode_ndjson([LogEvent.t()], keyword()) :: binary()
+  defp encode_ndjson(events, metadata) do
     events
-    |> NdjsonFormatter.encode()
+    |> NdjsonFormatter.encode(metadata)
     |> IO.iodata_to_binary()
   end
 
@@ -496,20 +504,32 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       events = for %{data: le} <- messages, do: le
       payload = WebhookAdaptor.format_payload(config, events)
 
-      case process_data(payload, config, backend_metadata, context) do
-        {:error, {Tesla.Middleware.JSON, :encode, _reason}} ->
-          Logger.warning(
-            "Dropped #{length(messages)} log events from webhook batch: JSON encoding failed",
-            source_id: context.source_id,
-            backend_id: context.backend_id
-          )
+      if empty_payload?(payload) do
+        Logger.warning(
+          "Skipped webhook batch: all #{length(messages)} log events were dropped",
+          source_id: context.source_id,
+          backend_id: context.backend_id
+        )
+      else
+        case process_data(payload, config, backend_metadata, context) do
+          {:error, {Tesla.Middleware.JSON, :encode, _reason}} ->
+            Logger.warning(
+              "Dropped #{length(messages)} log events from webhook batch: JSON encoding failed",
+              source_id: context.source_id,
+              backend_id: context.backend_id
+            )
 
-        _ ->
-          :ok
+          _ ->
+            :ok
+        end
       end
 
       messages
     end
+
+    @spec empty_payload?(term()) :: boolean()
+    defp empty_payload?(payload) when payload in ["", []], do: true
+    defp empty_payload?(_payload), do: false
 
     defp process_data(payload, config, backend_metadata, context) do
       backend_meta =

--- a/lib/logflare/backends/adaptor/webhook_adaptor.ex
+++ b/lib/logflare/backends/adaptor/webhook_adaptor.ex
@@ -424,6 +424,9 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
   defmodule Pipeline do
     @moduledoc false
     use Broadway
+
+    require Logger
+
     alias Broadway.Message
     alias Logflare.Backends.BufferProducer
     alias Logflare.Backends.Adaptor.WebhookAdaptor
@@ -493,7 +496,18 @@ defmodule Logflare.Backends.Adaptor.WebhookAdaptor do
       events = for %{data: le} <- messages, do: le
       payload = WebhookAdaptor.format_payload(config, events)
 
-      process_data(payload, config, backend_metadata, context)
+      case process_data(payload, config, backend_metadata, context) do
+        {:error, {Tesla.Middleware.JSON, :encode, _reason}} ->
+          Logger.warning(
+            "Dropped #{length(messages)} log events from webhook batch: JSON encoding failed",
+            source_id: context.source_id,
+            backend_id: context.backend_id
+          )
+
+        _ ->
+          :ok
+      end
+
       messages
     end
 

--- a/lib/logflare_web/live/backends/backends_live.ex
+++ b/lib/logflare_web/live/backends/backends_live.ex
@@ -7,6 +7,8 @@ defmodule LogflareWeb.BackendsLive do
   import LogflareWeb.Utils, only: [stringify_changeset_errors: 1, with_team_param: 2]
 
   alias Logflare.Backends
+  alias Logflare.Backends.Adaptor.HttpBased.Headers
+  alias Logflare.Backends.Adaptor.WebhookAdaptor
   alias Logflare.Backends.Backend
   alias Logflare.Rules
   alias Logflare.Sources
@@ -14,7 +16,7 @@ defmodule LogflareWeb.BackendsLive do
 
   require Logger
 
-  @header_form_key_regex ~r/^header(\d+)_(key|value)$/
+  @header_form_key_regex ~r/^header(\d+)_(stored_key|key|value)$/
 
   embed_templates("actions/*", suffix: "_action")
   embed_templates("components/*")
@@ -74,7 +76,7 @@ defmodule LogflareWeb.BackendsLive do
         %{"backend" => params},
         %{assigns: %{live_action: :edit}} = socket
       ) do
-    with {:ok, params} <- transform_params(params) do
+    with {:ok, params} <- transform_params(params, existing_headers(socket.assigns.backend)) do
       socket =
         case Backends.update_backend(socket.assigns.backend, params) do
           {:ok, backend} ->
@@ -454,8 +456,8 @@ defmodule LogflareWeb.BackendsLive do
   defp read_cluster_component_id(%Backend{id: id}), do: "read-cluster-urls-#{id}"
   defp read_cluster_component_id(_backend), do: "read-cluster-urls-new"
 
-  @spec transform_params(map()) :: {:ok, map()} | {:error, String.t()}
-  defp transform_params(params) do
+  @spec transform_params(map(), map()) :: {:ok, map()} | {:error, String.t()}
+  defp transform_params(params, existing_headers \\ %{}) do
     type = params["type"]
 
     params
@@ -466,13 +468,20 @@ defmodule LogflareWeb.BackendsLive do
         if map_size(header_params) == 0 do
           config
         else
-          Map.put(config, "headers", build_headers(header_params))
+          Map.put(config, "headers", build_headers(header_params, existing_headers))
         end
 
       transform_config_for_type(config, type)
     end)
     |> assemble_read_clusters()
   end
+
+  @spec existing_headers(Backend.t() | nil) :: map()
+  defp existing_headers(%Backend{config: config}) when is_map(config) do
+    Headers.normalize_keys(Map.get(config, :headers) || %{})
+  end
+
+  defp existing_headers(_backend), do: %{}
 
   @spec header_form_keys(map()) :: [String.t()]
   defp header_form_keys(config) when is_map(config) do
@@ -481,14 +490,32 @@ defmodule LogflareWeb.BackendsLive do
 
   defp header_form_keys(_config), do: []
 
-  @spec build_headers(map()) :: map()
-  defp build_headers(header_params) do
+  @spec build_headers(map(), map()) :: map()
+  defp build_headers(header_params, existing_headers) do
     for index <- header_form_indexes(header_params),
         key = header_params["header#{index}_key"],
         is_binary(key),
         key != "",
         into: %{} do
-      {key, header_params["header#{index}_value"]}
+      {key, header_value(header_params, index, existing_headers)}
+    end
+  end
+
+  # Restores the stored secret for a row whose value input still holds the redaction
+  # sentinel. The lookup uses the key the row was rendered with, so renaming a key
+  # carries its stored value over instead of writing the sentinel or dropping the
+  # header. Rows the user actually edited pass through untouched.
+  @spec header_value(map(), String.t(), map()) :: term()
+  defp header_value(header_params, index, existing_headers) do
+    value = header_params["header#{index}_value"]
+    stored_key = header_params["header#{index}_stored_key"]
+
+    with true <- value == WebhookAdaptor.redacted_value(),
+         true <- is_binary(stored_key) and stored_key != "",
+         {:ok, stored_value} <- Map.fetch(existing_headers, Headers.normalize_key(stored_key)) do
+      stored_value
+    else
+      _ -> value
     end
   end
 

--- a/lib/logflare_web/live/backends/backends_live.ex
+++ b/lib/logflare_web/live/backends/backends_live.ex
@@ -14,6 +14,8 @@ defmodule LogflareWeb.BackendsLive do
 
   require Logger
 
+  @header_form_key_regex ~r/^header(\d+)_(key|value)$/
+
   embed_templates("actions/*", suffix: "_action")
   embed_templates("components/*")
 
@@ -458,32 +460,45 @@ defmodule LogflareWeb.BackendsLive do
 
     params
     |> Map.update("config", nil, fn config ->
-      headers_form_keys =
-        for i <- 1..2 do
-          ["header#{i}_key", "header#{i}_value"]
-        end
-
-      {header_params, config} = Map.split(config, List.flatten(headers_form_keys))
-
-      headers =
-        for [form_key, form_value] <- headers_form_keys,
-            key = header_params[form_key],
-            key != "",
-            value = header_params[form_value],
-            into: %{} do
-          {key, value}
-        end
+      {header_params, config} = Map.split(config, header_form_keys(config))
 
       config =
         if map_size(header_params) == 0 do
           config
         else
-          Map.put(config, "headers", headers)
+          Map.put(config, "headers", build_headers(header_params))
         end
 
       transform_config_for_type(config, type)
     end)
     |> assemble_read_clusters()
+  end
+
+  @spec header_form_keys(map()) :: [String.t()]
+  defp header_form_keys(config) when is_map(config) do
+    for key <- Map.keys(config), Regex.match?(@header_form_key_regex, key), do: key
+  end
+
+  defp header_form_keys(_config), do: []
+
+  @spec build_headers(map()) :: map()
+  defp build_headers(header_params) do
+    for index <- header_form_indexes(header_params),
+        key = header_params["header#{index}_key"],
+        is_binary(key),
+        key != "",
+        into: %{} do
+      {key, header_params["header#{index}_value"]}
+    end
+  end
+
+  @spec header_form_indexes(map()) :: [String.t()]
+  defp header_form_indexes(header_params) do
+    header_params
+    |> Map.keys()
+    |> Enum.map(&Regex.run(@header_form_key_regex, &1, capture: :all_but_first))
+    |> Enum.map(fn [index, _field] -> index end)
+    |> Enum.uniq()
   end
 
   @spec assemble_read_clusters(map()) :: {:ok, map()} | {:error, String.t()}

--- a/lib/logflare_web/live/backends/backends_live.ex
+++ b/lib/logflare_web/live/backends/backends_live.ex
@@ -463,20 +463,25 @@ defmodule LogflareWeb.BackendsLive do
           ["header#{i}_key", "header#{i}_value"]
         end
 
-      {headers, config} = Map.split(config, List.flatten(headers_form_keys))
+      {header_params, config} = Map.split(config, List.flatten(headers_form_keys))
 
       headers =
         for [form_key, form_value] <- headers_form_keys,
-            key = headers[form_key],
+            key = header_params[form_key],
             key != "",
-            value = headers[form_value],
+            value = header_params[form_value],
             into: %{} do
           {key, value}
         end
 
-      config
-      |> Map.put("headers", headers)
-      |> transform_config_for_type(type)
+      config =
+        if map_size(header_params) == 0 do
+          config
+        else
+          Map.put(config, "headers", headers)
+        end
+
+      transform_config_for_type(config, type)
     end)
     |> assemble_read_clusters()
   end

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -57,6 +57,23 @@
             <% end %>
             {text_input(f_config, :url, class: "form-control")}
           </div>
+          <% headers_number = 2
+
+          fields =
+            (input_value(f_config, :headers) || %{})
+            |> Stream.concat(Stream.repeatedly(fn -> {"", ""} end))
+            |> Enum.take(headers_number) %>
+          <%= for {{key, val}, i} <- Enum.with_index(fields, 1) do %>
+            <div class="form-group">
+              {label(f_config, "header#{i}_key", "Custom header #{i} - Key")}
+              {text_input(f_config, "header#{i}_key", value: key, class: "form-control")}
+              {label(f_config, "header#{i}_value", "Custom header #{i} - Value")}
+              {text_input(f_config, "header#{i}_value", value: val, class: "form-control")}
+            </div>
+          <% end %>
+          <small class="form-text text-muted">
+            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>.
+          </small>
           <div class="form-group">
             {label(f_config, :format, "Payload format")}
             {select(f_config, :format, Logflare.Backends.Adaptor.WebhookAdaptor.formats(),
@@ -65,6 +82,13 @@
             )}
             <small class="form-text text-muted">
               Encoding of each batch. <code>json</code> sends a JSON array. <code>ndjson</code> sends newline-delimited JSON, one event per line.
+            </small>
+          </div>
+          <div class="form-group">
+            {label(f_config, :gzip, "Gzip")}
+            {checkbox(f_config, :gzip, id: "webhook-gzip")}
+            <small class="form-text text-muted">
+              Enable "gzip" compression in sent requests. Disable this when the receiver does not decompress request bodies.
             </small>
           </div>
         <% "postgres" -> %>

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -68,11 +68,14 @@
               {label(f_config, "header#{i}_key", "Custom header #{i} - Key")}
               {text_input(f_config, "header#{i}_key", value: key, class: "form-control")}
               {label(f_config, "header#{i}_value", "Custom header #{i} - Value")}
-              {text_input(f_config, "header#{i}_value", value: val, class: "form-control")}
+              {text_input(f_config, "header#{i}_value",
+                value: if(val in [nil, ""], do: val, else: "REDACTED"),
+                class: "form-control"
+              )}
             </div>
           <% end %>
           <small class="form-text text-muted">
-            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>.
+            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>. Stored values show as <code>REDACTED</code>; leave them unchanged to keep them.
           </small>
           <div class="form-group">
             {label(f_config, :format, "Payload format")}

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -57,12 +57,13 @@
             <% end %>
             {text_input(f_config, :url, class: "form-control")}
           </div>
-          <% headers_number = 2
+          <% stored_headers = input_value(f_config, :headers) || %{}
 
           fields =
-            (input_value(f_config, :headers) || %{})
+            stored_headers
+            |> Enum.sort_by(fn {key, _value} -> key end)
             |> Stream.concat(Stream.repeatedly(fn -> {"", ""} end))
-            |> Enum.take(headers_number) %>
+            |> Enum.take(max(map_size(stored_headers) + 1, 2)) %>
           <%= for {{key, val}, i} <- Enum.with_index(fields, 1) do %>
             <div class="form-group">
               {label(f_config, "header#{i}_key", "Custom header #{i} - Key")}
@@ -75,7 +76,7 @@
             </div>
           <% end %>
           <small class="form-text text-muted">
-            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>. Stored values show as <code>REDACTED</code>; leave them unchanged to keep them.
+            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>. Stored values show as <code>REDACTED</code>; leave them unchanged to keep them. Clear a key to remove the header.
           </small>
           <div class="form-group">
             {label(f_config, :format, "Payload format")}

--- a/lib/logflare_web/live/backends/components/backend_form.heex
+++ b/lib/logflare_web/live/backends/components/backend_form.heex
@@ -70,13 +70,19 @@
               {text_input(f_config, "header#{i}_key", value: key, class: "form-control")}
               {label(f_config, "header#{i}_value", "Custom header #{i} - Value")}
               {text_input(f_config, "header#{i}_value",
-                value: if(val in [nil, ""], do: val, else: "REDACTED"),
+                value:
+                  if(val in [nil, ""],
+                    do: val,
+                    else: Logflare.Backends.Adaptor.WebhookAdaptor.redacted_value()
+                  ),
                 class: "form-control"
               )}
+              {hidden_input(f_config, "header#{i}_stored_key", value: key)}
             </div>
           <% end %>
           <small class="form-text text-muted">
-            Headers sent with each request. For a bearer token, set the key to <code>authorization</code> and the value to <code>Bearer &lt;token&gt;</code>. Stored values show as <code>REDACTED</code>; leave them unchanged to keep them. Clear a key to remove the header.
+            Headers sent with each request. For a bearer token, set the key to <code>authorization</code>
+            and the value to <code>Bearer &lt;token&gt;</code>. Stored values show as <code>REDACTED</code>; leave them unchanged to keep them. You can rename a key without retyping its value. Clear a key to remove the header.
           </small>
           <div class="form-group">
             {label(f_config, :format, "Payload format")}
@@ -90,7 +96,10 @@
           </div>
           <div class="form-group">
             {label(f_config, :gzip, "Gzip")}
-            {checkbox(f_config, :gzip, id: "webhook-gzip")}
+            {checkbox(f_config, :gzip,
+              id: "webhook-gzip",
+              checked: input_value(f_config, :gzip) not in [false, "false"]
+            )}
             <small class="form-text text-muted">
               Enable "gzip" compression in sent requests. Disable this when the receiver does not decompress request bodies.
             </small>

--- a/test/logflare/backends/adaptor/http_based/ndjson_formatter_test.exs
+++ b/test/logflare/backends/adaptor/http_based/ndjson_formatter_test.exs
@@ -31,4 +31,30 @@ defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatterTest do
 
     assert log =~ "Dropped 2 log events from an NDJSON batch"
   end
+
+  test "attaches the given metadata to the dropped count log" do
+    events = [%LogEvent{body: %{"bad" => <<0xFF>>}}]
+
+    log =
+      capture_log([format: "$metadata$message", metadata: [:backend_id]], fn ->
+        NdjsonFormatter.encode(events, backend_id: 123)
+      end)
+
+    assert log =~ "backend_id=123"
+  end
+
+  test "returns an error instead of an empty body when every event is dropped" do
+    events = [%LogEvent{body: %{"bad" => <<0xFF>>}}, %LogEvent{body: %{"bad2" => <<0xFE>>}}]
+    env = %Tesla.Env{body: events, headers: []}
+
+    capture_log(fn ->
+      assert NdjsonFormatter.call(env, [], []) == {:error, :all_events_dropped}
+    end)
+  end
+
+  test "sends an empty batch through unchanged" do
+    env = %Tesla.Env{body: [], headers: []}
+
+    assert {:ok, %Tesla.Env{body: []}} = NdjsonFormatter.call(env, [], [])
+  end
 end

--- a/test/logflare/backends/adaptor/http_based/ndjson_formatter_test.exs
+++ b/test/logflare/backends/adaptor/http_based/ndjson_formatter_test.exs
@@ -1,0 +1,34 @@
+defmodule Logflare.Backends.Adaptor.HttpBased.NdjsonFormatterTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Logflare.Backends.Adaptor.HttpBased.NdjsonFormatter
+  alias Logflare.LogEvent
+
+  test "encodes one event body per line" do
+    events = [%LogEvent{body: %{"a" => 1}}, %LogEvent{body: %{"b" => 2}}]
+
+    assert IO.iodata_to_binary(NdjsonFormatter.encode(events)) == ~s({"a":1}\n{"b":2})
+  end
+
+  test "passes non-event terms through unchanged" do
+    assert NdjsonFormatter.encode("raw") == "raw"
+    assert NdjsonFormatter.encode(nil) == nil
+  end
+
+  test "drops unencodable events and logs the dropped count" do
+    events = [
+      %LogEvent{body: %{"ok" => true}},
+      %LogEvent{body: %{"bad" => <<0xFF>>}},
+      %LogEvent{body: %{"bad2" => <<0xFE>>}}
+    ]
+
+    log =
+      capture_log(fn ->
+        assert IO.iodata_to_binary(NdjsonFormatter.encode(events)) == ~s({"ok":true})
+      end)
+
+    assert log =~ "Dropped 2 log events from an NDJSON batch"
+  end
+end

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -159,6 +159,32 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       assert headers["content-type"] == "application/x-ndjson"
     end
 
+    test "skips the request when every event is dropped", %{source: source} do
+      insert(:backend,
+        type: :webhook,
+        sources: [source],
+        config: %{http: "http1", url: "https://example.com", format: "ndjson"}
+      )
+
+      start_supervised!({SourceSup, source})
+
+      @subject.Client
+      |> reject(:send, 1)
+
+      les =
+        for _ <- 1..2 do
+          build(:log_event, source: source, unencodable: <<0xFF>>)
+        end
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, _} = Backends.ingest_logs(les, source)
+          Process.sleep(500)
+        end)
+
+      assert log =~ "Skipped webhook batch: all 2 log events were dropped"
+    end
+
     test "keeps a user-configured content-type", %{source: source} do
       insert(:backend,
         type: :webhook,

--- a/test/logflare/backends/adaptor/webhook_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/webhook_adaptor_test.exs
@@ -71,6 +71,28 @@ defmodule Logflare.Backends.WebhookAdaptorTest do
       assert_receive ^ref, 2000
     end
 
+    test "logs the batch size when JSON encoding fails", %{source: source} do
+      this = self()
+      ref = make_ref()
+
+      @subject.Client
+      |> expect(:send, fn _req ->
+        send(this, ref)
+        {:error, {Tesla.Middleware.JSON, :encode, :invalid}}
+      end)
+
+      les = for _ <- 1..2, do: build(:log_event, source: source)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, _} = Backends.ingest_logs(les, source)
+          assert_receive ^ref, 2000
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Dropped 2 log events from webhook batch: JSON encoding failed"
+    end
+
     test "uses cache for config fetching", %{source: source} do
       Logflare.Repo.update_all(Backend,
         set: [config_encrypted: %{http: "http1", url: "https://other-email.com"}]

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -789,6 +789,95 @@ defmodule LogflareWeb.BackendsLiveTest do
       assert updated.config.headers == %{"authorization" => "Bearer secret-token"}
     end
 
+    test "webhook edit renders a row per stored header and keeps them all", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      headers = %{
+        "authorization" => "Bearer secret-token",
+        "x-one" => "1",
+        "x-two" => "2",
+        "x-three" => "3"
+      }
+
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{url: "https://example.com", headers: headers}
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      assert view
+             |> element("input[name='backend[config][header4_key]']")
+             |> render() =~ "x-two"
+
+      view
+      |> form("form", %{backend: %{config: %{url: "https://example.org"}}})
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.url == "https://example.org"
+      assert updated.config.headers == headers
+    end
+
+    test "webhook edit can add a header beyond the stored ones", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            headers: %{"x-one" => "1", "x-two" => "2"}
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{
+        backend: %{config: %{header3_key: "x-three", header3_value: "3"}}
+      })
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.headers == %{"x-one" => "1", "x-two" => "2", "x-three" => "3"}
+    end
+
+    test "webhook edit removes a header when its key is cleared", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            headers: %{"x-one" => "1", "x-two" => "2"}
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{backend: %{config: %{header1_key: "", header1_value: ""}}})
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.headers == %{"x-two" => "2"}
+    end
+
     test "webhook edit can set a header through the form", %{
       conn: conn,
       source: source,

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -764,11 +764,17 @@ defmodule LogflareWeb.BackendsLiveTest do
           }
         )
 
-      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+      {:ok, view, html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      refute html =~ "secret-token"
 
       assert view
              |> element("input[name='backend[config][header1_key]']")
              |> render() =~ "authorization"
+
+      assert view
+             |> element("input[name='backend[config][header1_value]']")
+             |> render() =~ "REDACTED"
 
       view
       |> form("form", %{

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -878,6 +878,123 @@ defmodule LogflareWeb.BackendsLiveTest do
       assert updated.config.headers == %{"x-two" => "2"}
     end
 
+    test "webhook create defaults gzip to true", %{conn: conn, user: user} do
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/new")
+
+      view |> element("select#type") |> render_change(%{backend: %{type: "webhook"}})
+
+      view
+      |> form("form", %{
+        backend: %{
+          name: "gzip default backend",
+          type: "webhook",
+          config: %{url: "https://example.com"}
+        }
+      })
+      |> render_submit()
+
+      backend =
+        Backends.list_backends_by_user_id(user.id)
+        |> Enum.find(&(&1.name == "gzip default backend"))
+
+      assert backend.config.gzip == true
+    end
+
+    test "webhook create can disable gzip", %{conn: conn, user: user} do
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/new")
+
+      view |> element("select#type") |> render_change(%{backend: %{type: "webhook"}})
+
+      view
+      |> form("form", %{
+        backend: %{
+          name: "gzip off backend",
+          type: "webhook",
+          config: %{url: "https://example.com", gzip: "false"}
+        }
+      })
+      |> render_submit()
+
+      backend =
+        Backends.list_backends_by_user_id(user.id)
+        |> Enum.find(&(&1.name == "gzip off backend"))
+
+      assert backend.config.gzip == false
+    end
+
+    test "webhook edit keeps gzip disabled", %{conn: conn, source: source, user: user} do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{url: "https://example.com", gzip: false}
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{backend: %{config: %{url: "https://example.org"}}})
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.gzip == false
+    end
+
+    test "webhook edit carries a stored header value to a renamed key", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            headers: %{"authorization" => "Bearer secret-token"}
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{backend: %{config: %{header1_key: "x-api-key"}}})
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.headers == %{"x-api-key" => "Bearer secret-token"}
+    end
+
+    test "webhook edit writes a header value the user actually changed", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            headers: %{"authorization" => "Bearer old-token"}
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{
+        backend: %{config: %{header1_key: "authorization", header1_value: "Bearer new-token"}}
+      })
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.headers == %{"authorization" => "Bearer new-token"}
+    end
+
     test "webhook edit can set a header through the form", %{
       conn: conn,
       source: source,

--- a/test/logflare_web/live/backends/backends_live_test.exs
+++ b/test/logflare_web/live/backends/backends_live_test.exs
@@ -748,6 +748,72 @@ defmodule LogflareWeb.BackendsLiveTest do
       assert html =~ "some description"
     end
 
+    test "webhook edit renders stored headers and preserves them on submit", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{
+            url: "https://example.com",
+            headers: %{"authorization" => "Bearer secret-token"}
+          }
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      assert view
+             |> element("input[name='backend[config][header1_key]']")
+             |> render() =~ "authorization"
+
+      view
+      |> form("form", %{
+        backend: %{
+          config: %{url: "https://example.org"}
+        }
+      })
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.url == "https://example.org"
+      assert updated.config.headers == %{"authorization" => "Bearer secret-token"}
+    end
+
+    test "webhook edit can set a header through the form", %{
+      conn: conn,
+      source: source,
+      user: user
+    } do
+      backend =
+        insert(:backend,
+          sources: [source],
+          user: user,
+          type: :webhook,
+          config: %{url: "https://example.com"}
+        )
+
+      {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")
+
+      view
+      |> form("form", %{
+        backend: %{
+          config: %{
+            url: "https://example.com",
+            header1_key: "authorization",
+            header1_value: "Bearer my-token"
+          }
+        }
+      })
+      |> render_submit()
+
+      updated = Backends.get_backend_by_user_access(user, backend.id)
+      assert updated.config.headers == %{"authorization" => "Bearer my-token"}
+    end
+
     test "will show correct config inputs", %{conn: conn, user: user} do
       backend = insert(:backend, type: :webhook, user: user)
       assert {:ok, view, _html} = live_with_redirect(conn, ~p"/backends/#{backend.id}/edit")


### PR DESCRIPTION
## Summary

- The webhook form gains custom header key/value rows. This allows a bearer token from the UI: key `authorization`, value `Bearer <token>`. The form renders one row per stored header, sorted by key, plus one blank row for a new entry. It keeps a minimum of 2 rows. Clearing a key removes the header.
- Stored header values render as the `REDACTED` sentinel, so the edit page HTML never carries a decrypted secret. Each row also carries a hidden `header<i>_stored_key`, so `transform_params/2` can resolve the sentinel by the key the row was rendered with. Renaming a key carries its stored value over. `WebhookAdaptor.unredact_headers/2` (merged in #3893) still covers the API path.
- The form gains a gzip checkbox. Some receivers do not decompress gzip request bodies, so the existing `gzip` config option is now visible in the UI. The box renders checked unless the value is explicitly false, so a backend created through the UI keeps the documented `true` default.
- `transform_params/1` derives the header indexes from the submitted params instead of a hardcoded `1..2` range, and only writes `headers` when the submitted form contains header fields. Before, every submit from a form without header inputs sent an empty headers map, which cleared headers set through the API.
- Poison-event handling: `NdjsonFormatter.encode/2` drops an event whose body cannot be JSON-encoded and logs the count per batch, with backend metadata. Before, one bad event raised and failed the whole batch. When every event in a batch is dropped, the pipeline skips the request instead of posting an empty body, and the formatter middleware returns `{:error, :all_events_dropped}` for the Google SecOps path.
- Docs: `webhook.mdx` documents the `headers` config option.

## Supporting changes

- `WebhookAdaptor.redacted_value/0` exposes the sentinel, so the form and the LiveView stop hardcoding the string.
- `Headers.normalize_key/1` for a single-key lookup. `normalize_keys/1` reuses it.
- `HttpBased.Client` gains `:formatter_opts`, so a formatter middleware can take options. It is omitted when unset, so a formatter that takes none stays a bare module.

## Review fixes

All four items from @amokan's review are fixed. Each one was reproduced with a probe test first.

| Item | Reproduced | Fix |
|---|---|---|
| Creating a webhook through the UI stored `gzip: false` | `CREATED VIA UI: %{gzip: false, ...}` | The checkbox renders checked unless the value is explicitly false. The edit path was already correct and rendered `checked`. |
| Renaming a header key dropped the credential | `HEADERS AFTER KEY RENAME: %{}` | Hidden `header<i>_stored_key` per row; `transform_params/2` resolves the sentinel against it. |
| A fully dropped batch posted an empty body | confirmed by reading both call paths | The pipeline skips the request and logs it. The middleware returns `{:error, :all_events_dropped}`. |
| The dropped-count log had no backend context | confirmed | The formatter takes metadata, from `encode/2` and from `:formatter_opts`. |

The OTLP and Loki header rows submit no `stored_key`, so `header_value/3` leaves them untouched and their behavior is unchanged.

**Why the original tests missed the first two.** Every test in the first round exercised the edit path and asserted only `updated.config.headers`. `backend_factory/1` writes config verbatim, so a stored `gzip: false` never failed an assertion. The header tests covered the unchanged, added, and cleared rows, but never a changed key.

## Testing

- `mix test test/logflare_web/live/backends/backends_live_test.exs` — 74 tests, 0 failures. New tests cover the gzip default on create, disabling gzip on create, keeping gzip off on edit, renaming a header key, and writing a header value the user actually changed.
- `mix test test/logflare/backends/adaptor/webhook_adaptor_test.exs` — 45 tests + 8 doctests, 0 failures. A new test asserts the request is skipped when every event is dropped.
- `mix test test/logflare/backends/adaptor/http_based/ndjson_formatter_test.exs` — 6 tests, 0 failures. New tests cover the log metadata, the all-dropped error, and an empty batch.
- `mix test test/logflare/backends/adaptor/google_secops_adaptor_test.exs test/logflare/backends/adaptor/http_based/ test/logflare/backends/adaptor/otlp_adaptor_test.exs` — 62 tests, 0 failures.

## Known limit

The OTLP header rows have the same secret-leak issue, but `OtlpAdaptor.cast_config` has no sentinel unredaction, so the same fix would corrupt stored OTLP headers on save. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPMHo5UmWRJnSVJcc36JJW
