### PR TITLE
perf: cache spool consumer source lookups

### DIFF
--- a/lib/logflare/backends/spool/consumer_pipeline.ex
+++ b/lib/logflare/backends/spool/consumer_pipeline.ex
@@ -141,7 +141,7 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline do
   end
 
   defp dispatch_group(source_id, lines) do
-    case Sources.get(source_id) do
+    case Sources.Cache.get_by(id: source_id) do
       nil ->
         emit_skipped_telemetry(:unknown_source_id, length(lines))
 


### PR DESCRIPTION
## Summary

- resolve spool-consumer source IDs through the existing read-through source cache
- avoid an uncached `sources` primary-key query for every distinct source in every consumer batch
- preserve existing unknown-source handling and downstream dispatch behavior

## Why

`ConsumerPipeline` grouped replayed events by source and then called `Sources.get/1`, which executes `Repo.get/2`. With the current 500-event batches and scheduler-scaled consumer concurrency, spooling can generate sustained, highly concurrent source lookup traffic.

`Sources.Cache` already provides the cache and WAL-driven invalidation used by live ingestion. Routing this lookup through that cache limits PostgreSQL reads to cache fills and invalidations rather than every replay batch.

This does not change consumer concurrency, batch sizing, database schema, or spool durability behavior.
