### PR TITLE
perf: preserve routing snapshots without copying unmatched rules

### DIFF
--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -52,7 +52,10 @@ defmodule Logflare.ContextCache.Supervisor do
         buster_specs()
       end
 
-    [Rules.RoutingSnapshotStore] ++
+    routing_snapshot_store =
+      {Rules.RoutingSnapshotStore, Application.get_env(:logflare, Rules.RoutingSnapshotStore, [])}
+
+    [routing_snapshot_store] ++
       caches ++
       List.wrap(maybe_transaction_broadcaster) ++
       List.wrap(maybe_cainophile) ++

--- a/lib/logflare/context_cache/supervisor.ex
+++ b/lib/logflare/context_cache/supervisor.ex
@@ -52,7 +52,8 @@ defmodule Logflare.ContextCache.Supervisor do
         buster_specs()
       end
 
-    caches ++
+    [Rules.RoutingSnapshotStore] ++
+      caches ++
       List.wrap(maybe_transaction_broadcaster) ++
       List.wrap(maybe_cainophile) ++
       List.wrap(maybe_busters)

--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -48,9 +48,17 @@ defmodule Logflare.Rules do
     where(query, [r], r.backend_id == ^backend_id)
   end
 
+  @doc """
+  Returns the routing snapshot for a source: the rules tree, and a lookup of the
+  rules it was built from keyed by rule id.
+
+  Both halves come from one `list_by_source_id/1` read, so every rule id in the
+  tree resolves to a rule in the lookup.
+  """
+  @spec rules_tree_by_source_id(integer()) :: {RulesTree.t(), %{Rule.id() => Rule.t()}}
   def rules_tree_by_source_id(id) do
     rules = list_by_source_id(id)
-    RulesTree.build(rules)
+    {RulesTree.build(rules), Map.new(rules, &{&1.id, &1})}
   end
 
   @doc """

--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -6,7 +6,7 @@ defmodule Logflare.Rules do
   alias Logflare.Repo
   alias Logflare.Rules.Rule
   alias Logflare.Sources.Source
-  alias Logflare.Sources.SourceRouter.RulesTree
+  alias Logflare.Sources.SourceRouter.{RulesTree, Target}
   alias Logflare.SourceSchemas
   alias Logflare.Backends.Backend
   alias Logflare.Backends.SourceSup
@@ -49,16 +49,22 @@ defmodule Logflare.Rules do
   end
 
   @doc """
-  Returns the routing snapshot for a source: the rules tree, and a lookup of the
-  rules it was built from keyed by rule id.
+  Returns a routing tree and its ordered compact routing targets.
 
-  Both halves come from one `list_by_source_id/1` read, so every rule id in the
-  tree resolves to a rule in the lookup.
+  Both halves come from one `list_by_source_id/1` read, so every rule ID in the
+  tree resolves to a target in the same immutable snapshot.
   """
-  @spec rules_tree_by_source_id(integer()) :: {RulesTree.t(), %{Rule.id() => Rule.t()}}
+  @spec rules_tree_by_source_id(integer()) ::
+          {RulesTree.t(), [{Rule.id(), Target.t()}]}
   def rules_tree_by_source_id(id) do
     rules = list_by_source_id(id)
-    {RulesTree.build(rules), Map.new(rules, &{&1.id, &1})}
+
+    targets =
+      rules
+      |> Enum.sort_by(& &1.id)
+      |> Enum.map(&{&1.id, Target.from_rule(&1)})
+
+    {RulesTree.build(rules), targets}
   end
 
   @doc """

--- a/lib/logflare/rules/cache.ex
+++ b/lib/logflare/rules/cache.ex
@@ -56,11 +56,65 @@ defmodule Logflare.Rules.Cache do
           {Logflare.Sources.SourceRouter.RulesTree.t(), Rules.RoutingSnapshot.t()}
   def rules_tree_by_source_id(id) do
     ContextCache.fetch(__MODULE__, {:rules_tree_by_source_id, [id]}, fn ->
-      {tree, rules_by_id} =
+      {tree, targets} =
         Logflare.Repo.apply_with_replica(Rules, :rules_tree_by_source_id, [id])
 
-      {tree, Rules.RoutingSnapshot.new(id, rules_by_id)}
+      snapshot =
+        Rules.RoutingSnapshot.new(id, targets, extra_estimated_bytes: :erlang.external_size(tree))
+
+      {tree, snapshot}
     end)
+  end
+
+  @doc false
+  @spec repair_routing_snapshot(integer(), Rules.RoutingSnapshot.t(), map()) ::
+          {:repaired, Rules.RoutingSnapshot.t()} | :stale | {:error, term()}
+  def repair_routing_snapshot(source_id, %Rules.RoutingSnapshot{} = snapshot, targets) do
+    cache_key = {:rules_tree_by_source_id, [source_id]}
+
+    try do
+      {:ok, result} =
+        Cachex.transaction(__MODULE__, [cache_key], fn cache ->
+          case Cachex.get(cache, cache_key) do
+            {:ok, {:cached, {tree, %Rules.RoutingSnapshot{key: key}}}}
+            when key == snapshot.key ->
+              replacement = Rules.RoutingSnapshot.rehydrate(snapshot, source_id, targets)
+              {:ok, true} = Cachex.put(cache, cache_key, {:cached, {tree, replacement}})
+              {:repaired, replacement}
+
+            _ ->
+              :stale
+          end
+        end)
+
+      result
+    catch
+      :exit, reason -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec delete_routing_snapshot({integer(), reference()}) :: :deleted | :stale
+  def delete_routing_snapshot({source_id, _generation} = snapshot_key) do
+    cache_key = {:rules_tree_by_source_id, [source_id]}
+
+    case Cachex.transaction(__MODULE__, [cache_key], fn cache ->
+           delete_routing_snapshot(cache, cache_key, snapshot_key)
+         end) do
+      {:ok, result} -> result
+      _ -> :stale
+    end
+  end
+
+  defp delete_routing_snapshot(cache, cache_key, snapshot_key) do
+    case Cachex.get(cache, cache_key) do
+      {:ok, {:cached, {_tree, %Rules.RoutingSnapshot{key: ^snapshot_key}}}} ->
+        Cachex.del(cache, cache_key)
+        :deleted
+
+      _ ->
+        :stale
+    end
   end
 
   @impl ContextCache

--- a/lib/logflare/rules/cache.ex
+++ b/lib/logflare/rules/cache.ex
@@ -52,7 +52,16 @@ defmodule Logflare.Rules.Cache do
   def list_by_source_id(id), do: apply_repo_fun(__ENV__.function, [id])
   def list_by_backend_id(id), do: apply_repo_fun(__ENV__.function, [id])
 
-  def rules_tree_by_source_id(id), do: apply_repo_fun(__ENV__.function, [id])
+  @spec rules_tree_by_source_id(integer()) ::
+          {Logflare.Sources.SourceRouter.RulesTree.t(), Rules.RoutingSnapshot.t()}
+  def rules_tree_by_source_id(id) do
+    ContextCache.fetch(__MODULE__, {:rules_tree_by_source_id, [id]}, fn ->
+      {tree, rules_by_id} =
+        Logflare.Repo.apply_with_replica(Rules, :rules_tree_by_source_id, [id])
+
+      {tree, Rules.RoutingSnapshot.new(id, rules_by_id)}
+    end)
+  end
 
   @impl ContextCache
   def bust_by(kw) do
@@ -82,8 +91,19 @@ defmodule Logflare.Rules.Cache do
 
   defp delete_and_count(cache, key) do
     case Cachex.take(cache, key) do
-      {:ok, nil} -> 0
-      {:ok, _value} -> 1
+      {:ok, nil} ->
+        0
+
+      {:ok, {:cached, {_tree, %Rules.RoutingSnapshot{} = snapshot}}} ->
+        Rules.RoutingSnapshotStore.delete(
+          Rules.RoutingSnapshotStore,
+          snapshot.key
+        )
+
+        1
+
+      {:ok, _value} ->
+        1
     end
   end
 

--- a/lib/logflare/rules/cache.ex
+++ b/lib/logflare/rules/cache.ex
@@ -73,24 +73,37 @@ defmodule Logflare.Rules.Cache do
     cache_key = {:rules_tree_by_source_id, [source_id]}
 
     try do
-      {:ok, result} =
-        Cachex.transaction(__MODULE__, [cache_key], fn cache ->
-          case Cachex.get(cache, cache_key) do
-            {:ok, {:cached, {tree, %Rules.RoutingSnapshot{key: key}}}}
-            when key == snapshot.key ->
-              replacement = Rules.RoutingSnapshot.rehydrate(snapshot, source_id, targets)
-              {:ok, true} = Cachex.put(cache, cache_key, {:cached, {tree, replacement}})
-              {:repaired, replacement}
-
-            _ ->
-              :stale
-          end
-        end)
-
-      result
+      case Cachex.transaction(__MODULE__, [cache_key], fn cache ->
+             repair_routing_snapshot(cache, source_id, snapshot, targets)
+           end) do
+        {:ok, result} -> result
+        {:error, reason} -> {:error, reason}
+      end
     catch
       :exit, reason -> {:error, reason}
     end
+  end
+
+  defp repair_routing_snapshot(cache, source_id, snapshot, targets) do
+    case Cachex.get(cache, {:rules_tree_by_source_id, [source_id]}) do
+      {:ok, {:cached, {tree, %Rules.RoutingSnapshot{key: key}}}}
+      when key == snapshot.key ->
+        replacement = Rules.RoutingSnapshot.rehydrate(snapshot, source_id, targets)
+
+        {:ok, true} =
+          Cachex.put(
+            cache,
+            {:rules_tree_by_source_id, [source_id]},
+            {:cached, {tree, replacement}}
+          )
+
+        {:repaired, replacement}
+
+      _ ->
+        :stale
+    end
+  catch
+    :exit, reason -> {:error, reason}
   end
 
   @doc false

--- a/lib/logflare/rules/routing_snapshot.ex
+++ b/lib/logflare/rules/routing_snapshot.ex
@@ -1,0 +1,113 @@
+defmodule Logflare.Rules.RoutingSnapshot do
+  @moduledoc """
+  Immutable rule storage for one routing-tree generation.
+
+  The hot cache header contains binary/table references rather than the full
+  rule map. A sorted binary index maps rule IDs to ETS tuple positions. Sparse
+  reads copy only the matched tuple elements; dense reads copy the whole tuple.
+  Every lookup uses the exact generation in the header.
+
+  The compressed map is a reader-owned fallback, not the normal lookup path. If
+  the backing store replaces, evicts or loses a generation, the reader decodes
+  its own immutable snapshot instead. The VM keeps this reference-counted binary
+  alive across cache invalidation and releases it on GC/process exit. Thus even
+  a suspended reader needs no lease, cleanup timer or retained ETS generation.
+
+  The tree and map must be constructed from the same database read before this
+  header is published. Encodings are internal, never user-supplied binaries.
+  """
+
+  alias Logflare.Rules.Rule
+  alias Logflare.Rules.RoutingSnapshotStore
+
+  @entry_bytes 8
+
+  @enforce_keys [:key, :table, :index, :encoded, :count]
+  defstruct [:key, :table, :index, :encoded, :count]
+
+  @type t() :: %__MODULE__{
+          key: {integer(), reference()},
+          table: :ets.tid(),
+          index: binary(),
+          encoded: binary(),
+          count: non_neg_integer()
+        }
+
+  @spec new(integer(), %{Rule.id() => Rule.t()}, GenServer.server()) :: t()
+  def new(source_id, rules_by_id, store \\ RoutingSnapshotStore) do
+    entries = Enum.sort_by(rules_by_id, &elem(&1, 0))
+    index = for {id, _rule} <- entries, into: <<>>, do: <<id::unsigned-64>>
+    encoded = :erlang.term_to_binary(rules_by_id, compressed: 1)
+    {table, key} = RoutingSnapshotStore.put(store, source_id, entries)
+
+    %__MODULE__{
+      key: key,
+      table: table,
+      index: index,
+      encoded: encoded,
+      count: map_size(rules_by_id)
+    }
+  end
+
+  @spec resolve(t(), [Rule.id()]) :: [Rule.t()]
+  def resolve(_snapshot, []), do: []
+
+  def resolve(%__MODULE__{count: count} = snapshot, ids) when length(ids) * 2 >= count do
+    case read_all(snapshot) do
+      [entries] -> entries |> Tuple.to_list() |> tl() |> Map.new() |> from_map(ids)
+      [] -> snapshot.encoded |> :erlang.binary_to_term() |> from_map(ids)
+    end
+  end
+
+  def resolve(%__MODULE__{} = snapshot, ids) do
+    case read_sparse(snapshot, ids, []) do
+      {:ok, rules} -> rules
+      :missing -> snapshot.encoded |> :erlang.binary_to_term() |> from_map(ids)
+    end
+  end
+
+  defp read_sparse(_snapshot, [], acc), do: {:ok, Enum.reverse(acc)}
+
+  defp read_sparse(snapshot, [id | rest], acc) do
+    case position(snapshot.index, id, 0, snapshot.count - 1) do
+      nil ->
+        read_sparse(snapshot, rest, acc)
+
+      position ->
+        case read_element(snapshot, position + 2) do
+          {_id, nil} -> read_sparse(snapshot, rest, acc)
+          {_id, rule} -> read_sparse(snapshot, rest, [rule | acc])
+          :missing -> :missing
+        end
+    end
+  end
+
+  defp read_all(snapshot) do
+    :ets.lookup(snapshot.table, snapshot.key)
+  rescue
+    ArgumentError -> []
+  end
+
+  defp read_element(snapshot, position) do
+    :ets.lookup_element(snapshot.table, snapshot.key, position)
+  rescue
+    ArgumentError -> :missing
+  end
+
+  defp position(_index, _id, low, high) when low > high, do: nil
+
+  defp position(index, id, low, high) do
+    middle = div(low + high, 2)
+    <<key::unsigned-64>> = binary_part(index, middle * @entry_bytes, @entry_bytes)
+
+    cond do
+      id < key -> position(index, id, low, middle - 1)
+      id > key -> position(index, id, middle + 1, high)
+      true -> middle
+    end
+  end
+
+  defp from_map(rules_by_id, ids) do
+    for id <- ids, rule = Map.get(rules_by_id, id), do: rule
+  end
+end

