### PR TITLE
fix: drop unresolvable rule ids in RulesTree.matching_rules/2

### DIFF
--- a/lib/logflare/backends/spool/consumer_pipeline.ex
+++ b/lib/logflare/backends/spool/consumer_pipeline.ex
@@ -144,16 +144,18 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline do
   end
 
   defp fail_dispatched(messages, failed_source_ids) do
-    if MapSet.size(failed_source_ids) == 0 do
+    if Enum.empty?(failed_source_ids) do
       messages
     else
-      Enum.map(messages, fn message ->
-        if MapSet.member?(failed_source_ids, record_source_id(message.data)) do
-          Message.failed(message, :dispatch_error)
-        else
-          message
-        end
-      end)
+      Enum.map(messages, &fail_message(&1, failed_source_ids))
+    end
+  end
+
+  defp fail_message(message, failed_source_ids) do
+    if MapSet.member?(failed_source_ids, record_source_id(message.data)) do
+      Message.failed(message, :dispatch_error)
+    else
+      message
     end
   end
 

--- a/lib/logflare/backends/spool/consumer_pipeline.ex
+++ b/lib/logflare/backends/spool/consumer_pipeline.ex
@@ -126,18 +126,35 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline do
       %{backend_type: :spool_consumer, batch_trigger: batch_trigger}
     )
 
-    messages
-    |> Enum.group_by(&record_source_id(&1.data), & &1.data)
-    |> Enum.each(fn
-      {nil, lines} ->
-        emit_skipped_telemetry(:missing_source_id, length(lines))
-        Logger.debug("spool_consumer: #{length(lines)} events missing source_id, skipping")
+    failed_source_ids =
+      messages
+      |> Enum.group_by(&record_source_id(&1.data), & &1.data)
+      |> Enum.flat_map(fn
+        {nil, lines} ->
+          emit_skipped_telemetry(:missing_source_id, length(lines))
+          Logger.debug("spool_consumer: #{length(lines)} events missing source_id, skipping")
+          []
 
-      {source_id, lines} ->
-        dispatch_group(source_id, lines)
-    end)
+        {source_id, lines} ->
+          dispatch_group(source_id, lines)
+      end)
+      |> MapSet.new()
 
-    messages
+    fail_dispatched(messages, failed_source_ids)
+  end
+
+  defp fail_dispatched(messages, failed_source_ids) do
+    if MapSet.size(failed_source_ids) == 0 do
+      messages
+    else
+      Enum.map(messages, fn message ->
+        if MapSet.member?(failed_source_ids, record_source_id(message.data)) do
+          Message.failed(message, :dispatch_error)
+        else
+          message
+        end
+      end)
+    end
   end
 
   defp dispatch_group(source_id, lines) do
@@ -149,10 +166,23 @@ defmodule Logflare.Backends.Spool.ConsumerPipeline do
           "spool_consumer: unknown source_id=#{source_id}, skipping #{length(lines)} events"
         )
 
+        []
+
       source ->
         {:ok, _} = Backends.dispatch_from_spool(lines, source)
-        :ok
+        []
     end
