### PR TITLE
fix: fence context cache writes against WAL invalidation

### DIFF
--- a/lib/logflare/backends/cache_warmer.ex
+++ b/lib/logflare/backends/cache_warmer.ex
@@ -1,16 +1,31 @@
 defmodule Logflare.Backends.CacheWarmer do
+  require Logger
+
   alias Logflare.Backends
+  alias Logflare.ContextCache.WriteFence
 
   use Cachex.Warmer
+
   @impl true
   def execute(_state) do
+    {:ok, snapshot} = WriteFence.begin_snapshot(Backends)
     backends = Backends.list_backends(ingesting: true, limit: 1_000)
 
-    get_kv =
-      for b <- backends do
-        {{:get_backend, [b.id]}, {:cached, b}}
+    entry_groups =
+      for backend <- backends do
+        {backend.id, [{{:get_backend, [backend.id]}, {:cached, backend}}]}
       end
 
-    {:ok, get_kv}
+    case WriteFence.commit(snapshot, Backends.Cache, entry_groups) do
+      {:ok, %{skipped: skipped}} ->
+        if skipped > 0 do
+          Logger.warning("Backends cache warmer skipped #{skipped} invalidated backends")
+        end
+
+      {:error, reason} ->
+        Logger.warning("Backends cache warmer could not commit: #{inspect(reason)}")
+    end
+
+    :ignore
   end
 end

--- a/lib/logflare/context_cache.ex
+++ b/lib/logflare/context_cache.ex
@@ -10,7 +10,8 @@ defmodule Logflare.ContextCache do
 
   The cache implementation directly queries the relevant context cache to be busted and performs
   primary key checking within the matchspec. This approach queries across a narrower set of records,
-  providing better performance compared to a reverse index approach.
+  providing better performance compared to a reverse index approach. Cache misses read from the
+  primary database so a completed WAL invalidation cannot be followed by a stale replica fill.
 
   If customization of busting is needed, cache module may implement `c:bust_by/1` callback expecting
   a keyword list instead of primary key for entry.
@@ -32,11 +33,14 @@ defmodule Logflare.ContextCache do
   ## Gossip
 
   Cache misses are optionally multicast to peer nodes via `:erpc` to warm the cluster.
-  To prevent race conditions, WAL invalidations write short-lived tombstones that
-  filter out stale incoming messages.
+  WAL invalidations are ordered against local cache population, while short-lived
+  tombstones filter stale incoming messages.
   """
 
+  import Cachex.Spec, only: [cache: 1]
+
   alias Logflare.ContextCache.Gossip
+  alias Logflare.ContextCache.WriteFence
 
   @doc """
   Optional callback implementing custom cache key busting by a keyword of values
@@ -51,7 +55,7 @@ defmodule Logflare.ContextCache do
     cache_key = {fun, args}
 
     fetch(cache, cache_key, fn ->
-      Logflare.Repo.apply_with_replica(context, fun, args)
+      apply(context, fun, args)
     end)
   end
 
@@ -82,6 +86,8 @@ defmodule Logflare.ContextCache do
   """
   @spec bust_keys(list()) :: {:ok, non_neg_integer()}
   def bust_keys(values) when is_list(values) do
+    :ok = WriteFence.invalidate(values)
+
     busted =
       for {context, primary_key} <- values, reduce: 0 do
         acc ->
@@ -90,6 +96,16 @@ defmodule Logflare.ContextCache do
       end
 
     {:ok, busted}
+  end
+
+  defp bust_key({context, :not_found}) do
+    context_cache = cache_name(context)
+    query = Cachex.Query.build(output: {:key, :value})
+
+    context_cache
+    |> Cachex.stream!(query)
+    |> Stream.filter(fn {_key, value} -> value in [{:cached, nil}, {:cached, []}] end)
+    |> delete_entries(context_cache)
   end
 
   defp bust_key({context, kw}) when is_list(kw) do
@@ -132,25 +148,56 @@ defmodule Logflare.ContextCache do
     Module.concat(context, Cache)
   end
 
+  @doc false
+  @spec context_name(Cachex.t()) :: atom()
+  def context_name(cache(name: name)), do: context_name(name)
+
+  def context_name(cache) when is_atom(cache) do
+    cache
+    |> Module.split()
+    |> Enum.drop(-1)
+    |> Module.concat()
+  end
+
   @doc """
   Low level API for fetching from cache. Allows wrapping calls with
   `Cachex.execute/2` and accessing arbitrary key or calling any getter function.
   """
   @spec fetch(Cachex.t(), {atom(), list()}, fun()) :: term()
   def fetch(cache, cache_key, getter_fn) do
+    caller = self()
+    cache_name = cache_identifier(cache)
+    context = context_name(cache_name)
+
     case Cachex.fetch(cache, cache_key, fn _cache_key ->
-           # Use a `:cached` tuple here otherwise when an fn returns nil Cachex will miss
-           # the cache because it thinks ETS returned nil
-           {:commit, {:cached, getter_fn.()}}
+           {:ok, snapshot} = WriteFence.begin_snapshot(context)
+           value = getter_fn.()
+           cached_value = {:cached, value}
+
+           published? =
+             match?(
+               {:ok, %{written: 1}},
+               WriteFence.commit(snapshot, cache_name, [
+                 {{:any, WriteFence.primary_keys(value)}, [{cache_key, cached_value}]}
+               ])
+             )
+
+           {:ignore, {:fenced, caller, published?, cached_value}}
          end) do
-      {:commit, {:cached, value}} ->
-        Gossip.multicast(cache, cache_key, value)
+      {:ignore, {:fenced, owner, published?, {:cached, value}}} ->
+        if owner == caller and published? do
+          Gossip.multicast(cache_name, cache_key, value)
+        end
+
         value
 
       {:ok, {:cached, value}} ->
         value
     end
   end
+
+  defp cache_identifier(cache(name: name)), do: name
+  defp cache_identifier(cache) when is_atom(cache), do: cache
 
   defp delete_matching_entries(entries, context_cache, pkey) do
     to_delete =
@@ -163,9 +210,13 @@ defmodule Logflare.ContextCache do
           true
       end)
 
+    delete_entries(to_delete, context_cache)
+  end
+
+  defp delete_entries(entries, context_cache) do
     Cachex.execute(context_cache, fn worker ->
-      Enum.reduce(to_delete, 0, fn {k, _v}, acc ->
-        Cachex.del(worker, k)
+      Enum.reduce(entries, 0, fn {key, _value}, acc ->
+        Cachex.del(worker, key)
         acc + 1
       end)
     end)

--- a/lib/logflare/context_cache.ex
+++ b/lib/logflare/context_cache.ex
@@ -10,8 +10,7 @@ defmodule Logflare.ContextCache do
 
   The cache implementation directly queries the relevant context cache to be busted and performs
   primary key checking within the matchspec. This approach queries across a narrower set of records,
-  providing better performance compared to a reverse index approach. Cache misses read from the
-  primary database so a completed WAL invalidation cannot be followed by a stale replica fill.
+  providing better performance compared to a reverse index approach.
 
   If customization of busting is needed, cache module may implement `c:bust_by/1` callback expecting
   a keyword list instead of primary key for entry.
@@ -33,8 +32,8 @@ defmodule Logflare.ContextCache do
   ## Gossip
 
   Cache misses are optionally multicast to peer nodes via `:erpc` to warm the cluster.
-  WAL invalidations are ordered against local cache population, while short-lived
-  tombstones filter stale incoming messages.
+  Cache population that overlaps a WAL invalidation is ordered against that invalidation,
+  while short-lived tombstones filter stale incoming messages.
   """
 
   import Cachex.Spec, only: [cache: 1]
