### PR TITLE
mapper: add `pick_mode` option to `json`/`flat_map` field config

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -126,6 +126,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("resource_attributes",
         paths: ["$.resource"],
+        exclude_keys: ["_project_region", "_service_name"],
+        pick_mode: :merge,
         pick: [
           {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
           {"application_name",
@@ -295,6 +297,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("resource_attributes",
         paths: ["$.resource"],
+        exclude_keys: ["_project_region", "_service_name"],
+        pick_mode: :merge,
         pick: [
           {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
           {"application",
@@ -591,6 +595,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("resource_attributes",
         paths: ["$.resource"],
+        exclude_keys: ["_project_region", "_service_name"],
+        pick_mode: :merge,
         pick: [
           {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
           {"application",

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -5,6 +5,24 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
   Defines how raw log event bodies are transformed into structured schemas
   before RowBinary encoding. Each event type (log, metric, trace) has its own
   field mapping with coalesced path resolution, defaults, and transforms.
+
+  ## `resource_attributes` contract
+
+  All three event types build `resource_attributes` with `pick_mode: :merge`, so the
+  column receives the curated `:pick` entries unioned with every remaining key under
+  `$.resource`. Uncurated resource keys pass through untouched, but the column is
+  intentionally *not* a lossless copy of the input when values disagree:
+
+    * **One canonical value per key.** On a key collision the curated pick wins over the
+      raw resource value. For example, when `metadata.environment` and
+      `resource.environment` are both present, `environment` holds the `metadata` value
+      and the raw `resource.environment` value is dropped.
+    * **Aliases are normalized, not preserved.** `_project_region` and `_service_name`
+      are read as fallbacks for the `region` and `service_name` picks and then removed via
+      `:exclude_keys`, so only the normalized key reaches the column.
+
+  This trade-off is deliberate: downstream queries get a stable, predictable key set
+  rather than having to reconcile aliases and duplicate keys per row.
   """
 
   alias Logflare.LogEvent.TypeDetection

--- a/lib/logflare/mapper/mapping_config.ex
+++ b/lib/logflare/mapper/mapping_config.ex
@@ -137,6 +137,7 @@ defmodule Logflare.Mapper.MappingConfig do
     |> maybe_add("exclude_keys", f.exclude_keys)
     |> maybe_add("elevate_keys", f.elevate_keys)
     |> maybe_add("value_type", f.value_type)
+    |> maybe_add("pick_mode", f.pick_mode)
     |> maybe_add_filters(f.filters)
     |> maybe_add_filter_nil(f.filter_nil)
     |> maybe_add_pick(f.pick)

--- a/lib/logflare/mapper/mapping_config.ex
+++ b/lib/logflare/mapper/mapping_config.ex
@@ -29,6 +29,25 @@ defmodule Logflare.Mapper.MappingConfig do
   The only cross-field mechanism is `from_output:`, which reads a previously
   resolved field's value.
 
+  ## Pick and merge semantics
+
+  `json` and `flat_map` fields accept a `:pick` list that assembles a curated map from
+  coalesce paths, plus a `:pick_mode` that decides how that map relates to the raw value
+  at `:path`/`:paths`:
+
+    * `:replace` (default) — a non-empty pick map *is* the field value; the raw source map
+      is discarded. Pick and source are either/or.
+    * `:merge` — the pick map is unioned with the raw source map. On a key collision the
+      pick entry wins and the source value for that key is dropped.
+
+  In `:merge` mode the output is deliberately **not a lossless copy** of the source map.
+  Each output key holds exactly one canonical value, chosen by the pick's coalesce order,
+  even when the source map carries a different value under the same key. `:exclude_keys`
+  and `:elevate_keys` are applied *after* the merge, which is how alias keys are folded
+  into a canonical key: list the alias as a fallback path on the pick entry, then drop it
+  via `:exclude_keys` so only the normalized key survives. See
+  `FieldConfig.json/2` for option details.
+
   ## Examples
 
   Log mapping with scalar types:

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -79,6 +79,12 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       coalesce paths; resolved entries are included in the output, unresolved are omitted.
       If pick produces a non-empty map, it becomes the field value. If empty, falls back
       to `:path`/`:paths`.
+    * `:pick_mode` — `:replace` (default) or `:merge`. Controls what a non-empty pick map
+      does to the `:path`/`:paths` value. `:replace` discards the source, so `:pick` and
+      `:paths` are effectively either/or. `:merge` unions the two, pick entries winning on
+      key collision, so curated keys and the raw source map both reach the output.
+      `:exclude_keys` and `:elevate_keys` apply to the merged result. Note `:paths` remains
+      a coalesce in both modes — only the first resolving path contributes.
 
   ### `flat_map/2`
 
@@ -93,7 +99,8 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     * Lists: JSON-encoded as strings (e.g. `[1, 2]` → `"[1,2]"`)
     * Scalars: coerced to string (`42` → `"42"`, `true` → `"true"`)
     * nil values: omitted from the output map
-    * Accepts the same options as `json/2`: `:exclude_keys`, `:elevate_keys`, `:pick`
+    * Accepts the same options as `json/2`: `:exclude_keys`, `:elevate_keys`, `:pick`,
+      `:pick_mode`
 
   ## Array Types
 
@@ -215,6 +222,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     field(:filters, :map)
     field(:filter_nil, :boolean, default: false)
     field(:value_type, :string)
+    field(:pick_mode, :string)
     embeds_many(:pick, PickEntry)
     embeds_many(:infer, InferRule)
   end
@@ -240,7 +248,8 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
         :elevate_keys,
         :filters,
         :filter_nil,
-        :value_type
+        :value_type,
+        :pick_mode
       ],
       empty_values: []
     )
@@ -308,6 +317,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
 
     base
     |> maybe_put_pick(opts[:pick])
+    |> maybe_put_pick_mode(opts[:pick_mode])
   end
 
   @spec array_string(String.t(), keyword()) :: t()
@@ -345,7 +355,10 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   def flat_map(name, opts \\ []) do
     opts = Keyword.put_new(opts, :value_type, "string")
     base = build(name, "flat_map", opts, [:exclude_keys, :elevate_keys, :value_type])
-    maybe_put_pick(base, opts[:pick])
+
+    base
+    |> maybe_put_pick(opts[:pick])
+    |> maybe_put_pick_mode(opts[:pick_mode])
   end
 
   @spec array_flat_map(String.t(), keyword()) :: t()
@@ -381,6 +394,12 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
 
   defp maybe_put(struct, _key, nil), do: struct
   defp maybe_put(struct, key, value), do: Map.put(struct, key, value)
+
+  defp maybe_put_pick_mode(struct, nil), do: struct
+  defp maybe_put_pick_mode(struct, :replace), do: struct
+  defp maybe_put_pick_mode(struct, "replace"), do: struct
+  defp maybe_put_pick_mode(struct, :merge), do: %{struct | pick_mode: "merge"}
+  defp maybe_put_pick_mode(struct, "merge"), do: %{struct | pick_mode: "merge"}
 
   defp maybe_put_pick(struct, nil), do: struct
 

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -86,6 +86,22 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       `:exclude_keys` and `:elevate_keys` apply to the merged result. Note `:paths` remains
       a coalesce in both modes — only the first resolving path contributes.
 
+      `:merge` is lossy by design when the pick and the source disagree: the source value
+      under a colliding key is dropped, not preserved under another name. Because
+      `:exclude_keys` runs after the merge, an alias key can be consumed as a pick fallback
+      and then removed so only the canonical key remains:
+
+          Field.flat_map("resource_attributes",
+            paths: ["$.resource"],
+            pick_mode: :merge,
+            pick: [{"region", ["$.metadata.region", "$.resource._project_region"]}],
+            exclude_keys: ["_project_region"]
+          )
+
+      Given `%{"resource" => %{"_project_region" => "us-east-1", "zone" => "a"}}` this
+      yields `%{"region" => "us-east-1", "zone" => "a"}`; `_project_region` does not
+      reach the output.
+
   ### `flat_map/2`
 
   Like `json/2` but flattens nested maps to dot-notation keys with values

--- a/lib/logflare/mapper/mapping_config/pick_entry.ex
+++ b/lib/logflare/mapper/mapping_config/pick_entry.ex
@@ -4,6 +4,11 @@ defmodule Logflare.Mapper.MappingConfig.PickEntry do
 
   Each entry defines an output `:key` and coalesce `:paths` to try. If any path
   resolves, the key is included in the output map; otherwise it's omitted (sparse).
+
+  Only the first resolving path contributes. When the parent field uses
+  `pick_mode: :merge`, a resolved entry also overrides any same-named key from the
+  field's raw `:path`/`:paths` source map. See `Logflare.Mapper.MappingConfig` for
+  the full merge semantics.
   """
 
   use TypedEctoSchema

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -405,10 +405,34 @@ fn select_json_value<'a>(
 
     let picked = build_pick_map(env, body, field, nil, flat_keys, cache);
     if picked == nil {
-        value
-    } else {
-        picked
+        return value;
     }
+
+    if !field.pick_merge {
+        return picked;
+    }
+
+    merge_pick_over_source(value, picked, nil)
+}
+
+/// Union a resolved pick map over the path/paths value, pick winning on key
+/// collision. Falls back to the pick map alone when the source did not resolve
+/// to a map, which is the same shape `:replace` would have produced.
+fn merge_pick_over_source<'a>(source: Term<'a>, picked: Term<'a>, nil: Term<'a>) -> Term<'a> {
+    if source == nil || !source.is_map() {
+        return picked;
+    }
+
+    let Some(entries) = MapIterator::new(picked) else {
+        return source;
+    };
+
+    let mut result = source;
+    for (key, value) in entries {
+        result = result.map_put(key, value).unwrap_or(result);
+    }
+
+    result
 }
 
 /// Build a sparse map from pick entries.

--- a/native/mapper_ex/src/mapping.rs
+++ b/native/mapper_ex/src/mapping.rs
@@ -40,6 +40,9 @@ pub struct CompiledField {
     pub exclude_keys: Vec<Vec<u8>>,
     pub elevate_keys: Vec<Vec<u8>>,
     pub pick: Vec<PickEntry>,
+    /// When true, a resolved pick map is unioned over the path/paths value
+    /// (pick winning on collision) instead of replacing it.
+    pub pick_merge: bool,
     pub enum8_data: Option<Enum8Data>,
     pub filter_nil: bool,
     pub flat_map_value_type: FlatMapValueType,
@@ -390,6 +393,7 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
     let exclude_keys = decode_string_list_bytes(env, field, "exclude_keys");
     let elevate_keys = decode_string_list_bytes(env, field, "elevate_keys");
     let pick = decode_pick(env, field)?;
+    let pick_merge = decode_pick_merge(env, field)?;
 
     let enum8_data = if matches!(field_type, FieldType::Enum8 { .. }) {
         Some(decode_enum8_data(env, field)?)
@@ -413,6 +417,7 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
         exclude_keys,
         elevate_keys,
         pick,
+        pick_merge,
         enum8_data,
         filter_nil,
         flat_map_value_type,
@@ -617,6 +622,17 @@ fn decode_value_map_str<'a>(
         result.insert(key.to_lowercase(), val);
     }
     Ok(result)
+}
+
+fn decode_pick_merge<'a>(env: Env<'a>, field: Term<'a>) -> Result<bool, String> {
+    match get_string_key(env, field, "pick_mode")?.as_deref() {
+        None | Some("replace") => Ok(false),
+        Some("merge") => Ok(true),
+        Some(other) => Err(format!(
+            "pick_mode must be \"replace\" or \"merge\", got {:?}",
+            other
+        )),
+    }
 }
 
 fn decode_pick<'a>(env: Env<'a>, field: Term<'a>) -> Result<Vec<PickEntry>, String> {

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -199,6 +199,150 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
     end
   end
 
+  describe "resource_attributes merges the raw resource map with pick entries" do
+    test "keeps uncurated resource keys alongside curated ones", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "project" => "supadev",
+        "resource" => %{
+          "_flow_name" => "branch-creation",
+          "_instance_color" => "green",
+          "_project_region" => "eu-central-1",
+          "_service_name" => "supadev",
+          "_supadev_nix_hash" => "9f9ab3c7408383251aae7378698b31e6",
+          "_telemetry_sdk_language" => "rust",
+          "_telemetry_sdk_name" => "opentelemetry",
+          "_telemetry_sdk_version" => "0.31.0",
+          "environment" => "staging",
+          "host" => "ip-10-0-1-129.eu-central-1.compute.internal"
+        },
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert map_size(res_attrs) == 11
+
+        for key <- ~w(
+              _flow_name _instance_color _supadev_nix_hash
+              _telemetry_sdk_language _telemetry_sdk_name _telemetry_sdk_version
+            ) do
+          assert Map.has_key?(res_attrs, key), "missing uncurated key #{key}"
+        end
+
+        refute Map.has_key?(res_attrs, "_project_region")
+        refute Map.has_key?(res_attrs, "_service_name")
+
+        assert res_attrs["project"] == "supadev"
+        assert res_attrs["region"] == "eu-central-1"
+        assert res_attrs["service_name"] == "supadev"
+        assert res_attrs["environment"] == "staging"
+        assert res_attrs["host"] == "ip-10-0-1-129.eu-central-1.compute.internal"
+      end
+    end
+
+    test "pick entries win over a colliding raw resource key", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "metadata" => %{"environment" => "from-metadata"},
+        "resource" => %{"environment" => "from-resource", "uncurated" => "kept"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs["environment"] == "from-metadata"
+        assert res_attrs["uncurated"] == "kept"
+      end
+    end
+
+    test "still yields the pick map alone when resource is absent", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{"project" => "proj", "timestamp" => 1_775_591_051_937_363}
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"] == %{"project" => "proj"}
+      end
+    end
+
+    test "still yields the raw resource map alone when no pick entry resolves", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "resource" => %{"only_uncurated" => "v"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        assert Mapper.map(payload, compiled)["resource_attributes"] == %{"only_uncurated" => "v"}
+      end
+    end
+
+    test "drops the underscore-namespaced duplicates that have a curated alias", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "resource" => %{"_project_region" => "eu-central-1", "_service_name" => "supadev"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs == %{"region" => "eu-central-1", "service_name" => "supadev"}
+      end
+    end
+
+    test "a resource-scoped value is dropped when metadata wins its curated alias", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "metadata" => %{"region" => "us-east-1"},
+        "resource" => %{"_project_region" => "eu-central-1"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs == %{"region" => "us-east-1"}
+      end
+    end
+
+    test "flattens nested resource values to dot keys", %{log: log, metric: metric, trace: trace} do
+      payload = %{
+        "project" => "proj",
+        "resource" => %{"nested" => %{"deep" => true}, "port" => 8080},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs["nested.deep"] == "true"
+        assert res_attrs["port"] == "8080"
+        assert res_attrs["project"] == "proj"
+      end
+    end
+  end
+
   describe "service_name resolution across all event types" do
     test "resolves an underscore-namespaced resource key", %{
       log: log,

--- a/test/logflare/mapper/mapping_config_test.exs
+++ b/test/logflare/mapper/mapping_config_test.exs
@@ -1,8 +1,8 @@
 defmodule Logflare.Mapper.MappingConfigTest do
   use ExUnit.Case, async: true
 
+  alias Logflare.Mapper
   alias Logflare.Mapper.MappingConfig
-  alias Logflare.Mapper.MappingConfig.FieldConfig
   alias Logflare.Mapper.MappingConfig.FieldConfig, as: Field
   alias Logflare.Mapper.MappingConfig.InferCondition
   alias Logflare.Mapper.MappingConfig.InferRule
@@ -13,7 +13,7 @@ defmodule Logflare.Mapper.MappingConfigTest do
     test "string/2 creates correct struct" do
       field = Field.string("trace_id", paths: ["$.trace_id", "$.traceId"], default: "")
 
-      assert %FieldConfig{} = field
+      assert %MappingConfig.FieldConfig{} = field
       assert field.name == "trace_id"
       assert field.type == "string"
       assert field.paths == ["$.trace_id", "$.traceId"]
@@ -139,6 +139,20 @@ defmodule Logflare.Mapper.MappingConfigTest do
 
       assert field.from_output == "severity_text"
       assert field.value_map == %{"INFO" => 9, "ERROR" => 17}
+    end
+
+    test "pick_mode option accepts the atom or string form" do
+      for mode <- [:merge, "merge"] do
+        assert Field.flat_map("attrs", pick_mode: mode).pick_mode == "merge"
+        assert Field.json("attrs", pick_mode: mode).pick_mode == "merge"
+      end
+    end
+
+    test "pick_mode defaults to nil, and :replace is stored as nil" do
+      assert Field.flat_map("attrs", paths: ["$.resource"]).pick_mode == nil
+      assert Field.json("attrs", paths: ["$.resource"]).pick_mode == nil
+      assert Field.flat_map("attrs", pick_mode: :replace).pick_mode == nil
+      assert Field.json("attrs", pick_mode: "replace").pick_mode == nil
     end
 
     test "flat_map/2 with exclude and elevate keys" do
@@ -294,6 +308,30 @@ defmodule Logflare.Mapper.MappingConfigTest do
       [region, cluster] = field.pick
       assert %PickEntry{key: "region", paths: ["$.metadata.region", "$.region"]} = region
       assert %PickEntry{key: "cluster", paths: ["$.metadata.cluster"]} = cluster
+    end
+
+    test "round-trip preserves pick_mode" do
+      config =
+        MappingConfig.new([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      assert {:ok, json} = MappingConfig.to_json(config)
+      assert {:ok, restored} = MappingConfig.from_json(json)
+
+      [field] = restored.fields
+      assert field.pick_mode == "merge"
+
+      document = %{"project" => "p", "resource" => %{"a" => 1}}
+      expected = %{"attrs" => %{"project" => "p", "a" => "1"}}
+
+      assert Mapper.map(document, Mapper.compile!(config)) == expected
+      assert Mapper.map(document, Mapper.compile!(restored)) == expected
     end
 
     test "round-trip preserves infer rules" do

--- a/test/logflare/mapper/optimized_mapper_test.exs
+++ b/test/logflare/mapper/optimized_mapper_test.exs
@@ -712,6 +712,240 @@ defmodule Logflare.Mapper.OptimizedMapperTest do
     end
   end
 
+  describe "pick_mode" do
+    test "defaults to :replace, so a resolved pick replaces the coalesced source" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource" => %{"a" => 1, "b" => 2}}
+
+      assert Mapper.map(document, compiled) == %{"attrs" => %{"project" => "p"}}
+    end
+
+    test ":merge unions a resolved pick over the coalesced source" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource" => %{"a" => 1, "b" => 2}}
+
+      assert Mapper.map(document, compiled) == %{
+               "attrs" => %{"project" => "p", "a" => "1", "b" => "2"}
+             }
+    end
+
+    test ":merge lets pick entries win on key collision" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"shared", ["$.top_shared"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{
+        "top_shared" => "from-pick",
+        "resource" => %{"shared" => "from-resource", "only_resource" => "r"}
+      }
+
+      assert Mapper.map(document, compiled) == %{
+               "attrs" => %{"shared" => "from-pick", "only_resource" => "r"}
+             }
+    end
+
+    test ":merge yields just the source when no pick entry resolves" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.absent"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"resource" => %{"a" => 1}}
+
+      assert Mapper.map(document, compiled) == %{"attrs" => %{"a" => "1"}}
+    end
+
+    test ":merge yields just the pick map when the source is absent" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      assert Mapper.map(%{"project" => "p"}, compiled) == %{"attrs" => %{"project" => "p"}}
+    end
+
+    test ":merge falls back to the default when neither pick nor source resolves" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.absent"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      assert Mapper.map(%{"other" => 1}, compiled) == %{"attrs" => %{}}
+    end
+
+    test ":merge flattens nested source values and stringifies them" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{
+        "project" => "p",
+        "resource" => %{"nested" => %{"deep" => true}, "port" => 8080}
+      }
+
+      assert Mapper.map(document, compiled) == %{
+               "attrs" => %{"project" => "p", "nested.deep" => "true", "port" => "8080"}
+             }
+    end
+
+    test ":merge works on json fields without stringifying" do
+      compiled =
+        compile([
+          Field.json("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource" => %{"a" => 1, "nested" => %{"deep" => true}}}
+
+      assert Mapper.map(document, compiled) == %{
+               "attrs" => %{"project" => "p", "a" => 1, "nested" => %{"deep" => true}}
+             }
+    end
+
+    test ":merge applies exclude_keys and elevate_keys after the merge" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            exclude_keys: ["drop_me"],
+            elevate_keys: ["nested"],
+            default: %{}
+          )
+        ])
+
+      document = %{
+        "project" => "p",
+        "resource" => %{"drop_me" => 1, "keep" => "k", "nested" => %{"inner" => "n"}}
+      }
+
+      assert Mapper.map(document, compiled) == %{
+               "attrs" => %{"project" => "p", "keep" => "k", "inner" => "n"}
+             }
+    end
+
+    test ":merge only reads the first resolving path, since paths is a coalesce" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource", "$.resource_extra"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{
+        "project" => "p",
+        "resource" => %{"a" => 1},
+        "resource_extra" => %{"b" => 2}
+      }
+
+      assert Mapper.map(document, compiled) == %{"attrs" => %{"project" => "p", "a" => "1"}}
+    end
+
+    test ":merge tolerates a non-map source value by keeping only the pick map" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource" => "not-a-map"}
+
+      assert Mapper.map(document, compiled) == %{"attrs" => %{"project" => "p"}}
+    end
+
+    test ":merge resolves against pre-flattened input under flat_keys" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource" => %{"a" => 1, "b" => 2}}
+
+      assert Mapper.map(document, compiled, flat_keys: true) == %{
+               "attrs" => %{"project" => "p", "a" => "1", "b" => "2"}
+             }
+    end
+
+    test ":merge cannot reach dot-notation source keys under flat_keys" do
+      compiled =
+        compile([
+          Field.flat_map("attrs",
+            paths: ["$.resource"],
+            pick: [{"project", ["$.project"]}],
+            pick_mode: :merge,
+            default: %{}
+          )
+        ])
+
+      document = %{"project" => "p", "resource.a" => 1, "resource.b" => 2}
+
+      assert Mapper.map(document, compiled, flat_keys: true) == %{
+               "attrs" => %{"project" => "p"}
+             }
+    end
+  end
+
   defp compile(fields) do
     fields
     |> MappingConfig.new()

--- a/test/profiling/mapper_bench.exs
+++ b/test/profiling/mapper_bench.exs
@@ -260,6 +260,16 @@ log_params = %{
     "url" => "https://zzzenjkohrkaatgpywnz.supabase.co/rest/v1/rpc/set_active_session"
   },
   "request_id" => "9f8bc2a6-57c0-7460-d3ad-9cebebcde78e",
+  "resource" => %{
+    "_instance_color" => "green",
+    "_project_region" => "ap-south-1",
+    "_service_name" => "supabase-edge-runtime",
+    "_telemetry_sdk_language" => "rust",
+    "_telemetry_sdk_name" => "opentelemetry",
+    "_telemetry_sdk_version" => "0.31.0",
+    "environment" => "prod",
+    "host" => "ip-10-0-42-17.ap-south-1.compute.internal"
+  },
   "response" => %{
     "headers" => %{
       "cf_cache_status" => "DYNAMIC",
@@ -310,17 +320,31 @@ Benchee.run(
 
 # Baseline results — Mapper.map(event.body) with MappingDefaults.for_log()
 # Apple M4 / 32 GB / macOS / Elixir 1.19.5 / Erlang 27.3.4.6
-# Recorded at d1b0bfa2b.
+# Recorded after adding a `resource` block to the payload, so the numbers below are
+# NOT comparable to any baseline recorded before that change.
 #
 # Name                             ips        average  deviation         median         99th %
-# [log] Mapper.map(body)       54.57 K       18.33 μs    ±35.74%       18.54 μs       39.54 μs
+# [log] Mapper.map(body)       49.32 K       20.28 μs    ±14.97%       21.46 μs       28.54 μs
 #
 # Memory usage statistics:
 #
 # Name                      Memory usage
-# [log] Mapper.map(body)         2.52 KB
+# [log] Mapper.map(body)         2.34 KB
 #
 # Reduction count statistics:
 #
 # Name                   Reduction count
-# [log] Mapper.map(body)             130
+# [log] Mapper.map(body)             141
+#
+# Same-payload A/B for `pick_mode: :merge` on resource_attributes, mapping the raw
+# payload rather than a LogEvent body (so absolute figures sit higher than above; the
+# comparison between rows is the point):
+#
+#   :replace              5 keys   49.74 K ips   20.11 μs   3.98 KB   204 reductions
+#   :merge               11 keys   48.39 K ips   20.67 μs   3.98 KB   208 reductions
+#   :merge + exclude      9 keys   47.92 K ips   20.87 μs   3.97 KB   207 reductions
+#
+# The merge costs +4 reductions for 6 extra keys of resource data. Excluding the two
+# underscore duplicates that already have a curated alias (`_project_region` ->
+# `region`, `_service_name` -> `service_name`) is free — one reduction cheaper than
+# plain merge, since the keys drop before the flatten pass.


### PR DESCRIPTION
## Overview

Adds a `:pick_mode` option to `json` / `flat_map` mapper fields so a curated `:pick` map and the raw source map can both reach the output. This PR also switches `resource_attributes` over to leverage this feature.

### Key Changes

- New `:pick_mode` field config option: `:replace` (_default, existing either/or behavior_) or `:merge`
- `:merge` unions the `:pick` entries with the remaining values from `:path` / `:paths`, with pick entries winning on key collision
- `:exclude_keys` and `:elevate_keys` continue to apply to the merged result
- `resource_attributes` now uses `:merge` on all three event types, so curated keys and uncurated resource keys both land in the map

### Risks / Considerations

- `:paths` remains a coalesce in both modes — only the first resolving path contributes. Payloads that split resource keys across multiple paths will still only pick up keys from the first one that resolves.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