+  rescue
+    exception ->
+      emit_skipped_telemetry(:dispatch_error, length(lines))
+
+      Logger.error(
+        "spool_consumer: dispatch failed for source_id=#{source_id}, " <>
+          "failing #{length(lines)} events: " <>
+          Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      [source_id]
   end
 
   defp emit_skipped_telemetry(reason, count) do

--- a/lib/logflare/sources/source_router.ex
+++ b/lib/logflare/sources/source_router.ex
@@ -23,7 +23,7 @@ defmodule Logflare.Sources.SourceRouter do
     do: le
 
   def route_to_sinks_and_ingest(%LE{via_rule_id: nil} = le, source, router) do
-    for rule <- router.matching_rules(le, source) do
+    for %Rule{} = rule <- router.matching_rules(le, source) do
       do_routing(rule, le, source)
     end
 

--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -28,6 +28,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
 
     matching_rule_ids(event, rule_set)
     |> Rules.Cache.get_rules()
+    |> Enum.reject(&is_nil/1)
   end
 
   @doc """

--- a/test/logflare/backends/spool/consumer_pipeline_test.exs
+++ b/test/logflare/backends/spool/consumer_pipeline_test.exs
@@ -141,6 +141,39 @@ defmodule Logflare.Backends.Spool.ConsumerPipelineTest do
       assert_receive {:telemetry_event, [:logflare, :backends, :spool, :consumer, :skipped],
                       %{count: 1}, %{reason: :missing_source_id}}
     end
+
+    test "a raising dispatch fails only that source's messages", %{source: source} do
+      TestUtils.attach_forwarder([:logflare, :backends, :spool, :consumer, :skipped])
+
+      user = insert(:user)
+      other_source = insert(:source, user: user)
+
+      poison = line_message(source.id, Ecto.UUID.generate())
+      healthy = line_message(other_source.id, Ecto.UUID.generate())
+
+      pid = self()
+
+      stub(Logflare.Backends, :dispatch_from_spool, fn event_params, dispatched_source ->
+        if dispatched_source.id == source.id do
+          raise FunctionClauseError
+        end
+
+        send(pid, {:dispatched, dispatched_source.id})
+        {:ok, length(event_params)}
+      end)
+
+      assert [returned_poison, returned_healthy] =
+               ConsumerPipeline.handle_batch(:default, [poison, healthy], %{}, %{})
+
+      assert returned_poison.status == {:failed, :dispatch_error}
+      assert returned_healthy.status == :ok
+
+      assert_receive {:dispatched, dispatched_id}
+      assert dispatched_id == other_source.id
+
+      assert_receive {:telemetry_event, [:logflare, :backends, :spool, :consumer, :skipped],
+                      %{count: 1}, %{reason: :dispatch_error}}
+    end
   end
 
   describe "ack/3" do

--- a/test/logflare/sources/source_router/rules_tree_test.exs
+++ b/test/logflare/sources/source_router/rules_tree_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
 
   alias Logflare.LogEvent
   alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Rules
   alias Logflare.Rules.Rule
   alias Logflare.Sources.SourceRouter.RulesTree
 
@@ -389,6 +390,28 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
 
       # Name  Reduction count
       # build        172.99 K
+    end
+  end
+
+  describe "matching_rules/2" do
+    setup do
+      insert(:plan)
+      user = insert(:user)
+      backend = insert(:backend, user: user)
+      rule = build(:rule, backend: backend, lql_string: "testing")
+      source = insert(:source, user: user, rules: [rule])
+
+      [source: source, log_event: build(:log_event, source: source, message: "testing123")]
+    end
+
+    test "returns the rules matching the event", %{source: source, log_event: le} do
+      assert [%Rule{}] = @subject.matching_rules(le, source)
+    end
+
+    test "drops matched ids whose rule no longer exists", %{source: source, log_event: le} do
+      stub(Rules, :get_rule, fn _id -> nil end)
+
+      assert @subject.matching_rules(le, source) == []
     end
   end
 

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.Sources.SourceRouterTest do
   alias Logflare.LogEvent
   alias Logflare.Lql.Parser
   alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Rules
   alias Logflare.Rules.Rule
   alias Logflare.Sources.SourceRouter
   alias Logflare.SystemMetrics.AllLogsLogged
@@ -755,6 +756,18 @@ defmodule Logflare.Sources.SourceRouterTest do
         {le, source} = build_data.(metadata, "value")
         assert unquote(router).matching_rules(le, source) == source.rules
       end
+    end
+  end
+
+  describe "RulesTree with an unresolvable rule id" do
+    test "does not raise when a matched rule no longer exists", %{user: user, backend: backend} do
+      rule = build(:rule, backend: backend, lql_string: "testing")
+      source = insert(:source, user: user, rules: [rule])
+      le = build(:log_event, source: source, message: "testing123")
+
+      stub(Rules, :get_rule, fn _id -> nil end)
+
+      assert SourceRouter.route_to_sinks_and_ingest(le, source, SourceRouter.RulesTree) == le
     end
   end
 end

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -765,7 +765,7 @@ defmodule Logflare.Sources.SourceRouterTest do
       source = insert(:source, user: user, rules: [rule])
       le = build(:log_event, source: source, message: "testing123")
 
-      stub(Rules, :get_rule, fn _id -> nil end)
+      expect(Rules, :get_rule, fn _id -> nil end)
 
       assert SourceRouter.route_to_sinks_and_ingest(le, source, SourceRouter.RulesTree) == le
     end


### PR DESCRIPTION
## Problem

Logflare prod had a two-minute error blip on **2026-09-04 22:09–22:10 UTC** (432 and 444 errors/min against a 30–130/min baseline), on `canary` (1.50.9), `prod-b`, `prod-d` and `prod-g` (1.50.7):

```
** (FunctionClauseError) no function clause matching in Logflare.Sources.SourceRouter.do_routing/3
    (logflare 1.50.7) lib/logflare/sources/source_router.ex:33:
      Logflare.Sources.SourceRouter.do_routing(nil, %Logflare.LogEvent{...}, ...)
    lib/broadway/topology/batch_processor_stage.ex:120
```

paired 1:1 with

```
spool_consumer: 500 messages failed during processing
```

The spool line is the effect, not a second bug: the raise happens inside `Broadway.Topology.BatchProcessorStage.handle_batch/4`, so one poison event fails the whole batch and `Spool.ConsumerPipeline.ack/3` reports it.

This is not a bad deploy. The same signature fired on 08-31 19:00 (745 errors), 09-03 12:00 and 09-03 23:00, each time for different source ids.

## Cause

`RulesTree.matching_rules/2`:

```elixir
matching_rule_ids(event, rule_set)
|> Rules.Cache.get_rules()
```

`Rules.Cache.get_rules/1` maps each id through `Rules.get_rule/1` = `Repo.get(Rule, id)`, which returns **`nil`** for a missing row. So a rule id that is still in the cached rules tree but no longer resolves to a rule row comes back as `nil` and goes straight into `do_routing/3`, whose clauses all match `%Rule{}`.

The id goes stale because the two reads do not hit the same database:

| read | path | source |
|---|---|---|
| `rules_tree_by_source_id/1` | `ContextCache.apply_fun/3` → `Repo.apply_with_replica/3` | a randomly picked **read replica** |
| `get_rules/1` | `ContextCache.fetch/3` → `Rules.get_rule/1` directly | the **primary** |

Both cache under the same key namespace, and `Rules.Cache.get_rule/1` (singular) *does* go through the replica — only the plural `get_rules/1` bypasses it. After a delete commits on the primary, a tree rebuilt from a lagging replica still carries the dead id while `get_rules/1` resolves it to `nil` against the primary. Every node reads the same small replica pool, which is why several clusters failed within the same second.

This also violates the router's own contract:

```elixir
@callback matching_rules(LE.t(), Source.t()) :: [Rule.t()]
```

The sibling `SourceRouter.Sequential` pattern-matches `%Rule{lql_filters: [_ | _]}` in its comprehension and cannot hit this.

## Fix

Three layers:

1. `RulesTree.matching_rules/2` rejects `nil` entries, restoring its `[Rule.t()]` callback contract.
2. `route_to_sinks_and_ingest/3` matches `%Rule{}` in its comprehension, so no router implementation can feed a non-`Rule` into `do_routing/3`.
3. `Spool.ConsumerPipeline.handle_batch/4` rescues a raising `dispatch_group/2` and marks only that source group's messages with `Message.failed/2`. A poison group no longer fails the other 499 messages, and the rescue emits `skipped` telemetry with a `:dispatch_error` reason.

## Tests

Three regression tests: one at the router level, one at the `RulesTree` level, and one at the spool-pipeline level (a raising dispatch for one source, a healthy dispatch for another, in the same batch). Each fails without its fix. The router one reproduces the exact production `FunctionClauseError`. The router test uses `expect/3` rather than `stub/3`, so `verify_on_exit!` catches a fixture drift that would otherwise leave it green while covering nothing.

```
mix test test/logflare/backends/spool/consumer_pipeline_test.exs \
         test/logflare/sources/source_router/rules_tree_test.exs \
         test/logflare/sources/source_router_test.exs
Result: 66 passed, 1 excluded     # incl. consumer_pipeline_test.exs
```

## Follow-ups (not in this PR)

- Count the rejected ids (a `Logger.warning` or `:telemetry` counter). The drop is silent today, so a stale-tree window — up to the `cache_expiration_min(60, 5)` TTL — is invisible.
- Make `Rules.Cache.get_rules/1` read the way `get_rule/1` does. Today the plural calls `Rules.get_rule/1` directly and so reads the primary, while the tree it is resolving ids for was built on a replica. Routing the two through the same repo would close the window rather than tolerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kMNrQA6RgNdnjwA2QQuhf



