### PR TITLE
fix: correct source and source schema cache warmers

### DIFF
--- a/lib/logflare/source_schemas/cache_warmer.ex
+++ b/lib/logflare/source_schemas/cache_warmer.ex
@@ -20,7 +20,7 @@ defmodule Logflare.SourceSchemas.CacheWarmer do
 
     get_kv =
       for ss <- source_schemas do
-        {:cached, {{:get_source_schema_by, [source_id: ss.source_id]}, ss}}
+        {{:get_source_schema_by, [source_id: ss.source_id]}, {:cached, ss}}
       end
 
     {:ok, get_kv}

--- a/lib/logflare/source_schemas/cache_warmer.ex
+++ b/lib/logflare/source_schemas/cache_warmer.ex
@@ -20,7 +20,7 @@ defmodule Logflare.SourceSchemas.CacheWarmer do
 
     get_kv =
       for ss <- source_schemas do
-        {{:get_source_schema_by, [source_id: ss.source_id]}, {:cached, ss}}
+        {{:get_source_schema_by, [[source_id: ss.source_id]]}, {:cached, ss}}
       end
 
     {:ok, get_kv}

--- a/lib/logflare/sources/cache_warmer.ex
+++ b/lib/logflare/sources/cache_warmer.ex
@@ -28,7 +28,8 @@ defmodule Logflare.Sources.CacheWarmer do
 
         [
           {{:get_by, [[id: s.id]]}, value},
-          {{:get_by, [[token: s.token]]}, value}
+          {{:get_by, [[token: s.token]]}, value},
+          {{:get_by, [[token: Atom.to_string(s.token)]]}, value}
         ]
       end
 

--- a/lib/logflare/sources/cache_warmer.ex
+++ b/lib/logflare/sources/cache_warmer.ex
@@ -20,8 +20,8 @@ defmodule Logflare.Sources.CacheWarmer do
         value = {:cached, s}
 
         [
-          {{:get_by, [id: s.id]}, value},
-          {{:get_by, [token: s.token]}, value}
+          {{:get_by, [[id: s.id]]}, value},
+          {{:get_by, [[token: s.token]]}, value}
         ]
       end
 

--- a/lib/logflare/sources/cache_warmer.ex
+++ b/lib/logflare/sources/cache_warmer.ex
@@ -1,9 +1,13 @@
 defmodule Logflare.Sources.CacheWarmer do
-  alias Logflare.Repo
-  alias Logflare.Sources.Source
+  use Cachex.Warmer
+
   import Ecto.Query
 
-  use Cachex.Warmer
+  alias Logflare.Billing
+  alias Logflare.Repo
+  alias Logflare.Sources
+  alias Logflare.Sources.Source
+  alias Logflare.User
   @impl true
   def execute(_state) do
     # Get sources that have been active in the last day, similar to ingesting users pattern
@@ -14,6 +18,7 @@ defmodule Logflare.Sources.CacheWarmer do
         limit: 1_000
       )
       |> Repo.all()
+      |> put_retention_days()
 
     get_kv =
       for s <- sources do
@@ -26,5 +31,25 @@ defmodule Logflare.Sources.CacheWarmer do
       end
 
     {:ok, List.flatten(get_kv)}
+  end
+
+  defp put_retention_days([]), do: []
+
+  defp put_retention_days(sources) do
+    user_ids = sources |> Enum.map(& &1.user_id) |> Enum.uniq()
+
+    users =
+      from(u in User,
+        where: u.id in ^user_ids,
+        preload: :billing_account
+      )
+      |> Repo.all()
+
+    plans_by_user_id = Billing.get_plans_by_users(users)
+
+    Enum.map(sources, fn source ->
+      plan = Map.fetch!(plans_by_user_id, source.user_id)
+      Sources.put_retention_days(source, plan)
+    end)
   end
 end

--- a/lib/logflare/sources/cache_warmer.ex
+++ b/lib/logflare/sources/cache_warmer.ex
@@ -3,6 +3,8 @@ defmodule Logflare.Sources.CacheWarmer do
 
   import Ecto.Query
 