--- a/lib/logflare/rules/routing_snapshot.ex
+++ b/lib/logflare/rules/routing_snapshot.ex
@@ -22,7 +22,7 @@ defmodule Logflare.Rules.RoutingSnapshot do
 
   @type t() :: %__MODULE__{
           key: {integer(), reference()},
-          table: :ets.tid(),
+          table: :ets.tid() | nil,
           index: binary(),
           encoded: binary(),
           count: non_neg_integer(),
@@ -46,7 +46,7 @@ defmodule Logflare.Rules.RoutingSnapshot do
         Keyword.get(opts, :extra_estimated_bytes, 0)
 
     store = Keyword.get(opts, :store, RoutingSnapshotStore)
-    {table, key} = RoutingSnapshotStore.put(store, source_id, entry_tuple, estimated_bytes)
+    {table, key} = put_or_fallback(store, source_id, entry_tuple, estimated_bytes)
 
     %__MODULE__{
       key: key,
@@ -56,6 +56,12 @@ defmodule Logflare.Rules.RoutingSnapshot do
       count: length(entries),
       estimated_bytes: estimated_bytes
     }
+  end
+
+  defp put_or_fallback(store, source_id, entries, estimated_bytes) do
+    RoutingSnapshotStore.put(store, source_id, entries, estimated_bytes)
+  catch
+    :exit, _reason -> {nil, {source_id, make_ref()}}
   end
 
   @doc false

--- a/lib/logflare/rules/routing_snapshot.ex
+++ b/lib/logflare/rules/routing_snapshot.ex
@@ -1,68 +1,107 @@
 defmodule Logflare.Rules.RoutingSnapshot do
   @moduledoc """
-  Immutable rule storage for one routing-tree generation.
+  Immutable compact routing targets for one rules-tree generation.
 
-  The hot cache header contains binary/table references rather than the full
-  rule map. A sorted binary index maps rule IDs to ETS tuple positions. Sparse
-  reads copy only the matched tuple elements; dense reads copy the whole tuple.
-  Every lookup uses the exact generation in the header.
+  The tree emits database rule IDs. A sorted binary index maps those IDs to ETS
+  tuple positions, so sparse reads copy only matched compact targets. Dense reads
+  copy the tuple once and reconstruct the compact lookup map.
 
-  The compressed map is a reader-owned fallback, not the normal lookup path. If
-  the backing store replaces, evicts or loses a generation, the reader decodes
-  its own immutable snapshot instead. The VM keeps this reference-counted binary
-  alive across cache invalidation and releases it on GC/process exit. Thus even
-  a suspended reader needs no lease, cleanup timer or retained ETS generation.
-
-  The tree and map must be constructed from the same database read before this
-  header is published. Encodings are internal, never user-supplied binaries.
+  The compressed target map is a reader-owned fallback. If the backing store
+  replaces, evicts or loses a generation, the caller resolves from that exact
+  immutable map and can conditionally rehydrate the still-current cache entry.
   """
 
   alias Logflare.Rules.Rule
   alias Logflare.Rules.RoutingSnapshotStore
+  alias Logflare.Sources.SourceRouter.Target
 
   @entry_bytes 8
 
-  @enforce_keys [:key, :table, :index, :encoded, :count]
-  defstruct [:key, :table, :index, :encoded, :count]
+  @enforce_keys [:key, :table, :index, :encoded, :count, :estimated_bytes]
+  defstruct [:key, :table, :index, :encoded, :count, :estimated_bytes, decoded: nil]
 
   @type t() :: %__MODULE__{
           key: {integer(), reference()},
           table: :ets.tid(),
           index: binary(),
           encoded: binary(),
-          count: non_neg_integer()
+          count: non_neg_integer(),
+          estimated_bytes: non_neg_integer(),
+          decoded: %{Rule.id() => Target.t()} | nil
         }
 
-  @spec new(integer(), %{Rule.id() => Rule.t()}, GenServer.server()) :: t()
-  def new(source_id, rules_by_id, store \\ RoutingSnapshotStore) do
-    entries = Enum.sort_by(rules_by_id, &elem(&1, 0))
-    index = for {id, _rule} <- entries, into: <<>>, do: <<id::unsigned-64>>
+  @type resolve_status() ::
+          {:ok, [Target.t()]} | {:fallback, [Target.t()], %{Rule.id() => Target.t()}}
+
+  @spec new(integer(), [{Rule.id(), Target.t()}], keyword()) :: t()
+  def new(source_id, entries, opts \\ []) when is_list(entries) do
+    entries = Enum.sort_by(entries, &elem(&1, 0))
+    rules_by_id = Map.new(entries)
+    entry_tuple = List.to_tuple(entries)
+    index = for {id, _target} <- entries, into: <<>>, do: <<id::unsigned-64>>
     encoded = :erlang.term_to_binary(rules_by_id, compressed: 1)
-    {table, key} = RoutingSnapshotStore.put(store, source_id, entries)
+
+    estimated_bytes =
+      :erlang.external_size(entry_tuple) + byte_size(index) + byte_size(encoded) +
+        Keyword.get(opts, :extra_estimated_bytes, 0)
+
+    store = Keyword.get(opts, :store, RoutingSnapshotStore)
+    {table, key} = RoutingSnapshotStore.put(store, source_id, entry_tuple, estimated_bytes)
 
     %__MODULE__{
       key: key,
       table: table,
       index: index,
       encoded: encoded,
-      count: map_size(rules_by_id)
+      count: length(entries),
+      estimated_bytes: estimated_bytes
     }
   end
 
-  @spec resolve(t(), [Rule.id()]) :: [Rule.t()]
-  def resolve(_snapshot, []), do: []
+  @doc false
+  @spec rehydrate(t(), integer(), %{Rule.id() => Target.t()}, GenServer.server()) :: t()
+  def rehydrate(
+        %__MODULE__{} = snapshot,
+        source_id,
+        rules_by_id,
+        store \\ RoutingSnapshotStore
+      )
+      when is_map(rules_by_id) do
+    entries = rules_by_id |> Enum.sort_by(&elem(&1, 0)) |> List.to_tuple()
 
-  def resolve(%__MODULE__{count: count} = snapshot, ids) when length(ids) * 2 >= count do
-    case read_all(snapshot) do
-      [entries] -> entries |> Tuple.to_list() |> tl() |> Map.new() |> from_map(ids)
-      [] -> snapshot.encoded |> :erlang.binary_to_term() |> from_map(ids)
+    {table, key} =
+      RoutingSnapshotStore.put(store, source_id, entries, snapshot.estimated_bytes)
+
+    %{snapshot | table: table, key: key, decoded: nil}
+  end
+
+  @spec resolve(t(), [Rule.id()]) :: [Target.t()]
+  def resolve(snapshot, ids) do
+    case resolve_with_status(snapshot, ids) do
+      {:ok, targets} -> targets
+      {:fallback, targets, _rules_by_id} -> targets
     end
   end
 
-  def resolve(%__MODULE__{} = snapshot, ids) do
+  @doc false
+  @spec resolve_with_status(t(), [Rule.id()]) :: resolve_status()
+  def resolve_with_status(_snapshot, []), do: {:ok, []}
+
+  def resolve_with_status(%__MODULE__{decoded: rules_by_id}, ids) when is_map(rules_by_id),
+    do: {:ok, from_map(rules_by_id, ids)}
+
+  def resolve_with_status(%__MODULE__{count: count} = snapshot, ids)
+      when length(ids) * 2 >= count do
+    case read_all(snapshot) do
+      [entries] -> {:ok, entries |> Tuple.to_list() |> tl() |> Map.new() |> from_map(ids)}
+      [] -> from_fallback(snapshot, ids)
+    end
+  end
+
+  def resolve_with_status(%__MODULE__{} = snapshot, ids) do
     case read_sparse(snapshot, ids, []) do
-      {:ok, rules} -> rules
-      :missing -> snapshot.encoded |> :erlang.binary_to_term() |> from_map(ids)
+      {:ok, targets} -> {:ok, targets}
+      :missing -> from_fallback(snapshot, ids)
     end
   end
 
@@ -76,7 +115,7 @@ defmodule Logflare.Rules.RoutingSnapshot do
       position ->
         case read_element(snapshot, position + 2) do
           {_id, nil} -> read_sparse(snapshot, rest, acc)
-          {_id, rule} -> read_sparse(snapshot, rest, [rule | acc])
+          {_id, target} -> read_sparse(snapshot, rest, [target | acc])
           :missing -> :missing
         end
     end
@@ -107,7 +146,17 @@ defmodule Logflare.Rules.RoutingSnapshot do
     end
   end
 
+  defp from_fallback(snapshot, ids) do
+    rules_by_id = :erlang.binary_to_term(snapshot.encoded)
+    {:fallback, from_map(rules_by_id, ids), rules_by_id}
+  end
+
+  @doc false
+  @spec with_decoded(t(), %{Rule.id() => Target.t()}) :: t()
+  def with_decoded(%__MODULE__{} = snapshot, rules_by_id) when is_map(rules_by_id),
+    do: %{snapshot | decoded: rules_by_id}
+
   defp from_map(rules_by_id, ids) do
-    for id <- ids, rule = Map.get(rules_by_id, id), do: rule
+    for id <- ids, target = Map.get(rules_by_id, id), do: target
   end
 end

--- a/lib/logflare/rules/routing_snapshot_store.ex
+++ b/lib/logflare/rules/routing_snapshot_store.ex
@@ -1,23 +1,29 @@
 defmodule Logflare.Rules.RoutingSnapshotStore do
   @moduledoc """
-  Bounded, disposable ETS acceleration for routing snapshots.
+  Byte-aware, disposable ETS acceleration for routing snapshots.
 
-  There is at most one complete rule tuple per source, published with one ETS
-  insert. Reads bind both source and generation, and copy only selected elements.
-  Replacing a source never mixes generations: older readers use the immutable
-  binary in their header. Store restart, age-based expiry and capacity eviction
-  likewise affect performance only, not snapshot correctness.
+  There is at most one complete target tuple per source. Replacing a source never
+  mixes generations: older readers use the immutable binary in their header.
+  Store restart, age-based expiry and capacity eviction affect correctness only
+  through a slower fallback, and the still-current header is rehydrated after
+  that first fallback.
 
-  Publication/retirement is serialized, but routing reads never call the server.
-  The source and expiry indexes each have exactly one entry per source; neither
-  repeated rebuilds nor suspended readers accumulate retired generations here.
+  Publication and retirement are serialized, but routing reads never call the
+  server. Capacity is bounded by both source count and estimated bytes. Byte
+  estimates include the tree, compact target tuple and compressed fallback;
+  the bound is soft for one individually oversized snapshot so it remains usable.
   """
 
   use GenServer
 
+  alias Logflare.Rules.Cache
+  alias Logflare.Utils.Tasks
+
   @default_limit 100_000
+  @default_max_bytes 512 * 1024 * 1024
   @default_ttl :timer.hours(1)
   @default_interval :timer.minutes(5)
+  @telemetry_event [:logflare, :rules, :routing_snapshot_store]
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
@@ -29,10 +35,10 @@ defmodule Logflare.Rules.RoutingSnapshotStore do
     super(Keyword.put_new(opts, :name, __MODULE__))
   end
 
-  @spec put(GenServer.server(), integer(), [{integer(), term()}]) ::
+  @spec put(GenServer.server(), integer(), tuple(), non_neg_integer()) ::
           {:ets.tid(), {integer(), reference()}}
-  def put(server, source_id, entries) do
-    GenServer.call(server, {:put, source_id, entries})
+  def put(server, source_id, targets, estimated_bytes) do
+    GenServer.call(server, {:put, source_id, targets, estimated_bytes})
   end
 
   @spec delete(GenServer.server(), {integer(), reference()}) :: :ok
@@ -49,6 +55,8 @@ defmodule Logflare.Rules.RoutingSnapshotStore do
       sources: :ets.new(__MODULE__, [:set, :private]),
       expiry: :ets.new(__MODULE__, [:ordered_set, :private]),
       limit: Keyword.get(opts, :limit, @default_limit),
+      max_bytes: Keyword.get(opts, :max_bytes, @default_max_bytes),
+      estimated_bytes: 0,
       ttl: Keyword.get(opts, :ttl, @default_ttl),
       interval: Keyword.get(opts, :interval, @default_interval)
     }
@@ -58,61 +66,116 @@ defmodule Logflare.Rules.RoutingSnapshotStore do
   end
 
   @impl true
-  def handle_call({:put, source_id, entries}, _from, state) do
-    remove_source(state, source_id)
+  def handle_call({:put, source_id, targets, estimated_bytes}, _from, state) do
+    state = remove_source(state, source_id, :replace)
     key = {source_id, make_ref()}
     expires_at = System.monotonic_time(:millisecond) + state.ttl
-    :ets.insert(state.table, List.to_tuple([key | entries]))
-    :ets.insert(state.sources, {source_id, key, expires_at})
+    estimated_bytes = max(estimated_bytes, 0)
+
+    :ets.insert(state.table, Tuple.insert_at(targets, 0, key))
+    :ets.insert(state.sources, {source_id, key, expires_at, estimated_bytes})
     :ets.insert(state.expiry, {{expires_at, key}})
-    trim(state, System.monotonic_time(:millisecond))
+
+    state =
+      state
+      |> Map.update!(:estimated_bytes, &(&1 + estimated_bytes))
+      |> trim(System.monotonic_time(:millisecond))
+
+    emit(state, :put)
     {:reply, {state.table, key}, state}
   end
 
   def handle_call(:prune, _from, state) do
-    trim(state, System.monotonic_time(:millisecond))
+    state = trim(state, System.monotonic_time(:millisecond))
     {:reply, :ok, state}
   end
 
   @impl true
   def handle_cast({:delete, {source_id, _generation} = key}, state) do
-    case :ets.lookup(state.sources, source_id) do
-      [{^source_id, ^key, _expires_at}] -> remove_source(state, source_id)
-      _ -> :ok
-    end
+    state =
+      case :ets.lookup(state.sources, source_id) do
+        [{^source_id, ^key, _expires_at, _estimated_bytes}] ->
+          state = remove_source(state, source_id, :delete)
+          emit(state, :delete)
+          state
+
+        _ ->
+          state
+      end
 
     {:noreply, state}
   end
 
   @impl true
   def handle_info(:prune, state) do
-    trim(state, System.monotonic_time(:millisecond))
+    state = trim(state, System.monotonic_time(:millisecond))
     schedule_prune(state)
     {:noreply, state}
   end
 
-  defp remove_source(state, source_id) do
+  defp remove_source(state, source_id, reason) do
     case :ets.take(state.sources, source_id) do
-      [{^source_id, key, expires_at}] ->
+      [{^source_id, key, expires_at, estimated_bytes}] ->
         :ets.delete(state.table, key)
         :ets.delete(state.expiry, {expires_at, key})
 
+        state = Map.update!(state, :estimated_bytes, &max(&1 - estimated_bytes, 0))
+        maybe_delete_header(reason, key)
+        state
+
       [] ->
-        :ok
+        state
     end
   end
 
   defp trim(state, now) do
     case :ets.first(state.expiry) do
       {expires_at, {source_id, _generation}} ->
-        if expires_at <= now or :ets.info(state.table, :size) > state.limit do
-          remove_source(state, source_id)
+        size = :ets.info(state.table, :size)
+
+        reason =
+          cond do
+            expires_at <= now -> :expire
+            size > state.limit -> :evict
+            over_byte_limit?(state, size) -> :evict
+            true -> nil
+          end
+
+        if reason do
+          state = remove_source(state, source_id, reason)
+          emit(state, reason)
           trim(state, now)
+        else
+          state
         end
 
       :"$end_of_table" ->
-        :ok
+        state
     end
+  end
+
+  defp over_byte_limit?(%{max_bytes: :infinity}, _size), do: false
+
+  defp over_byte_limit?(state, size) do
+    state.estimated_bytes > state.max_bytes and size > 1
+  end
+
+  defp maybe_delete_header(reason, key) when reason in [:expire, :evict] do
+    Tasks.start_child(fn -> Cache.delete_routing_snapshot(key) end)
+    :ok
+  end
+
+  defp maybe_delete_header(_reason, _key), do: :ok
+
+  defp emit(state, action) do
+    :telemetry.execute(
+      @telemetry_event,
+      %{
+        sources: :ets.info(state.table, :size),
+        estimated_bytes: state.estimated_bytes
+      },
+      %{action: action}
+    )
   end
 
   defp schedule_prune(state), do: Process.send_after(self(), :prune, state.interval)

