### PR TITLE
fix: build the rules tree and its rule lookup from one snapshot

### DIFF
--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -48,9 +48,17 @@ defmodule Logflare.Rules do
     where(query, [r], r.backend_id == ^backend_id)
   end
 
+  @doc """
+  Returns the routing snapshot for a source: the rules tree, and a lookup of the
+  rules it was built from keyed by rule id.
+
+  Both halves come from one `list_by_source_id/1` read, so every rule id in the
+  tree resolves to a rule in the lookup.
+  """
+  @spec rules_tree_by_source_id(integer()) :: {RulesTree.t(), %{Rule.id() => Rule.t()}}
   def rules_tree_by_source_id(id) do
     rules = list_by_source_id(id)
-    RulesTree.build(rules)
+    {RulesTree.build(rules), Map.new(rules, &{&1.id, &1})}
   end
 
   @doc """

--- a/lib/logflare/rules/cache.ex
+++ b/lib/logflare/rules/cache.ex
@@ -43,12 +43,6 @@ defmodule Logflare.Rules.Cache do
 
   def get_rule(id), do: apply_repo_fun(__ENV__.function, [id])
 
-  def get_rules(ids) do
-    Cachex.execute!(__MODULE__, fn cache ->
-      Enum.map(ids, &fetch_rule(cache, &1))
-    end)
-  end
-
   def list_by_source_id(id), do: apply_repo_fun(__ENV__.function, [id])
   def list_by_backend_id(id), do: apply_repo_fun(__ENV__.function, [id])
 
@@ -74,10 +68,6 @@ defmodule Logflare.Rules.Cache do
         acc + delete_and_count(worker, k)
       end)
     end)
-  end
-
-  defp fetch_rule(cache, id) do
-    ContextCache.fetch(cache, {:get_rule, [id]}, fn -> Rules.get_rule(id) end)
   end
 
   defp delete_and_count(cache, key) do

--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -24,11 +24,12 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
 
   @impl true
   def matching_rules(event, source) do
-    rule_set = Rules.Cache.rules_tree_by_source_id(source.id)
+    {rule_set, rules_by_id} = Rules.Cache.rules_tree_by_source_id(source.id)
 
-    matching_rule_ids(event, rule_set)
-    |> Rules.Cache.get_rules()
-    |> Enum.reject(&is_nil/1)
+    for id <- matching_rule_ids(event, rule_set),
+        rule = Map.get(rules_by_id, id) do
+      rule
+    end
   end
 
   @doc """

--- a/test/logflare/rules/rule_cache_test.exs
+++ b/test/logflare/rules/rule_cache_test.exs
@@ -18,24 +18,29 @@ defmodule Logflare.Rules.CacheTest do
   end
 
   describe "rules cache" do
-    test "get rules", %{rule_ids: rule_ids} do
-      assert rules = @subject.get_rules(rule_ids)
+    test "get rule", %{rule_ids: [rid1, _rid2]} do
+      assert %Rule{id: ^rid1} = @subject.get_rule(rid1)
 
-      for %Rule{id: id} <- rules do
-        assert id in rule_ids
-      end
-
-      assert Cachex.size!(@subject) == 2
-      assert %{hits: 0, writes: 2} = Cachex.stats!(@subject)
+      assert Cachex.size!(@subject) == 1
+      assert %{hits: 0, writes: 1} = Cachex.stats!(@subject)
 
       Mimic.reject(Rules, :get_rule, 1)
 
-      assert [_r1, _r2] = @subject.get_rules(rule_ids)
-      assert %{hits: 2, writes: 2} = Cachex.stats!(@subject)
-
-      [rid1, _rid2] = rule_ids
       assert %Rule{id: ^rid1} = @subject.get_rule(rid1)
-      assert %{hits: 3, writes: 2} = Cachex.stats!(@subject)
+      assert %{hits: 1, writes: 1} = Cachex.stats!(@subject)
+    end
+
+    test "rules tree by source id caches the tree with its rules", %{
+      source: source,
+      rule_ids: rule_ids
+    } do
+      assert {_tree, rules_by_id} = @subject.rules_tree_by_source_id(source.id)
+
+      assert Enum.sort(Map.keys(rules_by_id)) == Enum.sort(rule_ids)
+
+      for {id, %Rule{id: rule_id}} <- rules_by_id do
+        assert id == rule_id
+      end
     end
 
     test "list by source", %{source: source, rule_ids: expected_rule_ids} do

--- a/test/logflare/sources/source_router/rules_tree_test.exs
+++ b/test/logflare/sources/source_router/rules_tree_test.exs
@@ -408,10 +408,25 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
       assert [%Rule{}] = @subject.matching_rules(le, source)
     end
 
-    test "drops matched ids whose rule no longer exists", %{source: source, log_event: le} do
-      stub(Rules, :get_rule, fn _id -> nil end)
+    test "drops matched ids missing from the snapshot", %{source: source, log_event: le} do
+      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
 
       assert @subject.matching_rules(le, source) == []