+  require Logger
+
   alias Logflare.Billing
   alias Logflare.Repo
   alias Logflare.Sources
@@ -47,9 +49,23 @@ defmodule Logflare.Sources.CacheWarmer do
 
     plans_by_user_id = Billing.get_plans_by_users(users)
 
-    Enum.map(sources, fn source ->
-      plan = Map.fetch!(plans_by_user_id, source.user_id)
-      Sources.put_retention_days(source, plan)
-    end)
+    {hydrated_sources, skipped_count} =
+      Enum.reduce(sources, {[], 0}, fn source, {hydrated_sources, skipped_count} ->
+        case Map.fetch(plans_by_user_id, source.user_id) do
+          {:ok, plan} ->
+            {[Sources.put_retention_days(source, plan) | hydrated_sources], skipped_count}
+
+          :error ->
+            {hydrated_sources, skipped_count + 1}
+        end
+      end)
+
+    if skipped_count > 0 do
+      Logger.warning(
+        "Sources cache warmer skipped #{skipped_count} sources whose users could not be resolved"
+      )
+    end
+
+    Enum.reverse(hydrated_sources)
   end
 end

--- a/test/logflare/source_schemas/cache_warmer_test.exs
+++ b/test/logflare/source_schemas/cache_warmer_test.exs
@@ -1,0 +1,24 @@
+defmodule Logflare.SourceSchemas.CacheWarmerTest do
+  use Logflare.DataCase, async: false
+
+  alias Logflare.SourceSchemas.Cache
+  alias Logflare.SourceSchemas.CacheWarmer
+
+  setup do
+    Cachex.clear!(Cache)
+    :ok
+  end
+
+  test "warms source schemas under their read-through cache keys" do
+    user = insert(:user)
+    source = insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
+    source_schema = insert(:source_schema, source: source)
+    cache_key = {:get_source_schema_by, [source_id: source.id]}
+
+    assert {:ok, pairs} = CacheWarmer.execute(nil)
+    assert {^cache_key, {:cached, %{id: source_schema_id}}} = List.keyfind(pairs, cache_key, 0)
+    assert source_schema_id == source_schema.id
+    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert {:ok, {:cached, %{id: ^source_schema_id}}} = Cachex.get(Cache, cache_key)
+  end
+end

--- a/test/logflare/source_schemas/cache_warmer_test.exs
+++ b/test/logflare/source_schemas/cache_warmer_test.exs
@@ -19,6 +19,10 @@ defmodule Logflare.SourceSchemas.CacheWarmerTest do
     assert {^cache_key, {:cached, %{id: source_schema_id}}} = List.keyfind(pairs, cache_key, 0)
     assert source_schema_id == source_schema.id
     assert {:ok, true} = Cachex.put_many(Cache, pairs)
+
+    # Check Cachex directly so read-through fallback cannot hide malformed warmer output.
     assert {:ok, {:cached, %{id: ^source_schema_id}}} = Cachex.get(Cache, cache_key)
+
+    assert %{id: ^source_schema_id} = Cache.get_source_schema_by(source_id: source.id)
   end
 end

--- a/test/logflare/source_schemas/cache_warmer_test.exs
+++ b/test/logflare/source_schemas/cache_warmer_test.exs
@@ -1,30 +1,45 @@
 defmodule Logflare.SourceSchemas.CacheWarmerTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Repo
   alias Logflare.SourceSchemas.Cache
   alias Logflare.SourceSchemas.CacheWarmer
 
   setup do
-    Cachex.clear!(Cache)
-    :ok
-  end
-
-  test "warms source schemas under their read-through cache keys" do
     user = insert(:user)
     source = insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
     source_schema = insert(:source_schema, source: source)