@@ -55,7 +54,7 @@ defmodule Logflare.ContextCache do
     cache_key = {fun, args}
 
     fetch(cache, cache_key, fn ->
-      apply(context, fun, args)
+      Logflare.Repo.apply_with_replica(context, fun, args)
     end)
   end
 

--- a/lib/logflare/context_cache/cache_buster.ex
+++ b/lib/logflare/context_cache/cache_buster.ex
@@ -5,6 +5,7 @@ defmodule Logflare.ContextCache.CacheBuster do
   use GenServer
 
   alias Logflare.ContextCache.CacheBusterWorker
+  alias Logflare.ContextCache.WriteFence
   alias Cainophile.Changes.DeletedRecord
   alias Cainophile.Changes.NewRecord
   alias Cainophile.Changes.Transaction
@@ -21,7 +22,6 @@ defmodule Logflare.ContextCache.CacheBuster do
   alias Logflare.Sources
   alias Logflare.TeamUsers
   alias Logflare.Users
-  alias Logflare.ContextCache.CacheBusterWorker
 
   require Logger
 
@@ -30,7 +30,8 @@ defmodule Logflare.ContextCache.CacheBuster do
   end
 
   def init(_state) do
-    subscribe_to_transactions()
+    :ok = subscribe_to_transactions()
+    :ok = WriteFence.mark_ready()
     {:ok, %{}}
   end
 

--- a/lib/logflare/context_cache/gossip.ex
+++ b/lib/logflare/context_cache/gossip.ex
@@ -19,6 +19,7 @@ defmodule Logflare.ContextCache.Gossip do
   alias Logflare.Cluster.Utils, as: ClusterUtils
   alias Logflare.ContextCache
   alias Logflare.ContextCache.Tombstones
+  alias Logflare.ContextCache.WriteFence
 
   @telemetry_handler_id "context-cache-gossip-logger"
 
@@ -161,21 +162,32 @@ defmodule Logflare.ContextCache.Gossip do
       :refreshed
     else
       pkeys = pkeys_from_cached_value(value)
+      {:ok, snapshot} = WriteFence.begin_snapshot(ContextCache.context_name(cache))
 
       cond do
         # if we can't extract any primary keys from the cache key/value,
         # we have no way to detect staleness, so we drop it to be safe
         pkeys == [] ->
+          WriteFence.commit(snapshot, cache, [])
           :dropped_no_pkey
 
         # do nothing if the WAL recently busted this specific record
         Enum.any?(pkeys, fn pkey -> Tombstones.Cache.tombstoned?(cache, pkey) end) ->
+          WriteFence.commit(snapshot, cache, [])
           :dropped_stale
 
         true ->
-          Cachex.put(cache, key, {:cached, value})
-          :cached
+          commit_received(snapshot, cache, key, value, pkeys)
       end
+    end
+  end
+
+  defp commit_received(snapshot, cache, key, value, pkeys) do
+    case WriteFence.commit(snapshot, cache, [
+           {{:any, pkeys}, [{key, {:cached, value}}]}
+         ]) do
+      {:ok, %{written: 1}} -> :cached
+      _not_written -> :dropped_stale
     end
   end
 

--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -10,6 +10,7 @@ defmodule Logflare.ContextCache.Supervisor do
   alias Logflare.ContextCache.CacheBuster
   alias Logflare.ContextCache.CacheBusterWorker
   alias Logflare.ContextCache.Tombstones
+  alias Logflare.ContextCache.WriteFence
   alias Logflare.Endpoints
   alias Logflare.GenSingleton
   alias Logflare.KeyValues
@@ -52,7 +53,8 @@ defmodule Logflare.ContextCache.Supervisor do
         buster_specs()
       end
 
-    caches ++
+    [{WriteFence, ready?: env == :test}] ++
+      caches ++
       List.wrap(maybe_transaction_broadcaster) ++
       List.wrap(maybe_cainophile) ++
       List.wrap(maybe_busters)

--- a/lib/logflare/context_cache/write_fence.ex
+++ b/lib/logflare/context_cache/write_fence.ex
@@ -18,7 +18,7 @@ defmodule Logflare.ContextCache.WriteFence do
   @active_table Module.concat(__MODULE__, ActiveContexts)
 
   @type snapshot :: reference()
-  @type cache_entry :: {Cachex.key(), any()}
+  @type cache_entry :: {any(), any()}
   @type dependency :: any() | {:any, [any()]}
   @type entry_group :: {dependency(), [cache_entry()]}
   @type commit_result :: %{written: non_neg_integer(), skipped: non_neg_integer()}

