### PR TITLE
fix: make system cache warming best effort

### DIFF
--- a/lib/logflare/system.ex
+++ b/lib/logflare/system.ex
@@ -30,5 +30,7 @@ defmodule Logflare.System do
   @spec total_memory_bytes() :: non_neg_integer() | nil
   def total_memory_bytes do
     :memsup.get_system_memory_data()[:system_total_memory]
+  catch
+    :exit, _reason -> nil
   end
 end

--- a/lib/logflare/system_cache.ex
+++ b/lib/logflare/system_cache.ex
@@ -50,7 +50,7 @@ defmodule Logflare.SystemCache do
   @spec memory_utilization() :: float()
   def memory_utilization do
     case Cachex.fetch(@cache, :memory_utilization, fn _ ->
-           {:commit, Logflare.System.memory_utilization()}
+           {:commit, read_memory_utilization()}
          end) do
       {:ok, value} ->
         value
@@ -60,7 +60,22 @@ defmodule Logflare.SystemCache do
 
       {:error, err} ->
         Logger.warning("SystemCache.memory_utilization cache error: #{inspect(err)}")
-        Logflare.System.memory_utilization()
+        read_memory_utilization()
     end
+  end
+
+  defp read_memory_utilization do
+    Logflare.System.memory_utilization()
+  rescue
+    error ->
+      Logger.warning("SystemCache.memory_utilization read failed: #{Exception.message(error)}")
+      0.0
+  catch
+    kind, reason ->
+      Logger.warning(
+        "SystemCache.memory_utilization read failed: #{Exception.format(kind, reason, __STACKTRACE__)}"
+      )
+
+      0.0
   end
 end