--- a/lib/logflare/rules/routing_snapshot_store.ex
+++ b/lib/logflare/rules/routing_snapshot_store.ex
@@ -1,0 +1,119 @@
+defmodule Logflare.Rules.RoutingSnapshotStore do
+  @moduledoc """
+  Bounded, disposable ETS acceleration for routing snapshots.
+
+  There is at most one complete rule tuple per source, published with one ETS
+  insert. Reads bind both source and generation, and copy only selected elements.
+  Replacing a source never mixes generations: older readers use the immutable
+  binary in their header. Store restart, age-based expiry and capacity eviction
+  likewise affect performance only, not snapshot correctness.
+
+  Publication/retirement is serialized, but routing reads never call the server.
+  The source and expiry indexes each have exactly one entry per source; neither
+  repeated rebuilds nor suspended readers accumulate retired generations here.
+  """
+
+  use GenServer
+
+  @default_limit 100_000
+  @default_ttl :timer.hours(1)
+  @default_interval :timer.minutes(5)
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    super(Keyword.put_new(opts, :name, __MODULE__))
+  end
+
+  @spec put(GenServer.server(), integer(), [{integer(), term()}]) ::
+          {:ets.tid(), {integer(), reference()}}
+  def put(server, source_id, entries) do
+    GenServer.call(server, {:put, source_id, entries})
+  end
+
+  @spec delete(GenServer.server(), {integer(), reference()}) :: :ok
+  def delete(server, key), do: GenServer.cast(server, {:delete, key})
+
+  @doc false
+  @spec prune(GenServer.server()) :: :ok
+  def prune(server), do: GenServer.call(server, :prune)
+
+  @impl true
+  def init(opts) do
+    state = %{
+      table: :ets.new(__MODULE__, [:set, :protected, read_concurrency: true]),
+      sources: :ets.new(__MODULE__, [:set, :private]),
+      expiry: :ets.new(__MODULE__, [:ordered_set, :private]),
+      limit: Keyword.get(opts, :limit, @default_limit),
+      ttl: Keyword.get(opts, :ttl, @default_ttl),
+      interval: Keyword.get(opts, :interval, @default_interval)
+    }
+
+    schedule_prune(state)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:put, source_id, entries}, _from, state) do
+    remove_source(state, source_id)
+    key = {source_id, make_ref()}
+    expires_at = System.monotonic_time(:millisecond) + state.ttl
+    :ets.insert(state.table, List.to_tuple([key | entries]))
+    :ets.insert(state.sources, {source_id, key, expires_at})
+    :ets.insert(state.expiry, {{expires_at, key}})
+    trim(state, System.monotonic_time(:millisecond))
+    {:reply, {state.table, key}, state}
+  end
+
+  def handle_call(:prune, _from, state) do
+    trim(state, System.monotonic_time(:millisecond))
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast({:delete, {source_id, _generation} = key}, state) do
+    case :ets.lookup(state.sources, source_id) do
+      [{^source_id, ^key, _expires_at}] -> remove_source(state, source_id)
+      _ -> :ok
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:prune, state) do
+    trim(state, System.monotonic_time(:millisecond))
+    schedule_prune(state)
+    {:noreply, state}
+  end
+
+  defp remove_source(state, source_id) do
+    case :ets.take(state.sources, source_id) do
+      [{^source_id, key, expires_at}] ->
+        :ets.delete(state.table, key)
+        :ets.delete(state.expiry, {expires_at, key})
+
+      [] ->
+        :ok
+    end
+  end
+
+  defp trim(state, now) do
+    case :ets.first(state.expiry) do
+      {expires_at, {source_id, _generation}} ->
+        if expires_at <= now or :ets.info(state.table, :size) > state.limit do
+          remove_source(state, source_id)
+          trim(state, now)
+        end
+
+      :"$end_of_table" ->
+        :ok
+    end
+  end
+
+  defp schedule_prune(state), do: Process.send_after(self(), :prune, state.interval)
+end

--- a/lib/logflare/sources/source_router.ex
+++ b/lib/logflare/sources/source_router.ex
@@ -5,53 +5,96 @@ defmodule Logflare.Sources.SourceRouter do
   alias Logflare.Rules.Rule
   alias Logflare.Sources
   alias Logflare.Sources.Source
+  alias Logflare.Sources.SourceRouter.Target
 
   @default_router Logflare.Sources.SourceRouter.RulesTree
 
   @doc """
-  An algorithm returning Rules that match provided LogEvent
+  An algorithm returning compact routing targets that match a log event.
   """
-  @callback matching_rules(LE.t(), Source.t()) :: [Rule.t()]
+  @callback matching_rules(LE.t(), Source.t()) :: [Target.t() | Rule.t()]
+  @callback prepare(Source.t()) :: term()
+  @callback matching_rules(LE.t(), Source.t(), term()) :: [Target.t()]
+  @callback matching_rules_with_state(LE.t(), Source.t(), term()) :: {[Target.t()], term()}
+
+  @optional_callbacks prepare: 1, matching_rules: 3, matching_rules_with_state: 3
 
   @spec route_to_sinks_and_ingest(LE.t() | [LE.t()], Source.t(), module()) :: LE.t() | [LE.t()]
   def route_to_sinks_and_ingest(events, source, router \\ @default_router)
 
-  def route_to_sinks_and_ingest(events, source, router) when is_list(events),
-    do: Enum.map(events, &route_to_sinks_and_ingest(&1, source, router))
+  def route_to_sinks_and_ingest(events, source, router) when is_list(events) do
+    prepared = prepare(router, source, events)
 
-  def route_to_sinks_and_ingest(%LE{via_rule_id: id} = le, _source, _router) when id != nil,
-    do: le
+    {events, _prepared} =
+      Enum.map_reduce(events, prepared, &route_to_sinks_and_ingest(&1, source, router, &2))
 
-  def route_to_sinks_and_ingest(%LE{via_rule_id: nil} = le, source, router) do
-    for %Rule{} = rule <- router.matching_rules(le, source) do
-      do_routing(rule, le, source)
-    end
-
-    le
+    events
   end
 
-  defp do_routing(%Rule{backend_id: backend_id} = rule, %LE{} = le, source)
-       when backend_id != nil do
-    # route to a backend
-    backend = Backends.Cache.get_backend(backend_id)
-    le = %{le | via_rule_id: rule.id}
-    if SourceSup.rule_child_started?(rule) == false, do: SourceSup.start_rule_child(rule)
+  def route_to_sinks_and_ingest(%LE{} = event, source, router) do
+    prepared = prepare(router, source, [event])
+    {event, _prepared} = route_to_sinks_and_ingest(event, source, router, prepared)
+    event
+  end
 
-    # ingest to a specific backend
+  defp route_to_sinks_and_ingest(%LE{via_rule_id: id} = le, _source, _router, prepared)
+       when id != nil,
+       do: {le, prepared}
+
+  defp route_to_sinks_and_ingest(%LE{via_rule_id: nil} = le, source, router, prepared) do
+    {targets, prepared} = matching_targets(router, le, source, prepared)
+
+    for target <- targets do
+      do_routing(target, le, source)
+    end
+
+    {le, prepared}
+  end
+
+  defp prepare(router, source, events) do
+    if Enum.any?(events, &match?(%LE{via_rule_id: nil}, &1)) and Code.ensure_loaded?(router) and
+         function_exported?(router, :prepare, 1) and
+         function_exported?(router, :matching_rules, 3) do
+      router.prepare(source)
+    else
+      :unprepared
+    end
+  end
+
+  defp matching_targets(router, event, source, :unprepared),
+    do: {router.matching_rules(event, source), :unprepared}
+
+  defp matching_targets(router, event, source, prepared) do
+    if function_exported?(router, :matching_rules_with_state, 3) do
+      router.matching_rules_with_state(event, source, prepared)
+    else
+      {router.matching_rules(event, source, prepared), prepared}
+    end
+  end
+
+  defp do_routing(%Rule{} = rule, %LE{} = le, source),
+    do: rule |> Target.from_rule() |> do_routing(le, source)
+
+  defp do_routing({rule_id, backend_id, _sink}, %LE{} = le, source)
+       when backend_id != nil do
+    backend = Backends.Cache.get_backend(backend_id)
+    le = %{le | via_rule_id: rule_id}
+
+    if SourceSup.backend_child_started?(backend_id, source.id) == false,
+      do: SourceSup.start_backend_child_by_id(backend_id, source.id)
+
     Backends.ingest_logs([le], source, backend)
   end
 
-  defp do_routing(%Rule{sink: sink} = rule, %LE{} = le, _source) when sink != nil do
+  defp do_routing({rule_id, nil, sink}, %LE{} = le, _source) when sink != nil do
     sink_source =
-      Sources.Cache.get_by(token: rule.sink) |> Sources.refresh_source_metrics_for_ingest()
+      Sources.Cache.get_by(token: sink) |> Sources.refresh_source_metrics_for_ingest()
 
-    le = %{le | source_id: sink_source.id, via_rule_id: rule.id}
+    le = %{le | source_id: sink_source.id, via_rule_id: rule_id}
 
     Backends.ensure_source_sup_started(sink_source)
     Backends.ingest_logs([le], sink_source)
   end
 
-  defp do_routing(%Rule{sink: nil}, _le, _source) do
-    {:error, :no_sink}
-  end
+  defp do_routing({_rule_id, nil, nil}, _le, _source), do: {:error, :no_sink}
 end

--- a/lib/logflare/sources/source_router.ex
+++ b/lib/logflare/sources/source_router.ex
@@ -53,12 +53,16 @@ defmodule Logflare.Sources.SourceRouter do
 
   defp prepare(router, source, events) do
     if Enum.any?(events, &match?(%LE{via_rule_id: nil}, &1)) and Code.ensure_loaded?(router) and
-         function_exported?(router, :prepare, 1) and
-         function_exported?(router, :matching_rules, 3) do
+         function_exported?(router, :prepare, 1) and prepared_matching?(router) do
       router.prepare(source)
     else
       :unprepared
     end
+  end
+
+  defp prepared_matching?(router) do
+    function_exported?(router, :matching_rules, 3) or
+      function_exported?(router, :matching_rules_with_state, 3)
   end
 
   defp matching_targets(router, event, source, :unprepared),

--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -15,7 +15,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
           | {operator(), route()}
           | {:eq_index, eq_index()}
   @type route() :: {:route, target() | [target()]}
-  @type target() :: Rule.id() | {Rule.id(), filter_set()}
+  @type target() :: non_neg_integer() | {non_neg_integer(), filter_set()}
   @type key() :: binary()
   @type operator() :: {atom(), any()}
   @type eq_index() :: %{term() => target() | [target()]}
@@ -23,9 +23,34 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
   @type filter_set() :: non_neg_integer()
 
   @impl true
-  def matching_rules(event, source) do
-    {rule_set, snapshot} = Rules.Cache.rules_tree_by_source_id(source.id)
-    Rules.RoutingSnapshot.resolve(snapshot, matching_rule_ids(event, rule_set))
+  def prepare(source), do: Rules.Cache.rules_tree_by_source_id(source.id)
+
+  @impl true
+  def matching_rules(event, source), do: matching_rules(event, source, prepare(source))
+
+  @impl true
+  def matching_rules(event, source, prepared) do
+    {targets, _prepared} = matching_rules_with_state(event, source, prepared)
+    targets
+  end
+
+  @impl true
+  def matching_rules_with_state(event, source, {rule_set, snapshot}) do
+    rule_ids = matching_rule_ids(event, rule_set)
+
+    case Rules.RoutingSnapshot.resolve_with_status(snapshot, rule_ids) do
+      {:ok, targets} ->
+        {targets, {rule_set, snapshot}}
+
+      {:fallback, targets, encoded_targets} ->
+        snapshot =
+          case Rules.Cache.repair_routing_snapshot(source.id, snapshot, encoded_targets) do
+            {:repaired, repaired} -> repaired
+            _ -> Rules.RoutingSnapshot.with_decoded(snapshot, encoded_targets)
+          end
+
+        {targets, {rule_set, snapshot}}
+    end
   end
 
   @doc """

--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -24,11 +24,8 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
 
   @impl true
   def matching_rules(event, source) do
-    rule_set = Rules.Cache.rules_tree_by_source_id(source.id)
-
-    matching_rule_ids(event, rule_set)
-    |> Rules.Cache.get_rules()
-    |> Enum.reject(&is_nil/1)
+    {rule_set, snapshot} = Rules.Cache.rules_tree_by_source_id(source.id)
+    Rules.RoutingSnapshot.resolve(snapshot, matching_rule_ids(event, rule_set))
   end
 
   @doc """

--- a/lib/logflare/sources/source_router/sequential.ex
+++ b/lib/logflare/sources/source_router/sequential.ex
@@ -5,15 +5,20 @@ defmodule Logflare.Sources.SourceRouter.Sequential do
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Rules
   alias Logflare.Rules.Rule
+  alias Logflare.Sources.SourceRouter.Target
 
   @behaviour Logflare.Sources.SourceRouter
 
   @impl true
-  def matching_rules(le, source) do
-    rules = Rules.Cache.list_rules(source)
+  def prepare(source), do: Rules.Cache.list_rules(source)
 
+  @impl true
+  def matching_rules(le, source), do: matching_rules(le, source, prepare(source))
+
+  @impl true
+  def matching_rules(le, _source, rules) do
     for %Rule{lql_filters: [_ | _]} = rule <- rules, route_with_lql_rules?(le, rule) do
-      rule
+      Target.from_rule(rule)
     end
   end
 

--- a/lib/logflare/sources/source_router/target.ex
+++ b/lib/logflare/sources/source_router/target.ex
@@ -1,0 +1,14 @@
+defmodule Logflare.Sources.SourceRouter.Target do
+  @moduledoc false
+
+  alias Logflare.Rules.Rule
+
+  @type t() :: {Rule.id(), backend_id :: non_neg_integer() | nil, sink :: atom() | nil}
+
+  @spec from_rule(Rule.t()) :: t()
+  def from_rule(%Rule{id: id, backend_id: backend_id, sink: sink}),
+    do: {id, backend_id, sink}
+
+  @spec id(t()) :: Rule.id()
+  def id({id, _backend_id, _sink}), do: id
+end

--- a/test/logflare/rules/routing_snapshot_test.exs
+++ b/test/logflare/rules/routing_snapshot_test.exs
@@ -145,16 +145,36 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     assert_sizes(store, 1)
   end
 
-  test "store restart cannot invalidate a reader's snapshot", %{store: store} do
+  test "store outage preserves acquired readers and cold snapshots", %{store: store} do
     entries = entries(20)
     snapshot = RoutingSnapshot.new(1, entries, store: store)
     stop_supervised!(RoutingSnapshotStore)
-    new_store = start_supervised!({RoutingSnapshotStore, name: nil})
-    RoutingSnapshot.new(1, entries(20, 2), store: new_store)
+
+    cold_entries = entries(20, 2)
+    cold = RoutingSnapshot.new(2, cold_entries, store: store)
+
+    assert cold.table == nil
+    expected_cold_target = expected(cold_entries, [1])
+
+    assert {:fallback, ^expected_cold_target, _rules_by_id} =
+             RoutingSnapshot.resolve_with_status(cold, [1])
 
     assert :ets.info(snapshot.table) == :undefined
     assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
     assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(entries, 1..20)
+
+    new_store = start_supervised!({RoutingSnapshotStore, name: nil})
+
+    repaired =
+      RoutingSnapshot.rehydrate(
+        cold,
+        2,
+        :erlang.binary_to_term(cold.encoded),
+        new_store
+      )
+
+    assert {:ok, expected(cold_entries, [1])} ==
+             RoutingSnapshot.resolve_with_status(repaired, [1])
   end
 
   test "capacity eviction bounds all indexes and preserves acquired snapshots" do