--- a/lib/logflare/context_cache/write_fence.ex
+++ b/lib/logflare/context_cache/write_fence.ex
@@ -1,0 +1,357 @@
+defmodule Logflare.ContextCache.WriteFence do
+  @moduledoc """
+  Orders cache population against cache invalidations.
+
+  Cache reads and warmers open a snapshot before reading the database and commit
+  entries grouped by the primary keys they depend on. Invalidations recorded
+  while that snapshot is active cause only affected groups to be skipped. Cache
+  writes and invalidation recording are serialized by this process, so an
+  invalidation either prevents a stale write or runs before the existing
+  cache-busting pass removes it.
+  """
+
+  use GenServer
+
+  alias Logflare.ContextCache
+  alias Logflare.ContextCache.CacheBuster
+
+  @active_table Module.concat(__MODULE__, ActiveContexts)
+
+  @type snapshot :: reference()
+  @type cache_entry :: {Cachex.key(), any()}
+  @type dependency :: any() | {:any, [any()]}
+  @type entry_group :: {dependency(), [cache_entry()]}
+  @type commit_result :: %{written: non_neg_integer(), skipped: non_neg_integer()}
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec begin_snapshot(module(), GenServer.server()) :: {:ok, snapshot()}
+  def begin_snapshot(context, server \\ __MODULE__) do
+    GenServer.call(server, {:begin_snapshot, context, self()}, :infinity)
+  end
+
+  @spec mark_ready(GenServer.server()) :: :ok
+  def mark_ready(server \\ __MODULE__) do
+    GenServer.call(server, {:mark_ready, self()})
+  end
+
+  @spec invalidate([{module(), any()}], GenServer.server()) :: :ok
+  def invalidate(values, server \\ __MODULE__)
+
+  def invalidate([], _server), do: :ok
+
+  def invalidate(values, __MODULE__) do
+    invalidations = normalize_invalidations(values)
+
+    if active_context?(invalidations) do
+      try do
+        GenServer.call(__MODULE__, {:invalidate, invalidations}, :infinity)
+      catch
+        :exit, _reason -> :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  def invalidate(values, server) do
+    GenServer.call(server, {:invalidate, normalize_invalidations(values)}, :infinity)
+  end
+
+  @spec commit(snapshot(), module(), [entry_group()], GenServer.server()) ::
+          {:ok, commit_result()} | {:error, term()}
+  def commit(snapshot, cache, entry_groups, server \\ __MODULE__) do
+    GenServer.call(server, {:commit, snapshot, cache, entry_groups}, :infinity)
+  end
+
+  @doc false
+  @spec primary_keys(any()) :: [any()]
+  def primary_keys(nil), do: [:not_found]
+  def primary_keys([]), do: [:not_found]
+  def primary_keys(values) when is_list(values), do: Enum.flat_map(values, &primary_keys/1)
+  def primary_keys({:ok, value}), do: primary_keys(value)
+  def primary_keys({:ok, value, _other}), do: primary_keys(value)
+  def primary_keys(%{id: id}), do: [id]
+  def primary_keys(_value), do: [:unknown]
+
+  @impl GenServer
+  def init(opts) do
+    active_table = Keyword.get(opts, :active_table, @active_table)
+    :ets.new(active_table, [:named_table, :protected, :set, read_concurrency: true])
+
+    always_ready? = Keyword.get(opts, :ready?, false)
+    cache_buster = Process.whereis(CacheBuster)
+
+    state = %{
+      active_table: active_table,
+      always_ready?: always_ready?,
+      ready?: always_ready? or is_pid(cache_buster),
+      ready_monitor: monitor_process(cache_buster),
+      sessions: %{},
+      waiters: %{}
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:begin_snapshot, context, owner}, _from, %{ready?: true} = state) do
+    {snapshot, state} = open_session(state, context, owner)
+    {:reply, {:ok, snapshot}, state}
+  end
+
+  def handle_call({:begin_snapshot, context, owner}, from, state) do
+    monitor = Process.monitor(owner)
+    waiter = %{context: context, from: from, owner: owner}
+    {:noreply, put_in(state.waiters[monitor], waiter)}
+  end
+
+  def handle_call({:mark_ready, cache_buster}, _from, state) do
+    state =
+      state
+      |> monitor_cache_buster(cache_buster)
+      |> Map.put(:ready?, true)
+      |> release_waiters()
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:invalidate, invalidations}, _from, state) do
+    invalidations_by_context =
+      Enum.reduce(invalidations, %{}, fn {context, primary_key}, acc ->
+        Map.update(acc, context, MapSet.new([primary_key]), &MapSet.put(&1, primary_key))
+      end)
+
+    sessions =
+      Map.new(state.sessions, fn {snapshot, session} ->
+        invalidated =
+          case {session.invalidated, Map.fetch(invalidations_by_context, session.context)} do
+            {:all, _result} -> :all
+            {invalidated, {:ok, primary_keys}} -> MapSet.union(invalidated, primary_keys)
+            {invalidated, :error} -> invalidated
+          end
+
+        {snapshot, %{session | invalidated: invalidated}}
+      end)
+
+    {:reply, :ok, %{state | sessions: sessions}}
+  end
+
+  def handle_call({:commit, snapshot, cache, entry_groups}, {owner, _tag}, state) do
+    case Map.fetch(state.sessions, snapshot) do
+      :error ->
+        {:reply, {:error, :unknown_snapshot}, state}
+
+      {:ok, %{owner: session_owner}} when session_owner != owner ->
+        {:reply, {:error, :not_owner}, state}
+
+      {:ok, session} ->
+        {reply, state} = commit_and_close(state, snapshot, session, cache, entry_groups)
+        {:reply, reply, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, monitor, :process, _pid, _reason}, %{ready_monitor: monitor} = state) do
+    sessions =
+      Map.new(state.sessions, fn {snapshot, session} ->
+        {snapshot, %{session | invalidated: :all}}
+      end)
+
+    {:noreply, %{state | ready?: state.always_ready?, ready_monitor: nil, sessions: sessions}}
+  end
+
+  def handle_info({:DOWN, monitor, :process, _pid, _reason}, state) do
+    case Map.pop(state.waiters, monitor) do
+      {nil, waiters} ->
+        state = %{state | waiters: waiters}
+        {:noreply, close_session_by_monitor(state, monitor)}
+
+      {_waiter, waiters} ->
+        {:noreply, %{state | waiters: waiters}}
+    end
+  end
+
+  defp commit_and_close(state, snapshot, session, cache, entry_groups) do
+    reply =
+      with :ok <- validate_cache(session.context, cache),
+           {:ok, entries, skipped} <- prepare_entries(entry_groups, session.invalidated),
+           {:ok, _written?} <- put_many(cache, entries) do
+        {:ok, %{written: length(entries), skipped: skipped}}
+      end
+
+    {reply, close_session(state, snapshot, session)}
+  end
+
+  defp validate_cache(context, cache) do
+    if ContextCache.cache_name(context) == cache, do: :ok, else: {:error, :invalid_cache}
+  end
+
+  defp prepare_entries(entry_groups, invalidated) when is_list(entry_groups) do
+    entry_groups
+    |> Enum.reduce_while({[], 0}, fn
+      {primary_key, entries}, {acc, skipped} when is_list(entries) ->
+        if invalidated?(invalidated, primary_key) do
+          {:cont, {acc, skipped + 1}}
+        else
+          {:cont, {entries ++ acc, skipped}}
+        end
+
+      _invalid_group, _acc ->
+        {:halt, {:error, :invalid_entries}}
+    end)
+    |> case do
+      {:error, _reason} = error -> error
+      {entries, skipped} -> deduplicate_entries(entries, skipped)
+    end
+  end
+
+  defp prepare_entries(_entry_groups, _invalidated), do: {:error, :invalid_entries}
+
+  defp invalidated?(:all, _dependency), do: true
+
+  defp invalidated?(invalidated, {:any, primary_keys}) do
+    MapSet.member?(invalidated, :all) or
+      Enum.any?(primary_keys, &MapSet.member?(invalidated, &1))
+  end
+
+  defp invalidated?(invalidated, primary_key) do
+    MapSet.member?(invalidated, :all) or MapSet.member?(invalidated, primary_key)
+  end
+
+  defp deduplicate_entries(entries, skipped) do
+    entries
+    |> Enum.reduce_while(%{}, fn
+      {key, value}, acc ->
+        case Map.fetch(acc, key) do
+          :error -> {:cont, Map.put(acc, key, value)}
+          {:ok, ^value} -> {:cont, acc}
+          {:ok, _other_value} -> {:halt, {:error, :conflicting_entries}}
+        end
+
+      _invalid_entry, _acc ->
+        {:halt, {:error, :invalid_entries}}
+    end)
+    |> case do
+      {:error, _reason} = error -> error
+      entries_by_key -> {:ok, Map.to_list(entries_by_key), skipped}
+    end
+  end
+
+  defp put_many(_cache, []), do: {:ok, true}
+
+  defp put_many(cache, entries) do
+    Cachex.put_many(cache, entries)
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp open_session(state, context, owner, monitor \\ nil) do
+    snapshot = make_ref()
+    monitor = monitor || Process.monitor(owner)
+
+    session = %{
+      context: context,
+      invalidated: MapSet.new(),
+      monitor: monitor,
+      owner: owner
+    }
+
+    increment_active_context(state.active_table, context)
+    {snapshot, put_in(state.sessions[snapshot], session)}
+  end
+
+  defp close_session(state, snapshot, session) do
+    Process.demonitor(session.monitor, [:flush])
+    decrement_active_context(state.active_table, session.context)
+    %{state | sessions: Map.delete(state.sessions, snapshot)}
+  end
+
+  defp close_session_by_monitor(state, monitor) do
+    case Enum.find(state.sessions, fn {_snapshot, session} -> session.monitor == monitor end) do
+      nil ->
+        state
+
+      {snapshot, session} ->
+        decrement_active_context(state.active_table, session.context)
+        %{state | sessions: Map.delete(state.sessions, snapshot)}
+    end
+  end
+
+  defp release_waiters(state) do
+    Enum.reduce(state.waiters, %{state | waiters: %{}}, fn {monitor, waiter}, state ->
+      if Process.alive?(waiter.owner) do
+        {snapshot, state} = open_session(state, waiter.context, waiter.owner, monitor)
+        GenServer.reply(waiter.from, {:ok, snapshot})
+        state
+      else
+        Process.demonitor(monitor, [:flush])
+        state
+      end
+    end)
+  end
+
+  defp monitor_cache_buster(%{always_ready?: true} = state, _cache_buster), do: state
+
+  defp monitor_cache_buster(state, cache_buster) do
+    if state.ready_monitor do
+      Process.demonitor(state.ready_monitor, [:flush])
+    end
+
+    %{state | ready_monitor: Process.monitor(cache_buster)}
+  end
+
+  defp monitor_process(pid) when is_pid(pid), do: Process.monitor(pid)
+  defp monitor_process(_pid), do: nil
+
+  defp increment_active_context(table, context) do
+    :ets.update_counter(table, context, {2, 1}, {context, 0})
+  end
+
+  defp decrement_active_context(table, context) do
+    case :ets.update_counter(table, context, {2, -1}) do
+      0 -> :ets.delete(table, context)
+      _remaining -> :ok
+    end
+  end
+
+  defp active_context?(invalidations) do
+    case :ets.whereis(@active_table) do
+      :undefined ->
+        false
+
+      _table ->
+        Enum.any?(invalidations, fn {context, _primary_key} ->
+          :ets.member(@active_table, context)
+        end)
+    end
+  end
+
+  defp normalize_invalidations(values) do
+    Enum.flat_map(values, fn
+      {context, primary_key} ->
+        case normalize_primary_key(primary_key) do
+          nil -> []
+          primary_key -> [{context, primary_key}]
+        end
+
+      _invalid ->
+        []
+    end)
+  end
+
+  defp normalize_primary_key(primary_key)
+       when is_integer(primary_key) or is_binary(primary_key) or
+              primary_key in [:not_found, :unknown],
+       do: primary_key
+
+  # Keyword invalidations are interpreted by cache-specific `bust_by/1`
+  # callbacks, so the fence cannot safely reduce them to one primary key.
+  defp normalize_primary_key(primary_key) when is_list(primary_key), do: :all
+
+  defp normalize_primary_key(%{id: primary_key}), do: primary_key
+  defp normalize_primary_key(_primary_key), do: :all
+end