+    end
+
+    test "the snapshot resolves every rule id its tree can match", %{
+      source: source,
+      log_event: le
+    } do
+      {tree, rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      assert [_ | _] = ids = @subject.matching_rule_ids(le, tree)
+
+      for id <- ids do
+        assert Map.has_key?(rules_by_id, id)
+      end
     end
   end
 

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -760,12 +760,17 @@ defmodule Logflare.Sources.SourceRouterTest do
   end
 
   describe "RulesTree with an unresolvable rule id" do
-    test "does not raise when a matched rule no longer exists", %{user: user, backend: backend} do
+    test "does not raise when a matched id is missing from the snapshot", %{
+      user: user,
+      backend: backend
+    } do
       rule = build(:rule, backend: backend, lql_string: "testing")
       source = insert(:source, user: user, rules: [rule])
       le = build(:log_event, source: source, message: "testing123")
 
-      expect(Rules, :get_rule, fn _id -> nil end)
+      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
 
       assert SourceRouter.route_to_sinks_and_ingest(le, source, SourceRouter.RulesTree) == le
     end

--- a/test/profiling/source_routing_bench.exs
+++ b/test/profiling/source_routing_bench.exs
@@ -115,9 +115,8 @@ all_matching = fn rules_num ->
 end
 
 warmup = fn source ->
-  rules = Rules.Cache.list_rules(source)
-  for rule <- rules, do: Rules.Cache.get_rule(rule.id)
-  _rule_set = Rules.Cache.rules_tree_by_source_id(source.id)
+  Rules.Cache.list_rules(source)
+  Rules.Cache.rules_tree_by_source_id(source.id)
 end
 
 Benchee.run(


### PR DESCRIPTION
> **GitHub stack #3939** — this PR sits on top of #3935, so the diff below is its own. Merge #3935 first; GitHub retargets this to `main`.

#3935 stops the crash. This PR removes the condition that caused it.

## The condition

`RulesTree.matching_rules/2` is a two-step lookup. The tree stores bare rule **ids**, and `Rules.Cache.get_rules/1` resolves each id to a `Rule`. The two steps read different databases:

| read | path | source |
|---|---|---|
| `rules_tree_by_source_id/1` | `ContextCache.apply_fun/3` → `Repo.apply_with_replica/3` | a randomly picked **read replica** |
| `get_rules/1` | `ContextCache.fetch/3` → `Rules.get_rule/1` called directly | the **primary** |

`Rules.Cache.get_rule/1` (singular) *does* go through the replica. Only the plural bypassed it.

So after a rule delete commits on the primary, a tree rebuilt from a lagging replica still carries the dead id, and resolving that id against the primary returns `nil`. Every node reads the same small replica pool, which is why four clusters failed within the same second.

## The change

`Rules.rules_tree_by_source_id/1` already reads the rules it builds the tree from, then throws them away:

```elixir
def rules_tree_by_source_id(id) do
  rules = list_by_source_id(id)
  RulesTree.build(rules)          # keeps ids only
end
```

Keep them, in the same cache entry:

```elixir
def rules_tree_by_source_id(id) do
  rules = list_by_source_id(id)
  {RulesTree.build(rules), Map.new(rules, &{&1.id, &1})}
end
```

```elixir
def matching_rules(event, source) do
  {rule_set, rules_by_id} = Rules.Cache.rules_tree_by_source_id(source.id)

  for id <- matching_rule_ids(event, rule_set),
      rule = Map.get(rules_by_id, id) do
    rule
  end
end
```

One query, one cache entry, one bust. An id the tree can match always resolves, so the `nil` class is gone by construction rather than filtered after the fact.

This also drops `Rules.Cache.get_rules/1` and its private `fetch_rule/2` — the tree was their only caller.

## Why the cached value shape is safe to change

`CacheBuster` only ever emits keyword lists for `Rules` (`handle_rule_record/1` always returns one), so `Rules.Cache.bust_by/1` is the only bust path. The generic primary-key matchspec in `ContextCache.bust_key/1` is not involved.

## Tests

```
mix test test/logflare/rules_test.exs \
         test/logflare/rules/rule_cache_test.exs \
         test/logflare/sources/source_router/rules_tree_test.exs \
         test/logflare/sources/source_router_test.exs \
         test/logflare/backends/spool/consumer_pipeline_test.exs
Result: 89 passed, 1 excluded
```

- The two tests that stubbed `Rules.get_rule/1` now stub the snapshot instead.
- New: the snapshot resolves every rule id its own tree can match.
- `rule_cache_test.exs` "get rules" becomes a `get_rule/1` caching test.
- The profiling bench drops its now-dead per-rule warmup.

## Note on `matching_rule_ids/2`

Unchanged, along with all its tests. The tree format and the matching algorithm are untouched — only what the cache stores beside the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kMNrQA6RgNdnjwA2QQuhf
