### PR TITLE
fix: keep database work out of the SourceSup partition critical section

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -926,6 +926,8 @@ defmodule Logflare.Backends do
   """
   @spec start_source_sup(Source.t()) :: :ok | {:error, :already_started}
   def start_source_sup(%Source{} = source) do
+    SourceSup.prefetch(source)
+
     case DynamicSupervisor.start_child(
            {:via, PartitionSupervisor, {SourcesSup, source.id}},
            SourceSup.child_spec(source)

--- a/lib/logflare/backends/source_sup.ex
+++ b/lib/logflare/backends/source_sup.ex
@@ -31,6 +31,35 @@ defmodule Logflare.Backends.SourceSup do
     Supervisor.start_link(__MODULE__, source, name: Backends.via_source(source, __MODULE__))
   end
 
+  @doc """
+  Resolves everything `init/1` reads, so the supervisor's critical section does no database work.
+
+  `DynamicSupervisor.start_child/2` runs `init/1` inside the `SourcesSup` partition process, and
+  every lookup there is cache-fronted with a Postgres fallback. On a node with a cold cache that
+  makes each source start several database round trips, serialized through one partition, which
+  blocks every other source hashing to it.
+
+  Calling this first moves that latency to the caller, where it parallelizes across callers.
+  `init/1` is left unchanged, so a crash-restart still re-resolves and picks up configuration
+  changes.
+
+  This does not replace the cache warmers. They run once at cache start, are capped, and are
+  registered `required: false`, so a source outside their set or a node still warming has nothing
+  cached. This guarantees the partition never pays the miss.
+  """
+  @spec prefetch(Source.t()) :: :ok
+  def prefetch(%Source{} = source) do
+    Sources.Cache.preload_rules(source)
+    Backends.Cache.list_backends(source_id: source.id)
+    Backends.Cache.list_backends(rules_source_id: source.id)
+
+    source.user_id
+    |> Users.Cache.get()
+    |> Billing.Cache.get_plan_by_user()
+
+    :ok
+  end
+
   def init(source) do
     source = Sources.Cache.preload_rules(source)
 

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -763,6 +763,37 @@ defmodule Logflare.BackendsTest do
       assert :ok = Backends.ensure_source_sup_started(source)
     end
 
+    test "prefetch/1 warms the caches that init/1 reads", %{source: source} do
+      caches = [
+        Logflare.Backends.Cache,
+        Logflare.Users.Cache,
+        Logflare.Billing.Cache
+      ]
+
+      for cache <- caches, do: Cachex.clear(cache)
+      for cache <- caches, do: assert({:ok, 0} = Cachex.size(cache))
+
+      assert :ok = SourceSup.prefetch(source)
+
+      for cache <- caches do
+        assert {:ok, size} = Cachex.size(cache)
+        assert size > 0
+      end
+    end
+
+    test "start_source_sup/1 warms the caches before starting", %{source: source} do
+      for cache <- [Logflare.Backends.Cache, Logflare.Users.Cache, Logflare.Billing.Cache] do
+        Cachex.clear(cache)
+      end
+
+      assert :ok = Backends.start_source_sup(source)
+
+      for cache <- [Logflare.Backends.Cache, Logflare.Users.Cache, Logflare.Billing.Cache] do
+        assert {:ok, size} = Cachex.size(cache)
+        assert size > 0
+      end
+    end
+
     test "on attach to source, update SourceSup", %{source: source} do
       [backend1, backend2] = insert_pair(:backend)
       start_supervised!({SourceSup, source})


### PR DESCRIPTION
Only adds `SourceSup.prefetch/1` and a call to it from `start_source_sup/1`.

It warms the caches `init/1` reads, but the important part is *where* it runs: in the caller, before `start_child`. `init/1` runs inside the `SourcesSup` partition process, so a source that stalls resolving its config blocks every other source hashing to that partition. Prefetching first means the stall lands on the caller instead, and the rest keep starting.

`init/1` is unchanged, so a crash-restart still re-resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XJWSbFFxwiYB25iUAGmXc