--- a/lib/logflare/rules/cache_warmer.ex
+++ b/lib/logflare/rules/cache_warmer.ex
@@ -1,5 +1,9 @@
 defmodule Logflare.Rules.CacheWarmer do
+  require Logger
+
+  alias Logflare.ContextCache.WriteFence
   alias Logflare.Repo
+  alias Logflare.Rules
   alias Logflare.Sources.Source
 
   import Ecto.Query
@@ -8,6 +12,8 @@ defmodule Logflare.Rules.CacheWarmer do
 
   @impl true
   def execute(_state) do
+    {:ok, snapshot} = WriteFence.begin_snapshot(Rules)
+
     sources =
       from(s in Source,
         where: s.log_events_updated_at >= ago(2, "hour"),
@@ -17,11 +23,21 @@ defmodule Logflare.Rules.CacheWarmer do
       )
       |> Repo.all()
 
-    entries =
-      for s <- sources do
-        {{:list_by_source_id, [s.id]}, {:cached, s.rules}}
+    entry_groups =
+      for source <- sources do
+        {:unknown, [{{:list_by_source_id, [source.id]}, {:cached, source.rules}}]}
       end
 
-    {:ok, entries}
+    case WriteFence.commit(snapshot, Rules.Cache, entry_groups) do
+      {:ok, %{skipped: skipped}} ->
+        if skipped > 0 do
+          Logger.warning("Rules cache warmer skipped #{skipped} entries after invalidation")
+        end
+
+      {:error, reason} ->
+        Logger.warning("Rules cache warmer could not commit: #{inspect(reason)}")
+    end
+
+    :ignore
   end
 end

