### PR TITLE
fix: bound cache warmer source joins

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -80,13 +80,17 @@ defmodule Logflare.Backends do
         join(q, :inner, [b], r in assoc(b, :rules), on: r.source_id == ^source_id)
 
       # filter down to backends with sources that have recently ingested.
-      # orders by the last active.
+      # orders unique backends by the last active source.
       {:ingesting, true}, q ->
         q
         |> join(:inner, [b], s in assoc(b, :sources),
           on: s.log_events_updated_at >= ago(1, "day")
         )
-        |> order_by([..., s], {:desc, s.log_events_updated_at})
+        |> group_by([b], b.id)
+        |> order_by([..., s], desc: max(s.log_events_updated_at))
+
+      {:limit, limit}, q when is_integer(limit) and limit > 0 ->
+        limit(q, ^limit)
 
       {:user_id, id}, q ->
         where(q, [b], b.user_id == ^id)

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -67,60 +67,87 @@ defmodule Logflare.Backends do
   end
 
   defp filter_backends(query, filters) do
-    Enum.reduce(filters, query, fn
-      {:types, types}, q when is_list(types) ->
-        where(q, [b], b.type in ^types)
+    {ingesting?, filters} = Keyword.pop(filters, :ingesting, false)
+    {limit, filters} = Keyword.pop(filters, :limit)
 
-      # filter down to backends of this source
-      {:source_id, id}, q ->
-        join(q, :inner, [b], s in assoc(b, :sources), on: s.id == ^id)
+    query =
+      Enum.reduce(filters, query, fn
+        {:types, types}, q when is_list(types) ->
+          where(q, [b], b.type in ^types)
 
-      # filter down to backends with rules destinations
-      {:rules_source_id, source_id}, q ->
-        join(q, :inner, [b], r in assoc(b, :rules), on: r.source_id == ^source_id)
+        # filter down to backends of this source
+        {:source_id, id}, q ->
+          join(q, :inner, [b], s in assoc(b, :sources), on: s.id == ^id)
 
-      # filter down to backends with sources that have recently ingested.
-      # orders unique backends by the last active source.
-      {:ingesting, true}, q ->
-        q
-        |> join(:inner, [b], s in assoc(b, :sources),
-          on: s.log_events_updated_at >= ago(1, "day")
-        )
-        |> group_by([b], b.id)
-        |> order_by([b, ..., s], desc: max(s.log_events_updated_at), asc: b.id)
+        # filter down to backends with rules destinations
+        {:rules_source_id, source_id}, q ->
+          join(q, :inner, [b], r in assoc(b, :rules), on: r.source_id == ^source_id)
 
-      {:limit, limit}, q when is_integer(limit) and limit > 0 ->
-        limit(q, ^limit)
+        {:user_id, id}, q ->
+          where(q, [b], b.user_id == ^id)
 
-      {:user_id, id}, q ->
-        where(q, [b], b.user_id == ^id)
+        {:type, type}, q when is_atom(type) ->
+          where(q, [b], b.type == ^type)
 
-      {:type, type}, q when is_atom(type) ->
-        where(q, [b], b.type == ^type)
+        {:metadata, %{} = metadata}, q ->
+          normalized =
+            Enum.into(metadata, %{}, fn {k, v} ->
+              {k, if(v in ["true", "false"], do: String.to_existing_atom(v), else: v)}
+            end)
 
-      {:metadata, %{} = metadata}, q ->
-        normalized =
-          Enum.into(metadata, %{}, fn {k, v} ->
-            {k, if(v in ["true", "false"], do: String.to_existing_atom(v), else: v)}
-          end)
+          where(q, [b], b.metadata == ^normalized)
 
-        where(q, [b], b.metadata == ^normalized)
+        # filter by `default_ingest?` flag
+        {:default_ingest?, true}, q ->
+          where(q, [b], b.default_ingest? == true)
 
-      # filter by `default_ingest?` flag
-      {:default_ingest?, true}, q ->
-        where(q, [b], b.default_ingest? == true)
+        {:has_sources_or_rules, true}, q ->
+          q
+          |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
+          |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
+          |> where([b, ..., sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
+          |> distinct_backends()
 
-      {:has_sources_or_rules, true}, q ->
-        q
-        |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
-        |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
-        |> where([b, ..., sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
-        |> distinct_backends()
+        _, q ->
+          q
+      end)
 
-      _, q ->
-        q
-    end)
+    query
+    |> maybe_filter_ingesting(ingesting?)
+    |> maybe_limit(limit)
   end
+
+  defp maybe_filter_ingesting(query, true) do
+    backend_ids =
+      query
+      |> exclude(:distinct)
+      |> select([b], b.id)
+      |> distinct(true)
+
+    activity =
+      from(s in Source,
+        join: sb in "sources_backends",
+        on: sb.source_id == s.id,
+        where: s.log_events_updated_at >= ago(1, "day"),
+        group_by: sb.backend_id,
+        select: %{
+          backend_id: sb.backend_id,
+          last_active_at: max(s.log_events_updated_at)
+        }
+      )
+
+    from(b in Backend,
+      join: a in subquery(activity),
+      on: a.backend_id == b.id,
+      where: b.id in subquery(backend_ids),
+      order_by: [desc: a.last_active_at, asc: b.id]
+    )
+  end
+
+  defp maybe_filter_ingesting(query, _ingesting?), do: query
+
+  defp maybe_limit(query, limit) when is_pos_integer(limit), do: limit(query, ^limit)
+  defp maybe_limit(query, _limit), do: query
 
   defp distinct_backends(%Ecto.Query{distinct: nil} = query), do: distinct(query, [b], b.id)
   defp distinct_backends(query), do: query

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -87,7 +87,7 @@ defmodule Logflare.Backends do
           on: s.log_events_updated_at >= ago(1, "day")
         )
         |> group_by([b], b.id)
-        |> order_by([..., s], desc: max(s.log_events_updated_at))
+        |> order_by([b, ..., s], desc: max(s.log_events_updated_at), asc: b.id)
 
       {:limit, limit}, q when is_integer(limit) and limit > 0 ->
         limit(q, ^limit)

--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -70,49 +70,47 @@ defmodule Logflare.Backends do
     {ingesting?, filters} = Keyword.pop(filters, :ingesting, false)
     {limit, filters} = Keyword.pop(filters, :limit)
 
-    query =
-      Enum.reduce(filters, query, fn
-        {:types, types}, q when is_list(types) ->
-          where(q, [b], b.type in ^types)
+    filters
+    |> Enum.reduce(query, fn
+      {:types, types}, q when is_list(types) ->
+        where(q, [b], b.type in ^types)
 
-        # filter down to backends of this source
-        {:source_id, id}, q ->
-          join(q, :inner, [b], s in assoc(b, :sources), on: s.id == ^id)
+      # filter down to backends of this source
+      {:source_id, id}, q ->
+        join(q, :inner, [b], s in assoc(b, :sources), on: s.id == ^id)
 
-        # filter down to backends with rules destinations
-        {:rules_source_id, source_id}, q ->
-          join(q, :inner, [b], r in assoc(b, :rules), on: r.source_id == ^source_id)
+      # filter down to backends with rules destinations
+      {:rules_source_id, source_id}, q ->
+        join(q, :inner, [b], r in assoc(b, :rules), on: r.source_id == ^source_id)
 
-        {:user_id, id}, q ->
-          where(q, [b], b.user_id == ^id)
+      {:user_id, id}, q ->
+        where(q, [b], b.user_id == ^id)
 
-        {:type, type}, q when is_atom(type) ->
-          where(q, [b], b.type == ^type)
+      {:type, type}, q when is_atom(type) ->
+        where(q, [b], b.type == ^type)
 
-        {:metadata, %{} = metadata}, q ->
-          normalized =
-            Enum.into(metadata, %{}, fn {k, v} ->
-              {k, if(v in ["true", "false"], do: String.to_existing_atom(v), else: v)}
-            end)
+      {:metadata, %{} = metadata}, q ->
+        normalized =
+          Enum.into(metadata, %{}, fn {k, v} ->
+            {k, if(v in ["true", "false"], do: String.to_existing_atom(v), else: v)}
+          end)
 
-          where(q, [b], b.metadata == ^normalized)
+        where(q, [b], b.metadata == ^normalized)
 
-        # filter by `default_ingest?` flag
-        {:default_ingest?, true}, q ->
-          where(q, [b], b.default_ingest? == true)
+      # filter by `default_ingest?` flag
+      {:default_ingest?, true}, q ->
+        where(q, [b], b.default_ingest? == true)
 
-        {:has_sources_or_rules, true}, q ->
-          q
-          |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
-          |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
-          |> where([b, ..., sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
-          |> distinct_backends()
+      {:has_sources_or_rules, true}, q ->
+        q
+        |> join(:left, [b], sb in "sources_backends", on: sb.backend_id == b.id)
+        |> join(:left, [b], r in Rule, on: r.backend_id == b.id)
+        |> where([b, ..., sb, r], not is_nil(sb.backend_id) or not is_nil(r.backend_id))
+        |> distinct_backends()
 
-        _, q ->
-          q
-      end)
-
-    query
+      _, q ->
+        q
+    end)
     |> maybe_filter_ingesting(ingesting?)
     |> maybe_limit(limit)
   end

--- a/lib/logflare/users/users.ex
+++ b/lib/logflare/users/users.ex
@@ -40,7 +40,7 @@ defmodule Logflare.Users do
       join: s in assoc(u, :sources),
       where: s.log_events_updated_at >= ago(1, "day"),
       group_by: u.id,
-      order_by: [desc: max(s.log_events_updated_at)],
+      order_by: [desc: max(s.log_events_updated_at), asc: u.id],
       limit: ^limit,
       select: u
     )

--- a/lib/logflare/users/users.ex
+++ b/lib/logflare/users/users.ex
@@ -39,7 +39,8 @@ defmodule Logflare.Users do
     from(u in User,
       join: s in assoc(u, :sources),
       where: s.log_events_updated_at >= ago(1, "day"),
-      order_by: {:desc, s.log_events_updated_at},
+      group_by: u.id,
+      order_by: [desc: max(s.log_events_updated_at)],
       limit: ^limit,
       select: u
     )

--- a/test/logflare/backends/cache_test.exs
+++ b/test/logflare/backends/cache_test.exs
@@ -58,8 +58,8 @@ defmodule Logflare.Backends.CacheTest do
         log_events_updated_at: NaiveDateTime.shift(now, hour: -1)
       )
 
-    older_backend = insert(:backend, sources: [older_source])
-    newest_backend = insert(:backend, sources: [newest_source, oldest_source])
+    older_backend = insert(:backend, user: user, sources: [older_source])
+    newest_backend = insert(:backend, user: user, sources: [newest_source, oldest_source])
     newest_backend_id = newest_backend.id
     older_backend_id = older_backend.id
 
@@ -67,6 +67,23 @@ defmodule Logflare.Backends.CacheTest do
 
     assert [%{id: ^newest_backend_id}, %{id: ^older_backend_id}] =
              Backends.list_backends(ingesting: true)
+
+    assert [%{id: ^newest_backend_id}] =
+             Backends.list_backends(
+               ingesting: true,
+               has_sources_or_rules: true,
+               limit: 1
+             )
+
+    assert [%{id: ^newest_backend_id}] =
+             Backends.list_backends(
+               has_sources_or_rules: true,
+               ingesting: true,
+               limit: 1
+             )
+
+    assert [%{id: ^newest_backend_id}] =
+             Backends.list_backends_by_user_access(user, ingesting: true, limit: 1)
   end
 
   test "breaks ingesting backend activity ties by id", %{user: user} do

--- a/test/logflare/backends/cache_test.exs
+++ b/test/logflare/backends/cache_test.exs
@@ -41,6 +41,32 @@ defmodule Logflare.Backends.CacheTest do
     assert [] = Backends.Cache.list_backends(source_id: source.id)
   end
 
+  test "limits unique ingesting backends", %{user: user} do
+    now = NaiveDateTime.utc_now()
+    newest_source = insert(:source, user: user, log_events_updated_at: now)
+
+    second_source =
+      insert(:source,
+        user: user,
+        log_events_updated_at: NaiveDateTime.shift(now, second: -1)
+      )
+
+    older_source =
+      insert(:source,
+        user: user,
+        log_events_updated_at: NaiveDateTime.shift(now, hour: -1)
+      )
+
+    newest_backend = insert(:backend, sources: [newest_source, second_source])
+    older_backend = insert(:backend, sources: [older_source])
+
+    assert [%{id: newest_backend_id}] = Backends.list_backends(ingesting: true, limit: 1)
+    assert newest_backend_id == newest_backend.id
+
+    assert [first, second] = Backends.list_backends(ingesting: true)
+    assert MapSet.new([first.id, second.id]) == MapSet.new([newest_backend.id, older_backend.id])
+  end
+
   test "warmer", %{user: user} do
     assert {:ok, []} = CacheWarmer.execute(nil)
 

--- a/test/logflare/backends/cache_test.exs
+++ b/test/logflare/backends/cache_test.exs
@@ -41,14 +41,15 @@ defmodule Logflare.Backends.CacheTest do
     assert [] = Backends.Cache.list_backends(source_id: source.id)
   end
 
-  test "limits unique ingesting backends", %{user: user} do
+  test "limits unique ingesting backends by latest source activity", %{user: user} do
     now = NaiveDateTime.utc_now()
+
     newest_source = insert(:source, user: user, log_events_updated_at: now)
 
-    second_source =
+    oldest_source =
       insert(:source,
         user: user,
-        log_events_updated_at: NaiveDateTime.shift(now, second: -1)
+        log_events_updated_at: NaiveDateTime.shift(now, hour: -2)
       )
 
     older_source =
@@ -57,14 +58,26 @@ defmodule Logflare.Backends.CacheTest do
         log_events_updated_at: NaiveDateTime.shift(now, hour: -1)
       )
 
-    newest_backend = insert(:backend, sources: [newest_source, second_source])
     older_backend = insert(:backend, sources: [older_source])
+    newest_backend = insert(:backend, sources: [newest_source, oldest_source])
+    newest_backend_id = newest_backend.id
+    older_backend_id = older_backend.id
 
-    assert [%{id: newest_backend_id}] = Backends.list_backends(ingesting: true, limit: 1)
-    assert newest_backend_id == newest_backend.id
+    assert [%{id: ^newest_backend_id}] = Backends.list_backends(ingesting: true, limit: 1)
 
-    assert [first, second] = Backends.list_backends(ingesting: true)
-    assert MapSet.new([first.id, second.id]) == MapSet.new([newest_backend.id, older_backend.id])
+    assert [%{id: ^newest_backend_id}, %{id: ^older_backend_id}] =
+             Backends.list_backends(ingesting: true)
+  end
+
+  test "breaks ingesting backend activity ties by id", %{user: user} do
+    active_at = NaiveDateTime.utc_now()
+    first_source = insert(:source, user: user, log_events_updated_at: active_at)
+    second_source = insert(:source, user: user, log_events_updated_at: active_at)
+    first_backend = insert(:backend, sources: [first_source])
+    _second_backend = insert(:backend, sources: [second_source])
+    first_backend_id = first_backend.id
+
+    assert [%{id: ^first_backend_id}] = Backends.list_backends(ingesting: true, limit: 1)
   end
 
   test "warmer", %{user: user} do

--- a/test/logflare/users/users_test.exs
+++ b/test/logflare/users/users_test.exs
@@ -25,6 +25,28 @@ defmodule Logflare.UsersTest do
       insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
       assert [_] = Users.list_ingesting_users(limit: 500)
     end
+
+    test "deduplicates users before applying the limit" do
+      now = NaiveDateTime.utc_now()
+      newest_user = insert(:user)
+      older_user = insert(:user)
+
+      insert(:source, user: newest_user, log_events_updated_at: now)
+
+      insert(:source,
+        user: newest_user,
+        log_events_updated_at: NaiveDateTime.shift(now, second: -1)
+      )
+
+      insert(:source,
+        user: older_user,
+        log_events_updated_at: NaiveDateTime.shift(now, hour: -1)
+      )
+
+      assert [first, second] = Users.list_ingesting_users(limit: 2)
+      assert first.id == newest_user.id
+      assert second.id == older_user.id
+    end
   end
 
   describe "Users.list_users/1" do

--- a/test/logflare/users/users_test.exs
+++ b/test/logflare/users/users_test.exs
@@ -26,16 +26,16 @@ defmodule Logflare.UsersTest do
       assert [_] = Users.list_ingesting_users(limit: 500)
     end
 
-    test "deduplicates users before applying the limit" do
+    test "deduplicates users and orders by latest source before applying the limit" do
       now = NaiveDateTime.utc_now()
-      newest_user = insert(:user)
       older_user = insert(:user)
+      newest_user = insert(:user)
 
       insert(:source, user: newest_user, log_events_updated_at: now)
 
       insert(:source,
         user: newest_user,
-        log_events_updated_at: NaiveDateTime.shift(now, second: -1)
+        log_events_updated_at: NaiveDateTime.shift(now, hour: -2)
       )
 
       insert(:source,
@@ -43,9 +43,22 @@ defmodule Logflare.UsersTest do
         log_events_updated_at: NaiveDateTime.shift(now, hour: -1)
       )
 
-      assert [first, second] = Users.list_ingesting_users(limit: 2)
-      assert first.id == newest_user.id
-      assert second.id == older_user.id
+      newest_user_id = newest_user.id
+      older_user_id = older_user.id
+
+      assert [%{id: ^newest_user_id}, %{id: ^older_user_id}] =
+               Users.list_ingesting_users(limit: 2)
+    end
+
+    test "breaks ingesting user activity ties by id" do
+      active_at = NaiveDateTime.utc_now()
+      first_user = insert(:user)
+      second_user = insert(:user)
+      insert(:source, user: first_user, log_events_updated_at: active_at)
+      insert(:source, user: second_user, log_events_updated_at: active_at)
+      first_user_id = first_user.id
+
+      assert [%{id: ^first_user_id}] = Users.list_ingesting_users(limit: 1)
     end
   end
 


### PR DESCRIPTION
## Summary

- apply backend warmer limits in SQL instead of loading every ingesting backend before truncation
- pre-aggregate latest source activity per backend, then rank distinct filtered backend IDs so ingesting order composes with access and `has_sources_or_rules` filters
- make ingesting-user selection distinct before applying its limit
- add deterministic tie-breakers and regression coverage proving limits count unique backends and users
- use the shared positive-integer guard for backend limits

## Why

The original joins could return the same backend or user once per active source, so duplicates consumed the warmer limit and the application loaded an unbounded result before truncation.

Grouping ingesting activity directly in the outer backend query fixed the simple warmer call, but backend access and `has_sources_or_rules` filters already add `DISTINCT`. Combining those filters could either demote latest-activity ordering behind backend ID or produce PostgreSQL `42P10`.

The backend path now reduces ordinary filters to distinct backend IDs, joins them to a separately aggregated latest-activity query, and applies ordering and the limit only in the deduplication-free outer query.

## Test coverage

- limits unique ingesting backends by latest source activity
- preserves latest-activity ordering with `has_sources_or_rules` in either keyword order
- supports ingesting filters through `list_backends_by_user_access/2` without a `DISTINCT`/`ORDER BY` conflict
- deduplicates ingesting users before limiting
- deterministically breaks equal-activity ties by ID

## Test plan

- `../bin/test test/logflare/backends/cache_test.exs test/logflare/backends_test.exs test/logflare/users/users_test.exs test/logflare/users/cache_test.exs`
- included in the final affected stack suite: 2 doctests, 1 property and 169 tests, 0 failures (3 excluded)
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `MIX_ENV=test ../bin/x mix lint.all`
- `MIX_ENV=test ../bin/format --check-formatted`

## Stack

Review each PR against its immediate base:

1. #3913 — Sources and SourceSchemas cache entry correctness, value parity, and source-user deletion tolerance during retention hydration
2. #3915 — bounded, deduplicated, deterministic, and composable warmer queries (this PR; based on #3913)
3. #3916 — best-effort SystemCache startup and foreground monitor-failure handling

The proposed KeyValues changes in #3914 were removed from this stack and remain deferred. The WAL fence follow-up in #3924 was closed because its coordination complexity was disproportionate and it did not solve post-invalidation replica-lag refills; any future stronger guarantee should use replica replay/LSN coordination.


