### PR TITLE
ClickHouse OTEL mappings: consistent `resource_attributes`, elevate attribute keys

### DIFF
--- a/bench/clickhouse_encode_e2e.exs
+++ b/bench/clickhouse_encode_e2e.exs
@@ -9,6 +9,7 @@
 # (before/after) and saves Benchee results for cross-SHA comparison.
 
 alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults
 alias Logflare.LogEvent
 
 tag = System.get_env("TAG", "untagged")
@@ -17,7 +18,6 @@ File.mkdir_p!(save_dir)
 
 batch_size = String.to_integer(System.get_env("BATCH_SIZE", "500"))
 
-mapping_config_id = "00000000-0000-0000-0001-000000000003"
 source_uuid = String.to_atom("550e8400-e29b-41d4-a716-446655440000")
 
 # Realistic, *varied* resource attributes: ~12 keys spanning the typical OTEL
@@ -84,7 +84,7 @@ base_event = fn type, body ->
     source_name: "bench source",
     event_type: type,
     ingested_at: DateTime.utc_now(),
-    body: Map.merge(body, %{"mapping_config_id" => mapping_config_id})
+    body: Map.merge(body, %{"mapping_config_id" => MappingDefaults.config_id(type)})
   }
 end
 

--- a/bench/clickhouse_row_encoding.exs
+++ b/bench/clickhouse_row_encoding.exs
@@ -7,10 +7,11 @@
 #      old String.replace |> Base.decode16! approach.
 
 alias Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester
+alias Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults
 alias Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder
 alias Logflare.LogEvent
 
-mapping_config_id = "00000000-0000-0000-0001-000000000003"
+mapping_config_id = MappingDefaults.config_id(:log)
 source_uuid = "550e8400-e29b-41d4-a716-446655440000"
 
 # Old uuid/1 implementation, replicated locally as the #2 baseline.

--- a/bench/support/clickhouse_pipeline_bench_data.exs
+++ b/bench/support/clickhouse_pipeline_bench_data.exs
@@ -7,7 +7,6 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   alias Logflare.LogEvent
   alias Logflare.Mapper
 
-  @mapping_config_id "00000000-0000-0000-0001-000000000003"
   @source_uuid String.to_atom("550e8400-e29b-41d4-a716-446655440000")
 
   @type event_type :: :log | :metric | :trace
@@ -673,7 +672,7 @@ defmodule Logflare.Bench.ClickHousePipelineData do
       event_type: type,
       day_bucket: div(1_700_000_000 + i, 86_400),
       ingested_at: DateTime.from_unix!(1_700_000_000_000_000 + i, :microsecond),
-      body: Map.put(body, "mapping_config_id", @mapping_config_id)
+      body: Map.put(body, "mapping_config_id", MappingDefaults.config_id(type))
     }
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -136,7 +136,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.app_name",
              "$.metadata.parsed.application_name"
            ]},
