### PR TITLE
fix(repo): open read replica connections read-only

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -407,10 +407,8 @@ if(
     ]
   ]
 
-  # RFC 6066 §3 forbids IP literals in SNI. For IP hosts, suppress the SNI
-  # extension but still verify the host against iPAddress SANs via the :https
-  # match_fun. For hostnames, let OTP default SNI to `host` so dNSName SANs
-  # are checked.
+  # RFC 6066 §3 forbids IP literals in SNI. OTP does not perform hostname
+  # verification when SNI is disabled for an IP literal.
   db_ssl_opts =
     case :inet.parse_address(String.to_charlist(System.get_env("DB_HOSTNAME", ""))) do
       {:ok, _ip} -> Keyword.put(base_db_ssl_opts, :server_name_indication, :disable)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -407,8 +407,10 @@ if(
     ]
   ]
 
-  # RFC 6066 §3 forbids IP literals in SNI. OTP does not perform hostname
-  # verification when SNI is disabled for an IP literal.
+  # RFC 6066 §3 forbids IP literals in SNI. For IP hosts, suppress the SNI
+  # extension but still verify the host against iPAddress SANs via the :https
+  # match_fun. For hostnames, let OTP default SNI to `host` so dNSName SANs
+  # are checked.
   db_ssl_opts =
     case :inet.parse_address(String.to_charlist(System.get_env("DB_HOSTNAME", ""))) do
       {:ok, _ip} -> Keyword.put(base_db_ssl_opts, :server_name_indication, :disable)