--- a/lib/logflare/source_schemas/cache_warmer.ex
+++ b/lib/logflare/source_schemas/cache_warmer.ex
@@ -1,4 +1,8 @@
 defmodule Logflare.SourceSchemas.CacheWarmer do
+  require Logger
+
+  alias Logflare.ContextCache.WriteFence
+  alias Logflare.SourceSchemas
   alias Logflare.SourceSchemas.SourceSchema
   alias Logflare.Repo
   alias Logflare.Sources.Source
@@ -7,6 +11,8 @@ defmodule Logflare.SourceSchemas.CacheWarmer do
   use Cachex.Warmer
   @impl true
   def execute(_state) do
+    {:ok, snapshot} = WriteFence.begin_snapshot(SourceSchemas)
+
     # Get source schemas for sources that have been active in the last day
     source_schemas =
       from(ss in SourceSchema,
@@ -18,11 +24,25 @@ defmodule Logflare.SourceSchemas.CacheWarmer do
       )
       |> Repo.all()
 
-    get_kv =
-      for ss <- source_schemas do
-        {{:get_source_schema_by, [[source_id: ss.source_id]]}, {:cached, ss}}
+    entry_groups =
+      for source_schema <- source_schemas do
+        {source_schema.id,
+         [
+           {{:get_source_schema_by, [[source_id: source_schema.source_id]]},
+            {:cached, source_schema}}
+         ]}
       end
 
-    {:ok, get_kv}
+    case WriteFence.commit(snapshot, SourceSchemas.Cache, entry_groups) do
+      {:ok, %{skipped: skipped}} ->
+        if skipped > 0 do
+          Logger.warning("Source schemas cache warmer skipped #{skipped} invalidated schemas")
+        end
+
+      {:error, reason} ->
+        Logger.warning("Source schemas cache warmer could not commit: #{inspect(reason)}")
+    end
+
+    :ignore
   end
 end

--- a/lib/logflare/sources/cache_warmer.ex
+++ b/lib/logflare/sources/cache_warmer.ex
@@ -6,12 +6,15 @@ defmodule Logflare.Sources.CacheWarmer do
   require Logger
 
   alias Logflare.Billing
+  alias Logflare.ContextCache.WriteFence
   alias Logflare.Repo
   alias Logflare.Sources
   alias Logflare.Sources.Source
   alias Logflare.User
   @impl true
   def execute(_state) do