-    cache_key = {:get_source_schema_by, [[source_id: source.id]]}
+    Cachex.clear!(Cache)
+
+    {:ok, source: source, source_schema: source_schema}
+  end
+
+  test "warms entries under the key the read path uses", %{
+    source: source,
+    source_schema: source_schema
+  } do
+    schema_id = source_schema.id
+
+    assert %{id: ^schema_id} = Cache.get_source_schema_by(source_id: source.id)
+    assert {:ok, [read_key]} = Cachex.keys(Cache)
 
     assert {:ok, pairs} = CacheWarmer.execute(nil)
-    assert {^cache_key, {:cached, %{id: source_schema_id}}} = List.keyfind(pairs, cache_key, 0)
-    assert source_schema_id == source_schema.id
+    Cachex.clear!(Cache)
     assert {:ok, true} = Cachex.put_many(Cache, pairs)
 
-    # Check Cachex directly so read-through fallback cannot hide malformed warmer output.
-    assert {:ok, {:cached, %{id: ^source_schema_id}}} = Cachex.get(Cache, cache_key)
-    assert {:ok, size_before_read} = Cachex.size(Cache)
+    assert {:ok, {:cached, %{id: ^schema_id}}} = Cachex.get(Cache, read_key)
+  end
 
-    assert %{id: ^source_schema_id} = Cache.get_source_schema_by(source_id: source.id)
-    assert {:ok, ^size_before_read} = Cachex.size(Cache)
+  test "warmed entries are served without hitting the database", %{
+    source: source,
+    source_schema: source_schema
+  } do
+    schema_id = source_schema.id
+
+    assert {:ok, pairs} = CacheWarmer.execute(nil)
+    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert %{} = Repo.delete!(source_schema)
+
+    assert %{id: ^schema_id} = Cache.get_source_schema_by(source_id: source.id)
   end
 end

--- a/test/logflare/source_schemas/cache_warmer_test.exs
+++ b/test/logflare/source_schemas/cache_warmer_test.exs
@@ -13,7 +13,7 @@ defmodule Logflare.SourceSchemas.CacheWarmerTest do
     user = insert(:user)
     source = insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
     source_schema = insert(:source_schema, source: source)
-    cache_key = {:get_source_schema_by, [source_id: source.id]}
+    cache_key = {:get_source_schema_by, [[source_id: source.id]]}
 
     assert {:ok, pairs} = CacheWarmer.execute(nil)
     assert {^cache_key, {:cached, %{id: source_schema_id}}} = List.keyfind(pairs, cache_key, 0)
@@ -22,7 +22,9 @@ defmodule Logflare.SourceSchemas.CacheWarmerTest do
 
     # Check Cachex directly so read-through fallback cannot hide malformed warmer output.
     assert {:ok, {:cached, %{id: ^source_schema_id}}} = Cachex.get(Cache, cache_key)
+    assert {:ok, size_before_read} = Cachex.size(Cache)
 
     assert %{id: ^source_schema_id} = Cache.get_source_schema_by(source_id: source.id)
+    assert {:ok, ^size_before_read} = Cachex.size(Cache)
   end
 end

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -6,19 +6,26 @@ defmodule Logflare.Sources.CacheWarmerTest do
   alias Logflare.Sources.CacheWarmer
 
   setup do
-    insert(:plan)
+    plan = insert(:plan)
     user = insert(:user)
     source = insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
     Cachex.clear!(Cache)
 
-    {:ok, source: source}
+    {:ok, expected_retention_days: Sources.source_ttl_to_days(source, plan), source: source}
   end
 
-  test "warms id and token entries under the keys the read path uses", %{source: source} do
+  test "warms id and token entries under the keys the read path uses", %{
+    expected_retention_days: expected_retention_days,
+    source: source
+  } do
     source_id = source.id
 
-    assert %{id: ^source_id} = Cache.get_by(id: source.id)
-    assert %{id: ^source_id} = Cache.get_by(token: source.token)
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(id: source.id)
+
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(token: source.token)
+
     assert {:ok, read_keys} = Cachex.keys(Cache)
     assert length(read_keys) == 2
 
