### PR TITLE
mapper: canonicalize string filter keys so filters survive a JSON round trip

### DIFF
--- a/lib/logflare/mapper/mapping_config.ex
+++ b/lib/logflare/mapper/mapping_config.ex
@@ -203,33 +203,7 @@ defmodule Logflare.Mapper.MappingConfig do
   defp maybe_add_filters(map, nil), do: map
   defp maybe_add_filters(map, filters) when is_empty_map(filters), do: map
 
-  defp maybe_add_filters(map, filters) do
-    nif_filters =
-      Enum.reduce(filters, %{}, fn
-        {:len_eq, v}, acc when is_integer(v) ->
-          Map.put(acc, "len_eq", v)
-
-        {:len_gt, v}, acc when is_integer(v) ->
-          Map.put(acc, "len_gt", v)
-
-        {:len_gte, v}, acc when is_integer(v) ->
-          Map.put(acc, "len_gte", v)
-
-        {:len_lt, v}, acc when is_integer(v) ->
-          Map.put(acc, "len_lt", v)
-
-        {:len_lte, v}, acc when is_integer(v) ->
-          Map.put(acc, "len_lte", v)
-
-        {:char_class, v}, acc when v in ~w(alpha numeric alphanumeric) ->
-          Map.put(acc, "char_class", v)
-
-        _, acc ->
-          acc
-      end)
-
-    if nif_filters == %{}, do: map, else: Map.put(map, "filters", nif_filters)
-  end
+  defp maybe_add_filters(map, filters), do: Map.put(map, "filters", filters)
 
   @spec maybe_add_filter_nil(map(), boolean()) :: map()
   defp maybe_add_filter_nil(map, false), do: map

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -56,6 +56,11 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       Example: `filters: %{len_eq: 20, char_class: "alpha"}` ensures the resolved
       value is exactly 20 ASCII alphabetic characters.
 
+      Filter keys may be atoms or strings and are stored in canonical string form, so a
+      config survives a `MappingConfig.to_json/1` / `from_json/1` round trip unchanged. An
+      unrecognized key, a non-integer length, or an unsupported character class is rejected
+      when the config is built rather than dropped.
+
   ### `datetime64/2`
 
     * `:precision` — target precision 0-9 (default `9` for nanoseconds). Integer inputs are
@@ -210,6 +215,8 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   @valid_types ~w(string uint8 uint32 uint64 int32 float64 bool enum8 datetime64 json flat_map array_string array_uint64 array_float64 array_datetime64 array_json array_map array_flat_map)
   @valid_transforms ~w(upcase downcase)
   @valid_value_types ~w(string)