--- a/test/logflare/rules/routing_snapshot_test.exs
+++ b/test/logflare/rules/routing_snapshot_test.exs
@@ -1,7 +1,6 @@
 defmodule Logflare.Rules.RoutingSnapshotTest do
   use ExUnit.Case, async: true
 
-  alias Logflare.Rules.Rule
   alias Logflare.Rules.RoutingSnapshot
   alias Logflare.Rules.RoutingSnapshotStore
 
@@ -10,42 +9,42 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     %{store: store}
   end
 
-  test "sparse, dense and fallback reads preserve IDs, values and order", %{store: store} do
-    rules = rules(20)
-    snapshot = RoutingSnapshot.new(1, rules, store)
+  test "sparse, dense and fallback reads preserve IDs, targets and order", %{store: store} do
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
 
     for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
     end
 
-    RoutingSnapshot.new(1, rules(20, 2), store)
+    RoutingSnapshot.new(1, entries(20, 2), store: store)
     refute :ets.member(snapshot.table, snapshot.key)
 
     for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
     end
   end
 
-  test "empty snapshots and missing or nil rules are rejected", %{store: store} do
-    empty = RoutingSnapshot.new(1, %{}, store)
+  test "empty snapshots and missing or nil targets are rejected", %{store: store} do
+    empty = RoutingSnapshot.new(1, [], store: store)
     assert RoutingSnapshot.resolve(empty, [1]) == []
 
-    rules = rules(20) |> Map.put(1, nil)
-    snapshot = RoutingSnapshot.new(1, rules, store)
-    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [rules[2]]
-    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..30)) == expected(rules, 1..30)
+    entries = List.replace_at(entries(20), 0, {1, nil})
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [Map.new(entries)[2]]
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..30)) == expected(entries, 1..30)
 
-    RoutingSnapshot.new(1, %{}, store)
-    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [rules[2]]
+    RoutingSnapshot.new(1, [], store: store)
+    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [Map.new(entries)[2]]
   end
 
   test "binary index supports zero, non-contiguous IDs and bigint boundaries", %{store: store} do
     ids = [0, 5, 91, 4_294_967_297, 9_223_372_036_854_775_807]
-    rules = Map.new(ids, &{&1, %Rule{id: &1}})
-    snapshot = RoutingSnapshot.new(1, rules, store)
+    entries = Enum.map(ids, &{&1, {&1, &1, nil}})
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
 
     for id <- ids do
-      assert RoutingSnapshot.resolve(snapshot, [id]) == [rules[id]]
+      assert RoutingSnapshot.resolve(snapshot, [id]) == [Map.new(entries)[id]]
     end
 
     for id <- [1, 6, 90, 92, 4_294_967_296] do
@@ -54,26 +53,41 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
   end
 
   test "ETS paths do not decode the fallback", %{store: store} do
-    rules = rules(20)
-    snapshot = %{RoutingSnapshot.new(1, rules, store) | encoded: <<>>}
+    entries = entries(20)
+    snapshot = %{RoutingSnapshot.new(1, entries, store: store) | encoded: <<>>}
 
     for count <- [1, 9, 10, 11, 20] do
       ids = Enum.to_list(count..1//-1)
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
     end
   end
 
-  test "header heap size does not grow with the rule payload", %{store: store} do
-    small = RoutingSnapshot.new(1, rules(20), store)
-    large = RoutingSnapshot.new(2, rules(1000), store)
+  test "a decoded batch-local fallback avoids repeated decompression", %{store: store} do
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    RoutingSnapshot.new(1, entries(20, 2), store: store)
+
+    local =
+      snapshot
+      |> RoutingSnapshot.with_decoded(:erlang.binary_to_term(snapshot.encoded))
+      |> Map.put(:encoded, <<>>)
+
+    assert {:ok, expected(entries, [1, 20])} ==
+             RoutingSnapshot.resolve_with_status(local, [1, 20])
+  end
+
+  test "header heap size does not grow with the target payload", %{store: store} do
+    small = RoutingSnapshot.new(1, entries(20), store: store)
+    large = RoutingSnapshot.new(2, entries(1000), store: store)
     assert :erts_debug.flat_size(small) == :erts_debug.flat_size(large)
     assert byte_size(large.encoded) > byte_size(small.encoded)
+    assert large.estimated_bytes > small.estimated_bytes
   end
 
   test "suspended readers survive rebuilds without retaining ETS generations", %{store: store} do
     parent = self()
-    rules = rules(20)
-    snapshot = RoutingSnapshot.new(1, rules, store)
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
 
     reader =
       Task.async(fn ->
@@ -84,13 +98,13 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     assert_receive :acquired
 
     for generation <- 2..100 do
-      RoutingSnapshot.new(1, rules(20, generation), store)
+      RoutingSnapshot.new(1, entries(20, generation), store: store)
       assert_sizes(store, 1)
     end
 
     refute :ets.member(snapshot.table, snapshot.key)
     send(reader.pid, :resume)
-    assert Task.await(reader) == expected(rules, [1, 20])
+    assert Task.await(reader) == expected(entries, [1, 20])
   end
 
   test "concurrent replacement never mixes generations", %{store: store} do
@@ -98,10 +112,12 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     |> Task.async_stream(
       fn reader ->
         for generation <- 1..50 do
-          rules = rules(20, {reader, generation})
-          snapshot = RoutingSnapshot.new(1, rules, store)
-          assert RoutingSnapshot.resolve(snapshot, [20, 1, 10]) == expected(rules, [20, 1, 10])
-          assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(rules, 1..20)
+          entries = entries(20, {reader, generation})
+          snapshot = RoutingSnapshot.new(1, entries, store: store)
+          assert RoutingSnapshot.resolve(snapshot, [20, 1, 10]) == expected(entries, [20, 1, 10])
+
+          assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) ==
+                   expected(entries, 1..20)
         end
       end,
       max_concurrency: 8
@@ -113,7 +129,7 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
 
   test "a reader crash does not pin generations or require release", %{store: store} do
     parent = self()
-    snapshot = RoutingSnapshot.new(1, rules(20), store)
+    snapshot = RoutingSnapshot.new(1, entries(20), store: store)
 
     {pid, ref} =
       spawn_monitor(fn ->
@@ -121,65 +137,121 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
         receive do: (:crash -> exit(:reader_crashed))
       end)
 
-    assert_receive {:acquired, [%Rule{id: 1}]}
+    assert_receive {:acquired, [{1, _backend_id, nil}]}
     send(pid, :crash)
     assert_receive {:DOWN, ^ref, :process, ^pid, :reader_crashed}
-    RoutingSnapshot.new(1, rules(20, 2), store)
+    RoutingSnapshot.new(1, entries(20, 2), store: store)
     refute :ets.member(snapshot.table, snapshot.key)
     assert_sizes(store, 1)
   end
 
   test "store restart cannot invalidate a reader's snapshot", %{store: store} do
-    rules = rules(20)
-    snapshot = RoutingSnapshot.new(1, rules, store)
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
     stop_supervised!(RoutingSnapshotStore)
     new_store = start_supervised!({RoutingSnapshotStore, name: nil})
-    RoutingSnapshot.new(1, rules(20, 2), new_store)
+    RoutingSnapshot.new(1, entries(20, 2), store: new_store)
 
     assert :ets.info(snapshot.table) == :undefined
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
-    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(rules, 1..20)
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(entries, 1..20)
   end
 
   test "capacity eviction bounds all indexes and preserves acquired snapshots" do
     store = start_supervised!({RoutingSnapshotStore, name: nil, limit: 2}, id: :limited)
-    rules = rules(20)
-    snapshot = RoutingSnapshot.new(1, rules, store)
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
 
-    for source_id <- 2..50, do: RoutingSnapshot.new(source_id, rules, store)
+    for source_id <- 2..50, do: RoutingSnapshot.new(source_id, entries, store: store)
 
     assert_sizes(store, 2)
     refute :ets.member(snapshot.table, snapshot.key)
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
+  end
+
+  test "estimated-byte eviction bounds the store while retaining one oversized snapshot" do
+    sample_entries = entries(20)
+    entry_tuple = List.to_tuple(sample_entries)
+    rules_by_id = Map.new(sample_entries)
+    encoded = :erlang.term_to_binary(rules_by_id, compressed: 1)
+    weight = :erlang.external_size(entry_tuple) + 20 * 8 + byte_size(encoded)
+
+    store =
+      start_supervised!(
+        {RoutingSnapshotStore, name: nil, max_bytes: weight + 1},
+        id: :byte_limited
+      )
+
+    first = RoutingSnapshot.new(1, sample_entries, store: store)
+    second = RoutingSnapshot.new(2, sample_entries, store: store)
+
+    refute :ets.member(first.table, first.key)
+    assert :ets.member(second.table, second.key)
+    assert_sizes(store, 1)
+    assert :sys.get_state(store).estimated_bytes == second.estimated_bytes
+
+    oversized = RoutingSnapshot.new(3, entries(100), store: store)
+    assert :ets.member(oversized.table, oversized.key)
+    assert_sizes(store, 1)
+    assert :sys.get_state(store).estimated_bytes == oversized.estimated_bytes
   end
 
   test "expiry retires all indexes without invalidating readers" do
     store = start_supervised!({RoutingSnapshotStore, name: nil, ttl: 0}, id: :expired)
-    rules = rules(20)
-    snapshot = RoutingSnapshot.new(1, rules, store)
+    entries = entries(20)
+    snapshot = RoutingSnapshot.new(1, entries, store: store)
     RoutingSnapshotStore.prune(store)
 
     assert_sizes(store, 0)
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
+    assert :sys.get_state(store).estimated_bytes == 0
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
   end
 
   test "late retirement cannot remove the replacement generation", %{store: store} do
-    old = RoutingSnapshot.new(1, rules(20), store)
-    current = RoutingSnapshot.new(1, rules(20, 2), store)
+    old = RoutingSnapshot.new(1, entries(20), store: store)
+    current_entries = entries(20, 2)
+    current = RoutingSnapshot.new(1, current_entries, store: store)
     RoutingSnapshotStore.delete(store, old.key)
     assert_sizes(store, 1)
     assert :ets.member(current.table, current.key)
 
     RoutingSnapshotStore.delete(store, current.key)
     assert_sizes(store, 0)
-    assert RoutingSnapshot.resolve(current, [1]) == expected(rules(20, 2), [1])
+    assert RoutingSnapshot.resolve(current, [1]) == expected(current_entries, [1])
   end
 
-  defp rules(count, generation \\ 1) do
-    Map.new(1..count, &{&1, %Rule{id: &1, lql_string: inspect(generation)}})
+  test "store telemetry reports source and estimated-byte gauges", %{store: store} do
+    handler = "routing-snapshot-store-test-#{System.unique_integer([:positive])}"
+    parent = self()
+
+    :telemetry.attach(
+      handler,
+      [:logflare, :rules, :routing_snapshot_store],
+      fn event, measurements, metadata, pid -> send(pid, {event, measurements, metadata}) end,
+      parent
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    snapshot = RoutingSnapshot.new(999_999, entries(20), store: store)
+
+    assert_receive {
+      [:logflare, :rules, :routing_snapshot_store],
+      %{sources: 1, estimated_bytes: bytes},
+      %{action: :put}
+    }
+
+    assert bytes == snapshot.estimated_bytes
   end
 
-  defp expected(rules, ids), do: for(id <- ids, rule = rules[id], do: rule)
+  defp entries(count, generation \\ 1) do
+    generation = :erlang.phash2(generation)
+    for id <- 1..count, do: {id, {id, generation * 10_000 + id, nil}}
+  end
+
+  defp expected(entries, ids) do
+    rules_by_id = Map.new(entries)
+    for id <- ids, target = Map.get(rules_by_id, id), do: target
+  end
 
   defp assert_sizes(store, expected) do
     state = :sys.get_state(store)

--- a/test/logflare/rules/routing_snapshot_test.exs
+++ b/test/logflare/rules/routing_snapshot_test.exs
@@ -1,0 +1,190 @@
+defmodule Logflare.Rules.RoutingSnapshotTest do
+  use ExUnit.Case, async: true
+
+  alias Logflare.Rules.Rule
+  alias Logflare.Rules.RoutingSnapshot
+  alias Logflare.Rules.RoutingSnapshotStore
+
+  setup do
+    store = start_supervised!({RoutingSnapshotStore, name: nil})
+    %{store: store}
+  end
+
+  test "sparse, dense and fallback reads preserve IDs, values and order", %{store: store} do
+    rules = rules(20)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+
+    for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+    end
+
+    RoutingSnapshot.new(1, rules(20, 2), store)
+    refute :ets.member(snapshot.table, snapshot.key)
+
+    for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+    end
+  end
+
+  test "empty snapshots and missing or nil rules are rejected", %{store: store} do
+    empty = RoutingSnapshot.new(1, %{}, store)
+    assert RoutingSnapshot.resolve(empty, [1]) == []
+
+    rules = rules(20) |> Map.put(1, nil)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [rules[2]]
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..30)) == expected(rules, 1..30)
+
+    RoutingSnapshot.new(1, %{}, store)
+    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [rules[2]]
+  end
+
+  test "binary index supports zero, non-contiguous IDs and bigint boundaries", %{store: store} do
+    ids = [0, 5, 91, 4_294_967_297, 9_223_372_036_854_775_807]
+    rules = Map.new(ids, &{&1, %Rule{id: &1}})
+    snapshot = RoutingSnapshot.new(1, rules, store)
+
+    for id <- ids do
+      assert RoutingSnapshot.resolve(snapshot, [id]) == [rules[id]]
+    end
+
+    for id <- [1, 6, 90, 92, 4_294_967_296] do
+      assert RoutingSnapshot.resolve(snapshot, [id]) == []
+    end
+  end
+
+  test "ETS paths do not decode the fallback", %{store: store} do
+    rules = rules(20)
+    snapshot = %{RoutingSnapshot.new(1, rules, store) | encoded: <<>>}
+
+    for count <- [1, 9, 10, 11, 20] do
+      ids = Enum.to_list(count..1//-1)
+      assert RoutingSnapshot.resolve(snapshot, ids) == expected(rules, ids)
+    end
+  end
+
+  test "header heap size does not grow with the rule payload", %{store: store} do
+    small = RoutingSnapshot.new(1, rules(20), store)
+    large = RoutingSnapshot.new(2, rules(1000), store)
+    assert :erts_debug.flat_size(small) == :erts_debug.flat_size(large)
+    assert byte_size(large.encoded) > byte_size(small.encoded)
+  end
+
+  test "suspended readers survive rebuilds without retaining ETS generations", %{store: store} do
+    parent = self()
+    rules = rules(20)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+
+    reader =
+      Task.async(fn ->
+        send(parent, :acquired)
+        receive do: (:resume -> RoutingSnapshot.resolve(snapshot, [1, 20]))
+      end)
+
+    assert_receive :acquired
+
+    for generation <- 2..100 do
+      RoutingSnapshot.new(1, rules(20, generation), store)
+      assert_sizes(store, 1)
+    end
+
+    refute :ets.member(snapshot.table, snapshot.key)
+    send(reader.pid, :resume)
+    assert Task.await(reader) == expected(rules, [1, 20])
+  end
+
+  test "concurrent replacement never mixes generations", %{store: store} do
+    1..8
+    |> Task.async_stream(
+      fn reader ->
+        for generation <- 1..50 do
+          rules = rules(20, {reader, generation})
+          snapshot = RoutingSnapshot.new(1, rules, store)
+          assert RoutingSnapshot.resolve(snapshot, [20, 1, 10]) == expected(rules, [20, 1, 10])
+          assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(rules, 1..20)
+        end
+      end,
+      max_concurrency: 8
+    )
+    |> Enum.each(fn result -> assert {:ok, _} = result end)
+
+    assert_sizes(store, 1)
+  end
+
+  test "a reader crash does not pin generations or require release", %{store: store} do
+    parent = self()
+    snapshot = RoutingSnapshot.new(1, rules(20), store)
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        send(parent, {:acquired, RoutingSnapshot.resolve(snapshot, [1])})
+        receive do: (:crash -> exit(:reader_crashed))
+      end)
+
+    assert_receive {:acquired, [%Rule{id: 1}]}
+    send(pid, :crash)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :reader_crashed}
+    RoutingSnapshot.new(1, rules(20, 2), store)
+    refute :ets.member(snapshot.table, snapshot.key)
+    assert_sizes(store, 1)
+  end
+
+  test "store restart cannot invalidate a reader's snapshot", %{store: store} do
+    rules = rules(20)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+    stop_supervised!(RoutingSnapshotStore)
+    new_store = start_supervised!({RoutingSnapshotStore, name: nil})
+    RoutingSnapshot.new(1, rules(20, 2), new_store)
+
+    assert :ets.info(snapshot.table) == :undefined
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(rules, 1..20)
+  end
+
+  test "capacity eviction bounds all indexes and preserves acquired snapshots" do
+    store = start_supervised!({RoutingSnapshotStore, name: nil, limit: 2}, id: :limited)
+    rules = rules(20)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+
+    for source_id <- 2..50, do: RoutingSnapshot.new(source_id, rules, store)
+
+    assert_sizes(store, 2)
+    refute :ets.member(snapshot.table, snapshot.key)
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
+  end
+
+  test "expiry retires all indexes without invalidating readers" do
+    store = start_supervised!({RoutingSnapshotStore, name: nil, ttl: 0}, id: :expired)
+    rules = rules(20)
+    snapshot = RoutingSnapshot.new(1, rules, store)
+    RoutingSnapshotStore.prune(store)
+
+    assert_sizes(store, 0)
+    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(rules, [1])
+  end
+
+  test "late retirement cannot remove the replacement generation", %{store: store} do
+    old = RoutingSnapshot.new(1, rules(20), store)
+    current = RoutingSnapshot.new(1, rules(20, 2), store)
+    RoutingSnapshotStore.delete(store, old.key)
+    assert_sizes(store, 1)
+    assert :ets.member(current.table, current.key)
+
+    RoutingSnapshotStore.delete(store, current.key)
+    assert_sizes(store, 0)
+    assert RoutingSnapshot.resolve(current, [1]) == expected(rules(20, 2), [1])
+  end
+
+  defp rules(count, generation \\ 1) do
+    Map.new(1..count, &{&1, %Rule{id: &1, lql_string: inspect(generation)}})
+  end
+
+  defp expected(rules, ids), do: for(id <- ids, rule = rules[id], do: rule)
+
+  defp assert_sizes(store, expected) do
+    state = :sys.get_state(store)
+    assert :ets.info(state.table, :size) == expected
+    assert :ets.info(state.sources, :size) == expected
+    assert :ets.info(state.expiry, :size) == expected
+  end
+end