+    {:ok, snapshot} = WriteFence.begin_snapshot(Sources)
+
     # Get sources that have been active in the last day, similar to ingesting users pattern
     sources =
       from(s in Source,
@@ -22,18 +25,29 @@ defmodule Logflare.Sources.CacheWarmer do
       |> Repo.all()
       |> put_retention_days()
 
-    get_kv =
-      for s <- sources do
-        value = {:cached, s}
+    entry_groups =
+      for source <- sources do
+        value = {:cached, source}
 
-        [
-          {{:get_by, [[id: s.id]]}, value},
-          {{:get_by, [[token: s.token]]}, value},
-          {{:get_by, [[token: Atom.to_string(s.token)]]}, value}
-        ]
+        {source.id,
+         [
+           {{:get_by, [[id: source.id]]}, value},
+           {{:get_by, [[token: source.token]]}, value},
+           {{:get_by, [[token: Atom.to_string(source.token)]]}, value}
+         ]}
       end
 
-    {:ok, List.flatten(get_kv)}
+    case WriteFence.commit(snapshot, Sources.Cache, entry_groups) do
+      {:ok, %{skipped: skipped}} ->
+        if skipped > 0 do
+          Logger.warning("Sources cache warmer skipped #{skipped} invalidated sources")
+        end
+
+      {:error, reason} ->
+        Logger.warning("Sources cache warmer could not commit: #{inspect(reason)}")
+    end
+
+    :ignore
   end
 
   defp put_retention_days([]), do: []

--- a/lib/logflare/users/cache_warmer.ex
+++ b/lib/logflare/users/cache_warmer.ex
@@ -1,31 +1,38 @@
 defmodule Logflare.Users.CacheWarmer do
+  require Logger
+
+  alias Logflare.ContextCache.WriteFence
   alias Logflare.Users
 
   use Cachex.Warmer
+
   @impl true
   def execute(_state) do
+    {:ok, snapshot} = WriteFence.begin_snapshot(Users)
     users = Users.list_ingesting_users(limit: 1_000)
+    preloaded_users = Users.preload_defaults(users)
 
-    get_kv =
-      for u <- users do
-        [
-          {{:get, [u.id]}, u},
-          {{:get_by, [[api_key: u.api_key]]}, u}
-        ]
+    entry_groups =
+      for {user, preloaded} <- Enum.zip(users, preloaded_users) do
+        {user.id,
+         [
+           {{:get, [user.id]}, {:cached, user}},
+           {{:get_by, [[api_key: user.api_key]]}, {:cached, user}},
+           {{:get_by_and_preload, [[api_key: user.api_key]]}, {:cached, preloaded}},
+           {{:preload_defaults, [user]}, {:cached, preloaded}}
+         ]}
       end
 
-    preloaded_kv =
-      for {u, preloaded} <-
-            Enum.zip([
-              users,
-              Users.preload_defaults(users)
-            ]) do
-        [
-          {{:get_by_and_preload, [[api_key: u.api_key]]}, preloaded},
-          {{:preload_defaults, [u]}, preloaded}
-        ]
-      end
+    case WriteFence.commit(snapshot, Users.Cache, entry_groups) do
+      {:ok, %{skipped: skipped}} ->
+        if skipped > 0 do
+          Logger.warning("Users cache warmer skipped #{skipped} invalidated users")
+        end
 
-    {:ok, List.flatten(get_kv ++ preloaded_kv) |> Enum.map(fn {k, v} -> {k, {:cached, v}} end)}
+      {:error, reason} ->
+        Logger.warning("Users cache warmer could not commit: #{inspect(reason)}")
+    end
+
+    :ignore
   end
 end

--- a/test/logflare/backends/cache_test.exs
+++ b/test/logflare/backends/cache_test.exs
@@ -98,7 +98,7 @@ defmodule Logflare.Backends.CacheTest do
   end
 
   test "warmer", %{user: user} do
-    assert {:ok, []} = CacheWarmer.execute(nil)
+    assert :ignore = CacheWarmer.execute(nil)
 
     source =
       insert(:source,
@@ -108,8 +108,7 @@ defmodule Logflare.Backends.CacheTest do
 
     backend = insert(:backend, sources: [source])
 
-    assert {:ok, [_ | _] = pairs} = CacheWarmer.execute(nil)
-    assert {:ok, true} = Cachex.put_many(Backends.Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
 
     Backends
     |> reject(:get_backend, 1)

--- a/test/logflare/context_cache/write_fence_test.exs
+++ b/test/logflare/context_cache/write_fence_test.exs
@@ -1,0 +1,147 @@
+defmodule Logflare.ContextCache.WriteFenceTest do
+  use ExUnit.Case, async: false
+
+  alias Logflare.ContextCache
+  alias Logflare.ContextCache.WriteFence
+  alias Logflare.Rules
+  alias Logflare.Sources
+
+  setup do
+    Cachex.clear!(Rules.Cache)
+    Cachex.clear!(Sources.Cache)
+    :ok
+  end
+
+  test "an invalidation during a snapshot prevents every alias from being cached" do
+    source_id = 101
+    id_key = {:get_by, [[id: source_id]]}
+    token_key = {:get_by, [[token: "source-token"]]}
+    value = {:cached, %{id: source_id}}
+
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Sources)
+    assert {:ok, 0} = ContextCache.bust_keys([{Sources, source_id}])
+
+    assert {:ok, %{skipped: 1, written: 0}} =
+             WriteFence.commit(snapshot, Sources.Cache, [
+               {source_id, [{id_key, value}, {token_key, value}]}
+             ])
+
+    assert Cachex.get!(Sources.Cache, id_key) == nil
+    assert Cachex.get!(Sources.Cache, token_key) == nil
+  end
+
+  test "an invalidation after a commit removes the committed entries" do
+    source_id = 102
+    cache_key = {:get_by, [[id: source_id]]}
+    value = {:cached, %{id: source_id}}
+
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Sources)
+
+    assert {:ok, %{skipped: 0, written: 1}} =
+             WriteFence.commit(snapshot, Sources.Cache, [{source_id, [{cache_key, value}]}])
+
+    assert Cachex.get!(Sources.Cache, cache_key) == value
+    assert {:ok, 1} = ContextCache.bust_keys([{Sources, source_id}])
+    assert Cachex.get!(Sources.Cache, cache_key) == nil
+  end
+
+  test "only invalidated primary-key groups are skipped" do
+    invalidated_id = 103
+    fresh_id = 104
+    invalidated_key = {:get_by, [[id: invalidated_id]]}
+    fresh_key = {:get_by, [[id: fresh_id]]}
+
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Sources)
+    assert :ok = WriteFence.invalidate([{Sources, invalidated_id}])
+
+    assert {:ok, %{skipped: 1, written: 1}} =
+             WriteFence.commit(snapshot, Sources.Cache, [
+               {invalidated_id, [{invalidated_key, {:cached, %{id: invalidated_id}}}]},
+               {fresh_id, [{fresh_key, {:cached, %{id: fresh_id}}}]}
+             ])
+
+    assert Cachex.get!(Sources.Cache, invalidated_key) == nil
+    assert Cachex.get!(Sources.Cache, fresh_key) == {:cached, %{id: fresh_id}}
+  end
+
+  test "custom keyword invalidations fence cache-specific warmer entries" do
+    cache_key = {:list_by_source_id, [202]}
+
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Rules)
+    assert :ok = WriteFence.invalidate([{Rules, [id: 201, source_id: 202]}])
+
+    assert {:ok, %{skipped: 1, written: 0}} =
+             WriteFence.commit(snapshot, Rules.Cache, [
+               {:unknown, [{cache_key, {:cached, [%{id: 201}]}}]}
+             ])
+
+    assert Cachex.get!(Rules.Cache, cache_key) == nil
+  end
+
+  test "conflicting duplicate cache keys fail closed" do
+    cache_key = {:get_by, [[token: "duplicate"]]}
+
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Sources)
+
+    assert {:error, :conflicting_entries} =
+             WriteFence.commit(snapshot, Sources.Cache, [
+               {105, [{cache_key, {:cached, %{id: 105}}}]},
+               {106, [{cache_key, {:cached, %{id: 106}}}]}
+             ])
+
+    assert Cachex.get!(Sources.Cache, cache_key) == nil
+  end
+
+  test "snapshots wait until cache invalidation is ready" do
+    {server, active_table, child_id} = isolated_fence_names()
+
+    start_supervised!(
+      Supervisor.child_spec(
+        {WriteFence, name: server, active_table: active_table, ready?: false},
+        id: child_id
+      )
+    )
+
+    test_pid = self()
+
+    writer =
+      spawn_link(fn ->
+        {:ok, snapshot} = WriteFence.begin_snapshot(Sources, server)
+        send(test_pid, {:snapshot, snapshot})
+        receive do: (:stop -> :ok)
+      end)
+
+    refute_receive {:snapshot, _snapshot}
+    assert :ok = WriteFence.mark_ready(server)
+    assert_receive {:snapshot, _snapshot}
+    send(writer, :stop)
+  end
+
+  test "snapshots from an earlier fence incarnation cannot commit" do
+    {server, active_table, child_id} = isolated_fence_names()
+
+    child_spec =
+      Supervisor.child_spec(
+        {WriteFence, name: server, active_table: active_table, ready?: true},
+        id: child_id
+      )
+
+    start_supervised!(child_spec)
+    assert {:ok, snapshot} = WriteFence.begin_snapshot(Sources, server)
+    assert :ok = stop_supervised(child_id)
+    start_supervised!(child_spec)
+
+    assert {:error, :unknown_snapshot} =
+             WriteFence.commit(snapshot, Sources.Cache, [], server)
+  end
+
+  defp isolated_fence_names do
+    suffix = System.unique_integer([:positive])
+
+    {
+      Module.concat(__MODULE__, "Server#{suffix}"),
+      Module.concat(__MODULE__, "ActiveContexts#{suffix}"),
+      {__MODULE__, suffix}
+    }
+  end
+end