--- a/lib/logflare/system_cache.ex
+++ b/lib/logflare/system_cache.ex
@@ -19,7 +19,7 @@ defmodule Logflare.SystemCache do
       else
         [
           warmer(
-            required: true,
+            required: false,
             module: __MODULE__.Warmer,
             name: __MODULE__.Warmer,
             interval: :timer.seconds(3)

--- a/lib/logflare/system_cache/warmer.ex
+++ b/lib/logflare/system_cache/warmer.ex
@@ -9,8 +9,15 @@ defmodule Logflare.SystemCache.Warmer do
   def execute(_state) do
     {:ok, [{:memory_utilization, Logflare.System.memory_utilization()}]}
   rescue
-    e ->
-      Logger.warning("SystemCache warmer failed: #{inspect(e)}")
+    error ->
+      Logger.warning("SystemCache warmer failed: #{Exception.message(error)}")
+      :ignore
+  catch
+    kind, reason ->
+      Logger.warning(
+        "SystemCache warmer failed: #{Exception.format(kind, reason, __STACKTRACE__)}"
+      )
+
       :ignore
   end
 end

--- a/test/logflare/system_cache_test.exs
+++ b/test/logflare/system_cache_test.exs
@@ -23,6 +23,20 @@ defmodule Logflare.SystemCacheTest do
       assert SystemCache.memory_utilization() == 0.42
       assert SystemCache.memory_utilization() == 0.42
     end
+
+    test "caches a safe value when the monitor exits during a cache miss" do
+      Logflare.System
+      |> expect(:memory_utilization, 1, fn -> exit(:monitor_unavailable) end)
+
+      log =
+        capture_log([level: :warning], fn ->
+          assert SystemCache.memory_utilization() == 0.0
+          assert SystemCache.memory_utilization() == 0.0
+        end)
+
+      assert log =~ "SystemCache.memory_utilization read failed"
+      assert log =~ "monitor_unavailable"
+    end
   end
 
   test "does not require the warmer to finish during cache startup" do

--- a/test/logflare/system_cache_test.exs
+++ b/test/logflare/system_cache_test.exs
@@ -35,6 +35,38 @@ defmodule Logflare.SystemCacheTest do
     refute warmer(warmer_spec, :required)
   end
 
+  test "cache starts while the optional warmer handles monitor exits" do
+    previous_env = Application.get_env(:logflare, :env)
+    Application.put_env(:logflare, :env, :prod)
+    on_exit(fn -> Application.put_env(:logflare, :env, previous_env) end)
+    set_mimic_global()
+
+    assert %{start: {Cachex, :start_link, [SystemCache, options]}} = SystemCache.child_spec(nil)
+    assert [warmer_spec] = Keyword.fetch!(options, :warmers)
+
+    cache_name = Module.concat(__MODULE__, IntegrationCache)
+    warmer_name = Module.concat(__MODULE__, IntegrationWarmer)
+    options = Keyword.put(options, :warmers, [warmer(warmer_spec, name: warmer_name)])
+    test_pid = self()
+
+    stub(Logflare.System, :memory_utilization, fn ->
+      send(test_pid, :warmer_called)
+      exit(:monitor_unavailable)
+    end)
+
+    log =
+      capture_log([level: :warning], fn ->
+        cache_pid = start_supervised!({Cachex, [cache_name, options]})
+
+        assert_receive :warmer_called
+        :sys.get_state(warmer_name)
+        assert Process.alive?(cache_pid)
+      end)
+
+    assert log =~ "SystemCache warmer failed"
+    assert log =~ "monitor_unavailable"
+  end
+
   test "warmer treats monitor exits as a cache miss" do
     stub(Logflare.System, :memory_utilization, fn -> exit(:monitor_unavailable) end)
 

--- a/test/logflare/system_cache_test.exs
+++ b/test/logflare/system_cache_test.exs
@@ -1,11 +1,14 @@
 defmodule Logflare.SystemCacheTest do
   use ExUnit.Case, async: false
 
+  import Cachex.Spec
+  import ExUnit.CaptureLog
   import Mimic
 
   setup :verify_on_exit!
 
   alias Logflare.SystemCache
+  alias Logflare.SystemCache.Warmer
 
   setup do
     Cachex.clear(SystemCache)
@@ -20,5 +23,27 @@ defmodule Logflare.SystemCacheTest do
       assert SystemCache.memory_utilization() == 0.42
       assert SystemCache.memory_utilization() == 0.42
     end
+  end
+
+  test "does not require the warmer to finish during cache startup" do
+    previous_env = Application.get_env(:logflare, :env)
+    Application.put_env(:logflare, :env, :prod)
+    on_exit(fn -> Application.put_env(:logflare, :env, previous_env) end)
+
+    assert %{start: {Cachex, :start_link, [SystemCache, options]}} = SystemCache.child_spec(nil)
+    assert [warmer_spec] = Keyword.fetch!(options, :warmers)
+    refute warmer(warmer_spec, :required)
+  end
+
+  test "warmer treats monitor exits as a cache miss" do
+    stub(Logflare.System, :memory_utilization, fn -> exit(:monitor_unavailable) end)
+
+    log =
+      capture_log([level: :warning], fn ->
+        assert :ignore = Warmer.execute(nil)
+      end)
+
+    assert log =~ "SystemCache warmer failed"
+    assert log =~ "monitor_unavailable"
   end
 end


### PR DESCRIPTION
## Summary

- make the SystemCache warmer optional so a telemetry warm-up failure cannot prevent Cachex or application startup
- normalize exits from `:memsup` to the documented unavailable-memory result
- make foreground SystemCache misses cache a safe `0.0` value when the underlying memory read raises or exits, keeping ingestion's BufferLimiter available
- retain bounded periodic warming without repeatedly warning for ordinary `:memsup` unavailability
- add regression coverage for optional startup, unavailable system memory statistics, and foreground cache misses

## Why

Catching failures only inside the warmer allowed Cachex to start, but left the key empty. A request reaching `BufferLimiter` before a successful retry would execute the same unsafe memory call through `SystemCache.memory_utilization/0` and could still crash the ingestion request.

`Logflare.System.total_memory_bytes/0` now treats `:memsup` exits as the `nil` result its contract already documents. SystemCache also guards its foreground read-through path and commits `0.0` on unexpected errors or exits, so subsequent reads remain cached and safe.

## Test coverage

- asserts the production warmer is optional
- starts a real Cachex instance while its optional warmer handles an exit
- verifies the warmer's defensive catch behavior directly
- verifies a foreground SystemCache miss converts an exit to `0.0` and caches the safe result
- exercises the System doctests and BufferLimiter consumer suite

## Test plan

- `../bin/test test/logflare/system_test.exs test/logflare/system_cache_test.exs test/logflare_web/controllers/plugs/buffer_limiter_test.exs`
- included in the final affected stack suite: 2 doctests, 1 property and 169 tests, 0 failures (3 excluded)
- `MIX_ENV=test ../bin/x mix compile --warnings-as-errors`
- `MIX_ENV=test ../bin/x mix lint.all`
- `MIX_ENV=test ../bin/format --check-formatted`

## Stack

Review each PR against its immediate base:

1. #3913 — Sources and SourceSchemas cache entry correctness, value parity, and source-user deletion tolerance during retention hydration
2. #3915 — bounded, deduplicated, deterministic, and composable warmer queries
3. #3916 — best-effort SystemCache startup and foreground monitor-failure handling (this PR; based on #3915)

The proposed KeyValues changes in #3914 were removed from this stack and remain deferred. The WAL fence follow-up in #3924 was closed because its coordination complexity was disproportionate and it did not solve post-invalidation replica-lag refills; any future stronger guarantee should use replica replay/LSN coordination.