--- a/test/logflare/rules/rule_cache_test.exs
+++ b/test/logflare/rules/rule_cache_test.exs
@@ -3,6 +3,7 @@ defmodule Logflare.Rules.CacheTest do
   use Logflare.DataCase
 
   alias Logflare.Rules
+  alias Logflare.Rules.RoutingSnapshot
   alias Logflare.Sources
 
   @subject Rules.Cache
@@ -14,10 +15,24 @@ defmodule Logflare.Rules.CacheTest do
     source = insert(:source, user: user, log_events_updated_at: DateTime.utc_now())
     [r1, r2] = insert_list(2, :rule, source: source, backend: backend)
 
+    on_exit(fn -> @subject.bust_by(source_id: source.id) end)
+
     [source: source, backend: backend, rule_ids: [r1.id, r2.id]]
   end
 
   describe "rules cache" do
+    test "get rule", %{rule_ids: [rid1, _rid2]} do
+      assert %Rule{id: ^rid1} = @subject.get_rule(rid1)
+
+      assert Cachex.size!(@subject) == 1
+      assert %{hits: 0, writes: 1} = Cachex.stats!(@subject)
+
+      Mimic.reject(Rules, :get_rule, 1)
+
+      assert %Rule{id: ^rid1} = @subject.get_rule(rid1)
+      assert %{hits: 1, writes: 1} = Cachex.stats!(@subject)
+    end
+
     test "get rules", %{rule_ids: rule_ids} do
       assert rules = @subject.get_rules(rule_ids)
 
@@ -27,15 +42,70 @@ defmodule Logflare.Rules.CacheTest do
 
       assert Cachex.size!(@subject) == 2
       assert %{hits: 0, writes: 2} = Cachex.stats!(@subject)
-
       Mimic.reject(Rules, :get_rule, 1)
-
       assert [_r1, _r2] = @subject.get_rules(rule_ids)
       assert %{hits: 2, writes: 2} = Cachex.stats!(@subject)
-
       [rid1, _rid2] = rule_ids
       assert %Rule{id: ^rid1} = @subject.get_rule(rid1)
       assert %{hits: 3, writes: 2} = Cachex.stats!(@subject)
+    end
+
+    test "rules tree by source id caches the tree with its rules", %{
+      source: source,
+      rule_ids: rule_ids
+    } do
+      assert {tree, %RoutingSnapshot{} = snapshot} = @subject.rules_tree_by_source_id(source.id)
+      assert snapshot.count == length(rule_ids)
+      assert Enum.map(RoutingSnapshot.resolve(snapshot, rule_ids), & &1.id) == rule_ids
+
+      Mimic.reject(Rules, :rules_tree_by_source_id, 1)
+      assert @subject.rules_tree_by_source_id(source.id) == {tree, snapshot}
+    end
+
+    for invalidation <- [:bust, :expire, :clear] do
+      @invalidation invalidation
+      test "#{invalidation} and rebuild preserve a paused reader's snapshot", %{
+        source: source,
+        rule_ids: rule_ids
+      } do
+        {tree, old} = @subject.rules_tree_by_source_id(source.id)
+        old_rules = RoutingSnapshot.resolve(old, rule_ids)
+        parent = self()
+
+        reader =
+          Task.async(fn ->
+            send(parent, :snapshot_acquired)
+            receive do: (:resume -> RoutingSnapshot.resolve(old, rule_ids))
+          end)
+
+        assert_receive :snapshot_acquired
+
+        case @invalidation do
+          :bust ->
+            assert {:ok, 1} = @subject.bust_by(source_id: source.id)
+
+          :expire ->
+            assert {:ok, true} =
+                     Cachex.expire(@subject, {:rules_tree_by_source_id, [source.id]}, -1)
+
+          :clear ->
+            assert {:ok, 1} = Cachex.clear(@subject)
+        end
+
+        new_rules = Map.new(old_rules, &{&1.id, %{&1 | lql_string: "replacement"}})
+
+        expect(Rules, :rules_tree_by_source_id, fn id ->
+          assert id == source.id
+          {tree, new_rules}
+        end)
+
+        {^tree, current} = @subject.rules_tree_by_source_id(source.id)
+        assert current.key != old.key
+        assert RoutingSnapshot.resolve(current, rule_ids) == Enum.map(rule_ids, &new_rules[&1])
+        refute :ets.member(old.table, old.key)
+        send(reader.pid, :resume)
+        assert Task.await(reader) == old_rules
+      end
     end
 
     test "list by source", %{source: source, rule_ids: expected_rule_ids} do

--- a/test/logflare/rules/rule_cache_test.exs
+++ b/test/logflare/rules/rule_cache_test.exs
@@ -2,8 +2,10 @@ defmodule Logflare.Rules.CacheTest do
   alias Logflare.Rules.Rule
   use Logflare.DataCase
 
+  alias Logflare.ContextCache.Supervisor, as: ContextCacheSupervisor
   alias Logflare.Rules
   alias Logflare.Rules.RoutingSnapshot
+  alias Logflare.Rules.RoutingSnapshotStore
   alias Logflare.Sources
   alias Logflare.Sources.SourceRouter.Target
 
@@ -61,6 +63,36 @@ defmodule Logflare.Rules.CacheTest do
 
       Mimic.reject(Rules, :rules_tree_by_source_id, 1)
       assert @subject.rules_tree_by_source_id(source.id) == {tree, snapshot}
+    end
+
+    test "rules tree cache misses recover through fallback while the store is unavailable", %{
+      source: source,
+      rule_ids: rule_ids
+    } do
+      on_exit(fn ->
+        if Process.whereis(RoutingSnapshotStore) == nil do
+          Supervisor.restart_child(ContextCacheSupervisor, RoutingSnapshotStore)
+        end
+      end)
+
+      assert :ok = Supervisor.terminate_child(ContextCacheSupervisor, RoutingSnapshotStore)
+
+      assert {tree, %RoutingSnapshot{table: nil} = snapshot} =
+               @subject.rules_tree_by_source_id(source.id)
+
+      expected = RoutingSnapshot.resolve(snapshot, rule_ids)
+      assert Enum.map(expected, &Target.id/1) == rule_ids
+      assert @subject.rules_tree_by_source_id(source.id) == {tree, snapshot}
+
+      assert {:ok, _pid} = Supervisor.restart_child(ContextCacheSupervisor, RoutingSnapshotStore)
+
+      assert {:fallback, ^expected, rules_by_id} =
+               RoutingSnapshot.resolve_with_status(snapshot, rule_ids)
+
+      assert {:repaired, repaired} =
+               @subject.repair_routing_snapshot(source.id, snapshot, rules_by_id)
+
+      assert {^tree, ^repaired} = @subject.rules_tree_by_source_id(source.id)
     end
 
     for invalidation <- [:bust, :expire, :clear] do
@@ -133,6 +165,50 @@ defmodule Logflare.Rules.CacheTest do
       {_tree, ^repaired} = @subject.rules_tree_by_source_id(source.id)
       assert repaired.key != snapshot.key
       assert {:ok, ^expected} = RoutingSnapshot.resolve_with_status(repaired, rule_ids)
+    end
+
+    test "store failures do not strand repair transaction locks", %{source: source} do
+      {tree, snapshot} = @subject.rules_tree_by_source_id(source.id)
+      rules_by_id = :erlang.binary_to_term(snapshot.encoded)
+
+      on_exit(fn ->
+        if Process.whereis(RoutingSnapshotStore) == nil do
+          Supervisor.restart_child(ContextCacheSupervisor, RoutingSnapshotStore)
+        end
+      end)
+
+      assert :ok = Supervisor.terminate_child(ContextCacheSupervisor, RoutingSnapshotStore)
+
+      assert {:error, _reason} =
+               @subject.repair_routing_snapshot(source.id, snapshot, rules_by_id)
+
+      assert {:ok, _pid} = Supervisor.restart_child(ContextCacheSupervisor, RoutingSnapshotStore)
+
+      assert {:repaired, repaired} =
+               @subject.repair_routing_snapshot(source.id, snapshot, rules_by_id)
+
+      assert {^tree, ^repaired} = @subject.rules_tree_by_source_id(source.id)
+    end
+
+    test "stale repair cannot overwrite a newer cached generation", %{source: source} do
+      {tree, old} = @subject.rules_tree_by_source_id(source.id)
+      old_rules_by_id = :erlang.binary_to_term(old.encoded)
+
+      new_entries =
+        Enum.map(old_rules_by_id, fn {id, {target_id, backend_id, sink}} when target_id == id ->
+          {id, {id, backend_id + 1_000_000, sink}}
+        end)
+
+      current = RoutingSnapshot.new(source.id, new_entries)
+      cache_key = {:rules_tree_by_source_id, [source.id]}
+      assert {:ok, true} = Cachex.put(@subject, cache_key, {:cached, {tree, current}})
+
+      assert {:fallback, _targets, ^old_rules_by_id} =
+               RoutingSnapshot.resolve_with_status(old, Map.keys(old_rules_by_id))
+
+      assert :stale = @subject.repair_routing_snapshot(source.id, old, old_rules_by_id)
+      assert {^tree, ^current} = @subject.rules_tree_by_source_id(source.id)
+      assert :ets.member(current.table, current.key)
     end
 
     test "list by source", %{source: source, rule_ids: expected_rule_ids} do

--- a/test/logflare/rules/rule_cache_test.exs
+++ b/test/logflare/rules/rule_cache_test.exs
@@ -5,6 +5,7 @@ defmodule Logflare.Rules.CacheTest do
   alias Logflare.Rules
   alias Logflare.Rules.RoutingSnapshot
   alias Logflare.Sources
+  alias Logflare.Sources.SourceRouter.Target
 
   @subject Rules.Cache
 
@@ -50,13 +51,13 @@ defmodule Logflare.Rules.CacheTest do
       assert %{hits: 3, writes: 2} = Cachex.stats!(@subject)
     end
 
-    test "rules tree by source id caches the tree with its rules", %{
+    test "rules tree by source id caches the tree with compact targets", %{
       source: source,
       rule_ids: rule_ids
     } do
       assert {tree, %RoutingSnapshot{} = snapshot} = @subject.rules_tree_by_source_id(source.id)
       assert snapshot.count == length(rule_ids)
-      assert Enum.map(RoutingSnapshot.resolve(snapshot, rule_ids), & &1.id) == rule_ids
+      assert Enum.map(RoutingSnapshot.resolve(snapshot, rule_ids), &Target.id/1) == rule_ids
 
       Mimic.reject(Rules, :rules_tree_by_source_id, 1)
       assert @subject.rules_tree_by_source_id(source.id) == {tree, snapshot}
@@ -69,7 +70,7 @@ defmodule Logflare.Rules.CacheTest do
         rule_ids: rule_ids
       } do
         {tree, old} = @subject.rules_tree_by_source_id(source.id)
-        old_rules = RoutingSnapshot.resolve(old, rule_ids)
+        old_targets = RoutingSnapshot.resolve(old, rule_ids)
         parent = self()
 
         reader =
@@ -92,20 +93,46 @@ defmodule Logflare.Rules.CacheTest do
             assert {:ok, 1} = Cachex.clear(@subject)
         end
 
-        new_rules = Map.new(old_rules, &{&1.id, %{&1 | lql_string: "replacement"}})
+        new_entries =
+          Enum.map(old_targets, fn {id, backend_id, sink} ->
+            {id, {id, backend_id + 1_000_000, sink}}
+          end)
 
         expect(Rules, :rules_tree_by_source_id, fn id ->
           assert id == source.id
-          {tree, new_rules}
+          {tree, new_entries}
         end)
 
         {^tree, current} = @subject.rules_tree_by_source_id(source.id)
         assert current.key != old.key
-        assert RoutingSnapshot.resolve(current, rule_ids) == Enum.map(rule_ids, &new_rules[&1])
+        assert RoutingSnapshot.resolve(current, rule_ids) == Enum.map(new_entries, &elem(&1, 1))
         refute :ets.member(old.table, old.key)
         send(reader.pid, :resume)
-        assert Task.await(reader) == old_rules
+        assert Task.await(reader) == old_targets
       end
