### PR TITLE
fix: add Content-MD5 to S3 uploads

### DIFF
--- a/lib/logflare/backends/adaptor/s3_adaptor.ex
+++ b/lib/logflare/backends/adaptor/s3_adaptor.ex
@@ -292,10 +292,14 @@ defmodule Logflare.Backends.Adaptor.S3Adaptor do
   @spec put_parquet(DataFrame.t(), map(), key :: String.t()) :: :ok | {:error, term()}
   defp put_parquet(%DataFrame{} = df, config, key) when is_non_empty_binary(key) do
     with {:ok, body} <- DataFrame.dump_parquet(df),
+         content_md5 <- Base.encode64(:crypto.hash(:md5, body)),
          {:ok, _resp} <-
            config
            |> request_bucket()
-           |> S3.put_object(key, body, content_type: @parquet_content_type)
+           |> S3.put_object(key, body,
+             content_type: @parquet_content_type,
+             content_md5: content_md5
+           )
            |> ExAws.request(request_opts(config)) do
       :ok
     end

--- a/test/logflare/backends/adaptor/s3_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/s3_adaptor_test.exs
@@ -236,11 +236,15 @@ defmodule Logflare.Backends.Adaptor.S3AdaptorTest do
                bucket: "my-bucket",
                path: "_connection_test.parquet",
                body: body,
-               headers: %{"content-type" => "application/vnd.apache.parquet"}
+               headers: %{
+                 "content-md5" => content_md5,
+                 "content-type" => "application/vnd.apache.parquet"
+               }
              } = op
 
       assert is_binary(body)
       assert String.starts_with?(body, "PAR1")
+      assert content_md5 == Base.encode64(:crypto.hash(:md5, body))
       assert opts[:access_key_id] == "AKID"
       assert opts[:secret_access_key] == "SECRET"
       assert opts[:region] == "us-east-1"
@@ -300,11 +304,17 @@ defmodule Logflare.Backends.Adaptor.S3AdaptorTest do
 
       expected_token = source.token |> Atom.to_string() |> String.replace("-", "_")
 
-      assert %ExAws.Operation.S3{http_method: :put, bucket: "my-bucket", path: path, body: body} =
-               op
+      assert %ExAws.Operation.S3{
+               http_method: :put,
+               bucket: "my-bucket",
+               path: path,
+               body: body,
+               headers: headers
+             } = op
 
       assert path =~ ~r|^#{expected_token}/\d+\.parquet$|
       assert String.starts_with?(body, "PAR1")
+      assert headers["content-md5"] == Base.encode64(:crypto.hash(:md5, body))
       assert opts[:access_key_id] == "AKID"
       assert opts[:secret_access_key] == "SECRET"
       assert opts[:region] == "us-east-1"


### PR DESCRIPTION
## Summary

- add a base64 `Content-MD5` header to every parquet `PutObject` request
- cover both S3 connection probes and event uploads with exact-body checksum assertions

## Why

Amazon S3 requires `Content-MD5` or an SDK checksum header when Object Lock retention applies. ExAws adds `x-amz-content-sha256` for SigV4 signing, but that is not an Object Lock integrity checksum, so uploads to buckets with default retention are rejected.

The checksum is added in the shared `put_parquet/3` path, covering both connection tests and normal backend delivery.

## Validation

- `../bin/test test/logflare/backends/adaptor/s3_adaptor_test.exs` — 23 tests, 0 failures
- `MIX_ENV=test ../bin/format --check-formatted`
- `../bin/x mix compile`
- `MIX_ENV=test ../bin/x mix lint.all`
