### PR TITLE
fix: fence key value cache warming

### DIFF
--- a/lib/logflare/key_values/cache.ex
+++ b/lib/logflare/key_values/cache.ex
@@ -3,6 +3,7 @@ defmodule Logflare.KeyValues.Cache do
 
   alias Logflare.ContextCache
   alias Logflare.KeyValues
+  alias Logflare.KeyValues.CacheWarmer
   alias Logflare.Repo
   alias Logflare.Utils
 
@@ -77,6 +78,7 @@ defmodule Logflare.KeyValues.Cache do
 
   @impl ContextCache
   def bust_by(kw) do
+    CacheWarmer.mark_invalidation()
     entries = bust_entries(kw)
 
     Cachex.execute(__MODULE__, fn worker ->

--- a/lib/logflare/key_values/cache_warmer.ex
+++ b/lib/logflare/key_values/cache_warmer.ex
@@ -3,52 +3,166 @@ defmodule Logflare.KeyValues.CacheWarmer do
 
   use Cachex.Warmer
 
+  import Ecto.Query
+
+  require Logger
+
   alias Logflare.KeyValues.Cache
   alias Logflare.KeyValues.KeyValue
   alias Logflare.Repo
 
-  require Logger
-  import Ecto.Query
+  @generation_key {__MODULE__, :invalidation_generation}
+  @initialized_key {__MODULE__, :initialized}
+  @on_load :init_generation
 
-  @pt_key {__MODULE__, :initialized}
+  @doc false
+  def init_generation do
+    unless is_reference(:persistent_term.get(@generation_key, nil)) do
+      :persistent_term.put(@generation_key, :atomics.new(1, signed: false))
+    end
+
+    :ok
+  end
 
   @impl true
   def execute(_state) do
-    if initialized?() do
-      Repo.apply_with_replica(__MODULE__, :warm_recent, [])
-    else
-      try do
-        Repo.apply_with_replica(__MODULE__, :warm_full, [])
-        :persistent_term.put(@pt_key, true)
-      rescue
-        e ->
-          Logger.error("Error performing full KeyValues.Cache warming: #{inspect(e)}")
-      end
+    mode = if initialized?(), do: :recent, else: :full
+
+    case safely_warm(mode) do
+      :ok ->
+        if mode == :full do
+          :persistent_term.put(@initialized_key, Process.whereis(Cache))
+        end
+
+      {:error, reason} ->
+        if mode == :full, do: clear_cache()
+        Logger.error("Error performing #{mode} KeyValues.Cache warming: #{reason}")
     end
 
     :ignore
   end
 
+  @spec warm_full() :: :ok | {:error, term()}
   def warm_full do
-    Repo.transaction(fn ->
-      KeyValue
-      |> Repo.stream()
-      |> Stream.chunk_every(500)
-      |> Enum.each(fn chunk ->
-        entries = Enum.map(chunk, &to_cache_entry/1)
-        Cachex.put_many(Cache, entries)
-      end)
-    end)
+    generation = invalidation_generation()
+
+    transaction_result = Repo.transaction(fn -> warm_stream(generation) end)
+
+    case transaction_result do
+      {:ok, :ok} ->
+        if generation == invalidation_generation(), do: :ok, else: clear_cache()
+
+      {:ok, :invalidated} ->
+        clear_cache()
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
+  @spec warm_recent() :: :ok | {:error, term()}
   def warm_recent do
+    generation = invalidation_generation()
+
     entries =
       KeyValue
-      |> where([kv], kv.updated_at >= ago(1, "hour"))
+      |> where([kv], kv.updated_at >= ago(2, "hour"))
       |> Repo.all()
       |> Enum.map(&to_cache_entry/1)
 
-    if entries != [], do: Cachex.put_many(Cache, entries)
+    case put_if_unchanged(entries, generation) do
+      :invalidated -> :ok
+      result -> result
+    end
+  end
+
+  @doc false
+  @spec put_if_unchanged([{term(), term()}], non_neg_integer()) ::
+          :ok | :invalidated | {:error, term()}
+  def put_if_unchanged(entries, generation) do
+    with true <- generation == invalidation_generation(),
+         :ok <- put_entries(entries) do
+      discard_if_invalidated(entries, generation)
+    else
+      false -> :invalidated
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc false
+  @spec mark_invalidation() :: :ok
+  def mark_invalidation do
+    :atomics.add_get(generation_ref(), 1, 1)
+    :ok
+  end
+
+  @doc false
+  @spec invalidation_generation() :: non_neg_integer()
+  def invalidation_generation do
+    :atomics.get(generation_ref(), 1)
+  end
+
+  defp safely_warm(mode) do
+    function = if mode == :full, do: :warm_full, else: :warm_recent
+    result = apply(__MODULE__, function, [])
+
+    case result do
+      :ok -> :ok
+      {:error, reason} -> {:error, inspect(reason)}
+      other -> {:error, "unexpected return: #{inspect(other)}"}
+    end
+  rescue
+    error -> {:error, Exception.format(:error, error, __STACKTRACE__)}
+  catch
+    kind, reason -> {:error, Exception.format(kind, reason, __STACKTRACE__)}
+  end
+
+  defp warm_stream(generation) do
+    KeyValue
+    |> Repo.stream()
+    |> Stream.chunk_every(500)
+    |> Enum.reduce_while(:ok, fn chunk, status -> warm_chunk(chunk, status, generation) end)
+  end
+
+  defp warm_chunk(chunk, :ok, generation) do
+    case put_if_unchanged(Enum.map(chunk, &to_cache_entry/1), generation) do
+      :ok -> {:cont, :ok}
+      :invalidated -> {:halt, :invalidated}
+      {:error, reason} -> Repo.rollback({:cache_write_failed, reason})
+    end
+  end
+
+  defp discard_if_invalidated(entries, generation) do
+    if generation == invalidation_generation() do
+      :ok
+    else
+      with :ok <- delete_entries(entries), do: :invalidated
+    end
+  end
+
+  defp put_entries([]), do: :ok
+
+  defp put_entries(entries) do
+    case Cachex.put_many(Cache, entries) do
+      {:ok, _written?} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp delete_entries(entries) do
+    Enum.reduce_while(entries, :ok, fn {key, _value}, :ok ->
+      case Cachex.del(Cache, key) do
+        {:ok, _deleted?} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp clear_cache do
+    case Cachex.clear(Cache) do
+      {:ok, _count} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp to_cache_entry(%KeyValue{} = kv) do
@@ -56,6 +170,11 @@ defmodule Logflare.KeyValues.CacheWarmer do
   end
 
   defp initialized? do
-    :persistent_term.get(@pt_key, false)
+    cache_pid = Process.whereis(Cache)
+    is_pid(cache_pid) and :persistent_term.get(@initialized_key, nil) == cache_pid
+  end
+
+  defp generation_ref do
+    :persistent_term.get(@generation_key)
   end
 end

--- a/test/logflare/key_values/cache_test.exs
+++ b/test/logflare/key_values/cache_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.KeyValues.CacheTest do
   use Logflare.DataCase, async: false
 
   alias Logflare.KeyValues
+  alias Logflare.KeyValues.CacheWarmer
 
   setup do
     user = insert(:user)
@@ -49,6 +50,13 @@ defmodule Logflare.KeyValues.CacheTest do
 
   test "bust_by/1 returns 0 when key not cached", %{user: user} do
     assert {:ok, 0} = KeyValues.Cache.bust_by(user_id: user.id, key: "nonexistent")
+  end
+
+  test "bust_by/1 advances the cache warmer invalidation generation", %{user: user} do
+    generation = CacheWarmer.invalidation_generation()
+
+    assert {:ok, 0} = KeyValues.Cache.bust_by(user_id: user.id, key: "nonexistent")
+    assert CacheWarmer.invalidation_generation() == generation + 1
   end
 
   describe "count/1" do

--- a/test/logflare/key_values/cache_warmer_test.exs
+++ b/test/logflare/key_values/cache_warmer_test.exs
@@ -11,6 +11,7 @@ defmodule Logflare.KeyValues.CacheWarmerTest do
 
   setup do
     :persistent_term.erase(@pt_key)
+    Cachex.clear!(Cache)
     user = insert(:user)
     [user: user]
   end
@@ -26,12 +27,22 @@ defmodule Logflare.KeyValues.CacheWarmerTest do
       assert {:cached, kv2.value} == Cachex.get!(Cache, {:lookup, [user.id, "k2", nil]})
     end
 
-    test "marks itself as initialized after first run" do
+    test "marks itself as initialized for the current cache process" do
       refute :persistent_term.get(@pt_key, false)
 
       CacheWarmer.execute(nil)
 
-      assert :persistent_term.get(@pt_key, false)
+      assert :persistent_term.get(@pt_key) == Process.whereis(Cache)
+    end
+
+    test "performs a full warm when the marker belongs to an older cache process" do
+      :persistent_term.put(@pt_key, self())
+
+      expect(CacheWarmer, :warm_full, fn -> :ok end)
+      reject(CacheWarmer, :warm_recent, 0)
+
+      assert :ignore = CacheWarmer.execute(nil)
+      assert :persistent_term.get(@pt_key) == Process.whereis(Cache)
     end
 
     test "if cache warmer fails, does not mark itself as initialized" do
@@ -61,7 +72,7 @@ defmodule Logflare.KeyValues.CacheWarmerTest do
 
   describe "subsequent warm (recent records only)" do
     test "caches only recently inserted records", %{user: user} do
-      old_time = DateTime.add(DateTime.utc_now(), -2, :hour)
+      old_time = DateTime.add(DateTime.utc_now(), -3, :hour)
 
       Repo.insert!(%Logflare.KeyValues.KeyValue{
         user_id: user.id,
@@ -73,8 +84,7 @@ defmodule Logflare.KeyValues.CacheWarmerTest do
 
       insert(:key_value, user: user, key: "new_key", value: %{"v" => "new"})
 
-      # Mark as initialized to simulate subsequent warm
-      :persistent_term.put(@pt_key, true)
+      :persistent_term.put(@pt_key, Process.whereis(Cache))
 
       CacheWarmer.execute(nil)
 
@@ -85,9 +95,56 @@ defmodule Logflare.KeyValues.CacheWarmerTest do
     end
 
     test "no-ops when no recent records exist" do
-      :persistent_term.put(@pt_key, true)
+      :persistent_term.put(@pt_key, Process.whereis(Cache))
 
       assert :ignore = CacheWarmer.execute(nil)
+    end
+
+    test "handles a transient recent-warm failure without crashing" do
+      :persistent_term.put(@pt_key, Process.whereis(Cache))
+
+      stub(CacheWarmer, :warm_recent, fn ->
+        raise RuntimeError, "test"
+      end)
+
+      log =
+        capture_log([level: :error], fn ->
+          assert :ignore = CacheWarmer.execute(nil)
+        end)
+
+      assert log =~ "Error performing recent KeyValues.Cache warming"
+      assert log =~ "RuntimeError"
+      assert :persistent_term.get(@pt_key) == Process.whereis(Cache)
+    end
+
+    test "handles an exit from a recent warm without crashing" do
+      :persistent_term.put(@pt_key, Process.whereis(Cache))
+
+      stub(CacheWarmer, :warm_recent, fn -> exit(:database_unavailable) end)
+
+      log =
+        capture_log([level: :error], fn ->
+          assert :ignore = CacheWarmer.execute(nil)
+        end)
+
+      assert log =~ "Error performing recent KeyValues.Cache warming"
+      assert log =~ "database_unavailable"
+    end
+
+    test "drops a warm batch when an invalidation crosses its generation fence", %{user: user} do
+      cache_key = {:lookup, [user.id, "stale", nil]}
+      entries = [{cache_key, {:cached, %{"version" => "stale"}}}]
+      generation = CacheWarmer.invalidation_generation()
+
+      assert :ok = CacheWarmer.mark_invalidation()
+      assert :invalidated = CacheWarmer.put_if_unchanged(entries, generation)
+      assert {:ok, nil} = Cachex.get(Cache, cache_key)
+    end
+
+    test "propagates cache write failures" do
+      generation = CacheWarmer.invalidation_generation()
+
+      assert {:error, :invalid_pairs} = CacheWarmer.put_if_unchanged([:invalid], generation)
     end
   end
 end


### PR DESCRIPTION
> **Deferred:** This PR was removed from the active cache-warmer stack and closed for now.

## Summary

- fence KeyValues warming with a persistent atomic invalidation generation so concurrent updates and deletes cannot be reinserted from stale snapshots
- use primary reads and chunked streaming for warm queries, with conservative cleanup when a generation changes
- tie successful full-warm initialization to the current Cachex process PID so cache restarts trigger another full warm
- fail closed on Cachex write errors and recover from exceptions, throws, and exits while retaining bounded retry scheduling
- add deterministic regression coverage for invalidation races, cache restarts, write failures, and recovery

## Test plan

- `../bin/test test/logflare/key_values/cache_warmer_test.exs test/logflare/key_values/cache_test.exs`
- included in the final affected suite: 1 property and 155 tests, 0 failures
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `MIX_ENV=test ../bin/x mix lint.all`

## Stack

This PR is no longer part of the active stack. The remaining series is #3913 → #3915 → #3916.

## Operational note

KeyValues warm queries now read the primary to close the pre-run replica-lag window. If an invalidation occurs during an initial full warm, the newly warmed cache is cleared and marked initialized; this favors correctness and avoids repeated full-scan retries at the cost of losing that one prefetch.