+    end
+
+    test "repairs the still-current header after its ETS generation is lost", %{source: source} do
+      {_tree, snapshot} = @subject.rules_tree_by_source_id(source.id)
+      rule_ids = snapshot.encoded |> :erlang.binary_to_term() |> Map.keys()
+      expected = RoutingSnapshot.resolve(snapshot, rule_ids)
+
+      _replacement =
+        RoutingSnapshot.rehydrate(
+          snapshot,
+          source.id,
+          :erlang.binary_to_term(snapshot.encoded)
+        )
+
+      assert {:fallback, ^expected, encoded_targets} =
+               RoutingSnapshot.resolve_with_status(snapshot, rule_ids)
+
+      assert {:repaired, repaired} =
+               @subject.repair_routing_snapshot(source.id, snapshot, encoded_targets)
+
+      {_tree, ^repaired} = @subject.rules_tree_by_source_id(source.id)
+      assert repaired.key != snapshot.key
+      assert {:ok, ^expected} = RoutingSnapshot.resolve_with_status(repaired, rule_ids)
     end
 
     test "list by source", %{source: source, rule_ids: expected_rule_ids} do

--- a/test/logflare/sources/source_router/rules_tree_test.exs
+++ b/test/logflare/sources/source_router/rules_tree_test.exs
@@ -408,10 +408,25 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
       assert [%Rule{}] = @subject.matching_rules(le, source)
     end
 
-    test "drops matched ids whose rule no longer exists", %{source: source, log_event: le} do
-      stub(Rules, :get_rule, fn _id -> nil end)
+    test "drops matched ids missing from the snapshot", %{source: source, log_event: le} do
+      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
 
       assert @subject.matching_rules(le, source) == []
+    end
+
+    test "the snapshot resolves every rule id its tree can match", %{
+      source: source,
+      log_event: le
+    } do
+      {tree, rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      assert [_ | _] = ids = @subject.matching_rule_ids(le, tree)
+
+      for id <- ids do
+        assert Map.has_key?(rules_by_id, id)
+      end
     end
   end
 

--- a/test/logflare/sources/source_router/rules_tree_test.exs
+++ b/test/logflare/sources/source_router/rules_tree_test.exs
@@ -4,8 +4,10 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
   alias Logflare.LogEvent
   alias Logflare.Lql.Rules.FilterRule
   alias Logflare.Rules
+  alias Logflare.Rules.RoutingSnapshot
   alias Logflare.Rules.Rule
   alias Logflare.Sources.SourceRouter.RulesTree
+  alias Logflare.Sources.SourceRouter.Target
 
   @subject RulesTree
 
@@ -404,29 +406,52 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
       [source: source, log_event: build(:log_event, source: source, message: "testing123")]
     end
 
-    test "returns the rules matching the event", %{source: source, log_event: le} do
-      assert [%Rule{}] = @subject.matching_rules(le, source)
+    test "returns compact targets for the rules matching the event", %{
+      source: source,
+      log_event: le
+    } do
+      assert [target] = @subject.matching_rules(le, source)
+      assert Target.id(target) == hd(source.rules).id
     end
 
-    test "drops matched ids missing from the snapshot", %{source: source, log_event: le} do
-      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+    test "drops matched rule IDs missing from the snapshot", %{source: source, log_event: le} do
+      {tree, _targets} = Rules.rules_tree_by_source_id(source.id)
 
-      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, []} end)
 
       assert @subject.matching_rules(le, source) == []
     end
 
-    test "the snapshot resolves every rule id its tree can match", %{
+    test "the snapshot resolves every rule ID its tree can match", %{
       source: source,
       log_event: le
     } do
-      {tree, rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+      {tree, entries} = Rules.rules_tree_by_source_id(source.id)
 
-      assert [_ | _] = ids = @subject.matching_rule_ids(le, tree)
+      assert [_ | _] = rule_ids = @subject.matching_rule_ids(le, tree)
+      targets_by_id = Map.new(entries)
 
-      for id <- ids do
-        assert Map.has_key?(rules_by_id, id)
+      for rule_id <- rule_ids do
+        assert Map.has_key?(targets_by_id, rule_id)
       end
+    end
+
+    test "the first fallback rehydrates the still-current cached header", %{
+      source: source,
+      log_event: le
+    } do
+      {tree, snapshot} = Rules.Cache.rules_tree_by_source_id(source.id)
+      encoded_targets = :erlang.binary_to_term(snapshot.encoded)
+      _replacement = RoutingSnapshot.rehydrate(snapshot, source.id, encoded_targets)
+      refute :ets.member(snapshot.table, snapshot.key)
+
+      assert [target] = @subject.matching_rules(le, source, {tree, snapshot})
+
+      {^tree, repaired} = Rules.Cache.rules_tree_by_source_id(source.id)
+      assert repaired.key != snapshot.key
+
+      assert {:ok, [^target]} =
+               RoutingSnapshot.resolve_with_status(repaired, [hd(source.rules).id])
     end
   end
 

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -760,12 +760,17 @@ defmodule Logflare.Sources.SourceRouterTest do
   end
 
   describe "RulesTree with an unresolvable rule id" do
-    test "does not raise when a matched rule no longer exists", %{user: user, backend: backend} do
+    test "does not raise when a matched id is missing from the snapshot", %{
+      user: user,
+      backend: backend
+    } do
       rule = build(:rule, backend: backend, lql_string: "testing")
       source = insert(:source, user: user, rules: [rule])
       le = build(:log_event, source: source, message: "testing123")
 
-      expect(Rules, :get_rule, fn _id -> nil end)
+      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
 
       assert SourceRouter.route_to_sinks_and_ingest(le, source, SourceRouter.RulesTree) == le
     end

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -8,6 +8,7 @@ defmodule Logflare.Sources.SourceRouterTest do
   alias Logflare.Rules
   alias Logflare.Rules.Rule
   alias Logflare.Sources.SourceRouter
+  alias Logflare.Sources.SourceRouter.Target
   alias Logflare.SystemMetrics.AllLogsLogged
 
   @routers [SourceRouter.Sequential, SourceRouter.RulesTree]
@@ -17,6 +18,14 @@ defmodule Logflare.Sources.SourceRouterTest do
     insert(:plan)
     user = insert(:user)
     [user: user, backend: insert(:backend, user: user)]
+  end
+
+  test "prepares one routing snapshot for an event batch", %{user: user} do
+    source = insert(:source, user: user, rules: [build(:rule, lql_string: "match")])
+    events = List.duplicate(build(:log_event, source: source, message: "miss"), 10)
+
+    assert SourceRouter.route_to_sinks_and_ingest(events, source) == events
+    assert %{misses: 1, hits: 0, writes: 1} = Cachex.stats!(Rules.Cache)
   end
 
   for router <- @routers do
@@ -68,7 +77,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.([1, 2, 5, 0, -100, 1_000_000], 2)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.([], 2)
         assert unquote(router).matching_rules(le, source) == []
@@ -94,7 +103,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.("Chrome", "Chrome")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "list_includes_regexp operator", %{user: user} do
@@ -123,13 +132,13 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.(["a", "b", "abc123"], "23")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(["a", "b", "abc123"], "a\",")
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.("a, b, abc123", "b,")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.([], "23")
         assert unquote(router).matching_rules(le, source) == []
@@ -161,13 +170,13 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.("log error string", "error")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.("log info string", "error")
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.("stringstring", "string")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "string_contains operator 1", %{user: user} do
@@ -199,7 +208,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.("ten three")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "regex match operator", %{user: user} do
@@ -228,7 +237,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.("111", ~S|\d\d\d|)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.("11z", ~S|\d\d\d|)
         assert unquote(router).matching_rules(le, source) == []
@@ -256,7 +265,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.(123, "123")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "gt,lt,gte,lte operators", %{user: user} do
@@ -285,16 +294,16 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.(100, 1, :>)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(100, 200, :<)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(1, 1, :>=)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(1, 1, :<=)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "multiple filters", %{user: user} do
@@ -330,7 +339,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.(0, "string")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(1, "string")
         assert unquote(router).matching_rules(le, source) == []
@@ -371,7 +380,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.(1, "string")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "multiple negated filter", %{user: user} do
@@ -412,7 +421,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.("warn")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "nested lists with maps lvl4", %{user: user} do
@@ -472,7 +481,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         }
 
         {le, source} = build_data.(metadata, "value")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "nested lists with maps lvl1", %{user: user} do
@@ -508,7 +517,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         }
 
         {le, source} = build_data.(metadata, "value")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "range operator", %{user: user} do
@@ -537,7 +546,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         end
 
         {le, source} = build_data.(6, 1, 10, %{})
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(6, 1, 10, %{negate: true})
         assert unquote(router).matching_rules(le, source) == []
@@ -546,7 +555,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         assert unquote(router).matching_rules(le, source) == []
 
         {le, source} = build_data.(100, 101, 500, %{negate: true})
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
     end
 
@@ -595,13 +604,13 @@ defmodule Logflare.Sources.SourceRouterTest do
         }
 
         {le, source} = build_data.(metadata, 2)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(metadata, 4)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(metadata, 400)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
 
         {le, source} = build_data.(metadata, 350)
         assert unquote(router).matching_rules(le, source) == []
@@ -658,7 +667,7 @@ defmodule Logflare.Sources.SourceRouterTest do
 
         metadata = %{metadata | "ref" => "valid"}
         {le, source} = build_data.(metadata, 2)
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "eq operator with nested maps lvl4", %{user: user} do
@@ -718,7 +727,7 @@ defmodule Logflare.Sources.SourceRouterTest do
         }
 
         {le, source} = build_data.(metadata, "value")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
 
       test "eq operator with nested maps lvl1", %{user: user} do
@@ -754,13 +763,15 @@ defmodule Logflare.Sources.SourceRouterTest do
         }
 
         {le, source} = build_data.(metadata, "value")
-        assert unquote(router).matching_rules(le, source) == source.rules
+        assert unquote(router).matching_rules(le, source) == targets(source.rules)
       end
     end
   end
 
-  describe "RulesTree with an unresolvable rule id" do
-    test "does not raise when a matched id is missing from the snapshot", %{
+  defp targets(rules), do: Enum.map(rules, &Target.from_rule/1)
+
+  describe "RulesTree with an unresolvable position" do
+    test "does not raise when a matched position is missing from the snapshot", %{
       user: user,
       backend: backend
     } do
@@ -768,9 +779,9 @@ defmodule Logflare.Sources.SourceRouterTest do
       source = insert(:source, user: user, rules: [rule])
       le = build(:log_event, source: source, message: "testing123")
 
-      {tree, _rules_by_id} = Rules.rules_tree_by_source_id(source.id)
+      {tree, _targets} = Rules.rules_tree_by_source_id(source.id)
 
-      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, %{}} end)
+      expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, []} end)
 
       assert SourceRouter.route_to_sinks_and_ingest(le, source, SourceRouter.RulesTree) == le
     end

--- a/test/logflare/sources/source_router_test.exs
+++ b/test/logflare/sources/source_router_test.exs
@@ -1,3 +1,25 @@
+defmodule Logflare.Sources.SourceRouterTest.StateOnlyRouter do
+  @behaviour Logflare.Sources.SourceRouter
+
+  @impl true
+  def matching_rules(_event, _source) do
+    send(self(), :legacy_matching_rules_called)
+    []
+  end
+
+  @impl true
+  def prepare(_source) do
+    send(self(), :router_prepared)
+    0
+  end
+
+  @impl true
+  def matching_rules_with_state(_event, _source, state) do
+    send(self(), {:stateful_matching_rules_called, state})
+    {[], state + 1}
+  end
+end
+
 defmodule Logflare.Sources.SourceRouterTest do
   use Logflare.DataCase
 
@@ -12,6 +34,7 @@ defmodule Logflare.Sources.SourceRouterTest do
   alias Logflare.SystemMetrics.AllLogsLogged
 
   @routers [SourceRouter.Sequential, SourceRouter.RulesTree]
+  @state_only_router __MODULE__.StateOnlyRouter
 
   setup do
     start_supervised!(AllLogsLogged)
@@ -26,6 +49,21 @@ defmodule Logflare.Sources.SourceRouterTest do
 
     assert SourceRouter.route_to_sinks_and_ingest(events, source) == events
     assert %{misses: 1, hits: 0, writes: 1} = Cachex.stats!(Rules.Cache)
+  end
+
+  test "prepares and threads state for a state-only router", %{user: user} do
+    source = build(:source, user: user)
+    event = %LogEvent{body: %{}, via_rule_id: nil}
+
+    assert SourceRouter.route_to_sinks_and_ingest([event, event], source, @state_only_router) == [
+             event,
+             event
+           ]
+
+    assert_received :router_prepared
+    assert_received {:stateful_matching_rules_called, 0}
+    assert_received {:stateful_matching_rules_called, 1}
+    refute_received :legacy_matching_rules_called
   end
 
   for router <- @routers do

--- a/test/profiling/source_routing_batch_bench.exs
+++ b/test/profiling/source_routing_batch_bench.exs
@@ -1,0 +1,60 @@
+alias Logflare.LogEvent
+alias Logflare.Lql.Parser
+alias Logflare.Rules
+alias Logflare.Rules.Rule
+alias Logflare.Rules.RoutingSnapshot
+alias Logflare.Sources.Source
+alias Logflare.Sources.SourceRouter.RulesTree
+alias Logflare.Sources.SourceRouter.Target
+
+source_id = System.unique_integer([:positive])
+source = %Source{id: source_id}
+
+rules =
+  for i <- 1..1_000 do
+    {:ok, filters} = Parser.parse("severity_number:>#{i}")
+
+    %Rule{
+      id: i,
+      source_id: source_id,
+      backend_id: i,
+      lql_string: "severity_number:>#{i}",
+      lql_filters: filters
+    }
+  end
+
+tree = RulesTree.build(rules)
+targets = rules |> Enum.sort_by(& &1.id) |> Enum.map(&{&1.id, Target.from_rule(&1)})
+
+snapshot =
+  RoutingSnapshot.new(source_id, targets, extra_estimated_bytes: :erlang.external_size(tree))
+
+Cachex.put!(
+  Rules.Cache,
+  {:rules_tree_by_source_id, [source_id]},
+  {:cached, {tree, snapshot}}
+)
+
+event = %LogEvent{body: %{"severity_number" => 9}, source_id: source_id}
+8 = event |> RulesTree.matching_rule_ids(tree) |> length()
+
+Benchee.run(
+  %{
+    "fetch snapshot per event" => fn events ->
+      Enum.map(events, &RulesTree.matching_rules(&1, source))
+    end,
+    "fetch snapshot once per batch" => fn events ->
+      prepared = RulesTree.prepare(source)
+      Enum.map(events, &RulesTree.matching_rules(&1, source, prepared))
+    end
+  },
+  inputs: %{
+    "10 events, 1000 rules, 8 matches" => List.duplicate(event, 10),
+    "100 events, 1000 rules, 8 matches" => List.duplicate(event, 100)
+  },
+  pre_check: :all_same,
+  warmup: 1,
+  time: 3,
+  memory_time: 1,
+  print: [fast_warning: false]
+)

--- a/test/profiling/source_routing_bench.exs
+++ b/test/profiling/source_routing_bench.exs
@@ -59,7 +59,7 @@ one_matching = fn rules_num ->
     for i <- 1..rules_num do
       backend = insert(:backend, user: user)
 
