### PR TITLE
fix: stop inserting into billing_counts

### DIFF
--- a/lib/logflare/billing/billing_counts.ex
+++ b/lib/logflare/billing/billing_counts.ex
@@ -48,20 +48,11 @@ defmodule Logflare.Billing.BillingCounts do
     |> Repo.one()
   end
 
-  def insert(user, source, params) do
-    assoc = params |> assoc(user) |> assoc(source)
-    Repo.insert(assoc)
-  end
-
   defp billing_counts_for_period(user_id, start_date, end_date) do
     from(c in BillingCount,
       where: c.user_id == ^user_id,
       where: c.inserted_at >= ^start_date and c.inserted_at <= ^end_date
     )
-  end
-
-  defp assoc(params, user_or_source) do
-    Ecto.build_assoc(user_or_source, :billing_counts, params)
   end
 
   @doc """

--- a/lib/logflare/sources/source/billing_writer.ex
+++ b/lib/logflare/sources/source/billing_writer.ex
@@ -2,7 +2,6 @@ defmodule Logflare.Sources.Source.BillingWriter do
   @moduledoc false
   use GenServer
 
-  alias Logflare.Billing.BillingCounts
   alias Logflare.Billing
   alias Logflare.Sources.Source.Data
   alias Logflare.Backends
@@ -36,12 +35,8 @@ defmodule Logflare.Sources.Source.BillingWriter do
     node_count = Data.get_node_inserts(state.source.token)
     count = node_count - last_count
 
-    if count > 0 do
-      record_to_db(state, count)
-
-      if state.plan_type == "metered" do
-        record_to_stripe(state, count)
-      end
+    if count > 0 and state.plan_type == "metered" do
+      record_to_stripe(state, count)
     end
 
     write()
@@ -73,23 +68,6 @@ defmodule Logflare.Sources.Source.BillingWriter do
         Logger.error("Error recording usage with Stripe. #{inspect(resp)}",
           source_id: state.source.token,
           error_string: inspect(resp)
-        )
-    end
-  end
-
-  defp record_to_db(state, count) do
-    user = Users.Cache.get(state.user_id)
-
-    case BillingCounts.insert(user, state.source, %{
-           node: Atom.to_string(Node.self()),
-           count: count
-         }) do
-      {:ok, _resp} ->
-        :noop
-
-      {:error, _resp} ->
-        Logger.error("Error inserting billing count!",
-          source_id: state.source.token
         )
     end
   end

--- a/test/logflare/source/billing_writer_test.exs
+++ b/test/logflare/source/billing_writer_test.exs
@@ -17,24 +17,26 @@ defmodule Logflare.Sources.Source.BillingWriterTest do
 
     pid = start_supervised!({BillingWriter, source: source})
 
-    # Stripe mocks
+    test_pid = self()
+
     Stripe.UsageRecord
     |> expect(:create, fn sub_item_id, _params ->
       if is_nil(sub_item_id) do
         raise "subscription item id should not be nil"
       end
 
+      send(test_pid, :usage_recorded)
       {:ok, %{}}
     end)
 
     {:ok, pid: pid, source: source}
   end
 
-  test ":write_count", %{pid: pid, source: source} do
-    # increase log count
+  test ":write_count records usage with Stripe only", %{pid: pid, source: source} do
     Counters.increment(source.token)
     send(pid, :write_count)
-    :timer.sleep(200)
-    assert Repo.aggregate(BillingCount, :count) == 1
+
+    assert_receive :usage_recorded, 2_000
+    assert Repo.aggregate(BillingCount, :count) == 0
   end
 end


### PR DESCRIPTION
Stops every write to `billing_counts`. Nothing else changes.

The table grows without limit. The product no longer bills from it. Stripe holds the billing data.

`BillingWriter` now records usage with Stripe only, and only for metered plans. `BillingCounts.insert/3` is gone.

The table, its rows, its schema, and every read path stay. This PR is safe to deploy on its own.

Stacked on top of this: 3920 removes the reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EidfTqVNLJwC2QwMFQV5Q
