### PR TITLE
ClickHouse OTEL mappings: exclude `resource`/`scope` envelopes from attribute maps

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -211,7 +211,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("log_attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp"],
+        exclude_keys: ["id", "event_message", "timestamp", "resource", "scope"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.datetime64("timestamp", path: "$.timestamp", precision: 9)
@@ -382,7 +382,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp"],
+        exclude_keys: ["id", "event_message", "timestamp", "resource", "scope"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.string("aggregation_temporality",
@@ -674,9 +674,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
         ],
         default: %{}
       ),
+      # `scope` is deliberately not excluded here and must stay that way.
+      # otel_traces has no scope_attributes column and will not be getting one,
+      # so span_attributes is the permanent home for scope.schema_url and
+      # scope.attributes.*. Adding "scope" here would drop them entirely.
       Field.flat_map("span_attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp"],
+        exclude_keys: ["id", "event_message", "timestamp", "resource"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.array_datetime64("events.timestamp",

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -199,6 +199,87 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
     end
   end
 
+  describe "attribute maps exclude envelopes that have their own columns" do
+    setup do
+      payload = %{
+        "level" => "info",
+        "resource" => %{"host" => "h1", "schema_url" => "https://otel.io/schemas/1.21.0"},
+        "scope" => %{
+          "name" => "svc",
+          "version" => "1.2.3",
+          "schema_url" => "https://otel.io/schemas/1.21.0",
+          "attributes" => %{"library.language" => "rust"}
+        },
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      {:ok, payload: payload}
+    end
+
+    test "no attribute map carries resource.* keys", %{
+      log: log,
+      metric: metric,
+      trace: trace,
+      payload: payload
+    } do
+      for {compiled, field} <- [
+            {log, "log_attributes"},
+            {metric, "attributes"},
+            {trace, "span_attributes"}
+          ] do
+        attrs = Mapper.map(payload, compiled)[field]
+
+        assert Enum.filter(Map.keys(attrs), &String.starts_with?(&1, "resource")) == [],
+               "#{field} still carries resource.* keys"
+      end
+    end
+
+    test "resource data still reaches resource_attributes in full", %{
+      log: log,
+      metric: metric,
+      trace: trace,
+      payload: payload
+    } do
+      for compiled <- [log, metric, trace] do
+        res_attrs = Mapper.map(payload, compiled)["resource_attributes"]
+
+        assert res_attrs["host"] == "h1"
+        assert res_attrs["schema_url"] == "https://otel.io/schemas/1.21.0"
+      end
+    end
+
+    test "log and metric attribute maps drop scope.* since they have scope_attributes", %{
+      log: log,
+      metric: metric,
+      payload: payload
+    } do
+      for {compiled, field} <- [{log, "log_attributes"}, {metric, "attributes"}] do
+        result = Mapper.map(payload, compiled)
+
+        assert Enum.filter(Map.keys(result[field]), &String.starts_with?(&1, "scope")) == [],
+               "#{field} still carries scope.* keys"
+
+        assert result["scope_attributes"] == %{"library.language" => "rust"}
+        assert result["scope_schema_url"] == "https://otel.io/schemas/1.21.0"
+        assert result["scope_name"] == "svc"
+      end
+    end
+
+    test "trace span_attributes keeps scope.* because traces have no scope_attributes column",
+         %{trace: compiled, payload: payload} do
+      result = Mapper.map(payload, compiled)
+
+      refute Map.has_key?(result, "scope_attributes")
+      refute Map.has_key?(result, "scope_schema_url")
+
+      # These would be lost entirely if `scope` were excluded here.
+      assert result["span_attributes"]["scope.schema_url"] ==
+               "https://otel.io/schemas/1.21.0"
+
+      assert result["span_attributes"]["scope.attributes.library.language"] == "rust"
+    end
+  end
+
   describe "resource_attributes merges the raw resource map with pick entries" do
     test "keeps uncurated resource keys alongside curated ones", %{
       log: log,

--- a/test/profiling/mapper_bench.exs
+++ b/test/profiling/mapper_bench.exs
@@ -324,7 +324,7 @@ Benchee.run(
 # NOT comparable to any baseline recorded before that change.
 #
 # Name                             ips        average  deviation         median         99th %
-# [log] Mapper.map(body)       49.32 K       20.28 μs    ±14.97%       21.46 μs       28.54 μs
+# [log] Mapper.map(body)       50.98 K       19.61 μs        high       20.50 μs       30.83 μs
 #
 # Memory usage statistics:
 #
@@ -334,7 +334,10 @@ Benchee.run(
 # Reduction count statistics:
 #
 # Name                   Reduction count
-# [log] Mapper.map(body)             141
+# [log] Mapper.map(body)             135
+#
+# Excluding the `resource` and `scope` envelopes from log_attributes (they have
+# their own columns) took it from 141 -> 135 reductions and 106 -> 98 keys.
 #
 # Same-payload A/B for `pick_mode: :merge` on resource_attributes, mapping the raw
 # payload rather than a LogEvent body (so absolute figures sit higher than above; the


### PR DESCRIPTION
## Overview

Excludes the OTEL envelopes that already have dedicated columns from the `*_attribute` maps, so the same data isn't stored twice.

### Key Changes

- Excluded the `resource` envelope from `log_attributes`, `attributes`, and `span_attributes` on all three event types
- Excluded `scope` from logs and metrics, which have their own scope columns
- Traces intentionally keep `scope.*` in `span_attributes`, since `otel_traces` has no `scope_attributes` column

### Risks / Considerations

- Queries reading `resource.*` (_or `scope.*` on logs and metrics_) out of the attribute maps need to move to the dedicated columns. On the reference payload this drops span attributes from 29 keys to 19.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