-      lql_string = "metadata.rule_id:rule-#{i} severity_number:>8"
+      lql_string = ~s(metadata.rule_id:"rule-#{i}" severity_number:>8)
       {:ok, filters} = Parser.parse(lql_string)
 
       %Rule{
@@ -96,7 +96,7 @@ end
 
 all_matching = fn rules_num ->
   rules =
-    for i <- 1..rules_num do
+    for _i <- 1..rules_num do
       backend = insert(:backend, user: user)
 
       lql_string = "m.type:otel_log severity_number:>8"
@@ -116,34 +116,80 @@ end
 
 warmup = fn source ->
   rules = Rules.Cache.list_rules(source)
-  for rule <- rules, do: Rules.Cache.get_rule(rule.id)
-  _rule_set = Rules.Cache.rules_tree_by_source_id(source.id)
+  entries = for rule <- rules, do: {{:get_rule, [rule.id]}, {:cached, rule}}
+  Cachex.put_many!(Rules.Cache, entries)
+  Rules.Cache.rules_tree_by_source_id(source.id)
 end
 
+# ROUTING_BENCH_STAGES=1 isolates cache copying from matching/resolution.
+# ROUTING_BENCH_PARALLEL=6 measures concurrent readers without changing fixtures.
+# The stage harness supports both the #3937 map and #3942 per-rule cache baselines.
+stages? = System.get_env("ROUTING_BENCH_STAGES") == "1"
+parallel = System.get_env("ROUTING_BENCH_PARALLEL", "1") |> String.to_integer()
+
+scenarios =
+  if stages? do
+    %{
+      "Cache fetch" => fn {_event, source, _tree, _lookup, _ids} ->
+        Rules.Cache.rules_tree_by_source_id(source.id)
+      end,
+      "Match IDs (resident tree)" => fn {event, _source, tree, _lookup, _ids} ->
+        SourceRouter.RulesTree.matching_rule_ids(event, tree)
+      end,
+      "Resolve IDs (resident header)" => fn {_event, _source, _tree, lookup, ids} ->
+        case lookup do
+          :individual_rule_cache -> apply(Rules.Cache, :get_rules, [ids])
+          %{__struct__: _} -> apply(Rules.RoutingSnapshot, :resolve, [lookup, ids])
+          rules_by_id -> for id <- ids, rule = Map.get(rules_by_id, id), do: rule
+        end
+      end
+    }
+  else
+    %{
+      "Reference" => fn {event, source} ->
+        SourceRouter.Sequential.matching_rules(event, source) |> MapSet.new()
+      end,
+      "RulesTree" => fn {event, source} ->
+        SourceRouter.RulesTree.matching_rules(event, source) |> MapSet.new()
+      end
+    }
+  end
+
 Benchee.run(
-  %{
-    "Reference" => fn {event, source} ->
-      SourceRouter.Sequential.matching_rules(event, source) |> MapSet.new()
-    end,
-    "RulesTree" => fn {event, source} ->
-      SourceRouter.RulesTree.matching_rules(event, source) |> MapSet.new()
-    end
-  },
-  before_scenario: fn {event, source} ->
+  scenarios,
+  before_scenario: fn {event, source, expected_count} ->
     Cachex.clear!(Rules.Cache)
     warmup.(source)
-    {event, source}
+
+    {tree, lookup} =
+      case Rules.Cache.rules_tree_by_source_id(source.id) do
+        {tree, lookup} -> {tree, lookup}
+        tree when is_list(tree) -> {tree, :individual_rule_cache}
+      end
+
+    ids = SourceRouter.RulesTree.matching_rule_ids(event, tree)
+
+    if length(ids) != expected_count do
+      raise "expected #{expected_count} matching rules, got #{length(ids)}"
+    end
+
+    if stages? do
+      {event, source, tree, lookup, ids}
+    else
+      {event, source}
+    end
   end,
   inputs: %{
-    "source with 100 rules and few matching" => few_matching.(100),
-    "source with 100 rules and one matching" => one_matching.(100),
-    "source with 100 rules and all matching" => all_matching.(100),
-    "source with 1000 rules and few matching" => few_matching.(1000),
-    "source with 1000 rules and one matching" => one_matching.(1000),
-    "source with 1000 rules and all matching" => all_matching.(1000)
+    "source with 100 rules and few matching" => Tuple.insert_at(few_matching.(100), 2, 8),
+    "source with 100 rules and one matching" => Tuple.insert_at(one_matching.(100), 2, 1),
+    "source with 100 rules and all matching" => Tuple.insert_at(all_matching.(100), 2, 100),
+    "source with 1000 rules and few matching" => Tuple.insert_at(few_matching.(1000), 2, 8),
+    "source with 1000 rules and one matching" => Tuple.insert_at(one_matching.(1000), 2, 1),
+    "source with 1000 rules and all matching" => Tuple.insert_at(all_matching.(1000), 2, 1000)
   },
   # save: [path: Path.join(__DIR__, "source_routing.benchee")],
-  pre_check: :all_same,
+  pre_check: if(stages?, do: false, else: :all_same),
+  parallel: parallel,
   # profile_after: :tprof,
   time: 5,
   memory_time: 2

--- a/test/profiling/source_routing_cache_hardening_results.md
+++ b/test/profiling/source_routing_cache_hardening_results.md
@@ -1,0 +1,81 @@
+# Routing snapshot cache hardening follow-up
+
+This note records the measurements for the additive hardening commit on PR
+#3943. It intentionally excludes the stacked zero-based positional-tree change.
+
+The commit:
+
+- prepares one immutable tree/snapshot for an ingest batch;
+- stores compact `{rule_id, backend_id, sink}` targets rather than `%Rule{}`;
+- rehydrates the current cache header once after an ETS generation is lost and
+  otherwise carries a decoded reader-owned fallback for the rest of the batch;
+- adds a configurable estimated-byte bound and store lifecycle telemetry.
+
+## Environment and fixture
+
+The environment and corrected six-case fixtures are the same as
+[`source_routing_snapshot_results.md`](source_routing_snapshot_results.md):
+Linux, Elixir 1.18.4, OTP 27, JIT enabled, Benchee with one second warmup, three
+seconds measurement, one second memory measurement, and outlier exclusion
+disabled. Results are microbenchmarks rather than production throughput claims.
+
+## Single-event routing
+
+One local run of the checked-in `source_routing_bench.exs` produced:
+
+| Rules / matches | #3943 published runs | Cache hardening | Approximate mean change |
+| --- | ---: | ---: | ---: |
+| 100 / 8 | 7.63 / 7.20 us | 7.02 us | 1.06x faster |
+| 100 / 1 | 11.28 / 10.34 us | 11.65 us | comparable |
+| 100 / all | 74.60 / 72.57 us | 24.78 us | 2.97x faster |
+| 1,000 / 8 | 39.04 / 38.97 us | 35.97 us | 1.08x faster |
+| 1,000 / 1 | 86.07 / 86.89 us | 129.17 us | 1.49x slower |
+| 1,000 / all | 0.88 / 0.90 ms | 0.348 ms | 2.56x faster |
+
+The 1,000-rule/one-match result is disclosed rather than generalized away. The
+adjacent representation probe documented by the positional follow-up found the
+position-vs-ID matching phase within 1%, so this shape needs production-informed
+profiling rather than another speculative tree change.
+
+## Batch reuse
+
+The checked-in batch benchmark builds a 1,000-rule snapshot with eight matches
+and routes the same event 10 or 100 times. It compares calling the public router
+for every event with preparing once and carrying the immutable state through the
+batch.
+
+| Batch size | Prepare once | Fetch per event | Speedup | Allocation reduction |
+| --- | ---: | ---: | ---: | ---: |
+| 10 events | 90.78 us | 393.89 us | 4.34x | 8.85x |
+| 100 events | 0.66 ms | 3.87 ms | 5.85x | 11.33x |
+
+The positional child reduces the prepare-once allocations further, but those
+additional results are not attributed to this commit.
+
+## Compact target footprint
+
+A component model counted one externalized tree, sorted snapshot tuple, binary
+ID index, and compressed reader-owned fallback for both representations. It
+used the real six database-backed benchmark fixtures.
+
+| Rules / shape | Full `%Rule{}` snapshot | Compact ID/target snapshot | Reduction |
+| --- | ---: | ---: | ---: |
+| 100 / 8 | 119,678 B | 6,250 B | 94.8% |
+| 100 / 1 | 141,660 B | 6,936 B | 95.1% |
+| 100 / all | 135,339 B | 5,757 B | 95.7% |
+| 1,000 / 8 | 1,200,859 B | 65,572 B | 94.5% |
+| 1,000 / 1 | 1,415,404 B | 71,333 B | 95.0% |
+| 1,000 / all | 1,352,493 B | 58,385 B | 95.7% |
+
+This is a representation model, not resident-process memory. It excludes
+Cachex/ETS table overhead and allocator fragmentation equally from both sides.
+The measured compact snapshot publication step ranged from 0.42 to 0.57 ms for
+the 1,000-rule cases.
+
+## Commands
+
+```sh
+MIX_ENV=test ../bin/x mix run test/profiling/source_routing_bench.exs
+MIX_ENV=test ../bin/x mix run test/profiling/source_routing_batch_bench.exs
+MIX_ENV=test ../bin/x mix run /tmp/routing-base-footprint.exs
+```

--- a/test/profiling/source_routing_cache_hardening_results.md
+++ b/test/profiling/source_routing_cache_hardening_results.md
@@ -15,9 +15,8 @@ The commit:
 
 The environment and corrected six-case fixtures are the same as
 [`source_routing_snapshot_results.md`](source_routing_snapshot_results.md):
-Linux, Elixir 1.19.5, OTP 27.3.4.6, JIT enabled, Benchee with one second warmup,
-three
-seconds measurement, one second memory measurement, and outlier exclusion
+Linux, Elixir 1.19.5, OTP 27.3.4.6, JIT enabled, Benchee with two seconds warmup,
+five seconds measurement, two seconds memory measurement, and outlier exclusion
 disabled. Results are microbenchmarks rather than production throughput claims.
 
 ## Single-event routing

--- a/test/profiling/source_routing_cache_hardening_results.md
+++ b/test/profiling/source_routing_cache_hardening_results.md
@@ -15,7 +15,8 @@ The commit:
 
 The environment and corrected six-case fixtures are the same as
 [`source_routing_snapshot_results.md`](source_routing_snapshot_results.md):
-Linux, Elixir 1.18.4, OTP 27, JIT enabled, Benchee with one second warmup, three
+Linux, Elixir 1.19.5, OTP 27.3.4.6, JIT enabled, Benchee with one second warmup,
+three
 seconds measurement, one second memory measurement, and outlier exclusion
 disabled. Results are microbenchmarks rather than production throughput claims.
 

--- a/test/profiling/source_routing_snapshot_results.md
+++ b/test/profiling/source_routing_snapshot_results.md
@@ -1,0 +1,229 @@
+# Routing snapshot benchmark and lifetime protocol
+
+## Comparison
+
+Current parent: `130bdeb6` (#3942, the rollback of #3937). The implementation was
+rebased onto that revision before the final comparison below. An earlier,
+separately labeled comparison against `1bff0f28` (the #3937 regression baseline)
+is retained for context. Each comparison uses two runs per revision in the same
+workspace/runtime, with an identical harness within that comparison.
+
+Environment: Linux, 6 available cores, Elixir 1.19.5, OTP 27.3.4.6, JIT enabled.
+Benchee 1.5.0: parallel 1, warmup 2 seconds, measurement 5 seconds, memory 2 seconds
+per scenario. The sequential router is the reference; `pre_check: :all_same`
+passes, and fixture match counts are independently asserted before measurement.
+These are local microbenchmarks, not production throughput or CI-parity results.
+
+```sh
+MIX_ENV=test ../bin/x mix run test/profiling/source_routing_bench.exs
+MIX_ENV=test ROUTING_BENCH_STAGES=1 ../bin/x mix run test/profiling/source_routing_bench.exs
+```
+
+For the parent, copy the candidate harness outside the checkout, switch to the
+parent revision using jj, and run that same file via `mix run`. No dependencies
+or build caches are copied between workspaces.
+
+### End-to-end latency against current main (#3942)
+
+Each cell contains the average from run 1 / run 2. Speedup is the ratio of the
+two-run arithmetic means, using the rounded Benchee output.
+
+| Rules | Matches | Current main | Rebased candidate | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| 100 | 8 | 13.35 / 13.58 us | 7.63 / 7.20 us | 1.82x |
+| 100 | 1 | 11.86 / 12.08 us | 11.28 / 10.34 us | 1.11x |
+| 100 | 100 | 152.26 / 161.65 us | 74.60 / 72.57 us | 2.13x |
+| 1,000 | 8 | 47.52 / 48.30 us | 39.04 / 38.97 us | 1.23x |
+| 1,000 | 1 | 88.71 / 89.48 us | 86.07 / 86.89 us | 1.03x |
+| 1,000 | 1,000 | 1.52 / 1.54 ms | 0.88 / 0.90 ms | 1.72x |
+
+The single-match results are effectively comparable, especially at 1,000 rules;
+do not interpret a 3% difference as a demonstrated throughput improvement.
+The main benefits over the rollback are same-query snapshot consistency and
+dense routing. The current-main `get_rules/1` API and its tests remain intact,
+but snapshot routing no longer depends on individual cache entries.
+
+Both revisions bulk-prefill individual rule cache entries from the fixture's
+list query before measurement. This represents a fully warmed cache without
+thousands of redundant setup queries. Two earlier candidate attempts with
+per-rule database warmup timed out before producing summaries; neither is used
+in these results.
+
+### Earlier comparison against the #3937 regression baseline
+
+This comparison predates #3942/rebase and used the same corrected match fixtures,
+but did not prefill individual rule cache entries (neither implementation used
+them). It is **not** the current-main speedup claim.
+
+| Rules | Matches | #3937 baseline | Pre-rebase candidate | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| 100 | 8 | 46.29 / 46.52 us | 7.41 / 6.75 us | 6.55x |
+| 100 | 1 | 66.79 / 63.53 us | 10.96 / 10.25 us | 6.14x |
+| 100 | 100 | 99.33 / 99.25 us | 72.52 / 72.11 us | 1.37x |
+| 1,000 | 8 | 443.34 / 430.43 us | 40.53 / 39.19 us | 10.96x |
+| 1,000 | 1 | 603.11 / 592.24 us | 87.35 / 86.92 us | 6.86x |
+| 1,000 | 1,000 | 1.03 / 1.01 ms | 0.90 / 0.90 ms | 1.13x |
+
+The small sparse cases have high relative variance (candidate 100/8 deviation
+91-130%). Their medians are 6.09 / 5.97 us versus the parent's 43.35 / 43.09 us.
+The 1,000/8 medians are 36.79 / 36.40 us versus 390.66 / 382.46 us. The sparse
+improvement is substantially larger than that noise. Dense results improve in
+both final runs, rather than restoring the old per-rule-cache dense cost.
+
+**Fixture correction:** the previous `metadata.rule_id:rule-100` literal was
+unquoted. The parser interpreted it as equality to `"rule"` plus a negated
+message term, so the scenarios called "one matching" actually matched zero
+rules. This PR quotes the literal and checks that the scenarios really match
+8, 1, or all rules. Earlier v1.50.9/main "one match" numbers are not comparable
+to these corrected measurements. v1.50.9 was not rerun for this PR.
+
+### Isolating the copy cost
+
+Stage measurements have prefetched headers/trees and intentionally different
+return values; their pre-check is disabled. They are diagnostics, not timings
+to add together as if they had identical allocation/GC behavior.
+
+For 1,000 rules / 8 matches:
+
+| Stage | Parent average | Candidate average |
+| --- | ---: | ---: |
+| Cache fetch | 433.34 us | 30.40 us |
+| Matching IDs with resident tree | 6.17 us | 5.81 us |
+| Resolving IDs with resident header | 0.119 us | 2.19 us |
+
+This isolates full-map cache retrieval as the dominant sparse-path cost.
+Tree copying still scales with tree size; this change removes **unmatched rule
+payload** copying, not all O(number of rules) work from every possible tree.
+
+### Memory and cold construction
+
+A separate probe modeled **current main's fully warmed routing cache** with real
+Cachex entries: one tree header and one `get_rule` entry per rule. The candidate
+used a real Cachex header plus its store and two lifecycle indexes. Common list
+cache entries and fixed empty-table overhead are excluded. The figures count
+ETS memory deltas plus candidate index/fallback binary bytes, not VM RSS.
+
+| Rules / matches | Current-main layout bytes | Candidate layout bytes |
+| --- | ---: | ---: |
+| 100 / 8 | 153,016 | 149,273 |
+| 100 / 1 | 185,064 | 181,746 |
+| 100 / all | 178,144 | 173,569 |
+| 1,000 / 8 | 1,546,696 | 1,485,307 |
+| 1,000 / 1 | 1,864,632 | 1,807,773 |
+| 1,000 / all | 1,795,024 | 1,720,419 |
+
+The modeled candidate layout is about 2-4% smaller than the rollback's warmed
+routing layout. This is not a claim about total production cache memory, where
+other consumers can retain list or individual-rule entries too.
+
+The following older allocation/footprint measurements compare against **#3937**,
+not the rollback. This is not a blanket allocation reduction. Benchee's reported per-operation
+memory for 1,000/8 increases from 3.62 KB to 102.95 KB, while 1,000/all decreases
+from 785.76-787.27 KB to 671.97-674.10 KB. These are process allocation statistics,
+not total retained cache memory or RSS.
+
+A separate fixture footprint probe counted ETS memory deltas (including the
+candidate's source/expiry indexes and header) plus its external index/fallback
+binary byte sizes. It excludes fixed empty-table overhead and is not a whole-VM
+RSS measurement; common external binary payloads are not separately counted.
+
+| Rules / matches | Parent ETS bytes | Candidate ETS + snapshot binary bytes |
+| --- | ---: | ---: |
+| 100 / 8 | 141,512 | 149,398 |
+| 100 / 1 | 173,528 | 182,006 |
+| 100 / all | 166,528 | 173,555 |
+| 1,000 / 8 | 1,414,200 | 1,485,227 |
+| 1,000 / 1 | 1,731,848 | 1,808,882 |
+| 1,000 / all | 1,662,144 | 1,725,046 |
+
+The measured footprint increase is about 4-6%. Compression level 1 keeps the
+backup small without adding codec work to normal reads. One-shot snapshot
+construction (sorting, compression and store publication; excludes DB/tree
+construction) took 0.38-0.48 ms for 100 rules and 3.75-3.95 ms for 1,000 rules.
+These construction measurements were not repeated latency distributions.
+
+A six-reader Benchee attempt was killed with exit -9 before producing results.
+The cause was not established; no concurrent-throughput improvement is claimed.
+Concurrency correctness is covered separately by the test suite.
+
+## Lifetime protocol
+
+1. One `Rules.rules_tree_by_source_id/1` query produces the tree and complete map.
+2. Sort rule IDs into a compact binary index. Store a tuple keyed by
+   `{source_id, make_ref()}`, with `{id, rule}` entries at known tuple positions.
+3. Publish the complete `{tree, snapshot_header}` as one Cachex value only after
+   compression and ETS insertion succeed. Headers carry the ETS table identity,
+   generation, rule count, index binary and compressed map binary.
+4. Sparse reads binary-search IDs and use `:ets.lookup_element/3`. Dense reads
+   (at least half the rules) copy the tuple once and reconstruct the map. Neither
+   path calls a GenServer, reads individual rules from the database, or resolves
+   against a different generation.
+5. If **any** required ETS lookup loses its generation/table, discard the partial
+   result and resolve all IDs from that header's compressed map. Even a reader
+   suspended across eviction, rebuild or store restart retains its exact data.
+6. The store keeps only one generation per source, at most 100,000 sources, with
+   a one-hour TTL and five-minute sweep. Publication also prunes expired/overflow
+   entries. Data, source and expiry indexes retire together; old cache busts are
+   generation-qualified and cannot retire a newer publication.
+
+The compressed binary is the VM-managed reader reference. No explicit reader
+lease/refcount server or fixed grace-period safety assumption is necessary.
+Crashing readers release their binaries through the VM. Suspended readers can
+retain their acquired data, but never pin a growing store-side list of retired
+generations.
+
+Cachex remains authoritative for header expiry/limit/clear and WAL-driven
+`Rules.Cache.bust_by/1`. Source busts also request asynchronous retirement of the
+exact backing generation. Cachex expiry/clear/limit can leave disposable backing
+data until replacement/store TTL/capacity cleanup; this cannot cause partial
+snapshots. The list warmer is unchanged and cannot publish partial routing
+snapshots. Snapshot data remains per-node.
+
+## Tradeoffs / draft review points
+
+- The 50% dense threshold is a conservative hybrid policy, not a proven optimum
+  across all rule shapes; intermediate match densities need production-shaped
+  measurements before tuning it.
+- Invalidated/evicted generations use slower full-map decompression. After a
+  store restart, already cached headers keep using their fallback until header
+  invalidation/expiry; this implementation does not backfill those headers.
+- Cold publication is serialized in one store process. Hot reads are not.
+  Large simultaneous cold rebuilds and large-source capacity deserve load tests.
+- The store is bounded by source count, not an absolute byte budget. Memory held
+  by active readers is managed by normal VM reference counting/GC.
+- No production rollout, hosted throughput claim, or full-suite run is included.
+
+## Validation and artifacts
+
+104 tests, 0 failures, 1 existing excluded benchmark test across:
+
+- `test/logflare/rules/routing_snapshot_test.exs`
+- `test/logflare/rules/rule_cache_test.exs`
+- `test/logflare/sources/source_router/rules_tree_test.exs`
+- `test/logflare/sources/source_router_test.exs`
+- `test/logflare/context_cache_test.exs`
+- `test/logflare/context_cache/gossip_test.exs`
+- `test/logflare/context_cache/cache_buster_test.exs`
+- `test/logflare/backends/spool/consumer_pipeline_test.exs`
+
+Coverage includes sparse/dense/fallback equivalence, missing/nil IDs, bigint
+index boundaries, fixed header heap size, concurrent rebuilds, paused/crashed
+readers, capacity/expiry, late retirement, store restart, cache bust/expire/clear,
+and existing nil-rule/spool error-isolation regressions.
+
+Local captured artifacts (not portable repository links):
+
+- `/tmp/agent-capture-routing-main-final{1,2}.log` (current-main comparison)
+- `/tmp/agent-capture-routing-rebased-final{1,2}.log` (current candidate)
+- `/tmp/agent-capture-routing-current-main-footprint.log`
+- `/tmp/agent-capture-routing-final-validation.log`
+- `/tmp/agent-capture-routing-parent-release{1,2}.log`
+- `/tmp/agent-capture-routing-candidate-release{1,2}.log`
+- `/tmp/agent-capture-routing-parent-stages-corrected.log`
+- `/tmp/agent-capture-routing-candidate-stages-release.log`
+- `/tmp/agent-capture-routing-snapshot-footprint-compressed.log`
+- `/tmp/agent-capture-routing-snapshot-final-tests.log`
+
+Rejected prototypes: full binary decode regressed dense matching roughly 3x;
+selecting fields out of a single ETS map did not remove sparse scaling. Indexed
+ETS tuple elements avoid both costs on the normal path.


### PR DESCRIPTION
## Review scope

> This PR owns the generation-safe **ID-keyed** routing snapshot cache and its production hardening: compact targets, batch reuse, missing-generation repair, and byte-aware capacity/telemetry.
>
> It intentionally does **not** include zero-based positional addressing; that isolated change is stacked as #3946.

| Boundary | Revision | Purpose |
| --- | --- | --- |
| Main used for the original routing comparison | `130bdeb6` (#3942) | Per-rule Cachex lookup baseline |
| Initial generation-safe snapshot | `a943dc6a` | Original snapshot-cache implementation |
| This PR head | `6820c6ee` | Hardened ID-keyed snapshot |
| Positional child | `4754419c` (#3946) | Separate addressing optimization |

## What changes

- Build the routing tree and compact `{rule_id, backend_id, sink}` targets from one database query.
- Publish a small Cachex header and one generation-qualified ETS target tuple per source.
- Binary-search a compact rule-ID index for sparse matches; fetch the tuple once for dense matches.
- Prepare one immutable tree/snapshot per ingest batch rather than fetching it for every event.
- Keep a compressed reader-owned target map as the exact fallback for replacement, eviction, or store restart.
- After fallback, rehydrate only the still-current Cachex generation; stale readers continue with their own decoded snapshot.
- Bound the store by 100,000 sources, a configurable 512 MiB estimated-byte limit, one-hour TTL, and five-minute sweep.
- Emit `[:logflare, :rules, :routing_snapshot_store]` source/byte gauges on lifecycle changes.
- Preserve nil rejection, routing-target validation, and spool per-source error isolation.

## Architecture

```mermaid
flowchart LR
  Q["One rules query"] --> B["Routing tree + compact targets"]
  B --> C["Cachex header<br/>tree + generation + fallback"]
  B --> E["ETS generation<br/>target tuple"]

  P["Prepare once per batch"] --> C
  C --> M["Match rule IDs"]
  M --> H{"ETS generation available?"}
  H -->|Yes| R["Read matched targets"]
  H -->|No| F["Decode immutable fallback once"]
  F --> K{"Header still current?"}
  K -->|Yes| RH["Rehydrate ETS + Cachex header"]
  K -->|No| L["Carry decoded fallback through batch"]
```

### Consistency guarantees

- Tree and target snapshot come from the same query and are published together.
- Generation-qualified keys prevent a reader from combining old and new targets.
- Replacement retires old ETS data immediately without requiring reader acquisition/release bookkeeping.
- Suspended, crashed, or stale readers remain correct through their immutable fallback.
- Count, byte, TTL, and explicit invalidation retirement all preserve the same generation rules.

## Performance

These are local microbenchmarks, not production-throughput claims. The corrected fixtures assert the intended 1/8/all match counts before measurement. Environment: Linux, 6 available cores, Elixir 1.19.5, OTP 27.3.4.6, JIT, Benchee 1.5.0, parallel 1, warmup 2s, measurement 5s, memory 2s.

### 1. Initial snapshot vs then-current main

Two alternating runs per revision with fully warmed caches:

| Rules / matches | Main `130bdeb6` | Initial snapshot `a943dc6a` | Mean change |
| --- | ---: | ---: | ---: |
| 100 / 8 | 13.35 / 13.58 us | 7.63 / 7.20 us | 1.82x faster |
| 100 / 1 | 11.86 / 12.08 us | 11.28 / 10.34 us | 1.11x faster |
| 100 / all | 152.26 / 161.65 us | 74.60 / 72.57 us | 2.13x faster |
| 1,000 / 8 | 47.52 / 48.30 us | 39.04 / 38.97 us | 1.23x faster |
| 1,000 / 1 | 88.71 / 89.48 us | 86.07 / 86.89 us | comparable |
| 1,000 / all | 1.52 / 1.54 ms | 0.88 / 0.90 ms | 1.72x faster |

### 2. Hardening commit vs initial snapshot

One adjacent run after adding compact ID-keyed targets, batch state, recovery, and byte-aware lifecycle handling:

| Rules / matches | Initial snapshot | Hardened ID-keyed head | Approximate change |
| --- | ---: | ---: | ---: |
| 100 / 8 | 7.63 / 7.20 us | 7.02 us | 1.06x faster |
| 100 / 1 | 11.28 / 10.34 us | 11.65 us | comparable |
| 100 / all | 74.60 / 72.57 us | 24.78 us | 2.97x faster |
| 1,000 / 8 | 39.04 / 38.97 us | 35.97 us | 1.08x faster |
| 1,000 / 1 | 86.07 / 86.89 us | 129.17 us | **1.49x slower** |
| 1,000 / all | 0.88 / 0.90 ms | 0.348 ms | 2.56x faster |

The 1,000-rule/one-match regression is explicit. A matching-only probe found ID and positional keys within 1%, so this shape needs production-informed profiling rather than another speculative tree change.

### 3. Batch allocation and retained representation

For 1,000 rules / 8 matches, preparing the ID-keyed snapshot once per batch was:

| Batch | Prepare once vs fetch per event | Allocation reduction |
| --- | ---: | ---: |
| 10 events | 4.34x faster | 8.85x lower |
| 100 events | 5.85x faster | 11.33x lower |

Replacing full `%Rule{}` values with compact targets reduced the modeled tree/tuple/index/fallback representation by **94.5-95.7%**. The 1,000-rule fixtures fell from **1.20-1.42 MB to 58-71 KB**. This component model excludes Cachex/ETS table overhead and allocator fragmentation; it is not process RSS.

Full hardening details: [`source_routing_cache_hardening_results.md`](test/profiling/source_routing_cache_hardening_results.md).

The cumulative **final stack vs current main** retained-memory and batch-allocation comparison is in #3946. Those positional-head results are not attributed to this ID-keyed boundary.

<details>
<summary>Earlier #3937 comparison, fixture correction, and commands</summary>

Before the rebase, two runs against `1bff0f28` showed 6.1-11.0x faster sparse routing and 1.13-1.37x faster dense routing. Those gains are not claimed against current main. Stage isolation for 1,000 rules / 8 matches reduced cache fetch from 433.34 us to 30.40 us while resident-tree matching stayed around 6 us, identifying full-map retrieval as the dominant #3937 regression cost.

The previous unquoted `metadata.rule_id:rule-100` parsed as equality to `"rule"` plus a negated message term, so the case labeled “one matching” actually matched zero rules. The fixture is now quoted and every case asserts its intended count. Earlier mislabeled v1.50.9/main numbers are not comparable.

Initial snapshot details: [`source_routing_snapshot_results.md`](test/profiling/source_routing_snapshot_results.md).

```sh
MIX_ENV=test ../bin/x mix run test/profiling/source_routing_bench.exs
MIX_ENV=test ../bin/x mix run test/profiling/source_routing_batch_bench.exs
MIX_ENV=test ROUTING_BENCH_STAGES=1 ../bin/x mix run test/profiling/source_routing_bench.exs
```

A six-reader Benchee attempt was killed with exit -9 before results; no concurrent-throughput claim is made.
</details>

## Validation

- [x] 90 focused snapshot/cache/tree/router tests, 0 failures, 1 existing excluded benchmark test.
- [x] 25 additional rules/context-cache/gossip/cache-buster/BigQuery consumer tests, 0 failures.
- [x] Concurrent replacement, suspended/crashed readers, restart, conditional repair, batch-local fallback reuse, count/byte capacity, expiry, telemetry, late retirement, sparse/dense/fallback equivalence, and threshold boundaries.
- [x] Formatter and `MIX_ENV=test mix compile` through project wrappers.
- [x] `MIX_ENV=test mix lint.all`; only 32 existing design suggestions.
- [x] `MIX_ENV=test mix test.typings`; 158 configured errors skipped, 10 existing unnecessary skips, task passed.
- [x] Hosted Elixir CI and Playwright pass at `6820c6ee`.
- [ ] Production-shaped concurrent throughput and rollout were not performed locally.

## Remaining review points

- The 50% dense threshold is conservative rather than demonstrated optimal across production rule shapes.
- Estimated-byte accounting is approximate, and one oversized source is retained rather than made unroutable.
- Cold publication is serialized; hot reads are not.
- The 1,000-rule/one-match microbenchmark needs production-informed profiling.

Related: #3935, #3937, #3942. Positional follow-up: #3946.