@@ -27,11 +34,13 @@ defmodule Logflare.Sources.CacheWarmerTest do
     assert {:ok, true} = Cachex.put_many(Cache, pairs)
 
     for read_key <- read_keys do
-      assert {:ok, {:cached, %{id: ^source_id}}} = Cachex.get(Cache, read_key)
+      assert {:ok, {:cached, %{id: ^source_id, retention_days: ^expected_retention_days}}} =
+               Cachex.get(Cache, read_key)
     end
   end
 
   test "serves warmed id and token entries without falling back to the database", %{
+    expected_retention_days: expected_retention_days,
     source: source
   } do
     source_id = source.id
@@ -42,7 +51,10 @@ defmodule Logflare.Sources.CacheWarmerTest do
     Sources
     |> reject(:get_by, 1)
 
-    assert %{id: ^source_id} = Cache.get_by(id: source.id)
-    assert %{id: ^source_id} = Cache.get_by(token: source.token)
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(id: source.id)
+
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(token: source.token)
   end
 end

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -1,9 +1,11 @@
 defmodule Logflare.Sources.CacheWarmerTest do
   use Logflare.DataCase, async: false
 
+  alias Logflare.Billing
   alias Logflare.Sources
   alias Logflare.Sources.Cache
   alias Logflare.Sources.CacheWarmer
+  alias Logflare.Sources.Source
 
   setup do
     plan = insert(:plan)
@@ -56,5 +58,89 @@ defmodule Logflare.Sources.CacheWarmerTest do
 
     assert %{id: ^source_id, retention_days: ^expected_retention_days} =
              Cache.get_by(token: source.token)
+  end
+
+  test "hydrates retention values for sources from different user plans", %{
+    expected_retention_days: expected_retention_days,
+    source: source
+  } do
+    custom_plan =
+      insert(:plan,
+        name: "Custom",
+        stripe_id: "custom-plan",
+        limit_source_ttl: :timer.hours(24 * 7)
+      )
+
+    custom_user = insert(:user, billing_enabled: true)
+    insert(:billing_account, user: custom_user, stripe_plan_id: custom_plan.stripe_id)
+
+    custom_source =
+      insert(:source,
+        user: custom_user,
+        log_events_updated_at: NaiveDateTime.utc_now()
+      )
+
+    assert {:ok, pairs} = CacheWarmer.execute(nil)
+
+    warmed_sources =
+      pairs
+      |> Enum.map(fn {_key, {:cached, warmed_source}} -> warmed_source end)
+      |> Map.new(&{&1.id, &1})
+
+    assert %{retention_days: ^expected_retention_days} = warmed_sources[source.id]
+
+    expected_custom_retention_days = Sources.source_ttl_to_days(custom_source, custom_plan)
+
+    assert %{retention_days: ^expected_custom_retention_days} = warmed_sources[custom_source.id]
+  end
+
+  test "skips plan hydration when there are no active sources" do
+    Repo.update_all(Source, set: [log_events_updated_at: nil])
+
+    Billing
+    |> reject(:get_plans_by_users, 1)
+
+    assert {:ok, []} = CacheWarmer.execute(nil)
+  end
+
+  test "uses a bounded number of queries as the number of source users grows" do
+    {single_user_query_count, {:ok, _pairs}} =
+      count_repo_queries(fn -> CacheWarmer.execute(nil) end)
+
+    for _ <- 1..5 do
+      user = insert(:user)
+      insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
+    end
+
+    {multiple_user_query_count, {:ok, _pairs}} =
+      count_repo_queries(fn -> CacheWarmer.execute(nil) end)
+
+    assert single_user_query_count > 0
+    assert multiple_user_query_count == single_user_query_count
+  end
+
+  defp count_repo_queries(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:logflare, :repo, :query],
+        fn _event, _measurements, _metadata, config ->
+          if self() == config.test_pid do
+            Agent.update(config.counter, &(&1 + 1))
+          end
+        end,
+        %{counter: counter, test_pid: self()}
+      )
+
+    try do
+      result = fun.()
+      {Agent.get(counter, & &1), result}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
+    end
   end
 end

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -1,6 +1,8 @@
 defmodule Logflare.Sources.CacheWarmerTest do
   use Logflare.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Logflare.Billing
   alias Logflare.Sources
   alias Logflare.Sources.Cache