--- a/test/logflare/context_cache_test.exs
+++ b/test/logflare/context_cache_test.exs
@@ -52,6 +52,57 @@ defmodule Logflare.ContextCacheTest do
       assert {:ok, 1} = ContextCache.bust_keys([{Backends, backend.id}])
       assert is_nil(Cachex.get!(Backends.Cache, cache_key))
     end
+
+    test "fetch/3 does not retain a value read across an invalidation", %{source: source} do
+      cache_key = {:race_probe, [source.id]}
+      stale_value = %{id: source.id, name: "stale"}
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          ContextCache.fetch(Sources.Cache, cache_key, fn ->
+            send(test_pid, {:getter_started, self()})
+            receive do: (:continue -> stale_value)
+          end)
+        end)
+
+      assert_receive {:getter_started, getter}
+      assert {:ok, 0} = ContextCache.bust_keys([{Sources, source.id}])
+      send(getter, :continue)
+
+      assert Task.await(task) == stale_value
+      assert Cachex.get!(Sources.Cache, cache_key) == nil
+    end
+
+    test "bust_keys/1 removes cached negative lookups" do
+      cache_key = {:race_probe, [:missing]}
+
+      assert ContextCache.fetch(Sources.Cache, cache_key, fn -> nil end) == nil
+      assert Cachex.get!(Sources.Cache, cache_key) == {:cached, nil}
+
+      assert {:ok, 1} = ContextCache.bust_keys([{Sources, :not_found}])
+      assert Cachex.get!(Sources.Cache, cache_key) == nil
+    end
+
+    test "fetch/3 does not retain a negative lookup read across a new-record invalidation" do
+      cache_key = {:race_probe, [:created_during_fetch]}
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          ContextCache.fetch(Sources.Cache, cache_key, fn ->
+            send(test_pid, {:getter_started, self()})
+            receive do: (:continue -> nil)
+          end)
+        end)
+
+      assert_receive {:getter_started, getter}
+      assert {:ok, 0} = ContextCache.bust_keys([{Sources, :not_found}])
+      send(getter, :continue)
+
+      assert Task.await(task) == nil
+      assert Cachex.get!(Sources.Cache, cache_key) == nil
+    end
   end
 
   describe "unboxed transaction" do

--- a/test/logflare/source_schemas/cache_warmer_test.exs
+++ b/test/logflare/source_schemas/cache_warmer_test.exs
@@ -23,9 +23,8 @@ defmodule Logflare.SourceSchemas.CacheWarmerTest do
     assert %{id: ^schema_id} = Cache.get_source_schema_by(source_id: source.id)
     assert {:ok, [read_key]} = Cachex.keys(Cache)
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
     Cachex.clear!(Cache)
-    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
 
     assert {:ok, {:cached, %{id: ^schema_id}}} = Cachex.get(Cache, read_key)
   end
@@ -36,8 +35,7 @@ defmodule Logflare.SourceSchemas.CacheWarmerTest do
   } do
     schema_id = source_schema.id
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
-    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
     assert %{} = Repo.delete!(source_schema)
 
     assert %{id: ^schema_id} = Cache.get_source_schema_by(source_id: source.id)

--- a/test/logflare/sources/cache_warmer_test.exs
+++ b/test/logflare/sources/cache_warmer_test.exs
@@ -37,9 +37,8 @@ defmodule Logflare.Sources.CacheWarmerTest do
     assert {:ok, read_keys} = Cachex.keys(Cache)
     assert length(read_keys) == 3
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
     Cachex.clear!(Cache)
-    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
 
     for read_key <- read_keys do
       assert {:ok, {:cached, %{id: ^source_id, retention_days: ^expected_retention_days}}} =