+  @length_filters ~w(len_eq len_gt len_gte len_lt len_lte)
+  @char_classes ~w(alpha numeric alphanumeric)
 
   @type common_opts :: [
           path: String.t(),
@@ -273,6 +280,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     |> validate_inclusion(:type, @valid_types)
     |> validate_inclusion(:transform, @valid_transforms)
     |> validate_inclusion(:value_type, @valid_value_types)
+    |> normalize_filters()
     |> cast_embed(:pick, with: &PickEntry.changeset/2)
     |> cast_embed(:infer, with: &InferRule.changeset/2)
   end
@@ -409,7 +417,63 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   defp encode_default(val) when is_list(val), do: "[]"
 
   defp maybe_put(struct, _key, nil), do: struct
+
+  defp maybe_put(struct, :filters, filters) do
+    case canonicalize_filters(filters) do
+      {:ok, canonical} -> Map.put(struct, :filters, canonical)
+      {:error, reason} -> raise ArgumentError, reason
+    end
+  end
+
   defp maybe_put(struct, key, value), do: Map.put(struct, key, value)
+
+  defp normalize_filters(changeset) do
+    case fetch_change(changeset, :filters) do
+      {:ok, nil} ->
+        changeset
+
+      {:ok, filters} ->
+        case canonicalize_filters(filters) do
+          {:ok, canonical} -> put_change(changeset, :filters, canonical)
+          {:error, reason} -> add_error(changeset, :filters, reason)
+        end
+
+      :error ->
+        changeset
+    end
+  end
+
+  @spec canonicalize_filters(map()) :: {:ok, map()} | {:error, String.t()}
+  defp canonicalize_filters(filters) when is_map(filters) do
+    Enum.reduce_while(filters, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      case canonicalize_filter(to_string(key), value) do
+        {:ok, canonical_key} -> {:cont, {:ok, Map.put(acc, canonical_key, value)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp canonicalize_filters(filters),
+    do: {:error, "filters must be a map, got #{inspect(filters)}"}
+
+  @spec canonicalize_filter(String.t(), term()) :: {:ok, String.t()} | {:error, String.t()}
+  defp canonicalize_filter(key, value) when key in @length_filters and is_integer(value),
+    do: {:ok, key}
+
+  defp canonicalize_filter(key, value) when key in @length_filters,
+    do: {:error, "string filter \"#{key}\" must be an integer, got #{inspect(value)}"}
+
+  defp canonicalize_filter("char_class", value) when value in @char_classes,
+    do: {:ok, "char_class"}
+
+  defp canonicalize_filter("char_class", value) do
+    {:error,
+     "string filter \"char_class\" must be one of #{Enum.join(@char_classes, ", ")}, " <>
+       "got #{inspect(value)}"}
+  end
+
+  defp canonicalize_filter(key, _value),
+    do: {:error, "unknown string filter \"#{key}\""}
 
   defp maybe_put_pick_mode(struct, nil), do: struct
   defp maybe_put_pick_mode(struct, :replace), do: struct

--- a/test/logflare/mapper/mapping_config_test.exs
+++ b/test/logflare/mapper/mapping_config_test.exs
@@ -535,4 +535,58 @@ defmodule Logflare.Mapper.MappingConfigTest do
       assert field["default"] == 0.0
     end
   end
+
+  describe "string filter keys" do
+    test "constructor canonicalizes atom filter keys" do
+      field = Field.string("s", path: "$.s", filters: %{len_gt: 3})
+
+      assert field.filters == %{"len_gt" => 3}
+    end
+
+    test "constructor accepts string filter keys" do
+      field = Field.string("s", path: "$.s", filters: %{"len_gt" => 3})
+
+      assert field.filters == %{"len_gt" => 3}
+    end
+
+    test "constructor rejects an unknown filter key" do
+      assert_raise ArgumentError, ~r/len_gtt/, fn ->
+        Field.string("s", path: "$.s", filters: %{len_gtt: 3})
+      end
+    end
+
+    test "constructor rejects a non-integer length filter" do
+      assert_raise ArgumentError, ~r/len_gt/, fn ->
+        Field.string("s", path: "$.s", filters: %{len_gt: "3"})
+      end
+    end
+
+    test "constructor rejects an unsupported char_class" do
+      assert_raise ArgumentError, ~r/char_class/, fn ->
+        Field.string("s", path: "$.s", filters: %{char_class: "hex"})
+      end
+    end
+
+    test "filters reach the nif map after a to_json/from_json round trip" do
+      config =
+        MappingConfig.new([
+          Field.string("s", path: "$.s", filters: %{len_gt: 3}, default: "D")
+        ])
+
+      {:ok, json} = MappingConfig.to_json(config)
+      {:ok, restored} = MappingConfig.from_json(json)
+
+      assert hd(restored.fields).filters == %{"len_gt" => 3}
+
+      nif_field = restored |> MappingConfig.to_nif_map() |> Map.fetch!("fields") |> hd()
+
+      assert nif_field["filters"] == %{"len_gt" => 3}
+    end
+
+    test "from_json/1 rejects an unknown filter key" do
+      json = ~s({"fields":[{"name":"s","type":"string","path":"$.s","filters":{"len_gtt":3}}]})
+
+      assert {:error, %Ecto.Changeset{valid?: false}} = MappingConfig.from_json(json)
+    end
+  end
 end

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -3103,5 +3103,19 @@ defmodule Logflare.MapperTest do
       # Non-binary values are not filtered, they pass through to coercion
       assert result["val"] == "12345"
     end
+
+    test "filters still apply after a to_json/from_json round trip" do
+      config =
+        MappingConfig.new([
+          Field.string("val", path: "$.val", default: "fallback", filters: %{len_gt: 3})
+        ])
+
+      {:ok, json} = MappingConfig.to_json(config)
+      {:ok, restored} = MappingConfig.from_json(json)
+
+      result = Mapper.map(%{"val" => "ab"}, Mapper.compile!(restored))
+
+      assert result["val"] == "fallback"
+    end
   end
 end


### PR DESCRIPTION
## Overview

Mapper string filters were silently dropped after a JSON round trip, so a persisted config came back with no filters at all and values the filter should have rejected passed straight through to the column. Seventh layer of the mapping stack, sitting on the config validation work in #3931.

### Key Changes

- Filter keys are canonicalized to strings in both entry points — the `Field.*` constructors and the `FieldConfig` changeset — so the struct shape is the same whether a config is built inline or reloaded from JSON
- Unknown filter keys, non-integer lengths, and unsupported character classes are rejected where the config is built, instead of being dropped without an error, log, or warning
- `to_nif_map/1` no longer re-checks keys against its own whitelist, since validation now happens at the boundary
- Added round-trip coverage for both the config shape and the mapped output (_the existing filter tests all used atom keys and never round-tripped, which is why this went unnoticed_)

### Risks / Considerations

- Latent today — nothing in `lib/` configures `filters`, and `from_json/1` has no callers outside its own module, so no live config is currently losing them. This is about correcting a found gap if persisted configs come online.
- A config with a typo'd filter key that previously compiled clean will now raise from the constructor or fail the changeset. Intended, but it is a behavior change.
- Errors stay confined to config construction and decode; the per-event path is untouched.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
