### PR TITLE
Add failing tests for backend-level telemetry gaps (O11Y-1733)

### DIFF
--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -666,6 +666,57 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
     end
   end
 
+  describe "handle_batch/4 backend-level telemetry (O11Y-1733)" do
+    setup do
+      {source, backend} =
+        setup_clickhouse_test(metadata: %{"environment" => "test", "region" => "us-west"})
+
+      {:ok, supervisor_pid} = ClickHouseAdaptor.start_link(backend)
+
+      on_exit(fn ->
+        if Process.alive?(supervisor_pid) do
+          Process.exit(supervisor_pid, :shutdown)
+        end
+      end)
+
+      TestUtils.retry_assert(fn ->
+        assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+      end)
+
+      [source: source, backend: backend, context: %{backend_id: backend.id}]
+    end
+
+    test "emits backend metadata as attributes on the backend-level handle_batch metric", %{
+      context: context,
+      source: source,
+      backend: backend
+    } do
+      log_event = build(:log_event, source: source, message: "Test message")
+      gen_tid = setup_generation_events([log_event])
+      messages = [batch_message(log_event, gen_tid, backend.id)]
+
+      batch_info = %Broadway.BatchInfo{
+        batcher: :ch,
+        batch_key: {:log, @day_bucket},
+        size: 1,
+        trigger: :size
+      }
+
+      telemetry_event = [:logflare, :backends, :pipeline, :handle_batch]
+      TestUtils.attach_forwarder(telemetry_event)
+
+      Pipeline.handle_batch(:ch, messages, batch_info, context)
+
+      assert_receive {:telemetry_event, ^telemetry_event, _measurements, metadata}
+
+      # Each backend adaptor's backend-level telemetry should surface the
+      # backend's free-form `metadata` map as metric attributes, mirroring
+      # what the webhook adaptor already does for its egress metric.
+      assert metadata[:_backend_environment] == "test" or metadata["_backend_environment"] == "test"
+      assert metadata[:_backend_region] == "us-west" or metadata["_backend_region"] == "us-west"
+    end
+  end
+
   describe "handle_batch/4 async insert decision" do
     setup do
       {async_source, async_backend} =

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -272,18 +272,26 @@ defmodule Logflare.Backends.UserMonitoringTest do
 
       assert {:ok, _} = Backends.ingest_logs([%{"message" => "test clickhouse ingest"}], source)
 
+      backend_id = backend.id
+
       # `ingested_count`/`ingested_bytes` today are only emitted from the BigQuery
-      # pipeline (lib/logflare/sources/source/bigquery/pipeline.ex). Per O11Y-1733,
-      # this should be emitted once at the Backends context/source level, prior to
-      # per-backend dispatch, so it applies uniformly regardless of which backend(s)
-      # a source is routed to - including non-BigQuery backends like ClickHouse.
+      # pipeline (lib/logflare/sources/source/bigquery/pipeline.ex), tagged with
+      # whichever backend that legacy pipeline runs against. Per O11Y-1733, this
+      # should instead be emitted once at the Backends context/source level, prior
+      # to per-backend dispatch, tagged with the backend the event actually routed
+      # to - including non-BigQuery backends like ClickHouse.
       TestUtils.retry_assert(fn ->
         events = Backends.list_recent_logs_local(metrics_source)
 
         assert Enum.any?(
                  events,
                  &match?(
-                   %LogEvent{body: %{"event_message" => "logflare.backends.ingest.ingested_count"}},
+                   %LogEvent{
+                     body: %{
+                       "event_message" => "logflare.backends.ingest.ingested_count",
+                       "attributes" => %{"backend_id" => ^backend_id}
+                     }
+                   },
                    &1
                  )
                )
@@ -291,7 +299,12 @@ defmodule Logflare.Backends.UserMonitoringTest do
         assert Enum.any?(
                  events,
                  &match?(
-                   %LogEvent{body: %{"event_message" => "logflare.backends.ingest.ingested_bytes"}},
+                   %LogEvent{
+                     body: %{
+                       "event_message" => "logflare.backends.ingest.ingested_bytes",
+                       "attributes" => %{"backend_id" => ^backend_id}
+                     }
+                   },
                    &1
                  )
                )

--- a/test/logflare/backends/user_monitoring_test.exs
+++ b/test/logflare/backends/user_monitoring_test.exs
@@ -255,6 +255,49 @@ defmodule Logflare.Backends.UserMonitoringTest do
       end)
     end
 