@@ -54,8 +53,7 @@ defmodule Logflare.Sources.CacheWarmerTest do
     source_id = source.id
     external_token = Atom.to_string(source.token)
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
-    assert {:ok, true} = Cachex.put_many(Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
 
     Sources
     |> reject(:get_by, 1)
@@ -90,18 +88,15 @@ defmodule Logflare.Sources.CacheWarmerTest do
         log_events_updated_at: NaiveDateTime.utc_now()
       )
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
+    assert :ignore = CacheWarmer.execute(nil)
 
-    warmed_sources =
-      pairs
-      |> Enum.map(fn {_key, {:cached, warmed_source}} -> warmed_source end)
-      |> Map.new(&{&1.id, &1})
-
-    assert %{retention_days: ^expected_retention_days} = warmed_sources[source.id]
+    assert {:cached, %{retention_days: ^expected_retention_days}} =
+             Cachex.get!(Cache, {:get_by, [[id: source.id]]})
 
     expected_custom_retention_days = Sources.source_ttl_to_days(custom_source, custom_plan)
 
-    assert %{retention_days: ^expected_custom_retention_days} = warmed_sources[custom_source.id]
+    assert {:cached, %{retention_days: ^expected_custom_retention_days}} =
+             Cachex.get!(Cache, {:get_by, [[id: custom_source.id]]})
   end
 
   test "skips plan hydration when there are no active sources" do
@@ -110,7 +105,8 @@ defmodule Logflare.Sources.CacheWarmerTest do
     Billing
     |> reject(:get_plans_by_users, 1)
 
-    assert {:ok, []} = CacheWarmer.execute(nil)
+    assert :ignore = CacheWarmer.execute(nil)
+    assert Cachex.size!(Cache) == 0
   end
 
   test "skips sources whose users cannot be resolved" do
@@ -118,14 +114,15 @@ defmodule Logflare.Sources.CacheWarmerTest do
 
     log =
       capture_log(fn ->
-        assert {:ok, []} = CacheWarmer.execute(nil)
+        assert :ignore = CacheWarmer.execute(nil)
       end)
 
     assert log =~ "skipped 1 sources whose users could not be resolved"
+    assert Cachex.size!(Cache) == 0
   end
 
   test "uses a bounded number of queries as the number of source users grows" do
-    {single_user_query_count, {:ok, _pairs}} =
+    {single_user_query_count, :ignore} =
       count_repo_queries(fn -> CacheWarmer.execute(nil) end)
 
     for _ <- 1..5 do
@@ -133,7 +130,7 @@ defmodule Logflare.Sources.CacheWarmerTest do
       insert(:source, user: user, log_events_updated_at: NaiveDateTime.utc_now())
     end
 
-    {multiple_user_query_count, {:ok, _pairs}} =
+    {multiple_user_query_count, :ignore} =
       count_repo_queries(fn -> CacheWarmer.execute(nil) end)
 
     assert single_user_query_count > 0

--- a/test/logflare/users/cache_test.exs
+++ b/test/logflare/users/cache_test.exs
@@ -31,7 +31,7 @@ defmodule Logflare.Users.CacheTest do
   end
 
   test "warmer" do
-    assert {:ok, []} = CacheWarmer.execute(nil)
+    assert :ignore = CacheWarmer.execute(nil)
     user = insert(:user)
 
     insert(:source,
@@ -39,8 +39,7 @@ defmodule Logflare.Users.CacheTest do
       log_events_updated_at: NaiveDateTime.shift(NaiveDateTime.utc_now(), hour: -2)
     )
 
-    assert {:ok, pairs} = CacheWarmer.execute(nil)
-    assert {:ok, true} = Cachex.put_many(Users.Cache, pairs)
+    assert :ignore = CacheWarmer.execute(nil)
 
     Users
     |> reject(:get, 1)


### PR DESCRIPTION
## Summary

- add a session-scoped `ContextCache.WriteFence` that serializes cache publication with WAL invalidation
- route read-through misses, gossip receives, and first-party WAL-backed warmers through fenced writes
- preserve configured read-replica use for ContextCache misses
- remove cached `nil`/empty-list lookups when a new-record invalidation arrives

## Why

Cachex executes fallback getters and warmer callbacks before it performs their eventual cache write. A WAL invalidation could therefore scan and delete the cache while a stale database snapshot was still loading, after which Cachex would publish that stale value back into the cache.

Short-lived gossip tombstones narrow one instance of the race, but they do not order local read-through or warmer writes and cannot provide a durable happens-before relationship.

## Ordering

The write fence starts before the context caches and only releases writers after `CacheBuster` subscribes to WAL transaction broadcasts.

For each active database snapshot:

- if invalidation reaches the fence first, affected primary-key groups are omitted from the cache write
- if publication reaches the fence first, the following invalidation scan sees and removes the published entries
- if `CacheBuster` exits, active snapshots fail closed and new snapshots wait for its replacement
- if the fence restarts, tokens from the previous incarnation cannot commit

Keyword-based custom busts conservatively fence the whole affected context. Normal primary-key invalidations only discard the matching groups from a bounded warmer batch.

## Scope

Covered write paths:

- `ContextCache.fetch/3` read-through misses
- `ContextCache.Gossip.receive/3` miss publication
- Backends, Rules, SourceSchemas, Sources, and Users Cachex warmers

The KeyValues batch warmer remains separately deferred. SystemCache is not WAL-backed.

ContextCache misses continue to use configured read replicas. The fence prevents a cache population already in flight from surviving an overlapping invalidation; it does not prevent a later cache fill from observing ordinary replica lag after that invalidation has completed. A stronger guarantee would require replica replay/LSN coordination and is outside this PR.

## Tests

- deterministic invalidate-before-commit and commit-before-invalidate coverage
- mixed-batch, alias-group, custom keyword bust, readiness, restart, and duplicate-key coverage
- positive and negative read-through race coverage
- focused/affected suite: 1 property, 80 tests, 0 failures
- distributed gossip: 2 tests, 0 failures
- format check, warnings-as-errors compile, `mix lint.all`, and `mix test.typings`

## Stack

Stacked after #3916:

`#3913 → #3915 → #3916 → this PR`