--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -166,13 +166,15 @@ The configuration follows the [Erlang Security Working Group recommendations](ht
 
 ## Read Replicas
 
-`LOGFLARE_READ_REPLICAS` is a comma-separated list of PostgreSQL read replicas to distribute ingest-path data fetching queries across. If unset or empty, all queries go to the primary database.
+`LOGFLARE_READ_REPLICAS` is a comma-separated list of PostgreSQL read replicas for selected context-cache and key-value-cache reads. If unset or empty, those reads use the primary database.
 
 Each entry is either a **bare hostname** or a **connection URI** (`postgres://user:pass@host:port/database?ssl=true&pool_size=5`). In both cases, only the parts given override the primary's `DB_*` settings - anything omitted (port, database, credentials, SSL, ...) is inherited from the primary. Query params: `ssl` (`true`/`false`), `pool_size` (positive integer).
 
 Example: `LOGFLARE_READ_REPLICAS=replica1.example.com,postgres://user:pass@replica2.example.com:5432/logflare`
 
-Replica connections open their sessions read-only (`SET default_transaction_read_only = on`), so a write that reaches a replica fails immediately rather than diverging from the primary. This matters for a logical replica, whose server would otherwise accept the write; on a physical standby it is redundant with the server's own read-only state.
+Logflare marks each replica session read-only with `SET default_transaction_read_only = on`. This makes accidental writes fail immediately on logical replicas; physical standbys already enforce read-only operation.
+
+PostgreSQL RDS Proxy [pins sessions that issue `SET`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html), so each Logflare replica connection keeps one database connection for its lifetime. Size the proxy and database connection limits for that behavior.
 
 ## Database Encryption
 

--- a/docs/docs.logflare.com/docs/self-hosting/index.md
+++ b/docs/docs.logflare.com/docs/self-hosting/index.md
@@ -172,6 +172,8 @@ Each entry is either a **bare hostname** or a **connection URI** (`postgres://us
 
 Example: `LOGFLARE_READ_REPLICAS=replica1.example.com,postgres://user:pass@replica2.example.com:5432/logflare`
 
+Replica connections open their sessions read-only (`SET default_transaction_read_only = on`), so a write that reaches a replica fails immediately rather than diverging from the primary. This matters for a logical replica, whose server would otherwise accept the write; on a physical standby it is redundant with the server's own read-only state.
+
 ## Database Encryption
 
 Certain database columns that store sensitive data are encrypted with the `LOGFLARE_DB_ENCRYPTION_KEY` key.

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -22,18 +22,13 @@ defmodule Logflare.Repo.Replicas do
   a function call using `apply_with_replica/3` on `Logflare.Repo`, which swaps
   the dynamic repo and restores it afterwards.
 
-  Every replica connection opens its session read-only, so a write that reaches a
-  replica fails immediately instead of diverging from the primary.
+  Every replica connection opens its session read-only.
   """
 
   @registry __MODULE__.Registry
 
-  # Replicas serve reads only: `Logflare.Repo.apply_with_replica/3` and
-  # `apply_with_random_repo/3` are the only ways to reach one, and both are read
-  # paths. Marking the session read-only turns a write that slips through into an
-  # immediate error rather than a silent divergence. That matters most when the
-  # replica is a logical subscriber, which - unlike a physical standby - has a
-  # server that will happily accept the write.
+  # A physical standby rejects a stray write on its own; a logical subscriber accepts it, and
+  # the divergence only surfaces later as a conflict that stalls replication.
   @read_only_statement "SET default_transaction_read_only = on"
 
   def child_spec(options) do
@@ -85,13 +80,11 @@ defmodule Logflare.Repo.Replicas do
   end
 
   @doc """
-  Runs on every replica connection: the primary's own `:after_connect`, if it has
-  one, then the read-only session setting.
+  Runs the primary's own `:after_connect`, then marks the session read-only.
 
-  A replica's config is the primary's with the entry's overrides applied, so
-  setting `:after_connect` on a replica would otherwise drop the primary's -
-  which is what sets `search_path` when `DB_SCHEMA` is configured. The primary's
-  hook runs first so that this stays compatible with one that needs to write.
+  A replica's config is the primary's with the entry's overrides applied, so setting
+  `:after_connect` here would otherwise drop the primary's - the one that sets `search_path`
+  from `DB_SCHEMA`. It runs first, so a hook that needs to write still can.
   """
   @spec after_connect(pid(), {module(), atom(), [term()]} | (pid() -> any()) | nil) ::
           Postgrex.Result.t()

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -192,14 +192,17 @@ defmodule Logflare.Repo.Replicas do
 
   defp primary_ssl_opts(hostname) do
     case Keyword.get(Logflare.Repo.config(), :ssl) do
-      opts when is_list(opts) ->
-        case :inet.parse_address(String.to_charlist(hostname || "")) do
-          {:ok, _ip} -> Keyword.put(opts, :server_name_indication, :disable)
-          {:error, _} -> opts
-        end
+      opts when is_list(opts) -> replica_ssl_opts(opts, hostname)
+      _ -> true
+    end
+  end
 
-      _ ->
-        true
+  defp replica_ssl_opts(opts, hostname) do
+    opts = Keyword.delete(opts, :server_name_indication)
+
+    case :inet.parse_address(String.to_charlist(hostname || "")) do
+      {:ok, _ip} -> Keyword.put(opts, :server_name_indication, :disable)
+      {:error, _} -> opts
     end
   end
 

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -7,17 +7,16 @@ defmodule Logflare.Repo.Replicas do
   `Registry`. If no replicas are configured, the supervisor is skipped entirely.
 
   Each `LOGFLARE_READ_REPLICAS` entry is either a bare hostname or a Postgres URI
-  (`postgres://user:pass@host:port/database?ssl=true&pool_size=5`). In both
-  cases, only the parts explicitly given override the primary `Logflare.Repo`
-  config - anything not specified (host, port, database, credentials, ssl, ...) is
-  inherited from the primary's `DB_*` settings, without ever baking the primary's
-  actual values into the parsed result. URIs are parsed and validated entirely by
-  `Ecto.Repo.Supervisor.parse_url/1`.
+  (`postgres://user:pass@host:port/database?ssl=true&pool_size=5`). Supplied
+  connection settings override the primary `Logflare.Repo` configuration; omitted
+  settings inherit the primary's `DB_*` values without copying them into the parsed
+  result. IP literal hosts also derive the matching socket address family. URIs are
+  parsed and validated by `Ecto.Repo.Supervisor.parse_url/1`.
 
-  Replica pools are identified by a key derived from the entry (host/port/database
-  plus a `:erlang.phash2/2` hash of the raw entry, to avoid collisions between
-  entries that only differ by credentials or query params) that never contains
-  credentials, so it is safe to include in log or error messages.
+  Replica pools are identified by the parsed hostname plus an `:erlang.phash2/2`
+  hash of the parsed configuration. The key never contains credentials, so it is
+  safe to include in log or error messages.
+
   Callers can temporarily redirect Ecto queries to a replica for the duration of
   a function call using `apply_with_replica/3` on `Logflare.Repo`, which swaps
   the dynamic repo and restores it afterwards.
@@ -27,8 +26,8 @@ defmodule Logflare.Repo.Replicas do
 
   @registry __MODULE__.Registry
 
-  # A physical standby rejects a stray write on its own; a logical subscriber accepts it, and
-  # the divergence only surfaces later as a conflict that stalls replication.
+  # Physical standbys already reject writes. Logical subscribers do not, so a
+  # read-only default turns accidental writes into immediate errors.
   @read_only_statement "SET default_transaction_read_only = on"
 
   def child_spec(options) do
@@ -80,14 +79,17 @@ defmodule Logflare.Repo.Replicas do
   end
 
   @doc """
-  Runs the primary's own `:after_connect`, then marks the session read-only.
+  Runs the primary repository's `:after_connect` hook, then makes the replica session
+  read-only.
 
-  A replica's config is the primary's with the entry's overrides applied, so setting
-  `:after_connect` here would otherwise drop the primary's - the one that sets `search_path`
-  from `DB_SCHEMA`. It runs first, so a hook that needs to write still can.
+  Replica pools inherit the primary configuration. Replacing `:after_connect` without
+  composition would discard settings such as the `search_path` configured by `DB_SCHEMA`.
+  The inherited hook runs first so it can perform any required writes.
   """
-  @spec after_connect(pid(), {module(), atom(), [term()]} | (pid() -> any()) | nil) ::
-          Postgrex.Result.t()
+  @spec after_connect(
+          DBConnection.conn(),
+          {module(), atom(), [term()]} | (DBConnection.t() -> any()) | nil
+        ) :: Postgrex.Result.t()
   def after_connect(conn, primary_after_connect) do
     run_after_connect(conn, primary_after_connect)
     Postgrex.query!(conn, @read_only_statement, [])

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -21,9 +21,20 @@ defmodule Logflare.Repo.Replicas do
   Callers can temporarily redirect Ecto queries to a replica for the duration of
   a function call using `apply_with_replica/3` on `Logflare.Repo`, which swaps
   the dynamic repo and restores it afterwards.
+
+  Every replica connection opens its session read-only, so a write that reaches a
+  replica fails immediately instead of diverging from the primary.
   """
 
   @registry __MODULE__.Registry
+
+  # Replicas serve reads only: `Logflare.Repo.apply_with_replica/3` and
+  # `apply_with_random_repo/3` are the only ways to reach one, and both are read
+  # paths. Marking the session read-only turns a write that slips through into an
+  # immediate error rather than a silent divergence. That matters most when the
+  # replica is a logical subscriber, which - unlike a physical standby - has a
+  # server that will happily accept the write.
+  @read_only_statement "SET default_transaction_read_only = on"
 
   def child_spec(options) do
     %{
@@ -40,9 +51,16 @@ defmodule Logflare.Repo.Replicas do
     if entries == [] do
       :ignore
     else
+      primary_after_connect = Logflare.Repo.config()[:after_connect]
+
       replicas =
         Enum.map(entries, fn {key, config} ->
-          config = [name: {:via, Registry, {@registry, key}}] ++ resolve_ssl(config)
+          config =
+            [
+              name: {:via, Registry, {@registry, key}},
+              after_connect: {__MODULE__, :after_connect, [primary_after_connect]}
+            ] ++ resolve_ssl(config)
+
           Supervisor.child_spec({Logflare.Repo, config}, id: key)
         end)
 
@@ -65,6 +83,29 @@ defmodule Logflare.Repo.Replicas do
       [] -> raise "unknown replica: #{inspect(key)}"
     end
   end
+
+  @doc """
+  Runs on every replica connection: the primary's own `:after_connect`, if it has
+  one, then the read-only session setting.
+
+  A replica's config is the primary's with the entry's overrides applied, so
+  setting `:after_connect` on a replica would otherwise drop the primary's -
+  which is what sets `search_path` when `DB_SCHEMA` is configured. The primary's
+  hook runs first so that this stays compatible with one that needs to write.
+  """
+  @spec after_connect(pid(), {module(), atom(), [term()]} | (pid() -> any()) | nil) ::
+          Postgrex.Result.t()
+  def after_connect(conn, primary_after_connect) do
+    run_after_connect(conn, primary_after_connect)
+    Postgrex.query!(conn, @read_only_statement, [])
+  end
+
+  defp run_after_connect(_conn, nil), do: :ok
+
+  defp run_after_connect(conn, {module, function, args}),
+    do: apply(module, function, [conn | args])
+
+  defp run_after_connect(conn, fun) when is_function(fun, 1), do: fun.(conn)
 
   @doc """
   Parses a single `LOGFLARE_READ_REPLICAS` entry into a `{key, config}` pair.

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -184,9 +184,19 @@ defmodule Logflare.Repo.Replicas do
   defp redact(message, userinfo), do: String.replace(message, userinfo, "REDACTED")
 
   defp resolve_ssl(config) do
-    case Keyword.get(config, :ssl) do
-      true -> Keyword.put(config, :ssl, primary_ssl_opts(config[:hostname]))
-      _ -> config
+    primary_ssl = Keyword.get(Logflare.Repo.config(), :ssl)
+    effective_ssl = Keyword.get(config, :ssl, primary_ssl)
+    hostname = config[:hostname]
+
+    case effective_ssl do
+      true ->
+        Keyword.put(config, :ssl, primary_ssl_opts(hostname))
+
+      opts when is_list(opts) ->
+        Keyword.put(config, :ssl, replica_ssl_opts(opts, hostname))
+
+      _ ->
+        config
     end
   end
 

--- a/lib/logflare/repo/replicas.ex
+++ b/lib/logflare/repo/replicas.ex
@@ -184,35 +184,22 @@ defmodule Logflare.Repo.Replicas do
   defp redact(message, userinfo), do: String.replace(message, userinfo, "REDACTED")
 
   defp resolve_ssl(config) do
-    primary_ssl = Keyword.get(Logflare.Repo.config(), :ssl)
-    effective_ssl = Keyword.get(config, :ssl, primary_ssl)
-    hostname = config[:hostname]
-
-    case effective_ssl do
-      true ->
-        Keyword.put(config, :ssl, primary_ssl_opts(hostname))
-
-      opts when is_list(opts) ->
-        Keyword.put(config, :ssl, replica_ssl_opts(opts, hostname))
-
-      _ ->
-        config
+    case Keyword.get(config, :ssl) do
+      true -> Keyword.put(config, :ssl, primary_ssl_opts(config[:hostname]))
+      _ -> config
     end
   end
 
   defp primary_ssl_opts(hostname) do
     case Keyword.get(Logflare.Repo.config(), :ssl) do
-      opts when is_list(opts) -> replica_ssl_opts(opts, hostname)
-      _ -> true
-    end
-  end
+      opts when is_list(opts) ->
+        case :inet.parse_address(String.to_charlist(hostname || "")) do
+          {:ok, _ip} -> Keyword.put(opts, :server_name_indication, :disable)
+          {:error, _} -> opts
+        end
 
-  defp replica_ssl_opts(opts, hostname) do
-    opts = Keyword.delete(opts, :server_name_indication)
-
-    case :inet.parse_address(String.to_charlist(hostname || "")) do
-      {:ok, _ip} -> Keyword.put(opts, :server_name_indication, :disable)
-      {:error, _} -> opts
+      _ ->
+        true
     end
   end
 

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -4,22 +4,26 @@ defmodule Logflare.RepoTest do
   alias Logflare.Repo
   alias Logflare.Repo.Replicas
 
-  defp start_read_replicas(raw_entries) do
+  defp start_read_replicas(raw_entries, entry_overrides \\ []) do
     primary_hostname = Keyword.fetch!(Repo.config(), :hostname)
-    entries = Enum.map(raw_entries, &Replicas.parse!/1)
 
-    # sanity check that our test replicas are not the same as the primary
+    entries =
+      Enum.map(raw_entries, fn entry ->
+        {key, config} = Replicas.parse!(entry)
+        {key, Keyword.merge(config, entry_overrides)}
+      end)
+
     for {_key, config} <- entries do
       refute config[:hostname] == primary_hostname,
              "replica hostname #{config[:hostname]} should be different from primary hostname"
     end
 
-    # we read the replicas from env in `apply_with_replica/3`, so we need to set it there for the test
+    # apply_with_replica/3 reads the configured entries from the application environment.
     prev_read_replicas = Application.get_env(:logflare, :read_replicas)
     Application.put_env(:logflare, :read_replicas, entries)
     on_exit(fn -> Application.put_env(:logflare, :read_replicas, prev_read_replicas) end)
 
-    # attach repo init handler to ensure we start the replicas with the expected config
+    # Observe the effective Ecto configuration for each replica pool.
     telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
     on_exit(fn -> :telemetry.detach(telemetry_ref) end)
 
@@ -55,8 +59,29 @@ defmodule Logflare.RepoTest do
       refute Enum.any?(repos, fn repo -> repo == Repo end),
              "expected every call to use a replica, never the primary"
 
-      # verify that after the call, we're back to the default repo
       assert Repo.get_dynamic_repo() == Repo
+    end
+
+    test "makes replica pool connections read-only" do
+      start_read_replicas(["127.0.0.1"],
+        pool: DBConnection.ConnectionPool,
+        pool_size: 1
+      )
+
+      assert %Postgrex.Result{rows: [["on"]]} =
+               Repo.apply_with_replica(
+                 Repo,
+                 :query!,
+                 ["SHOW default_transaction_read_only", []]
+               )
+
+      assert_raise Postgrex.Error, ~r/read-only transaction/, fn ->
+        Repo.apply_with_replica(
+          Repo,
+          :query!,
+          ["CREATE TEMP TABLE read_only_replica_probe (id integer)", []]
+        )
+      end
     end
 
     test "reverts repo if function raises" do

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -147,6 +147,34 @@ defmodule Logflare.RepoTest do
     end
   end
 
+  describe "replica SSL configuration" do
+    test "a DNS replica removes primary-specific SNI" do
+      put_repo_config(ssl: [server_name_indication: :disable])
+
+      entries = [Replicas.parse!("postgres://replica.example.com/logflare?ssl=true")]
+      telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
+      on_exit(fn -> :telemetry.detach(telemetry_ref) end)
+
+      start_supervised!({Replicas, entries: entries})
+
+      assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
+      refute Keyword.has_key?(Keyword.fetch!(opts, :ssl), :server_name_indication)
+    end
+
+    test "an IP replica disables SNI without forwarding the primary value" do
+      put_repo_config(ssl: [server_name_indication: "primary"])
+
+      entries = [Replicas.parse!("postgres://127.0.0.2/logflare?ssl=true")]
+      telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
+      on_exit(fn -> :telemetry.detach(telemetry_ref) end)
+
+      start_supervised!({Replicas, entries: entries})
+
+      assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
+      assert Keyword.fetch!(Keyword.fetch!(opts, :ssl), :server_name_indication) == :disable
+    end
+  end
+
   describe "Replicas.parse/1" do
     test "a bare hostname only overrides the hostname, keyed by hostname" do
       assert {:ok, {"host", [hostname: "host"]}} = Replicas.parse("host")
@@ -206,4 +234,14 @@ defmodule Logflare.RepoTest do
       refute Exception.message(error) =~ "supersecret"
     end
   end
+
+  defp put_repo_config(overrides) do
+    previous_config = Application.fetch_env(:logflare, Repo)
+    config = Application.get_env(:logflare, Repo, [])
+    Application.put_env(:logflare, Repo, Keyword.merge(config, overrides))
+    on_exit(fn -> restore_application_env(:logflare, Repo, previous_config) end)
+  end
+
+  defp restore_application_env(app, key, {:ok, value}), do: Application.put_env(app, key, value)
+  defp restore_application_env(app, key, :error), do: Application.delete_env(app, key)
 end

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -31,6 +31,9 @@ defmodule Logflare.RepoTest do
       for {k, v} <- config, k != :ssl do
         assert Keyword.fetch!(opts, k) == v
       end
+
+      assert {Replicas, :after_connect, [_primary_after_connect]} =
+               Keyword.fetch!(opts, :after_connect)
     end
 
     start_result
@@ -71,6 +74,51 @@ defmodule Logflare.RepoTest do
 
       repos = for _ <- 1..30, do: Repo.apply_with_replica(Repo, :get_dynamic_repo, [])
       assert Enum.all?(repos, &(&1 != Repo))
+    end
+  end
+
+  describe "Replicas.after_connect/2" do
+    setup do
+      opts = Keyword.take(Repo.config(), [:hostname, :port, :username, :password, :database])
+
+      %{conn: start_supervised!({Postgrex, opts})}
+    end
+
+    test "opens the session read-only", %{conn: conn} do
+      Replicas.after_connect(conn, _no_primary_hook = nil)
+
+      assert %Postgrex.Result{rows: [["on"]]} =
+               Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
+    end
+
+    test "rejects writes on the session", %{conn: conn} do
+      Replicas.after_connect(conn, _no_primary_hook = nil)
+
+      assert_raise Postgrex.Error, ~r/read-only transaction/, fn ->
+        Postgrex.query!(conn, "CREATE TEMP TABLE read_only_probe (id integer)", [])
+      end
+    end
+
+    test "still runs the primary's after_connect, given as an MFA", %{conn: conn} do
+      Replicas.after_connect(conn, {Postgrex, :query!, ["SET application_name = 'mfa'", []]})
+
+      assert %Postgrex.Result{rows: [["mfa"]]} =
+               Postgrex.query!(conn, "SHOW application_name", [])
+
+      assert %Postgrex.Result{rows: [["on"]]} =
+               Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
+    end
+
+    test "still runs the primary's after_connect, given as a function", %{conn: conn} do
+      hook = fn conn -> Postgrex.query!(conn, "SET application_name = 'fun'", []) end
+
+      Replicas.after_connect(conn, hook)
+
+      assert %Postgrex.Result{rows: [["fun"]]} =
+               Postgrex.query!(conn, "SHOW application_name", [])
+
+      assert %Postgrex.Result{rows: [["on"]]} =
+               Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
     end
   end
 

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -62,11 +62,28 @@ defmodule Logflare.RepoTest do
       assert Repo.get_dynamic_repo() == Repo
     end
 
-    test "makes replica pool connections read-only" do
+    test "runs the primary hook before making replica pool connections read-only" do
+      previous_repo_config = Application.fetch_env!(:logflare, Repo)
+
+      Application.put_env(
+        :logflare,
+        Repo,
+        Keyword.put(
+          previous_repo_config,
+          :after_connect,
+          {Postgrex, :query!, ["SET application_name = 'replica_after_connect'", []]}
+        )
+      )
+
+      on_exit(fn -> Application.put_env(:logflare, Repo, previous_repo_config) end)
+
       start_read_replicas(["127.0.0.1"],
         pool: DBConnection.ConnectionPool,
         pool_size: 1
       )
+
+      assert %Postgrex.Result{rows: [["replica_after_connect"]]} =
+               Repo.apply_with_replica(Repo, :query!, ["SHOW application_name", []])
 
       assert %Postgrex.Result{rows: [["on"]]} =
                Repo.apply_with_replica(

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -148,6 +148,44 @@ defmodule Logflare.RepoTest do
   end
 
   describe "replica SSL configuration" do
+    for {entry, primary_sni, expected_sni} <- [
+          {"replica.invalid", :disable, nil},
+          {"replica.invalid", ~c"primary.invalid", nil},
+          {"postgres://replica.invalid/logflare", :disable, nil},
+          {"postgres://replica.invalid/logflare", ~c"primary.invalid", nil},
+          {"127.0.0.2", ~c"primary.invalid", :disable},
+          {"postgres://127.0.0.2/logflare", ~c"primary.invalid", :disable},
+          {"postgres://replica.invalid/logflare?ssl=false", :disable, false}
+        ] do
+      test "#{entry} normalizes inherited SSL with primary SNI #{inspect(primary_sni)}" do
+        primary_ssl = [
+          verify: :verify_peer,
+          depth: 4,
+          server_name_indication: unquote(primary_sni)
+        ]
+
+        put_repo_config(ssl: primary_ssl)
+        entries = [Replicas.parse!(unquote(entry))]
+        telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
+        on_exit(fn -> :telemetry.detach(telemetry_ref) end)
+
+        start_supervised!({Replicas, entries: entries})
+
+        assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
+
+        case unquote(expected_sni) do
+          false ->
+            assert opts[:ssl] == false
+
+          nil ->
+            assert opts[:ssl] == Keyword.delete(primary_ssl, :server_name_indication)
+
+          :disable ->
+            assert opts[:ssl] == Keyword.put(primary_ssl, :server_name_indication, :disable)
+        end
+      end
+    end
+
     test "a DNS replica removes primary-specific SNI" do
       put_repo_config(ssl: [server_name_indication: :disable])
 

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -147,72 +147,6 @@ defmodule Logflare.RepoTest do
     end
   end
 
-  describe "replica SSL configuration" do
-    for {entry, primary_sni, expected_sni} <- [
-          {"replica.invalid", :disable, nil},
-          {"replica.invalid", ~c"primary.invalid", nil},
-          {"postgres://replica.invalid/logflare", :disable, nil},
-          {"postgres://replica.invalid/logflare", ~c"primary.invalid", nil},
-          {"127.0.0.2", ~c"primary.invalid", :disable},
-          {"postgres://127.0.0.2/logflare", ~c"primary.invalid", :disable},
-          {"postgres://replica.invalid/logflare?ssl=false", :disable, false}
-        ] do
-      test "#{entry} normalizes inherited SSL with primary SNI #{inspect(primary_sni)}" do
-        primary_ssl = [
-          verify: :verify_peer,
-          depth: 4,
-          server_name_indication: unquote(primary_sni)
-        ]
-
-        put_repo_config(ssl: primary_ssl)
-        entries = [Replicas.parse!(unquote(entry))]
-        telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
-        on_exit(fn -> :telemetry.detach(telemetry_ref) end)
-
-        start_supervised!({Replicas, entries: entries})
-
-        assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
-
-        case unquote(expected_sni) do
-          false ->
-            assert opts[:ssl] == false
-
-          nil ->
-            assert opts[:ssl] == Keyword.delete(primary_ssl, :server_name_indication)
-
-          :disable ->
-            assert opts[:ssl] == Keyword.put(primary_ssl, :server_name_indication, :disable)
-        end
-      end
-    end
-
-    test "a DNS replica removes primary-specific SNI" do
-      put_repo_config(ssl: [server_name_indication: :disable])
-
-      entries = [Replicas.parse!("postgres://replica.example.com/logflare?ssl=true")]
-      telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
-      on_exit(fn -> :telemetry.detach(telemetry_ref) end)
-
-      start_supervised!({Replicas, entries: entries})
-
-      assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
-      refute Keyword.has_key?(Keyword.fetch!(opts, :ssl), :server_name_indication)
-    end
-
-    test "an IP replica disables SNI without forwarding the primary value" do
-      put_repo_config(ssl: [server_name_indication: "primary"])
-
-      entries = [Replicas.parse!("postgres://127.0.0.2/logflare?ssl=true")]
-      telemetry_ref = :telemetry_test.attach_event_handlers(self(), [[:ecto, :repo, :init]])
-      on_exit(fn -> :telemetry.detach(telemetry_ref) end)
-
-      start_supervised!({Replicas, entries: entries})
-
-      assert_receive {[:ecto, :repo, :init], ^telemetry_ref, _, %{repo: Repo, opts: opts}}
-      assert Keyword.fetch!(Keyword.fetch!(opts, :ssl), :server_name_indication) == :disable
-    end
-  end
-
   describe "Replicas.parse/1" do
     test "a bare hostname only overrides the hostname, keyed by hostname" do
       assert {:ok, {"host", [hostname: "host"]}} = Replicas.parse("host")
@@ -272,14 +206,4 @@ defmodule Logflare.RepoTest do
       refute Exception.message(error) =~ "supersecret"
     end
   end
-
-  defp put_repo_config(overrides) do
-    previous_config = Application.fetch_env(:logflare, Repo)
-    config = Application.get_env(:logflare, Repo, [])
-    Application.put_env(:logflare, Repo, Keyword.merge(config, overrides))
-    on_exit(fn -> restore_application_env(:logflare, Repo, previous_config) end)
-  end
-
-  defp restore_application_env(app, key, {:ok, value}), do: Application.put_env(app, key, value)
-  defp restore_application_env(app, key, :error), do: Application.delete_env(app, key)
 end

--- a/test/logflare/repo_test.exs
+++ b/test/logflare/repo_test.exs
@@ -109,13 +109,6 @@ defmodule Logflare.RepoTest do
       %{conn: start_supervised!({Postgrex, opts})}
     end
 
-    test "opens the session read-only", %{conn: conn} do
-      Replicas.after_connect(conn, _no_primary_hook = nil)
-
-      assert %Postgrex.Result{rows: [["on"]]} =
-               Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
-    end
-
     test "rejects writes on the session", %{conn: conn} do
       Replicas.after_connect(conn, _no_primary_hook = nil)
 
@@ -134,13 +127,19 @@ defmodule Logflare.RepoTest do
                Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
     end
 
-    test "still runs the primary's after_connect, given as a function", %{conn: conn} do
-      hook = fn conn -> Postgrex.query!(conn, "SET application_name = 'fun'", []) end
+    test "runs a function after_connect before making the session read-only", %{conn: conn} do
+      test_pid = self()
+
+      hook = fn conn ->
+        %Postgrex.Result{rows: [[setting]]} =
+          Postgrex.query!(conn, "SHOW default_transaction_read_only", [])
+
+        send(test_pid, {:read_only_setting_in_primary_hook, setting})
+      end
 
       Replicas.after_connect(conn, hook)
 
-      assert %Postgrex.Result{rows: [["fun"]]} =
-               Postgrex.query!(conn, "SHOW application_name", [])
+      assert_receive {:read_only_setting_in_primary_hook, "off"}
 
       assert %Postgrex.Result{rows: [["on"]]} =
                Postgrex.query!(conn, "SHOW default_transaction_read_only", [])


### PR DESCRIPTION
Replica connection pools now open their sessions read-only.

## Why

`LOGFLARE_READ_REPLICAS` serves selected cache reads through `Repo.apply_with_replica/3`, but the pools did not guard against accidental writes. Physical standbys reject writes themselves; logical replicas can accept them, causing divergence and later replication conflicts.

## Behavior

- Runs the primary's `:after_connect` hook first, preserving setup such as the `DB_SCHEMA` search path, then issues `SET default_transaction_read_only = on`. This guards accidental writes; it is a session default, not an immutable permission boundary.
- The `SET` pins PostgreSQL RDS Proxy sessions to database connections. Size proxy and database connection limits accordingly.

IAM authentication for primary and replica connections is added separately in stacked PR #3903.

## Validation

`test/logflare/repo_test.exs`: **14 tests pass**, including read-only sessions and hook composition. Formatting passes.