+    test "backends.ingest.ingested_bytes and backends.ingest.ingested_count are emitted at the Backends context/source level, independent of backend adaptor (O11Y-1733)" do
+      user = insert(:user, system_monitoring: true)
+      metrics_source = insert(:source, user: user, system_source_type: :metrics)
+      start_supervised!({SourceSup, metrics_source}, id: :metrics_source)
+
+      {source, backend} = setup_clickhouse_test(user: user)
+      start_supervised!({SourceSup, source}, id: :source)
+
+      {:ok, supervisor_pid} = ClickHouseAdaptor.start_link(backend)
+      on_exit(fn -> if Process.alive?(supervisor_pid), do: Process.exit(supervisor_pid, :shutdown) end)
+
+      TestUtils.retry_assert(fn ->
+        assert :ok = ClickHouseAdaptor.provision_ingest_tables(backend)
+      end)
+
+      assert {:ok, _} = Backends.ingest_logs([%{"message" => "test clickhouse ingest"}], source)
+
+      # `ingested_count`/`ingested_bytes` today are only emitted from the BigQuery
+      # pipeline (lib/logflare/sources/source/bigquery/pipeline.ex). Per O11Y-1733,
+      # this should be emitted once at the Backends context/source level, prior to
+      # per-backend dispatch, so it applies uniformly regardless of which backend(s)
+      # a source is routed to - including non-BigQuery backends like ClickHouse.
+      TestUtils.retry_assert(fn ->
+        events = Backends.list_recent_logs_local(metrics_source)
+
+        assert Enum.any?(
+                 events,
+                 &match?(
+                   %LogEvent{body: %{"event_message" => "logflare.backends.ingest.ingested_count"}},
+                   &1
+                 )
+               )
+
+        assert Enum.any?(
+                 events,
+                 &match?(
+                   %LogEvent{body: %{"event_message" => "logflare.backends.ingest.ingested_bytes"}},
+                   &1
+                 )
+               )
+      end)
+    end
+
     test "other users metrics" do
       pid = self()
       test_ref = make_ref()
@@ -394,6 +437,55 @@ defmodule Logflare.Backends.UserMonitoringTest do
       assert attributes["backend_id"] == webhook_backend.id
       assert attributes["_backend_environment"] == "test"
       assert attributes["_backend_region"] == "us-west"
+    end
+
+    test "backends.ingest.egress.request_bytes tags log drain backends with _backend_type" do
+      pid = self()
+
+      GoogleApi.BigQuery.V2.Api.Tabledata
+      |> stub(:bigquery_tabledata_insert_all, fn _, _, _, _, opts ->
+        send(pid, {:insert_all, opts[:body].rows})
+        {:ok, %GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{insertErrors: nil}}
+      end)
+
+      user = insert(:user, system_monitoring: true)
+      metrics_source = insert(:source, user: user, system_source_type: :metrics)
+
+      webhook_backend =
+        insert(:backend,
+          user: user,
+          type: :webhook,
+          config: %{url: "http://127.0.0.1:9999/webhook"}
+        )
+
+      source = insert(:source, user: user)
+
+      start_supervised!({SourceSup, metrics_source}, id: :metrics_source)
+      start_supervised!({SourceSup, source}, id: :source)
+
+      {:ok, _} = Backends.update_source_backends(source, [webhook_backend])
+      Backends.Cache.get_backend(webhook_backend.id)
+
+      assert {:ok, _} = Backends.ingest_logs([%{"message" => "test webhook egress"}], source)
+
+      assert_receive {:insert_all, [%{json: %{"attributes" => _}} | _] = rows}, 15_000
+
+      rows = for row <- rows, do: row.json
+
+      egress_row =
+        Enum.find(
+          rows,
+          &match?(%{"event_message" => "logflare.backends.ingest.egress.request_bytes"}, &1)
+        )
+
+      assert egress_row, "Expected egress metric to be present"
+
+      [attributes] = egress_row["attributes"]
+
+      # webhook backends are "log drain" style backends; the egress metric should
+      # carry a filterable `_backend_type` attribute so drain traffic can be
+      # isolated from other egress (e.g. `attributes._backend_type: "log-drain"`).
+      assert attributes["_backend_type"] == "log-drain"
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -129,10 +129,12 @@ defmodule Logflare.DataCase do
   - `:source` - Existing source to use (creates one if not provided)
   - `:default_ingest_backend?` - Whether to set the backend as the default ingest backend (requires a source to be provided with the default ingest backend option set to true)
   - `:cleanup?` - Whether to drop the backend's ClickHouse tables on exit (defaults to true)
+  - `:metadata` - Backend metadata map (defaults to `nil`)
   """
   def setup_clickhouse_test(opts \\ []) do
     config = Keyword.get(opts, :config, %{})
     default_ingest_backend? = Keyword.get(opts, :default_ingest_backend?, false)
+    metadata = Keyword.get(opts, :metadata)
 
     user =
       case Keyword.get(opts, :user) do
@@ -160,6 +162,7 @@ defmodule Logflare.DataCase do
         type: :clickhouse,
         config: Map.merge(default_config, config),
         default_ingest?: default_ingest_backend?,
+        metadata: metadata,
         user: user,
         sources: [source]
       )


### PR DESCRIPTION
Covers three gaps from the issue: egress.request_bytes should tag
log-drain backends with attributes._backend_type: "log-drain" for
filtering; each backend adaptor should emit backend-level telemetry
that surfaces backend metadata as metric attributes (currently only
the webhook adaptor does this, ClickHouse does not); and
ingested_count/ingested_bytes should be emitted at the Backends
context/source level prior to dispatch rather than only from the
BigQuery pipeline, so it applies to all backends.

Adds a :metadata option to setup_clickhouse_test/1 to support the new
ClickHouse pipeline test.