@@ -101,6 +103,17 @@ defmodule Logflare.Sources.CacheWarmerTest do
     |> reject(:get_plans_by_users, 1)
 
     assert {:ok, []} = CacheWarmer.execute(nil)
+  end
+
+  test "skips sources whose users cannot be resolved" do
+    stub(Billing, :get_plans_by_users, fn _users -> %{} end)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, []} = CacheWarmer.execute(nil)
+      end)
+
+    assert log =~ "skipped 1 sources whose users could not be resolved"
   end
 
   test "uses a bounded number of queries as the number of source users grows" do

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -1,0 +1,48 @@
+defmodule Logflare.Sources.CacheWarmerTest do
+  use Logflare.DataCase, async: false
+
+  alias Logflare.Sources
+  alias Logflare.Sources.Cache
+  alias Logflare.Sources.CacheWarmer
+
+  setup do
+    insert(:plan)
+    user = insert(:user)
+    source = insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
+    Cachex.clear!(Cache)
+
+    {:ok, source: source}
+  end
+
+  test "warms id and token entries under the keys the read path uses", %{source: source} do
+    source_id = source.id
+
+    assert %{id: ^source_id} = Cache.get_by(id: source.id)
+    assert %{id: ^source_id} = Cache.get_by(token: source.token)
+    assert {:ok, read_keys} = Cachex.keys(Cache)
+    assert length(read_keys) == 2
+
+    assert {:ok, pairs} = CacheWarmer.execute(nil)
+    Cachex.clear!(Cache)
+    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+
+    for read_key <- read_keys do
+      assert {:ok, {:cached, %{id: ^source_id}}} = Cachex.get(Cache, read_key)
+    end
+  end
+
+  test "serves warmed id and token entries without falling back to the database", %{
+    source: source
+  } do
+    source_id = source.id
+
+    assert {:ok, pairs} = CacheWarmer.execute(nil)
+    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+
+    Sources
+    |> reject(:get_by, 1)
+
+    assert %{id: ^source_id} = Cache.get_by(id: source.id)
+    assert %{id: ^source_id} = Cache.get_by(token: source.token)
+  end
+end

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -18,11 +18,12 @@ defmodule Logflare.Sources.CacheWarmerTest do
     {:ok, expected_retention_days: Sources.source_ttl_to_days(source, plan), source: source}
   end
 
