### PR TITLE
mapper: only accept a supplied `severity_number` inside the OTEL 1-24 range

### DIFF
--- a/bench/support/clickhouse_pipeline_bench_data.exs
+++ b/bench/support/clickhouse_pipeline_bench_data.exs
@@ -553,7 +553,7 @@ defmodule Logflare.Bench.ClickHousePipelineData do
   defp maybe_compute_duration(body, _type), do: body
 
   defp resolve_severity_number(%{"severity_number_alt" => alt} = body, :log)
-       when is_integer(alt) and alt > 0 do
+       when is_integer(alt) and alt in 1..24 do
     %{body | "severity_number" => alt}
   end
 

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -23,6 +23,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
 
   This trade-off is deliberate: downstream queries get a stable, predictable key set
   rather than having to reconcile aliases and duplicate keys per row.
+
+  ## `severity_number` contract
+
+  A supplied `severity_number` is stored only when it is an integer (or a string holding
+  one) inside the OTEL 1-24 range. `severity_number_alt` uses `coercion: :strict`, so a
+  float or boolean resolves to `0` instead of being truncated to a plausible severity, and
+  the RowBinary encoder rejects anything outside 1-24. Both cases fall back to the
+  `severity_number` derived from `severity_text`.
   """
 
   alias Logflare.LogEvent.TypeDetection
@@ -84,6 +92,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.uint8("severity_number_alt",
         paths: ["$.severity_number", "$.severityNumber"],
+        coercion: :strict,
         default: 0
       ),
       Field.uint8("severity_number",

--- a/lib/logflare/mapper/mapping_config.ex
+++ b/lib/logflare/mapper/mapping_config.ex
@@ -24,6 +24,11 @@ defmodule Logflare.Mapper.MappingConfig do
   filters, it is skipped and the next coalesce path is tried. See
   `FieldConfig` for the full list of filter keys.
 
+  Unsigned integer fields accept a `:coercion` option. The default `:lenient` mode
+  converts floats, booleans, and numeric strings; `:strict` only accepts integer
+  terms (or strings holding one) and treats anything else as unresolved, so the
+  field's `:default` applies. See `FieldConfig` for details.
+
   Every field reads from the **original input document** — operations like
   `exclude_keys` and `elevate_keys` only transform that field's own output value.
   The only cross-field mechanism is `from_output:`, which reads a previously
@@ -157,6 +162,7 @@ defmodule Logflare.Mapper.MappingConfig do
     |> maybe_add("elevate_keys", f.elevate_keys)
     |> maybe_add("value_type", f.value_type)
     |> maybe_add("pick_mode", f.pick_mode)
+    |> maybe_add("coercion", f.coercion)
     |> maybe_add_filters(f.filters)
     |> maybe_add_filter_nil(f.filter_nil)
     |> maybe_add_pick(f.pick)

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -61,6 +61,19 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       unrecognized key, a non-integer length, or an unsupported character class is rejected
       when the config is built rather than dropped.
 
+  ### `uint8/2`, `uint32/2`, `uint64/2`
+
+    * `:coercion` — `:lenient` (default) or `:strict`. Lenient coercion converts whatever
+      it is given: floats truncate (`13.9` → `13`), booleans become `1`/`0`, numeric
+      strings are parsed, and anything else becomes `0`. Strict coercion only accepts an
+      integer term or a string that parses as an integer; any other type is treated as
+      unresolved, so coalesce moves on to the next path and the field's `:default` applies
+      when nothing resolves. Range handling is the same in both modes: negative values
+      clamp to `0` and values above the type's maximum saturate.
+
+      Use `:strict` when a truncated or converted value would be misread downstream, e.g.
+      an OTEL `severity_number` where `true` must not silently become `TRACE` (`1`).
+
   ### `datetime64/2`
 
     * `:precision` — target precision 0-9 (default `9` for nanoseconds). Integer inputs are
@@ -215,6 +228,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   @valid_types ~w(string uint8 uint32 uint64 int32 float64 bool enum8 datetime64 json flat_map array_string array_uint64 array_float64 array_datetime64 array_json array_map array_flat_map)
   @valid_transforms ~w(upcase downcase)
   @valid_value_types ~w(string)
+  @valid_coercions ~w(lenient strict)
   @length_filters ~w(len_eq len_gt len_gte len_lt len_lte)
   @char_classes ~w(alpha numeric alphanumeric)
 
@@ -246,6 +260,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     field(:filter_nil, :boolean, default: false)
     field(:value_type, :string)
     field(:pick_mode, :string)
+    field(:coercion, :string)
     embeds_many(:pick, PickEntry)
     embeds_many(:infer, InferRule)
   end
@@ -272,7 +287,8 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
         :filters,
         :filter_nil,
         :value_type,
-        :pick_mode
+        :pick_mode,
+        :coercion
       ],
       empty_values: []
     )
@@ -280,6 +296,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
     |> validate_inclusion(:type, @valid_types)
     |> validate_inclusion(:transform, @valid_transforms)
     |> validate_inclusion(:value_type, @valid_value_types)
+    |> validate_inclusion(:coercion, @valid_coercions)
     |> normalize_filters()
     |> cast_embed(:pick, with: &PickEntry.changeset/2)
     |> cast_embed(:infer, with: &InferRule.changeset/2)
@@ -292,17 +309,17 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
 
   @spec uint8(String.t(), keyword()) :: t()
   def uint8(name, opts \\ []) do
-    build(name, "uint8", opts)
+    build(name, "uint8", opts, [:coercion])
   end
 
   @spec uint32(String.t(), keyword()) :: t()
   def uint32(name, opts \\ []) do
-    build(name, "uint32", opts)
+    build(name, "uint32", opts, [:coercion])
   end
 
   @spec uint64(String.t(), keyword()) :: t()
   def uint64(name, opts \\ []) do
-    build(name, "uint64", opts)
+    build(name, "uint64", opts, [:coercion])
   end
 
   @spec int32(String.t(), keyword()) :: t()
@@ -424,6 +441,14 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       {:error, reason} -> raise ArgumentError, reason
     end
   end
+
+  defp maybe_put(struct, :coercion, mode) when mode in [:lenient, "lenient"], do: struct
+
+  defp maybe_put(struct, :coercion, mode) when mode in [:strict, "strict"],
+    do: %{struct | coercion: "strict"}
+
+  defp maybe_put(_struct, :coercion, mode),
+    do: raise(ArgumentError, "coercion must be :lenient or :strict, got #{inspect(mode)}")
 
   defp maybe_put(struct, key, value), do: Map.put(struct, key, value)
 

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -69,7 +69,9 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       integer term or a string that parses as an integer; any other type is treated as
       unresolved, so coalesce moves on to the next path and the field's `:default` applies
       when nothing resolves. Range handling is the same in both modes: negative values
-      clamp to `0` and values above the type's maximum saturate.
+      clamp to `0` and values above the type's maximum saturate. The check also applies
+      to `:from_output` sources. Strict cannot be combined with `:value_map`, since the
+      map's string keys would never pass the integer check; the compiler rejects it.
 
       Use `:strict` when a truncated or converted value would be misread downstream, e.g.
       an OTEL `severity_number` where `true` must not silently become `TRACE` (`1`).

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -69,8 +69,10 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
       integer term or a string that parses as an integer; any other type is treated as
       unresolved, so coalesce moves on to the next path and the field's `:default` applies
       when nothing resolves. Range handling is the same in both modes: negative values
-      clamp to `0` and values above the type's maximum saturate. The check also applies
-      to `:from_output` sources. Strict cannot be combined with `:value_map`, since the
+      clamp to `0` and values above the type's maximum saturate, at any magnitude, so a
+      BEAM bignum or an overflowing numeric string lands on the maximum rather than `0`.
+      The check applies to every source: `:path`, `:paths`, `:from_output`, and the root
+      document. Strict cannot be combined with `:value_map`, since the
       map's string keys would never pass the integer check; the compiler rejects it.
 
       Use `:strict` when a truncated or converted value would be misread downstream, e.g.

--- a/native/mapper_ex/src/clickhouse_rowbinary.rs
+++ b/native/mapper_ex/src/clickhouse_rowbinary.rs
@@ -96,6 +96,12 @@ fn field_type_name(field_type: FieldType) -> &'static str {
     }
 }
 
+/// OTEL `SeverityNumber` defines 1-24; 0 is UNSPECIFIED. `uint8` coercion saturates
+/// anything larger to 255, so a supplied value outside this range is not a severity
+/// and the `severity_text` mapping is used instead.
+const OTEL_SEVERITY_MIN: u64 = 1;
+const OTEL_SEVERITY_MAX: u64 = 24;
+
 const LOG_FIELDS: &[(&str, WireType)] = &[
     ("project", WireType::String),
     ("trace_id", WireType::String),
@@ -401,7 +407,7 @@ fn append_log(
 
     let severity_alt = decode_u64(values.next("severity_number_alt")?)?;
     let mapped_severity = values.next("severity_number")?;
-    let severity = if severity_alt > 0 {
+    let severity = if (OTEL_SEVERITY_MIN..=OTEL_SEVERITY_MAX).contains(&severity_alt) {
         severity_alt
     } else {
         decode_u64(mapped_severity)?

--- a/native/mapper_ex/src/clickhouse_rowbinary.rs
+++ b/native/mapper_ex/src/clickhouse_rowbinary.rs
@@ -98,7 +98,9 @@ fn field_type_name(field_type: FieldType) -> &'static str {
 
 /// OTEL `SeverityNumber` defines 1-24; 0 is UNSPECIFIED. `uint8` coercion saturates
 /// anything larger to 255, so a supplied value outside this range is not a severity
-/// and the `severity_text` mapping is used instead.
+/// and the `severity_text` mapping is used instead. Non-integer inputs (floats,
+/// booleans) never reach this check: `severity_number_alt` is configured with
+/// `coercion: :strict`, which resolves them to the field default of 0.
 const OTEL_SEVERITY_MIN: u64 = 1;
 const OTEL_SEVERITY_MAX: u64 = 24;
 

--- a/native/mapper_ex/src/coerce.rs
+++ b/native/mapper_ex/src/coerce.rs
@@ -29,6 +29,22 @@ pub fn case_insensitive_get<'b, V>(map: &'b HashMap<String, V>, term: Term<'_>) 
     }
 }
 
+/// True when `value` is an integer term or a binary that parses as an integer —
+/// the only inputs `coerce_uint` can convert without changing the producer's
+/// meaning. Floats and booleans are rejected. Backs `coercion: :strict`.
+#[inline]
+pub fn is_integer_term(value: Term<'_>) -> bool {
+    if value.is_integer() {
+        return true;
+    }
+    match value.decode::<Binary>() {
+        Ok(binary) => std::str::from_utf8(binary.as_slice())
+            .map(|s| s.parse::<i64>().is_ok())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
 /// Coerce a BEAM term to the target field type.
 #[inline]
 pub fn coerce<'a>(

--- a/native/mapper_ex/src/coerce.rs
+++ b/native/mapper_ex/src/coerce.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::IntErrorKind;
 
 use chrono::DateTime as ChronoDateTime;
 use rustler::types::list::ListIterator;
@@ -29,9 +30,10 @@ pub fn case_insensitive_get<'b, V>(map: &'b HashMap<String, V>, term: Term<'_>) 
     }
 }
 
-/// True when `value` is an integer term or a binary that parses as an integer —
-/// the only inputs `coerce_uint` can convert without changing the producer's
-/// meaning. Floats and booleans are rejected. Backs `coercion: :strict`.
+/// True when `value` is an integer term (of any magnitude) or a binary holding a
+/// decimal integer literal — the only inputs `coerce_uint` can convert without
+/// changing the producer's meaning. Floats and booleans are rejected. Range is
+/// not checked here; `coerce_uint` saturates. Backs `coercion: :strict`.
 #[inline]
 pub fn is_integer_term(value: Term<'_>) -> bool {
     if value.is_integer() {
@@ -39,10 +41,18 @@ pub fn is_integer_term(value: Term<'_>) -> bool {
     }
     match value.decode::<Binary>() {
         Ok(binary) => std::str::from_utf8(binary.as_slice())
-            .map(|s| s.parse::<i64>().is_ok())
+            .map(is_decimal_integer)
             .unwrap_or(false),
         Err(_) => false,
     }
+}
+
+fn is_decimal_integer(s: &str) -> bool {
+    let digits = s
+        .strip_prefix('-')
+        .or_else(|| s.strip_prefix('+'))
+        .unwrap_or(s);
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// Coerce a BEAM term to the target field type.
@@ -315,6 +325,10 @@ fn coerce_string<'a>(env: Env<'a>, value: Term<'a>) -> Term<'a> {
     crate::encode_string(env, "")
 }
 
+/// Integers saturate to `[0, max]` at any magnitude: `i64`/`u64` decode covers
+/// the machine range, and a bignum outside it is clamped by sign rather than
+/// falling through to `0`. Numeric strings follow the same rule, including
+/// overflow.
 fn coerce_uint<'a>(env: Env<'a>, value: Term<'a>, max: u64) -> Term<'a> {
     if let Ok(i) = value.decode::<i64>() {
         if i < 0 {
@@ -322,6 +336,15 @@ fn coerce_uint<'a>(env: Env<'a>, value: Term<'a>, max: u64) -> Term<'a> {
         }
         let u = i as u64;
         return u.min(max).encode(env);
+    }
+
+    if let Ok(u) = value.decode::<u64>() {
+        return u.min(max).encode(env);
+    }
+
+    if value.is_integer() {
+        let positive = value > 0i64.encode(env);
+        return if positive { max } else { 0u64 }.encode(env);
     }
 
     if let Ok(f) = value.decode::<f64>() {
@@ -334,9 +357,12 @@ fn coerce_uint<'a>(env: Env<'a>, value: Term<'a>, max: u64) -> Term<'a> {
 
     if let Ok(binary) = value.decode::<Binary>() {
         if let Ok(s) = std::str::from_utf8(binary.as_slice()) {
-            if let Ok(u) = s.parse::<u64>() {
-                return u.min(max).encode(env);
+            return match s.parse::<u64>() {
+                Ok(u) => u.min(max),
+                Err(e) if *e.kind() == IntErrorKind::PosOverflow => max,
+                Err(_) => 0u64,
             }
+            .encode(env);
         }
     }
 

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -294,7 +294,7 @@ fn resolve_value<'a>(
         }
         PathSource::FromOutput(idx) => {
             let v = output_values[*idx];
-            if v != nil {
+            if v != nil && options.accepts(v) {
                 v
             } else {
                 coerce::encode_default(env, &field.default, nil)

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -7,7 +7,6 @@ use crate::mapping::{
     CompiledField, CompiledMapping, Enum8Data, FieldType, PathSource, Predicate, PredicateValue,
 };
 use crate::query;
-use crate::string_filters;
 
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
@@ -238,9 +237,15 @@ fn resolve_value_raw<'a>(
     match &field.path_source {
         PathSource::Root => body,
         PathSource::Single(path) => query::evaluate(env, body, path, nil, flat_keys, cache),
-        PathSource::Coalesce(paths) => {
-            query::evaluate_first(env, body, paths, (false, None), nil, flat_keys, cache)
-        }
+        PathSource::Coalesce(paths) => query::evaluate_first(
+            env,
+            body,
+            paths,
+            query::ResolveOptions::NONE,
+            nil,
+            flat_keys,
+            cache,
+        ),
         PathSource::FromOutput(idx) => {
             let v = output_values[*idx];
             if v != nil {
@@ -263,46 +268,24 @@ fn resolve_value<'a>(
     flat_keys: bool,
     cache: &mut query::QueryCache<'a>,
 ) -> Term<'a> {
-    let skip_empty = field.field_type == FieldType::String;
+    let options = query::ResolveOptions {
+        skip_empty_strings: field.field_type == FieldType::String,
+        string_filters: field.filters.as_ref(),
+        strict_uint: field.strict_uint,
+    };
 
     match &field.path_source {
         PathSource::Root => body,
         PathSource::Single(path) => {
             let v = query::evaluate(env, body, path, nil, flat_keys, cache);
-            if v == nil {
+            if v == nil || !options.accepts(v) {
                 coerce::encode_default(env, &field.default, nil)
-            } else if skip_empty {
-                // Check binary length without allocating a String
-                if let Ok(b) = v.decode::<Binary>() {
-                    if b.is_empty() {
-                        coerce::encode_default(env, &field.default, nil)
-                    } else if let Some(ref f) = field.filters {
-                        if !string_filters::passes_filters(b.as_slice(), f) {
-                            coerce::encode_default(env, &field.default, nil)
-                        } else {
-                            v
-                        }
-                    } else {
-                        v
-                    }
-                } else {
-                    v
-                }
             } else {
                 v
             }
         }
         PathSource::Coalesce(paths) => {
-            let string_filters = field.filters.as_ref();
-            let result = query::evaluate_first(
-                env,
-                body,
-                paths,
-                (skip_empty, string_filters),
-                nil,
-                flat_keys,
-                cache,
-            );
+            let result = query::evaluate_first(env, body, paths, options, nil, flat_keys, cache);
             if result == nil {
                 coerce::encode_default(env, &field.default, nil)
             } else {
@@ -452,7 +435,7 @@ fn build_pick_map<'a>(
             env,
             body,
             &entry.paths,
-            (false, None),
+            query::ResolveOptions::NONE,
             nil,
             flat_keys,
             cache,

--- a/native/mapper_ex/src/mapper.rs
+++ b/native/mapper_ex/src/mapper.rs
@@ -275,7 +275,13 @@ fn resolve_value<'a>(
     };
 
     match &field.path_source {
-        PathSource::Root => body,
+        PathSource::Root => {
+            if options.accepts(body) {
+                body
+            } else {
+                coerce::encode_default(env, &field.default, nil)
+            }
+        }
         PathSource::Single(path) => {
             let v = query::evaluate(env, body, path, nil, flat_keys, cache);
             if v == nil || !options.accepts(v) {

--- a/native/mapper_ex/src/mapping.rs
+++ b/native/mapper_ex/src/mapping.rs
@@ -43,6 +43,9 @@ pub struct CompiledField {
     /// When true, a resolved pick map is unioned over the path/paths value
     /// (pick winning on collision) instead of replacing it.
     pub pick_merge: bool,
+    /// When true (`coercion: :strict` on a uint field), only integer terms and
+    /// binaries holding an integer resolve; floats and booleans are unresolved.
+    pub strict_uint: bool,
     pub enum8_data: Option<Enum8Data>,
     pub filter_nil: bool,
     pub flat_map_value_type: FlatMapValueType,
@@ -394,6 +397,7 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
     let elevate_keys = decode_string_list_bytes(env, field, "elevate_keys");
     let pick = decode_pick(env, field)?;
     let pick_merge = decode_pick_merge(env, field)?;
+    let strict_uint = decode_coercion(env, field, &field_type)?;
 
     let enum8_data = if matches!(field_type, FieldType::Enum8 { .. }) {
         Some(decode_enum8_data(env, field)?)
@@ -418,6 +422,7 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
         elevate_keys,
         pick,
         pick_merge,
+        strict_uint,
         enum8_data,
         filter_nil,
         flat_map_value_type,
@@ -630,6 +635,27 @@ fn decode_pick_merge<'a>(env: Env<'a>, field: Term<'a>) -> Result<bool, String> 
         Some("merge") => Ok(true),
         Some(other) => Err(format!(
             "pick_mode must be \"replace\" or \"merge\", got {:?}",
+            other
+        )),
+    }
+}
+
+fn decode_coercion<'a>(
+    env: Env<'a>,
+    field: Term<'a>,
+    field_type: &FieldType,
+) -> Result<bool, String> {
+    match get_string_key(env, field, "coercion")?.as_deref() {
+        None | Some("lenient") => Ok(false),
+        Some("strict") => match field_type {
+            FieldType::UInt8 | FieldType::UInt32 | FieldType::UInt64 => Ok(true),
+            _ => Err(
+                "coercion \"strict\" is only supported on uint8, uint32, and uint64 fields"
+                    .to_string(),
+            ),
+        },
+        Some(other) => Err(format!(
+            "coercion must be \"lenient\" or \"strict\", got {:?}",
             other
         )),
     }

--- a/native/mapper_ex/src/mapping.rs
+++ b/native/mapper_ex/src/mapping.rs
@@ -398,6 +398,14 @@ fn decode_field<'a>(env: Env<'a>, field: Term<'a>) -> Result<CompiledField, Stri
     let pick = decode_pick(env, field)?;
     let pick_merge = decode_pick_merge(env, field)?;
     let strict_uint = decode_coercion(env, field, &field_type)?;
+    if strict_uint && !value_map.is_empty() {
+        return Err(
+            "coercion \"strict\" cannot be combined with value_map: the map's string keys \
+             would never pass the integer check, so the field would always resolve to its \
+             default"
+                .to_string(),
+        );
+    }
 
     let enum8_data = if matches!(field_type, FieldType::Enum8 { .. }) {
         Some(decode_enum8_data(env, field)?)

--- a/native/mapper_ex/src/query.rs
+++ b/native/mapper_ex/src/query.rs
@@ -4,8 +4,53 @@ use rustler::types::map::MapIterator;
 use rustler::types::ListIterator;
 use rustler::{Binary, Encoder, Env, Term};
 
+use crate::coerce;
 use crate::path::{CompiledPath, PathSegment};
 use crate::string_filters::{self, StringFilters};
+
+/// Per-field acceptance rules applied to each candidate value while resolving a
+/// field. A candidate that fails is skipped as if its path had not resolved, so
+/// coalesce continues to the next path and the field default applies at the end.
+#[derive(Clone, Copy)]
+pub struct ResolveOptions<'f> {
+    /// String fields skip empty binaries.
+    pub skip_empty_strings: bool,
+    /// String fields may additionally require the value to pass length/char-class filters.
+    pub string_filters: Option<&'f StringFilters>,
+    /// Unsigned integer fields with `coercion: :strict` only accept integer terms
+    /// (or binaries holding one); floats and booleans are treated as unresolved.
+    pub strict_uint: bool,
+}
+
+impl ResolveOptions<'static> {
+    pub const NONE: Self = ResolveOptions {
+        skip_empty_strings: false,
+        string_filters: None,
+        strict_uint: false,
+    };
+}
+
+impl ResolveOptions<'_> {
+    #[inline]
+    pub fn accepts(&self, value: Term<'_>) -> bool {
+        if self.skip_empty_strings {
+            if let Ok(binary) = value.decode::<Binary>() {
+                if binary.is_empty() {
+                    return false;
+                }
+                if let Some(filters) = self.string_filters {
+                    if !string_filters::passes_filters(binary.as_slice(), filters) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if self.strict_uint && !coerce::is_integer_term(value) {
+            return false;
+        }
+        true
+    }
+}
 
 pub struct QueryCache<'a> {
     values: Vec<Option<Term<'a>>>,
@@ -268,36 +313,22 @@ fn evaluate_wildcard<'a>(
     results.encode(env)
 }
 
-/// Evaluates multiple paths against a document, returning the first
-/// non-nil result. For String field types, also skips empty strings.
-/// When filters are provided, resolved strings must pass all filters.
+/// Evaluates multiple paths against a document, returning the first non-nil
+/// result that passes `options` (see `ResolveOptions`).
 #[inline]
 pub fn evaluate_first<'a>(
     env: Env<'a>,
     document: Term<'a>,
     paths: &[CompiledPath],
-    string_options: (bool, Option<&StringFilters>),
+    options: ResolveOptions<'_>,
     nil: Term<'a>,
     flat_keys: bool,
     cache: &mut QueryCache<'a>,
 ) -> Term<'a> {
-    let (skip_empty_strings, filters) = string_options;
     for path in paths {
         let result = evaluate(env, document, path, nil, flat_keys, cache);
-        if result == nil {
+        if result == nil || !options.accepts(result) {
             continue;
-        }
-        if skip_empty_strings {
-            if let Ok(binary) = result.decode::<Binary>() {
-                if binary.is_empty() {
-                    continue;
-                }
-                if let Some(filters) = filters {
-                    if !string_filters::passes_filters(binary.as_slice(), filters) {
-                        continue;
-                    }
-                }
-            }
         }
         return result;
     }

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapper_output_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapper_output_test.exs
@@ -35,6 +35,28 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MapperOutputTest do
     assert_fused_matches_separate(event, :log)
   end
 
+  test "a severity_number outside the OTEL range falls back to the severity_text mapping" do
+    event = raw_event(:log, %{})
+
+    assert encoded_severity_number(event, severity_body(300)) == 9
+    assert encoded_severity_number(event, severity_body(25)) == 9
+  end
+
+  test "a severity_number within the OTEL range wins over the severity_text mapping" do
+    event = raw_event(:log, %{})
+
+    assert encoded_severity_number(event, severity_body(1)) == 1
+    assert encoded_severity_number(event, severity_body(13)) == 13
+    assert encoded_severity_number(event, severity_body(24)) == 24
+  end
+
+  test "an unspecified severity_number falls back to the severity_text mapping" do
+    event = raw_event(:log, %{})
+
+    assert encoded_severity_number(event, severity_body()) == 9
+    assert encoded_severity_number(event, severity_body(0)) == 9
+  end
+
   test "fused metric output is byte-identical for arrays, maps, and nullable times" do
     event =
       raw_event(:metric, %{
@@ -411,6 +433,33 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MapperOutputTest do
     assert Mapper.map(event.body, output_compiled, output_context: output_context) == expected
   end
 
+  defp severity_body(severity_number \\ nil) do
+    body = %{
+      "event_message" => "request failed",
+      "severity_text" => "info",
+      "timestamp" => 1_700_000_000_000_001
+    }
+
+    if severity_number, do: Map.put(body, "severity_number", severity_number), else: body
+  end
+
+  defp encoded_severity_number(event, body) do
+    [_prefix, <<severity::unsigned-8, _rest::binary>>] =
+      event
+      |> fused_log_row(body)
+      |> :binary.split(<<4, "INFO">>)
+
+    severity
+  end
+
+  defp fused_log_row(event, body) do
+    compiled = Mapper.compile!(MappingDefaults.for_log())
+    config_id = encoded_config_id(:log)
+    output_context = OutputContext.clickhouse_row_binary(%{event | body: body}, config_id)
+
+    Mapper.map(body, compiled, output_context: output_context)
+  end
+
   defp compile_map_output(event_type) do
     config = MappingDefaults.for_type(event_type)
     Mapper.compile!(%{config | output: nil})
@@ -446,7 +495,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MapperOutputTest do
   defp maybe_compute_duration(body, _event_type), do: body
 
   defp resolve_severity_number(%{"severity_number_alt" => alt} = body, :log)
-       when is_integer(alt) and alt > 0 do
+       when is_integer(alt) and alt in 1..24 do
     %{body | "severity_number" => alt}
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapper_output_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapper_output_test.exs
@@ -57,6 +57,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MapperOutputTest do
     assert encoded_severity_number(event, severity_body(0)) == 9
   end
 
+  test "a non-integer severity_number falls back to the severity_text mapping" do
+    event = raw_event(:log, %{})
+
+    assert encoded_severity_number(event, severity_body(true)) == 9
+    assert encoded_severity_number(event, severity_body(13.9)) == 9
+    assert encoded_severity_number(event, severity_body("ERROR")) == 9
+  end
+
+  test "a string severity_number holding an OTEL integer is accepted" do
+    event = raw_event(:log, %{})
+
+    assert encoded_severity_number(event, severity_body("13")) == 13
+  end
+
   test "fused metric output is byte-identical for arrays, maps, and nullable times" do
     event =
       raw_event(:metric, %{

--- a/test/logflare/mapper/mapping_config_test.exs
+++ b/test/logflare/mapper/mapping_config_test.exs
@@ -155,6 +155,20 @@ defmodule Logflare.Mapper.MappingConfigTest do
       assert Field.json("attrs", pick_mode: "replace").pick_mode == nil
     end
 
+    test "coercion option accepts the atom or string form on unsigned integer fields" do
+      for mode <- [:strict, "strict"] do
+        assert Field.uint8("val", coercion: mode).coercion == "strict"
+        assert Field.uint32("val", coercion: mode).coercion == "strict"
+        assert Field.uint64("val", coercion: mode).coercion == "strict"
+      end
+    end
+
+    test "coercion defaults to nil, and :lenient is stored as nil" do
+      assert Field.uint8("val", path: "$.val").coercion == nil
+      assert Field.uint8("val", coercion: :lenient).coercion == nil
+      assert Field.uint8("val", coercion: "lenient").coercion == nil
+    end
+
     test "flat_map/2 with exclude and elevate keys" do
       field =
         Field.flat_map("log_attributes",
@@ -334,6 +348,25 @@ defmodule Logflare.Mapper.MappingConfigTest do
       assert Mapper.map(document, Mapper.compile!(restored)) == expected
     end
 
+    test "round-trip preserves coercion" do
+      config =
+        MappingConfig.new([
+          Field.uint8("val", path: "$.val", coercion: :strict, default: 99)
+        ])
+
+      assert {:ok, json} = MappingConfig.to_json(config)
+      assert {:ok, restored} = MappingConfig.from_json(json)
+
+      [field] = restored.fields
+      assert field.coercion == "strict"
+
+      document = %{"val" => true}
+      expected = %{"val" => 99}
+
+      assert Mapper.map(document, Mapper.compile!(config)) == expected
+      assert Mapper.map(document, Mapper.compile!(restored)) == expected
+    end
+
     test "round-trip preserves infer rules" do
       config =
         MappingConfig.new([
@@ -418,6 +451,20 @@ defmodule Logflare.Mapper.MappingConfigTest do
       json = Jason.encode!(%{"fields" => [%{"type" => "string"}]})
 
       assert {:error, %Ecto.Changeset{}} = MappingConfig.from_json(json)
+    end
+
+    test "from_json/1 rejects an unknown coercion value" do
+      json =
+        Jason.encode!(%{
+          "fields" => [
+            %{"name" => "val", "type" => "uint8", "path" => "$.val", "coercion" => "bogus"}
+          ]
+        })
+
+      assert {:error, %Ecto.Changeset{} = changeset} = MappingConfig.from_json(json)
+
+      assert [%Ecto.Changeset{errors: [coercion: {"is invalid", _}]}] =
+               Ecto.Changeset.get_change(changeset, :fields)
     end
 
     test "from_json/1 validates the output format" do

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -225,6 +225,116 @@ defmodule Logflare.MapperTest do
     end
   end
 
+  describe "type coercion: strict unsigned integers" do
+    test "accepts an integer term" do
+      result =
+        compile_and_map(
+          [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)],
+          %{"val" => 17}
+        )
+
+      assert result["val"] == 17
+    end
+
+    test "accepts a string holding an unsigned integer" do
+      result =
+        compile_and_map(
+          [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)],
+          %{"val" => "17"}
+        )
+
+      assert result["val"] == 17
+    end
+
+    test "still clamps out-of-range integers in either form" do
+      fields = [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)]
+
+      assert compile_and_map(fields, %{"val" => 300}) == %{"val" => 255}
+      assert compile_and_map(fields, %{"val" => -5}) == %{"val" => 0}
+      assert compile_and_map(fields, %{"val" => "-5"}) == %{"val" => 0}
+    end
+
+    test "treats a float as unresolved and uses the default" do
+      result =
+        compile_and_map(
+          [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)],
+          %{"val" => 13.9}
+        )
+
+      assert result["val"] == 99
+    end
+
+    test "treats a boolean as unresolved and uses the default" do
+      for bool <- [true, false] do
+        result =
+          compile_and_map(
+            [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)],
+            %{"val" => bool}
+          )
+
+        assert result["val"] == 99
+      end
+    end
+
+    test "treats a non-numeric string as unresolved and uses the default" do
+      for str <- ["ERROR", "13.9", ""] do
+        result =
+          compile_and_map(
+            [Field.uint8("val", path: "$.val", coercion: :strict, default: 99)],
+            %{"val" => str}
+          )
+
+        assert result["val"] == 99, "expected #{inspect(str)} to be unresolved"
+      end
+    end
+
+    test "coalesce skips a non-integer term and continues to the next path" do
+      result =
+        compile_and_map(
+          [Field.uint8("val", paths: ["$.a", "$.b"], coercion: :strict, default: 99)],
+          %{"a" => true, "b" => 7}
+        )
+
+      assert result["val"] == 7
+    end
+
+    test "applies to uint32 and uint64 as well" do
+      fields = [
+        Field.uint32("u32", path: "$.val", coercion: :strict, default: 1),
+        Field.uint64("u64", path: "$.val", coercion: :strict, default: 2)
+      ]
+
+      assert compile_and_map(fields, %{"val" => 4.2}) == %{"u32" => 1, "u64" => 2}
+      assert compile_and_map(fields, %{"val" => 42}) == %{"u32" => 42, "u64" => 42}
+    end
+
+    test "lenient coercion remains the default and keeps truncating floats and booleans" do
+      fields = [Field.uint8("val", path: "$.val", default: 99)]
+
+      assert compile_and_map(fields, %{"val" => 13.9}) == %{"val" => 13}
+      assert compile_and_map(fields, %{"val" => true}) == %{"val" => 1}
+      assert compile_and_map(fields, %{"val" => "ERROR"}) == %{"val" => 0}
+    end
+
+    test "compile rejects strict coercion on a non-unsigned-integer field" do
+      for field <- [
+            %Field{name: "s", type: "string", path: "$.s", coercion: "strict"},
+            %Field{name: "f", type: "float64", path: "$.f", coercion: "strict"},
+            %Field{name: "i", type: "int32", path: "$.i", coercion: "strict"}
+          ] do
+        assert {:error, reason} = Mapper.compile(MappingConfig.new([field]))
+        assert reason =~ "coercion \"strict\" is only supported on uint8, uint32, and uint64"
+      end
+    end
+
+    test "compile rejects an unknown coercion value" do
+      field = %Field{name: "val", type: "uint8", path: "$.val", coercion: "bogus"}
+
+      assert {:error, reason} = Mapper.compile(MappingConfig.new([field]))
+      assert reason =~ "coercion must be \"lenient\" or \"strict\""
+    end
+  end
+
   describe "type coercion: float64" do
     test "float pass-through" do
       result =

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -308,6 +308,22 @@ defmodule Logflare.MapperTest do
       assert compile_and_map(fields, %{"val" => 42}) == %{"u32" => 42, "u64" => 42}
     end
 
+    test "applies to from_output sources as well" do
+      fields = [
+        Field.bool("flag", path: "$.flag"),
+        Field.string("text", path: "$.text"),
+        Field.uint8("from_flag", from_output: "flag", coercion: :strict, default: 99),
+        Field.uint8("from_text", from_output: "text", coercion: :strict, default: 99)
+      ]
+
+      result = compile_and_map(fields, %{"flag" => true, "text" => "17"})
+      assert result["from_flag"] == 99
+      assert result["from_text"] == 17
+
+      result = compile_and_map(fields, %{"flag" => true, "text" => "ERROR"})
+      assert result["from_text"] == 99
+    end
+
     test "lenient coercion remains the default and keeps truncating floats and booleans" do
       fields = [Field.uint8("val", path: "$.val", default: 99)]
 
@@ -325,6 +341,22 @@ defmodule Logflare.MapperTest do
         assert {:error, reason} = Mapper.compile(MappingConfig.new([field]))
         assert reason =~ "coercion \"strict\" is only supported on uint8, uint32, and uint64"
       end
+    end
+
+    test "compile rejects strict coercion combined with value_map" do
+      config =
+        MappingConfig.new([
+          Field.string("severity_text", path: "$.level"),
+          Field.uint8("severity_number",
+            from_output: "severity_text",
+            coercion: :strict,
+            value_map: %{"ERROR" => 17},
+            default: 0
+          )
+        ])
+
+      assert {:error, reason} = Mapper.compile(config)
+      assert reason =~ "coercion \"strict\" cannot be combined with value_map"
     end
 
     test "compile rejects an unknown coercion value" do

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -214,6 +214,48 @@ defmodule Logflare.MapperTest do
       assert result["val"] == 2_147_483_647
     end
 
+    test "uint64 accepts integers above i64 max" do
+      fields = [Field.uint64("val", path: "$.val")]
+      above_i64 = Integer.pow(2, 63) + 1
+      u64_max = Integer.pow(2, 64) - 1
+
+      assert compile_and_map(fields, %{"val" => above_i64}) == %{"val" => above_i64}
+      assert compile_and_map(fields, %{"val" => u64_max}) == %{"val" => u64_max}
+    end
+
+    test "integers beyond u64 saturate by sign instead of collapsing to zero" do
+      huge = Integer.pow(2, 70)
+      u64_max = Integer.pow(2, 64) - 1
+
+      assert compile_and_map([Field.uint64("val", path: "$.val")], %{"val" => huge}) ==
+               %{"val" => u64_max}
+
+      assert compile_and_map([Field.uint8("val", path: "$.val")], %{"val" => huge}) ==
+               %{"val" => 255}
+
+      assert compile_and_map([Field.uint64("val", path: "$.val")], %{"val" => -huge}) ==
+               %{"val" => 0}
+    end
+
+    test "numeric strings above i64 max parse and overflowing strings saturate" do
+      u64_max = Integer.pow(2, 64) - 1
+
+      assert compile_and_map(
+               [Field.uint64("val", path: "$.val")],
+               %{"val" => Integer.to_string(u64_max)}
+             ) == %{"val" => u64_max}
+
+      assert compile_and_map(
+               [Field.uint64("val", path: "$.val")],
+               %{"val" => "99999999999999999999"}
+             ) == %{"val" => u64_max}
+
+      assert compile_and_map(
+               [Field.uint8("val", path: "$.val")],
+               %{"val" => "99999999999999999999"}
+             ) == %{"val" => 255}
+    end
+
     test "float truncation to uint" do
       result =
         compile_and_map(
@@ -306,6 +348,31 @@ defmodule Logflare.MapperTest do
 
       assert compile_and_map(fields, %{"val" => 4.2}) == %{"u32" => 1, "u64" => 2}
       assert compile_and_map(fields, %{"val" => 42}) == %{"u32" => 42, "u64" => 42}
+    end
+
+    test "accepts integers of any magnitude and saturates them" do
+      fields = [Field.uint64("val", path: "$.val", coercion: :strict, default: 7)]
+      above_i64 = Integer.pow(2, 63) + 1
+      u64_max = Integer.pow(2, 64) - 1
+
+      assert compile_and_map(fields, %{"val" => above_i64}) == %{"val" => above_i64}
+      assert compile_and_map(fields, %{"val" => Integer.pow(2, 70)}) == %{"val" => u64_max}
+
+      assert compile_and_map(fields, %{"val" => Integer.to_string(u64_max)}) == %{
+               "val" => u64_max
+             }
+
+      assert compile_and_map(fields, %{"val" => "99999999999999999999"}) == %{"val" => u64_max}
+    end
+
+    test "applies to the root path as well" do
+      result =
+        compile_and_map(
+          [Field.uint8("val", path: "$", coercion: :strict, default: 7)],
+          %{"x" => 1}
+        )
+
+      assert result["val"] == 7
     end
 
     test "applies to from_output sources as well" do

--- a/test/support/clickhouse_mapped_events.ex
+++ b/test/support/clickhouse_mapped_events.ex
@@ -156,7 +156,7 @@ defmodule Logflare.ClickHouseMappedEvents do
   @spec deep_merge_opts(map(), map()) :: map()
   @spec resolve_severity_number(map()) :: map()
   defp resolve_severity_number(%{"severity_number_alt" => alt} = body)
-       when is_integer(alt) and alt > 0 do
+       when is_integer(alt) and alt in 1..24 do
     %{body | "severity_number" => alt}
   end
 


### PR DESCRIPTION
## Overview

A `severity_number` supplied on an incoming payload could be written to the column even when it wasn't a valid OTEL severity. Found while investigating O11Y-1377 — the existing severity resolution turned out to be sound, but probing it surfaced this clamping bug.

### Key Changes

- The RowBinary encoder now treats a supplied `severity_number` as a severity only when it falls inside the OTEL `SeverityNumber` range, instead of accepting any non-zero value
- Added a `coercion: :strict` option to `uint8`/`uint32`/`uint64` fields in the mapper. `:strict` only accepts an integer term or a string holding one; floats and booleans are treated as unresolved so coalesce moves on and the field default applies. `:lenient` stays the default and is unchanged
  - `severity_number_alt` now uses `coercion: :strict`. Without it `true` coerced to `1` and `13.9` to `13` before the encoder ever saw them, so both passed the range guard as valid severities
  - Applies to `from_output` sources too. Combining `:strict` with a string-keyed `value_map` is rejected at compile time, since resolution runs before the map is applied and the string keys could never pass the integer check
- Out-of-range values fall back to the `severity_text` mapping, which is what a log carrying a foreign severity scale should resolve to
- Updated the three copies of the severity collapse rule used by the test and benchmark harnesses, so fused-vs-separate encoder parity still holds
- Added coverage asserting the encoded severity byte directly (_the existing parity tests compare two implementations of the same rule, so they could never catch this_)
- `uint` fields now saturate integers above `i64::MAX` instead of coercing them to 0. Valid `uint64` values in the upper half of the range were previously lost.


### Risks / Considerations

- `severity_number_alt` is a `uint8`, so `coerce_uint` saturated anything above 255 down to 255 and passed 25-255 through untouched. A payload carrying `severity_number: 300` stored 255; one carrying 30 stored 30. Both now resolve from `severity_text`.
- Behavior for 1-24 is unchanged, and 0 keeps falling through to the text mapping — that matches `SEVERITY_NUMBER_UNSPECIFIED`.
- Rows already written with an out-of-range severity are not corrected by this; it only affects new ingest.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