-          {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
+          {"cluster",
+           [
+             "$.metadata.cluster",
+             "$.metadata.context.cluster",
+             "$.cluster",
+             "$.resource.cluster"
+           ]},
           {"environment",
            [
              "$.metadata.environment",
@@ -147,7 +153,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
           {"instance_id", ["$.metadata.instance_id"]},
           {"machine_id", ["$.machine_id"]},
-          {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
+          {"node",
+           [
+             "$.metadata.node",
+             "$.metadata.context.vm.node",
+             "$.node",
+             "$.resource.node"
+           ]},
           {"organization_id", ["$.organization_id", "$.org_id"]},
           {"organization_slug", ["$.organization_slug"]},
           {"project",
@@ -159,7 +171,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.tenant",
              "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"region",
+           [
+             "$.metadata.region",
+             "$.region",
+             "$.resource.region",
+             "$.resource._project_region"
+           ]},
           {"service_name",
            ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
           {"vector_file", ["$.metadata.vector_file"]},
@@ -287,7 +305,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.app_name",
              "$.metadata.parsed.application_name"
            ]},
-          {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
+          {"cluster",
+           [
+             "$.metadata.cluster",
+             "$.metadata.context.cluster",
+             "$.cluster",
+             "$.resource.cluster"
+           ]},
           {"environment",
            [
              "$.metadata.environment",
@@ -298,7 +322,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
           {"instance_id", ["$.metadata.instance_id"]},
           {"machine_id", ["$.machine_id"]},
-          {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
+          {"node",
+           [
+             "$.metadata.node",
+             "$.metadata.context.vm.node",
+             "$.node",
+             "$.resource.node"
+           ]},
           {"organization_id", ["$.organization_id", "$.org_id"]},
           {"organization_slug", ["$.organization_slug"]},
           {"project",
@@ -310,7 +340,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.tenant",
              "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"region",
+           [
+             "$.metadata.region",
+             "$.region",
+             "$.resource.region",
+             "$.resource._project_region"
+           ]},
           {"service_name",
            ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
           {"vector_file", ["$.metadata.vector_file"]},
@@ -565,7 +601,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.app_name",
              "$.metadata.parsed.application_name"
            ]},
-          {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
+          {"cluster",
+           [
+             "$.metadata.cluster",
+             "$.metadata.context.cluster",
+             "$.cluster",
+             "$.resource.cluster"
+           ]},
           {"environment",
            [
              "$.metadata.environment",
@@ -576,7 +618,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
           {"instance_id", ["$.metadata.instance_id"]},
           {"machine_id", ["$.machine_id"]},
-          {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
+          {"node",
+           [
+             "$.metadata.node",
+             "$.metadata.context.vm.node",
+             "$.node",
+             "$.resource.node"
+           ]},
           {"organization_id", ["$.organization_id", "$.org_id"]},
           {"organization_slug", ["$.organization_slug"]},
           {"project",
@@ -588,7 +636,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.tenant",
              "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"region",
+           [
+             "$.metadata.region",
+             "$.region",
+             "$.resource.region",
+             "$.resource._project_region"
+           ]},
           {"service_name",
            ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
           {"vector_file", ["$.metadata.vector_file"]},

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -192,7 +192,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.flat_map("log_attributes",
         path: "$",
         exclude_keys: ["id", "event_message", "timestamp"],
-        elevate_keys: ["metadata"]
+        elevate_keys: ["metadata", "attributes"]
       ),
       Field.datetime64("timestamp", path: "$.timestamp", precision: 9)
     ]
@@ -361,7 +361,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.flat_map("attributes",
         path: "$",
         exclude_keys: ["id", "event_message", "timestamp"],
-        elevate_keys: ["metadata"]
+        elevate_keys: ["metadata", "attributes"]
       ),
       Field.string("aggregation_temporality",
         paths: ["$.aggregation_temporality", "$.aggregationTemporality"]
@@ -653,7 +653,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.flat_map("span_attributes",
         path: "$",
         exclude_keys: ["id", "event_message", "timestamp"],
-        elevate_keys: ["metadata"]
+        elevate_keys: ["metadata", "attributes"]
       ),
       Field.array_datetime64("events.timestamp",
         path: "$.events[*].time_unix_nano",

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -14,9 +14,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
   alias Logflare.Mapper.MappingConfig.InferRule
   alias Logflare.Mapper.MappingConfig.OutputFormat
 
-  @log_config_id "00000000-0000-0000-0001-000000000003"
-  @metric_config_id "00000000-0000-0000-0002-000000000003"
-  @trace_config_id "00000000-0000-0000-0003-000000000004"
+  @log_config_id "00000000-0000-0000-0001-000000000004"
+  @metric_config_id "00000000-0000-0000-0002-000000000004"
+  @trace_config_id "00000000-0000-0000-0003-000000000005"
 
   @spec config_id(TypeDetection.event_type()) :: String.t()
   def config_id(:log), do: @log_config_id
@@ -90,6 +90,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.string("service_name",
         paths: [
           "$.resource.service.name",
+          "$.resource._service_name",
           "$.service_name",
           "$.resource.name",
           "$.metadata.context.application",
@@ -136,7 +137,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.parsed.application_name"
            ]},
           {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
-          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host"]},
+          {"environment",
+           [
+             "$.metadata.environment",
+             "$.metadata.context.environment",
+             "$.environment",
+             "$.resource.environment"
+           ]},
+          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
           {"instance_id", ["$.metadata.instance_id"]},
           {"machine_id", ["$.machine_id"]},
           {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
@@ -151,8 +159,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
              "$.metadata.tenant",
              "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region"]},
-          {"service_name", ["$.resource.service.name", "$.service_name"]},
+          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"service_name",
+           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
           {"vector_file", ["$.metadata.vector_file"]},
           {"vector_host", ["$.metadata.vector_host"]}
         ],
@@ -233,9 +242,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.string("service_name",
         paths: [
           "$.resource.service.name",
+          "$.resource._service_name",
           "$.service_name",
           "$.resource.name",
-          "$.metadata.context.application"
+          "$.metadata.context.application",
+          "$.metadata.context.service",
+          "$.SYSLOG_IDENTIFIER",
+          "$._SYSTEMD_UNIT"
         ]
       ),
       Field.string("event_message",
@@ -265,19 +278,43 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.flat_map("resource_attributes",
         paths: ["$.resource"],
         pick: [
-          {"application", ["$.metadata.context.application"]},
+          {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
+          {"application",
+           [
+             "$.metadata.context.application",
+             "$.app_name",
+             "$.application_name",
+             "$.metadata.app_name",
+             "$.metadata.parsed.application_name"
+           ]},
           {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
+          {"environment",
+           [
+             "$.metadata.environment",
+             "$.metadata.context.environment",
+             "$.environment",
+             "$.resource.environment"
+           ]},
+          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
+          {"instance_id", ["$.metadata.instance_id"]},
+          {"machine_id", ["$.machine_id"]},
           {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
+          {"organization_id", ["$.organization_id", "$.org_id"]},
+          {"organization_slug", ["$.organization_slug"]},
           {"project",
            [
              "$.project",
              "$.project_ref",
              "$.project_id",
              "$.metadata.project",
-             "$.metadata.tenant"
+             "$.metadata.tenant",
+             "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region"]},
-          {"service_name", ["$.resource.service.name", "$.service_name"]}
+          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"service_name",
+           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
+          {"vector_file", ["$.metadata.vector_file"]},
+          {"vector_host", ["$.metadata.vector_host"]}
         ],
         default: %{}
       ),
@@ -461,9 +498,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.string("service_name",
         paths: [
           "$.resource.service.name",
+          "$.resource._service_name",
           "$.service_name",
           "$.resource.name",
-          "$.metadata.context.application"
+          "$.metadata.context.application",
+          "$.metadata.context.service",
+          "$.SYSLOG_IDENTIFIER",
+          "$._SYSTEMD_UNIT"
         ]
       ),
       Field.string("event_message",
@@ -515,19 +556,43 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.flat_map("resource_attributes",
         paths: ["$.resource"],
         pick: [
-          {"application", ["$.metadata.context.application"]},
+          {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
+          {"application",
+           [
+             "$.metadata.context.application",
+             "$.app_name",
+             "$.application_name",
+             "$.metadata.app_name",
+             "$.metadata.parsed.application_name"
+           ]},
           {"cluster", ["$.metadata.cluster", "$.cluster", "$.resource.cluster"]},
+          {"environment",
+           [
+             "$.metadata.environment",
+             "$.metadata.context.environment",
+             "$.environment",
+             "$.resource.environment"
+           ]},
+          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
+          {"instance_id", ["$.metadata.instance_id"]},
+          {"machine_id", ["$.machine_id"]},
           {"node", ["$.metadata.context.vm.node", "$.resource.node"]},
+          {"organization_id", ["$.organization_id", "$.org_id"]},
+          {"organization_slug", ["$.organization_slug"]},
           {"project",
            [
              "$.project",
              "$.project_ref",
              "$.project_id",
              "$.metadata.project",
-             "$.metadata.tenant"
+             "$.metadata.tenant",
+             "$.metadata.tenantId"
            ]},
-          {"region", ["$.metadata.region", "$.region"]},
-          {"service_name", ["$.resource.service.name", "$.service_name"]}
+          {"region", ["$.metadata.region", "$.region", "$.resource._project_region"]},
+          {"service_name",
+           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
+          {"vector_file", ["$.metadata.vector_file"]},
+          {"vector_host", ["$.metadata.vector_host"]}
         ],
         default: %{}
       ),

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -110,6 +110,201 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       result2 = Mapper.map(%{"severityText" => "debug"}, compiled)
       assert result2["severity_text"] == "DEBUG"
     end
+
+    test "resolves host from a resource-scoped key", %{log: compiled} do
+      payload = %{"resource" => %{"host" => "ip-10-0-1-129.internal"}}
+
+      assert Mapper.map(payload, compiled)["resource_attributes"]["host"] ==
+               "ip-10-0-1-129.internal"
+    end
+
+    test "prefers metadata host over a resource-scoped host", %{log: compiled} do
+      payload = %{
+        "metadata" => %{"host" => "from-metadata"},
+        "resource" => %{"host" => "from-resource"}
+      }
+
+      assert Mapper.map(payload, compiled)["resource_attributes"]["host"] == "from-metadata"
+    end
+  end
+
+  describe "service_name resolution across all event types" do
+    test "resolves an underscore-namespaced resource key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"resource" => %{"_service_name" => "supadev", "environment" => "staging"}}
+
+      for compiled <- [log, metric, trace] do
+        result = Mapper.map(payload, compiled)
+
+        assert result["service_name"] == "supadev"
+        assert result["resource_attributes"]["service_name"] == "supadev"
+      end
+    end
+
+    test "prefers the OTEL-standard path over the underscore form", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "resource" => %{"service" => %{"name" => "standard"}, "_service_name" => "underscore"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        result = Mapper.map(payload, compiled)
+
+        assert result["service_name"] == "standard"
+        assert result["resource_attributes"]["service_name"] == "standard"
+      end
+    end
+
+    test "environment resolves from a resource-scoped key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"resource" => %{"environment" => "staging"}}
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["environment"] == "staging"
+      end
+    end
+
+    test "environment prefers metadata over a resource-scoped key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "metadata" => %{"environment" => "prod"},
+        "resource" => %{"environment" => "staging"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["environment"] == "prod"
+      end
+    end
+
+    test "region resolves an underscore-namespaced resource key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"resource" => %{"_project_region" => "eu-central-1"}}
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["region"] == "eu-central-1"
+      end
+    end
+
+    test "region prefers metadata over the underscore-namespaced resource key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "metadata" => %{"region" => "us-east-1"},
+        "resource" => %{"_project_region" => "eu-central-1"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["region"] == "us-east-1"
+      end
+    end
+
+    test "falls back to journald identifiers", %{log: log, metric: metric, trace: trace} do
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(%{"SYSLOG_IDENTIFIER" => "postgres"}, compiled)["service_name"] ==
+                 "postgres"
+
+        assert Mapper.map(%{"_SYSTEMD_UNIT" => "pgbouncer.service"}, compiled)["service_name"] ==
+                 "pgbouncer.service"
+      end
+    end
+  end
+
+  describe "resource_attributes pick entries are consistent across event types" do
+    test "every type resolves the shared curated keys", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "app_id" => "app-1",
+        "machine_id" => "mach-1",
+        "organization_id" => "org-1",
+        "organization_slug" => "acme",
+        "project" => "proj-1",
+        "metadata" => %{
+          "cluster" => "clus-1",
+          "context" => %{"host" => "host-1", "vm" => %{"node" => "node-1"}},
+          "environment" => "staging",
+          "instance_id" => "inst-1",
+          "region" => "us-east-1",
+          "vector_file" => "/var/log/app.log",
+          "vector_host" => "collector-1"
+        }
+      }
+
+      shared_keys = ~w(
+        application_id cluster environment host instance_id machine_id node
+        organization_id organization_slug project region vector_file vector_host
+      )
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        for key <- shared_keys do
+          assert Map.has_key?(res_attrs, key), "missing #{key} in #{inspect(res_attrs)}"
+        end
+
+        assert res_attrs["application_id"] == "app-1"
+        assert res_attrs["cluster"] == "clus-1"
+        assert res_attrs["environment"] == "staging"
+        assert res_attrs["host"] == "host-1"
+        assert res_attrs["instance_id"] == "inst-1"
+        assert res_attrs["machine_id"] == "mach-1"
+        assert res_attrs["node"] == "node-1"
+        assert res_attrs["organization_id"] == "org-1"
+        assert res_attrs["organization_slug"] == "acme"
+        assert res_attrs["project"] == "proj-1"
+        assert res_attrs["region"] == "us-east-1"
+        assert res_attrs["vector_file"] == "/var/log/app.log"
+        assert res_attrs["vector_host"] == "collector-1"
+      end
+    end
+
+    test "log uses application_name while metric and trace use application", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"app_name" => "supadev"}
+
+      assert Mapper.map(payload, log)["resource_attributes"]["application_name"] == "supadev"
+
+      for compiled <- [metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["application"] == "supadev"
+      end
+    end
+
+    test "project resolves from metadata.tenantId in every type", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"metadata" => %{"tenantId" => "tenant-1"}}
+
+      for compiled <- [log, metric, trace] do
+        result = Mapper.map(payload, compiled)
+
+        assert result["project"] == "tenant-1"
+        assert result["resource_attributes"]["project"] == "tenant-1"
+      end
+    end
   end
 
   describe "metrics mapping" do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -128,6 +128,77 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
     end
   end
 
+  describe "attribute maps elevate both metadata and attributes" do
+    test "children of attributes land unprefixed", %{log: log, metric: metric, trace: trace} do
+      payload = %{
+        "attributes" => %{"_flow_name" => "branch-creation", "busy_ns" => 705_777_024_470},
+        "metadata" => %{"type" => "span"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for {compiled, field} <- [
+            {log, "log_attributes"},
+            {metric, "attributes"},
+            {trace, "span_attributes"}
+          ] do
+        attrs = Mapper.map(payload, compiled)[field]
+
+        assert attrs["_flow_name"] == "branch-creation"
+        assert attrs["busy_ns"] == "705777024470"
+        assert attrs["type"] == "span"
+        refute Map.has_key?(attrs, "attributes._flow_name")
+        refute Map.has_key?(attrs, "attributes")
+      end
+    end
+
+    test "metadata wins over attributes on a duplicate child key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "attributes" => %{"shared" => "from-attributes", "only_attrs" => "a"},
+        "metadata" => %{"shared" => "from-metadata", "only_meta" => "m"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for {compiled, field} <- [
+            {log, "log_attributes"},
+            {metric, "attributes"},
+            {trace, "span_attributes"}
+          ] do
+        attrs = Mapper.map(payload, compiled)[field]
+
+        assert attrs["shared"] == "from-metadata"
+        assert attrs["only_attrs"] == "a"
+        assert attrs["only_meta"] == "m"
+      end
+    end
+
+    test "a non-map attributes value is preserved as a literal key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "attributes" => "not-a-map",
+        "metadata" => %{"type" => "span"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for {compiled, field} <- [
+            {log, "log_attributes"},
+            {metric, "attributes"},
+            {trace, "span_attributes"}
+          ] do
+        attrs = Mapper.map(payload, compiled)[field]
+
+        assert attrs["attributes"] == "not-a-map"
+        assert attrs["type"] == "span"
+      end
+    end
+  end
+
   describe "service_name resolution across all event types" do
     test "resolves an underscore-namespaced resource key", %{
       log: log,

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -188,6 +188,75 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       end
     end
 
+    test "cluster and node resolve from top-level and resource-scoped keys", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      top_level = %{"cluster" => "clus-top", "node" => "node-top"}
+      resource_scoped = %{"resource" => %{"cluster" => "clus-res", "node" => "node-res"}}
+      metadata_context = %{"metadata" => %{"context" => %{"cluster" => "clus-ctx"}}}
+
+      for compiled <- [log, metric, trace] do
+        top = Mapper.map(top_level, compiled)["resource_attributes"]
+        assert top["cluster"] == "clus-top"
+        assert top["node"] == "node-top"
+
+        res = Mapper.map(resource_scoped, compiled)["resource_attributes"]
+        assert res["cluster"] == "clus-res"
+        assert res["node"] == "node-res"
+
+        ctx = Mapper.map(metadata_context, compiled)["resource_attributes"]
+        assert ctx["cluster"] == "clus-ctx"
+      end
+    end
+
+    test "cluster and node prefer metadata over top-level and resource keys", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "cluster" => "clus-top",
+        "node" => "node-top",
+        "metadata" => %{
+          "cluster" => "clus-meta",
+          "node" => "node-meta",
+          "context" => %{"vm" => %{"node" => "node-vm"}}
+        },
+        "resource" => %{"cluster" => "clus-res", "node" => "node-res"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs["cluster"] == "clus-meta"
+        assert res_attrs["node"] == "node-meta"
+      end
+    end
+
+    test "region resolves a resource-scoped key", %{log: log, metric: metric, trace: trace} do
+      payload = %{"resource" => %{"region" => "ap-southeast-2"}}
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["region"] == "ap-southeast-2"
+      end
+    end
+
+    test "region prefers the generic resource key over the underscore-namespaced form", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "resource" => %{"region" => "ap-southeast-2", "_project_region" => "eu-central-1"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"]["region"] == "ap-southeast-2"
+      end
+    end
+
     test "region resolves an underscore-namespaced resource key", %{
       log: log,
       metric: metric,

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -232,6 +232,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       end
     end
 
+    test "prefers the underscore-namespaced resource key over a top-level service_name", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "service_name" => "top-level",
+        "resource" => %{"_service_name" => "underscore"}
+      }
+
+      for compiled <- [log, metric, trace] do
+        result = Mapper.map(payload, compiled)
+
+        assert result["service_name"] == "underscore"
+        assert result["resource_attributes"]["service_name"] == "underscore"
+      end
+    end
+
     test "environment resolves from a resource-scoped key", %{
       log: log,
       metric: metric,

--- a/test/profiling/mapper_bench.exs
+++ b/test/profiling/mapper_bench.exs
@@ -310,16 +310,17 @@ Benchee.run(
 
 # Baseline results — Mapper.map(event.body) with MappingDefaults.for_log()
 # Apple M4 / 32 GB / macOS / Elixir 1.19.5 / Erlang 27.3.4.6
+# Recorded at a53e24086.
 #
 # Name                             ips        average  deviation         median         99th %
-# [log] Mapper.map(body)       17.09 K       58.53 μs    ±32.69%          49 μs      132.46 μs
+# [log] Mapper.map(body)       55.62 K       17.98 μs    ±44.38%       18.46 μs       34.54 μs
 #
 # Memory usage statistics:
 #
 # Name                      Memory usage
-# [log] Mapper.map(body)         5.90 KB
+# [log] Mapper.map(body)         2.52 KB
 #
 # Reduction count statistics:
 #
 # Name                   Reduction count
-# [log] Mapper.map(body)             637
+# [log] Mapper.map(body)             130


### PR DESCRIPTION
## Overview

Brings the `resource_attributes` mapping in line across logs, metrics, and traces, and elevates attribute keys out of their `$.metadata` / `$.attributes` envelopes. First layer of the mapping improvements stack — config only, no NIF changes.

### Key Changes

- Unified the `resource_attributes` path set across all three event types, so the same key resolves the same way regardless of signal
- Added `resource_attributes.environment` to all three types (_with validation on the `prod` value_)
- Added fallback paths for `cluster`, `node`, and `region`, including the underscore-namespaced variants emitted by some collectors
- Changed `log_attributes` (_logs_), `attributes` (_metrics_), and `span_attributes` (_traces_) to elevate keys for both `$.metadata` and `$.attributes`
- Replaced hardcoded mapping configuration ids in the benchmark scripts with calls to `MappingDefaults.config_id/1`

### Risks / Considerations

- Existing queries referencing things like `log_attributes["attributes.foo"]` would fail as the attribute is now elevated to `log_attributes["foo"]`. Traces and metrics have the same concern within their `attributes[...]` and `span_attributes` fields, but very little concern with those as they are generally not user-facing.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