-  test "warms id and token entries under the keys the read path uses", %{
+  test "warms ID and internal and external token entries under the read-path keys", %{
     expected_retention_days: expected_retention_days,
     source: source
   } do
     source_id = source.id
+    external_token = Atom.to_string(source.token)
 
     assert %{id: ^source_id, retention_days: ^expected_retention_days} =
              Cache.get_by(id: source.id)
@@ -30,8 +31,11 @@ defmodule Logflare.Sources.CacheWarmerTest do
     assert %{id: ^source_id, retention_days: ^expected_retention_days} =
              Cache.get_by(token: source.token)
 
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(token: external_token)
+
     assert {:ok, read_keys} = Cachex.keys(Cache)
-    assert length(read_keys) == 2
+    assert length(read_keys) == 3
 
     assert {:ok, pairs} = CacheWarmer.execute(nil)
     Cachex.clear!(Cache)
@@ -43,11 +47,12 @@ defmodule Logflare.Sources.CacheWarmerTest do
     end
   end
 
-  test "serves warmed id and token entries without falling back to the database", %{
+  test "serves warmed ID and token entries without falling back to the database", %{
     expected_retention_days: expected_retention_days,
     source: source
   } do
     source_id = source.id
+    external_token = Atom.to_string(source.token)
 
     assert {:ok, pairs} = CacheWarmer.execute(nil)
     assert {:ok, true} = Cachex.put_many(Cache, pairs)
@@ -60,6 +65,9 @@ defmodule Logflare.Sources.CacheWarmerTest do
 
     assert %{id: ^source_id, retention_days: ^expected_retention_days} =
              Cache.get_by(token: source.token)
+
+    assert %{id: ^source_id, retention_days: ^expected_retention_days} =
+             Cache.get_by(token: external_token)
   end
 
   test "hydrates retention values for sources from different user plans", %{


### PR DESCRIPTION
## Summary

- correct `SourceSchemas.CacheWarmer` entries so Cachex stores the exact read-through argument key and `{:cached, schema}` value expected by `ContextCache`
- correct `Sources.CacheWarmer` ID and token entries to use the same argument shape as `Sources.Cache.get_by/1`, including both internal atom and external binary UUID token forms
- preserve `Sources.get_by/1` value semantics by hydrating each warmed source's computed `retention_days`
- resolve source plans in bounded bulk queries, including preloaded billing accounts, rather than introducing per-source database lookups
- skip sources whose users disappear during plan hydration instead of aborting the entire warm pass

## Why

`ContextCache` keys function calls as `{function, arguments}`. Both source cache APIs accept a keyword list as one function argument, so their read-through keys contain a nested argument list such as `{:get_by, [[id: source_id]]}`.

The previous warmers emitted differently shaped entries. `SourceSchemas.CacheWarmer` also placed the key and schema inside the cached value. Cachex accepted those pairs, but normal reads could not reach them, so the first request still queried Postgres and inserted a separate correctly keyed entry.

Source tokens are stored as atoms by `Ecto.UUID.Atom`, while HTTP ingestion supplies binary UUIDs. Because `ContextCache` keys the exact arguments, the warmer now stores both token representations so internal and external reads reach the preloaded value.

Correcting the `Sources` keys exposed a second issue: the warmer loaded raw `Source` records, while the normal `Sources.get_by/1` path computes the virtual `retention_days` field. Without hydration, a warmed cache hit would return a different source shape from a cache miss. The warmer now bulk-loads the relevant users and billing accounts, resolves their plans once, and applies the same retention calculation before storing entries.

The source and user reads are separate statements, so an account deletion can remove a user after its source was selected. That source is now skipped with one aggregate warning instead of making the one-shot warmer discard every entry.

## Test coverage

- derive SourceSchemas and Sources cache keys through their public read paths instead of duplicating key construction in tests
- inspect raw Cachex values to verify the expected key and `{:cached, value}` contracts
- reject database fallback for warmed SourceSchemas entries and Sources ID, internal atom-token, and external binary-token entries
- verify warmed sources preserve plan-derived `retention_days`
- cover empty warmer input, unresolved users, and distinct retention outcomes across multiple user plans
- verify repository query count remains constant when growing from one to six source users

## Test plan

- `../bin/test test/logflare/source_schemas/cache_warmer_test.exs test/logflare/sources/cache_warmer_test.exs test/logflare/sources/sources_cache_test.exs`
- included in the final affected stack suite: 2 doctests, 1 property and 169 tests, 0 failures (3 excluded)
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `MIX_ENV=test ../bin/x mix lint.all`
- `MIX_ENV=test ../bin/format --check-formatted`

## Stack

Review each PR against its immediate base:

1. #3913 — Sources and SourceSchemas cache entry correctness, value parity, and source-user deletion tolerance during retention hydration (this PR; based on `main`)
2. #3915 — bounded, deduplicated, deterministic, and composable warmer queries
3. #3916 — best-effort SystemCache startup and foreground monitor-failure handling

The proposed KeyValues changes in #3914 were removed from this stack and remain deferred. The WAL fence follow-up in #3924 was closed because its coordination complexity was disproportionate and it did not solve post-invalidation replica-lag refills; any future stronger guarantee should use replica replay/LSN coordination.


