### PR TITLE
perf: address routing snapshots by position

### DIFF
--- a/lib/logflare/rules.ex
+++ b/lib/logflare/rules.ex
@@ -6,7 +6,7 @@ defmodule Logflare.Rules do
   alias Logflare.Repo
   alias Logflare.Rules.Rule
   alias Logflare.Sources.Source
-  alias Logflare.Sources.SourceRouter.{RulesTree, Target}
+  alias Logflare.Sources.SourceRouter.RulesTree
   alias Logflare.SourceSchemas
   alias Logflare.Backends.Backend
   alias Logflare.Backends.SourceSup
@@ -49,22 +49,15 @@ defmodule Logflare.Rules do
   end
 
   @doc """
-  Returns a routing tree and its ordered compact routing targets.
+  Returns a positional routing tree and its ordered compact routing targets.
 
-  Both halves come from one `list_by_source_id/1` read, so every rule ID in the
+  Both halves come from one `list_by_source_id/1` read, so every position in the
   tree resolves to a target in the same immutable snapshot.
   """
   @spec rules_tree_by_source_id(integer()) ::
-          {RulesTree.t(), [{Rule.id(), Target.t()}]}
+          {RulesTree.t(), [Logflare.Sources.SourceRouter.Target.t()]}
   def rules_tree_by_source_id(id) do
-    rules = list_by_source_id(id)
-
-    targets =
-      rules
-      |> Enum.sort_by(& &1.id)
-      |> Enum.map(&{&1.id, Target.from_rule(&1)})
-
-    {RulesTree.build(rules), targets}
+    id |> list_by_source_id() |> RulesTree.build_routing()
   end
 
   @doc """

--- a/lib/logflare/rules/cache.ex
+++ b/lib/logflare/rules/cache.ex
@@ -67,7 +67,7 @@ defmodule Logflare.Rules.Cache do
   end
 
   @doc false
-  @spec repair_routing_snapshot(integer(), Rules.RoutingSnapshot.t(), map()) ::
+  @spec repair_routing_snapshot(integer(), Rules.RoutingSnapshot.t(), tuple()) ::
           {:repaired, Rules.RoutingSnapshot.t()} | :stale | {:error, term()}
   def repair_routing_snapshot(source_id, %Rules.RoutingSnapshot{} = snapshot, targets) do
     cache_key = {:rules_tree_by_source_id, [source_id]}

--- a/lib/logflare/rules/routing_snapshot.ex
+++ b/lib/logflare/rules/routing_snapshot.ex
@@ -1,123 +1,112 @@
 defmodule Logflare.Rules.RoutingSnapshot do
   @moduledoc """
-  Immutable compact routing targets for one rules-tree generation.
+  Immutable compact routing targets for one positional rules-tree generation.
 
-  The tree emits database rule IDs. A sorted binary index maps those IDs to ETS
-  tuple positions, so sparse reads copy only matched compact targets. Dense reads
-  copy the tuple once and reconstruct the compact lookup map.
+  The tree emits zero-based tuple positions rather than database IDs. Sparse
+  reads copy only those ETS tuple elements, while dense reads copy the tuple once
+  and address it directly. No per-event ID index or full-map reconstruction is
+  required.
 
-  The compressed target map is a reader-owned fallback. If the backing store
+  The compressed target tuple is a reader-owned fallback. If the backing store
   replaces, evicts or loses a generation, the caller resolves from that exact
-  immutable map and can conditionally rehydrate the still-current cache entry.
+  immutable tuple and can conditionally rehydrate the still-current cache entry.
   """
 
-  alias Logflare.Rules.Rule
   alias Logflare.Rules.RoutingSnapshotStore
   alias Logflare.Sources.SourceRouter.Target
 
-  @entry_bytes 8
-
-  @enforce_keys [:key, :table, :index, :encoded, :count, :estimated_bytes]
-  defstruct [:key, :table, :index, :encoded, :count, :estimated_bytes, decoded: nil]
+  @enforce_keys [:key, :table, :encoded, :count, :estimated_bytes]
+  defstruct [:key, :table, :encoded, :count, :estimated_bytes, decoded: nil]
 
   @type t() :: %__MODULE__{
           key: {integer(), reference()},
           table: :ets.tid(),
-          index: binary(),
           encoded: binary(),
           count: non_neg_integer(),
           estimated_bytes: non_neg_integer(),
-          decoded: %{Rule.id() => Target.t()} | nil
+          decoded: tuple() | nil
         }
 
   @type resolve_status() ::
-          {:ok, [Target.t()]} | {:fallback, [Target.t()], %{Rule.id() => Target.t()}}
+          {:ok, [Target.t()]} | {:fallback, [Target.t()], tuple()}
 
-  @spec new(integer(), [{Rule.id(), Target.t()}], keyword()) :: t()
-  def new(source_id, entries, opts \\ []) when is_list(entries) do
-    entries = Enum.sort_by(entries, &elem(&1, 0))
-    rules_by_id = Map.new(entries)
-    entry_tuple = List.to_tuple(entries)
-    index = for {id, _target} <- entries, into: <<>>, do: <<id::unsigned-64>>
-    encoded = :erlang.term_to_binary(rules_by_id, compressed: 1)
+  @spec new(integer(), [Target.t()], keyword()) :: t()
+  def new(source_id, targets, opts \\ []) when is_list(targets) do
+    target_tuple = List.to_tuple(targets)
+    encoded = :erlang.term_to_binary(target_tuple, compressed: 1)
 
     estimated_bytes =
-      :erlang.external_size(entry_tuple) + byte_size(index) + byte_size(encoded) +
+      :erlang.external_size(target_tuple) + byte_size(encoded) +
         Keyword.get(opts, :extra_estimated_bytes, 0)
 
     store = Keyword.get(opts, :store, RoutingSnapshotStore)
-    {table, key} = RoutingSnapshotStore.put(store, source_id, entry_tuple, estimated_bytes)
+    {table, key} = RoutingSnapshotStore.put(store, source_id, target_tuple, estimated_bytes)
 
     %__MODULE__{
       key: key,
       table: table,
-      index: index,
       encoded: encoded,
-      count: length(entries),
+      count: tuple_size(target_tuple),
       estimated_bytes: estimated_bytes
     }
   end
 
   @doc false
-  @spec rehydrate(t(), integer(), %{Rule.id() => Target.t()}, GenServer.server()) :: t()
+  @spec rehydrate(t(), integer(), tuple(), GenServer.server()) :: t()
   def rehydrate(
         %__MODULE__{} = snapshot,
         source_id,
-        rules_by_id,
+        targets,
         store \\ RoutingSnapshotStore
       )
-      when is_map(rules_by_id) do
-    entries = rules_by_id |> Enum.sort_by(&elem(&1, 0)) |> List.to_tuple()
-
+      when is_tuple(targets) do
     {table, key} =
-      RoutingSnapshotStore.put(store, source_id, entries, snapshot.estimated_bytes)
+      RoutingSnapshotStore.put(store, source_id, targets, snapshot.estimated_bytes)
 
     %{snapshot | table: table, key: key, decoded: nil}
   end
 
-  @spec resolve(t(), [Rule.id()]) :: [Target.t()]
-  def resolve(snapshot, ids) do
-    case resolve_with_status(snapshot, ids) do
+  @spec resolve(t(), [non_neg_integer()]) :: [Target.t()]
+  def resolve(snapshot, positions) do
+    case resolve_with_status(snapshot, positions) do
       {:ok, targets} -> targets
-      {:fallback, targets, _rules_by_id} -> targets
+      {:fallback, targets, _encoded_targets} -> targets
     end
   end
 
   @doc false
-  @spec resolve_with_status(t(), [Rule.id()]) :: resolve_status()
+  @spec resolve_with_status(t(), [non_neg_integer()]) :: resolve_status()
   def resolve_with_status(_snapshot, []), do: {:ok, []}
 
-  def resolve_with_status(%__MODULE__{decoded: rules_by_id}, ids) when is_map(rules_by_id),
-    do: {:ok, from_map(rules_by_id, ids)}
+  def resolve_with_status(%__MODULE__{decoded: targets}, positions) when is_tuple(targets),
+    do: {:ok, from_target_tuple(targets, positions)}
 
-  def resolve_with_status(%__MODULE__{count: count} = snapshot, ids)
-      when length(ids) * 2 >= count do
+  def resolve_with_status(%__MODULE__{count: count} = snapshot, positions)
+      when length(positions) * 2 >= count do
     case read_all(snapshot) do
-      [entries] -> {:ok, entries |> Tuple.to_list() |> tl() |> Map.new() |> from_map(ids)}
-      [] -> from_fallback(snapshot, ids)
+      [entries] -> {:ok, from_store_tuple(entries, positions, count)}
+      [] -> from_fallback(snapshot, positions)
     end
   end
 
-  def resolve_with_status(%__MODULE__{} = snapshot, ids) do
-    case read_sparse(snapshot, ids, []) do
+  def resolve_with_status(%__MODULE__{} = snapshot, positions) do
+    case read_sparse(snapshot, positions, []) do
       {:ok, targets} -> {:ok, targets}
-      :missing -> from_fallback(snapshot, ids)
+      :missing -> from_fallback(snapshot, positions)
     end
   end
 
   defp read_sparse(_snapshot, [], acc), do: {:ok, Enum.reverse(acc)}
 
-  defp read_sparse(snapshot, [id | rest], acc) do
-    case position(snapshot.index, id, 0, snapshot.count - 1) do
-      nil ->
-        read_sparse(snapshot, rest, acc)
-
-      position ->
-        case read_element(snapshot, position + 2) do
-          {_id, nil} -> read_sparse(snapshot, rest, acc)
-          {_id, target} -> read_sparse(snapshot, rest, [target | acc])
-          :missing -> :missing
-        end
+  defp read_sparse(%__MODULE__{count: count} = snapshot, [position | rest], acc) do
+    if valid_position?(position, count) do
+      case read_element(snapshot, position + 2) do
+        nil -> read_sparse(snapshot, rest, acc)
+        :missing -> :missing
+        target -> read_sparse(snapshot, rest, [target | acc])
+      end
+    else
+      read_sparse(snapshot, rest, acc)
     end
   end
 
@@ -133,30 +122,34 @@ defmodule Logflare.Rules.RoutingSnapshot do
     ArgumentError -> :missing
   end
 
-  defp position(_index, _id, low, high) when low > high, do: nil
-
-  defp position(index, id, low, high) do
-    middle = div(low + high, 2)
-    <<key::unsigned-64>> = binary_part(index, middle * @entry_bytes, @entry_bytes)
-
-    cond do
-      id < key -> position(index, id, low, middle - 1)
-      id > key -> position(index, id, middle + 1, high)
-      true -> middle
-    end
+  defp from_store_tuple(entries, positions, count) do
+    for position <- positions,
+        valid_position?(position, count),
+        target = elem(entries, position + 1),
+        target != nil,
+        do: target
   end
 
-  defp from_fallback(snapshot, ids) do
-    rules_by_id = :erlang.binary_to_term(snapshot.encoded)
-    {:fallback, from_map(rules_by_id, ids), rules_by_id}
+  defp from_fallback(snapshot, positions) do
+    targets = :erlang.binary_to_term(snapshot.encoded)
+    {:fallback, from_target_tuple(targets, positions), targets}
   end
 
   @doc false
-  @spec with_decoded(t(), %{Rule.id() => Target.t()}) :: t()
-  def with_decoded(%__MODULE__{} = snapshot, rules_by_id) when is_map(rules_by_id),
-    do: %{snapshot | decoded: rules_by_id}
+  @spec with_decoded(t(), tuple()) :: t()
+  def with_decoded(%__MODULE__{} = snapshot, targets) when is_tuple(targets),
+    do: %{snapshot | decoded: targets}
 
-  defp from_map(rules_by_id, ids) do
-    for id <- ids, target = Map.get(rules_by_id, id), do: target
+  defp from_target_tuple(targets, positions) do
+    count = tuple_size(targets)
+
+    for position <- positions,
+        valid_position?(position, count),
+        target = elem(targets, position),
+        target != nil,
+        do: target
   end
+
+  defp valid_position?(position, count),
+    do: is_integer(position) and position >= 0 and position < count
 end

--- a/lib/logflare/sources/source_router/rules_tree.ex
+++ b/lib/logflare/sources/source_router/rules_tree.ex
@@ -4,6 +4,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
   alias Logflare.Rules
   alias Logflare.Rules.Rule
   alias Logflare.Lql.Rules.FilterRule
+  alias Logflare.Sources.SourceRouter.Target
 
   import Logflare.Utils, only: [stringify: 1]
 
@@ -36,9 +37,9 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
 
   @impl true
   def matching_rules_with_state(event, source, {rule_set, snapshot}) do
-    rule_ids = matching_rule_ids(event, rule_set)
+    positions = matching_positions(event, rule_set)
 
-    case Rules.RoutingSnapshot.resolve_with_status(snapshot, rule_ids) do
+    case Rules.RoutingSnapshot.resolve_with_status(snapshot, positions) do
       {:ok, targets} ->
         {targets, {rule_set, snapshot}}
 
@@ -52,6 +53,10 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
         {targets, {rule_set, snapshot}}
     end
   end
+
+  @doc false
+  @spec matching_positions(LogEvent.t(), t()) :: [non_neg_integer()]
+  def matching_positions(event, rules_tree), do: matching_rule_ids(event, rules_tree)
 
   @doc """
   Finds ids of matching rules.
@@ -230,11 +235,24 @@ defmodule Logflare.Sources.SourceRouter.RulesTree do
   You can find more examples by looking at `rules_tree_test.exs`
   """
   @spec build([Rule.t()]) :: t()
-  def build(rules) do
-    for rule <- rules,
+  def build(rules), do: rules |> Enum.map(&{&1, &1.id}) |> build_targets()
+
+  @doc false
+  @spec build_routing([Rule.t()]) :: {t(), [Target.t()]}
+  def build_routing(rules) do
+    indexed_rules = rules |> Enum.sort_by(& &1.id) |> Enum.with_index()
+
+    tree = build_targets(indexed_rules)
+
+    targets = Enum.map(indexed_rules, fn {rule, _position} -> Target.from_rule(rule) end)
+    {tree, targets}
+  end
+
+  defp build_targets(rule_targets) do
+    for {rule, route_key} <- rule_targets,
         filters_num = length(rule.lql_filters),
         {filter, index} <- Enum.with_index(rule.lql_filters) do
-      target = build_target(rule.id, filters_num, index)
+      target = build_target(route_key, filters_num, index)
 
       reverse_path = String.split(filter.path, ".") |> Enum.reverse()
 

--- a/test/logflare/rules/routing_snapshot_test.exs
+++ b/test/logflare/rules/routing_snapshot_test.exs
@@ -9,76 +9,71 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     %{store: store}
   end
 
-  test "sparse, dense and fallback reads preserve IDs, targets and order", %{store: store} do
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+  test "sparse, dense and fallback reads preserve targets and order", %{store: store} do
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
 
-    for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
+    for positions <- [[], [0], [19, 0, 9], Enum.to_list(19..0//-1), [-1, 20], [0, 0]] do
+      assert RoutingSnapshot.resolve(snapshot, positions) == expected(targets, positions)
     end
 
-    RoutingSnapshot.new(1, entries(20, 2), store: store)
+    RoutingSnapshot.new(1, targets(20, 2), store: store)
     refute :ets.member(snapshot.table, snapshot.key)
 
-    for ids <- [[], [1], [20, 1, 10], Enum.to_list(20..1//-1), [0, 21], [1, 1]] do
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
+    for positions <- [[], [0], [19, 0, 9], Enum.to_list(19..0//-1), [-1, 20], [0, 0]] do
+      assert RoutingSnapshot.resolve(snapshot, positions) == expected(targets, positions)
     end
   end
 
-  test "empty snapshots and missing or nil targets are rejected", %{store: store} do
+  test "empty snapshots and missing or nil positions are rejected", %{store: store} do
     empty = RoutingSnapshot.new(1, [], store: store)
-    assert RoutingSnapshot.resolve(empty, [1]) == []
+    assert RoutingSnapshot.resolve(empty, [0]) == []
 
-    entries = List.replace_at(entries(20), 0, {1, nil})
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
-    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [Map.new(entries)[2]]
-    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..30)) == expected(entries, 1..30)
+    targets = List.replace_at(targets(20), 0, nil)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
+    assert RoutingSnapshot.resolve(snapshot, [-1, 0, 1, 30]) == [Enum.at(targets, 1)]
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(0..29)) == expected(targets, 0..29)
 
     RoutingSnapshot.new(1, [], store: store)
-    assert RoutingSnapshot.resolve(snapshot, [1, 2, 30]) == [Map.new(entries)[2]]
+    assert RoutingSnapshot.resolve(snapshot, [-1, 0, 1, 30]) == [Enum.at(targets, 1)]
   end
 
-  test "binary index supports zero, non-contiguous IDs and bigint boundaries", %{store: store} do
-    ids = [0, 5, 91, 4_294_967_297, 9_223_372_036_854_775_807]
-    entries = Enum.map(ids, &{&1, {&1, &1, nil}})
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+  test "position lookup supports boundaries without an ID index", %{store: store} do
+    targets = targets(5)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
 
-    for id <- ids do
-      assert RoutingSnapshot.resolve(snapshot, [id]) == [Map.new(entries)[id]]
-    end
-
-    for id <- [1, 6, 90, 92, 4_294_967_296] do
-      assert RoutingSnapshot.resolve(snapshot, [id]) == []
-    end
+    assert RoutingSnapshot.resolve(snapshot, [0, 4]) == [hd(targets), List.last(targets)]
+    assert RoutingSnapshot.resolve(snapshot, [-1, 5, 4_294_967_297]) == []
+    refute Map.has_key?(snapshot, :index)
   end
 
   test "ETS paths do not decode the fallback", %{store: store} do
-    entries = entries(20)
-    snapshot = %{RoutingSnapshot.new(1, entries, store: store) | encoded: <<>>}
+    targets = targets(20)
+    snapshot = %{RoutingSnapshot.new(1, targets, store: store) | encoded: <<>>}
 
     for count <- [1, 9, 10, 11, 20] do
-      ids = Enum.to_list(count..1//-1)
-      assert RoutingSnapshot.resolve(snapshot, ids) == expected(entries, ids)
+      positions = Enum.to_list((count - 1)..0//-1)
+      assert RoutingSnapshot.resolve(snapshot, positions) == expected(targets, positions)
     end
   end
 
   test "a decoded batch-local fallback avoids repeated decompression", %{store: store} do
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
-    RoutingSnapshot.new(1, entries(20, 2), store: store)
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
+    RoutingSnapshot.new(1, targets(20, 2), store: store)
 
     local =
       snapshot
       |> RoutingSnapshot.with_decoded(:erlang.binary_to_term(snapshot.encoded))
       |> Map.put(:encoded, <<>>)
 
-    assert {:ok, expected(entries, [1, 20])} ==
-             RoutingSnapshot.resolve_with_status(local, [1, 20])
+    assert {:ok, expected(targets, [0, 19])} ==
+             RoutingSnapshot.resolve_with_status(local, [0, 19])
   end
 
   test "header heap size does not grow with the target payload", %{store: store} do
-    small = RoutingSnapshot.new(1, entries(20), store: store)
-    large = RoutingSnapshot.new(2, entries(1000), store: store)
+    small = RoutingSnapshot.new(1, targets(20), store: store)
+    large = RoutingSnapshot.new(2, targets(1000), store: store)
     assert :erts_debug.flat_size(small) == :erts_debug.flat_size(large)
     assert byte_size(large.encoded) > byte_size(small.encoded)
     assert large.estimated_bytes > small.estimated_bytes
@@ -86,25 +81,25 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
 
   test "suspended readers survive rebuilds without retaining ETS generations", %{store: store} do
     parent = self()
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
 
     reader =
       Task.async(fn ->
         send(parent, :acquired)
-        receive do: (:resume -> RoutingSnapshot.resolve(snapshot, [1, 20]))
+        receive do: (:resume -> RoutingSnapshot.resolve(snapshot, [0, 19]))
       end)
 
     assert_receive :acquired
 
     for generation <- 2..100 do
-      RoutingSnapshot.new(1, entries(20, generation), store: store)
+      RoutingSnapshot.new(1, targets(20, generation), store: store)
       assert_sizes(store, 1)
     end
 
     refute :ets.member(snapshot.table, snapshot.key)
     send(reader.pid, :resume)
-    assert Task.await(reader) == expected(entries, [1, 20])
+    assert Task.await(reader) == expected(targets, [0, 19])
   end
 
   test "concurrent replacement never mixes generations", %{store: store} do
@@ -112,12 +107,12 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     |> Task.async_stream(
       fn reader ->
         for generation <- 1..50 do
-          entries = entries(20, {reader, generation})
-          snapshot = RoutingSnapshot.new(1, entries, store: store)
-          assert RoutingSnapshot.resolve(snapshot, [20, 1, 10]) == expected(entries, [20, 1, 10])
+          targets = targets(20, {reader, generation})
+          snapshot = RoutingSnapshot.new(1, targets, store: store)
+          assert RoutingSnapshot.resolve(snapshot, [19, 0, 9]) == expected(targets, [19, 0, 9])
 
-          assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) ==
-                   expected(entries, 1..20)
+          assert RoutingSnapshot.resolve(snapshot, Enum.to_list(0..19)) ==
+                   expected(targets, 0..19)
         end
       end,
       max_concurrency: 8
@@ -129,52 +124,50 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
 
   test "a reader crash does not pin generations or require release", %{store: store} do
     parent = self()
-    snapshot = RoutingSnapshot.new(1, entries(20), store: store)
+    snapshot = RoutingSnapshot.new(1, targets(20), store: store)
 
     {pid, ref} =
       spawn_monitor(fn ->
-        send(parent, {:acquired, RoutingSnapshot.resolve(snapshot, [1])})
+        send(parent, {:acquired, RoutingSnapshot.resolve(snapshot, [0])})
         receive do: (:crash -> exit(:reader_crashed))
       end)
 
     assert_receive {:acquired, [{1, _backend_id, nil}]}
     send(pid, :crash)
     assert_receive {:DOWN, ^ref, :process, ^pid, :reader_crashed}
-    RoutingSnapshot.new(1, entries(20, 2), store: store)
+    RoutingSnapshot.new(1, targets(20, 2), store: store)
     refute :ets.member(snapshot.table, snapshot.key)
     assert_sizes(store, 1)
   end
 
   test "store restart cannot invalidate a reader's snapshot", %{store: store} do
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
     stop_supervised!(RoutingSnapshotStore)
     new_store = start_supervised!({RoutingSnapshotStore, name: nil})
-    RoutingSnapshot.new(1, entries(20, 2), store: new_store)
+    RoutingSnapshot.new(1, targets(20, 2), store: new_store)
 
     assert :ets.info(snapshot.table) == :undefined
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
-    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(1..20)) == expected(entries, 1..20)
+    assert RoutingSnapshot.resolve(snapshot, [0]) == expected(targets, [0])
+    assert RoutingSnapshot.resolve(snapshot, Enum.to_list(0..19)) == expected(targets, 0..19)
   end
 
   test "capacity eviction bounds all indexes and preserves acquired snapshots" do
     store = start_supervised!({RoutingSnapshotStore, name: nil, limit: 2}, id: :limited)
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
 
-    for source_id <- 2..50, do: RoutingSnapshot.new(source_id, entries, store: store)
+    for source_id <- 2..50, do: RoutingSnapshot.new(source_id, targets, store: store)
 
     assert_sizes(store, 2)
     refute :ets.member(snapshot.table, snapshot.key)
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
+    assert RoutingSnapshot.resolve(snapshot, [0]) == expected(targets, [0])
   end
 
   test "estimated-byte eviction bounds the store while retaining one oversized snapshot" do
-    sample_entries = entries(20)
-    entry_tuple = List.to_tuple(sample_entries)
-    rules_by_id = Map.new(sample_entries)
-    encoded = :erlang.term_to_binary(rules_by_id, compressed: 1)
-    weight = :erlang.external_size(entry_tuple) + 20 * 8 + byte_size(encoded)
+    sample_targets = targets(20)
+    encoded = :erlang.term_to_binary(List.to_tuple(sample_targets), compressed: 1)
+    weight = :erlang.external_size(List.to_tuple(sample_targets)) + byte_size(encoded)
 
     store =
       start_supervised!(
@@ -182,15 +175,15 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
         id: :byte_limited
       )
 
-    first = RoutingSnapshot.new(1, sample_entries, store: store)
-    second = RoutingSnapshot.new(2, sample_entries, store: store)
+    first = RoutingSnapshot.new(1, sample_targets, store: store)
+    second = RoutingSnapshot.new(2, sample_targets, store: store)
 
     refute :ets.member(first.table, first.key)
     assert :ets.member(second.table, second.key)
     assert_sizes(store, 1)
     assert :sys.get_state(store).estimated_bytes == second.estimated_bytes
 
-    oversized = RoutingSnapshot.new(3, entries(100), store: store)
+    oversized = RoutingSnapshot.new(3, targets(100), store: store)
     assert :ets.member(oversized.table, oversized.key)
     assert_sizes(store, 1)
     assert :sys.get_state(store).estimated_bytes == oversized.estimated_bytes
@@ -198,26 +191,26 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
 
   test "expiry retires all indexes without invalidating readers" do
     store = start_supervised!({RoutingSnapshotStore, name: nil, ttl: 0}, id: :expired)
-    entries = entries(20)
-    snapshot = RoutingSnapshot.new(1, entries, store: store)
+    targets = targets(20)
+    snapshot = RoutingSnapshot.new(1, targets, store: store)
     RoutingSnapshotStore.prune(store)
 
     assert_sizes(store, 0)
     assert :sys.get_state(store).estimated_bytes == 0
-    assert RoutingSnapshot.resolve(snapshot, [1]) == expected(entries, [1])
+    assert RoutingSnapshot.resolve(snapshot, [0]) == expected(targets, [0])
   end
 
   test "late retirement cannot remove the replacement generation", %{store: store} do
-    old = RoutingSnapshot.new(1, entries(20), store: store)
-    current_entries = entries(20, 2)
-    current = RoutingSnapshot.new(1, current_entries, store: store)
+    old = RoutingSnapshot.new(1, targets(20), store: store)
+    current_targets = targets(20, 2)
+    current = RoutingSnapshot.new(1, current_targets, store: store)
     RoutingSnapshotStore.delete(store, old.key)
     assert_sizes(store, 1)
     assert :ets.member(current.table, current.key)
 
     RoutingSnapshotStore.delete(store, current.key)
     assert_sizes(store, 0)
-    assert RoutingSnapshot.resolve(current, [1]) == expected(current_entries, [1])
+    assert RoutingSnapshot.resolve(current, [0]) == expected(current_targets, [0])
   end
 
   test "store telemetry reports source and estimated-byte gauges", %{store: store} do
@@ -232,7 +225,7 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     )
 
     on_exit(fn -> :telemetry.detach(handler) end)
-    snapshot = RoutingSnapshot.new(999_999, entries(20), store: store)
+    snapshot = RoutingSnapshot.new(999_999, targets(20), store: store)
 
     assert_receive {
       [:logflare, :rules, :routing_snapshot_store],
@@ -243,14 +236,17 @@ defmodule Logflare.Rules.RoutingSnapshotTest do
     assert bytes == snapshot.estimated_bytes
   end
 
-  defp entries(count, generation \\ 1) do
+  defp targets(count, generation \\ 1) do
     generation = :erlang.phash2(generation)
-    for id <- 1..count, do: {id, {id, generation * 10_000 + id, nil}}
+    for id <- 1..count, do: {id, generation * 10_000 + id, nil}
   end
 
-  defp expected(entries, ids) do
-    rules_by_id = Map.new(entries)
-    for id <- ids, target = Map.get(rules_by_id, id), do: target
+  defp expected(targets, positions) do
+    for position <- positions,
+        is_integer(position) and position >= 0,
+        target = Enum.at(targets, position),
+        target != nil,
+        do: target
   end
 
   defp assert_sizes(store, expected) do

--- a/test/logflare/rules/rule_cache_test.exs
+++ b/test/logflare/rules/rule_cache_test.exs
@@ -56,8 +56,9 @@ defmodule Logflare.Rules.CacheTest do
       rule_ids: rule_ids
     } do
       assert {tree, %RoutingSnapshot{} = snapshot} = @subject.rules_tree_by_source_id(source.id)
+      positions = Enum.to_list(0..(snapshot.count - 1))
       assert snapshot.count == length(rule_ids)
-      assert Enum.map(RoutingSnapshot.resolve(snapshot, rule_ids), &Target.id/1) == rule_ids
+      assert Enum.map(RoutingSnapshot.resolve(snapshot, positions), &Target.id/1) == rule_ids
 
       Mimic.reject(Rules, :rules_tree_by_source_id, 1)
       assert @subject.rules_tree_by_source_id(source.id) == {tree, snapshot}
@@ -66,17 +67,17 @@ defmodule Logflare.Rules.CacheTest do
     for invalidation <- [:bust, :expire, :clear] do
       @invalidation invalidation
       test "#{invalidation} and rebuild preserve a paused reader's snapshot", %{
-        source: source,
-        rule_ids: rule_ids
+        source: source
       } do
         {tree, old} = @subject.rules_tree_by_source_id(source.id)
-        old_targets = RoutingSnapshot.resolve(old, rule_ids)
+        positions = Enum.to_list(0..(old.count - 1))
+        old_targets = RoutingSnapshot.resolve(old, positions)
         parent = self()
 
         reader =
           Task.async(fn ->
             send(parent, :snapshot_acquired)
-            receive do: (:resume -> RoutingSnapshot.resolve(old, rule_ids))
+            receive do: (:resume -> RoutingSnapshot.resolve(old, positions))
           end)
 
         assert_receive :snapshot_acquired
@@ -93,19 +94,19 @@ defmodule Logflare.Rules.CacheTest do
             assert {:ok, 1} = Cachex.clear(@subject)
         end
 
-        new_entries =
+        new_targets =
           Enum.map(old_targets, fn {id, backend_id, sink} ->
-            {id, {id, backend_id + 1_000_000, sink}}
+            {id, backend_id + 1_000_000, sink}
           end)
 
         expect(Rules, :rules_tree_by_source_id, fn id ->
           assert id == source.id
-          {tree, new_entries}
+          {tree, new_targets}
         end)
 
         {^tree, current} = @subject.rules_tree_by_source_id(source.id)
         assert current.key != old.key
-        assert RoutingSnapshot.resolve(current, rule_ids) == Enum.map(new_entries, &elem(&1, 1))
+        assert RoutingSnapshot.resolve(current, positions) == new_targets
         refute :ets.member(old.table, old.key)
         send(reader.pid, :resume)
         assert Task.await(reader) == old_targets
@@ -114,8 +115,8 @@ defmodule Logflare.Rules.CacheTest do
 
     test "repairs the still-current header after its ETS generation is lost", %{source: source} do
       {_tree, snapshot} = @subject.rules_tree_by_source_id(source.id)
-      rule_ids = snapshot.encoded |> :erlang.binary_to_term() |> Map.keys()
-      expected = RoutingSnapshot.resolve(snapshot, rule_ids)
+      positions = Enum.to_list(0..(snapshot.count - 1))
+      expected = RoutingSnapshot.resolve(snapshot, positions)
 
       _replacement =
         RoutingSnapshot.rehydrate(
@@ -125,14 +126,14 @@ defmodule Logflare.Rules.CacheTest do
         )
 
       assert {:fallback, ^expected, encoded_targets} =
-               RoutingSnapshot.resolve_with_status(snapshot, rule_ids)
+               RoutingSnapshot.resolve_with_status(snapshot, positions)
 
       assert {:repaired, repaired} =
                @subject.repair_routing_snapshot(source.id, snapshot, encoded_targets)
 
       {_tree, ^repaired} = @subject.rules_tree_by_source_id(source.id)
       assert repaired.key != snapshot.key
-      assert {:ok, ^expected} = RoutingSnapshot.resolve_with_status(repaired, rule_ids)
+      assert {:ok, ^expected} = RoutingSnapshot.resolve_with_status(repaired, positions)
     end
 
     test "list by source", %{source: source, rule_ids: expected_rule_ids} do

--- a/test/logflare/sources/source_router/rules_tree_test.exs
+++ b/test/logflare/sources/source_router/rules_tree_test.exs
@@ -414,7 +414,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
       assert Target.id(target) == hd(source.rules).id
     end
 
-    test "drops matched rule IDs missing from the snapshot", %{source: source, log_event: le} do
+    test "drops matched positions missing from the snapshot", %{source: source, log_event: le} do
       {tree, _targets} = Rules.rules_tree_by_source_id(source.id)
 
       expect(Rules, :rules_tree_by_source_id, fn _id -> {tree, []} end)
@@ -422,17 +422,17 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
       assert @subject.matching_rules(le, source) == []
     end
 
-    test "the snapshot resolves every rule ID its tree can match", %{
+    test "the snapshot resolves every position its tree can match", %{
       source: source,
       log_event: le
     } do
-      {tree, entries} = Rules.rules_tree_by_source_id(source.id)
+      {tree, targets} = Rules.rules_tree_by_source_id(source.id)
 
-      assert [_ | _] = rule_ids = @subject.matching_rule_ids(le, tree)
-      targets_by_id = Map.new(entries)
+      assert [_ | _] = positions = @subject.matching_positions(le, tree)
 
-      for rule_id <- rule_ids do
-        assert Map.has_key?(targets_by_id, rule_id)
+      for position <- positions do
+        assert position >= 0
+        assert position < length(targets)
       end
     end
 
@@ -449,9 +449,7 @@ defmodule Logflare.Sources.SourceRouter.RulesTreeTest do
 
       {^tree, repaired} = Rules.Cache.rules_tree_by_source_id(source.id)
       assert repaired.key != snapshot.key
-
-      assert {:ok, [^target]} =
-               RoutingSnapshot.resolve_with_status(repaired, [hd(source.rules).id])
+      assert {:ok, [^target]} = RoutingSnapshot.resolve_with_status(repaired, [0])
     end
   end
 

--- a/test/profiling/source_routing_batch_bench.exs
+++ b/test/profiling/source_routing_batch_bench.exs
@@ -5,7 +5,6 @@ alias Logflare.Rules.Rule
 alias Logflare.Rules.RoutingSnapshot
 alias Logflare.Sources.Source
 alias Logflare.Sources.SourceRouter.RulesTree
-alias Logflare.Sources.SourceRouter.Target
 
 source_id = System.unique_integer([:positive])
 source = %Source{id: source_id}
@@ -23,8 +22,7 @@ rules =
     }
   end
 
-tree = RulesTree.build(rules)
-targets = rules |> Enum.sort_by(& &1.id) |> Enum.map(&{&1.id, Target.from_rule(&1)})
+{tree, targets} = RulesTree.build_routing(rules)
 
 snapshot =
   RoutingSnapshot.new(source_id, targets, extra_estimated_bytes: :erlang.external_size(tree))
@@ -36,7 +34,7 @@ Cachex.put!(
 )
 
 event = %LogEvent{body: %{"severity_number" => 9}, source_id: source_id}
-8 = event |> RulesTree.matching_rule_ids(tree) |> length()
+8 = event |> RulesTree.matching_positions(tree) |> length()
 
 Benchee.run(
   %{

--- a/test/profiling/source_routing_followup_results.md
+++ b/test/profiling/source_routing_followup_results.md
@@ -1,0 +1,73 @@
+# Positional routing snapshot follow-up
+
+This note isolates the stacked zero-based positional-tree change from the cache
+hardening included in PR #3943. The parent already owns compact targets, batch
+reuse, missing-generation repair, byte-aware capacity, and lifecycle telemetry.
+
+The child changes only how the tree addresses those compact targets:
+
+- build the tree and ordered target tuple from the same rule ordering;
+- emit zero-based tuple positions instead of database rule IDs;
+- remove the binary ID index and binary search;
+- read sparse target tuple elements directly and return the whole tuple on dense
+  matches instead of rebuilding an ID-keyed map.
+
+## Environment and fixture
+
+The environment and corrected six-case fixtures are the same as
+[`source_routing_snapshot_results.md`](source_routing_snapshot_results.md):
+Linux, Elixir 1.19.5, OTP 27.3.4.6, JIT enabled, Benchee with two seconds warmup, five
+seconds measurement, two seconds memory measurement, and outlier exclusion
+disabled. Results are microbenchmarks rather than production throughput claims.
+
+## Single-event comparison with the ID-keyed parent
+
+One adjacent run per representation produced:
+
+| Rules / matches | ID-keyed parent | Positional child | Approximate change |
+| --- | ---: | ---: | ---: |
+| 100 / 8 | 7.02 us | 5.92 us | 1.19x faster |
+| 100 / 1 | 11.65 us | 10.60 us | 1.10x faster |
+| 100 / all | 24.78 us | 19.11 us | 1.30x faster |
+| 1,000 / 8 | 35.97 us | 33.92 us | 1.06x faster |
+| 1,000 / 1 | 129.17 us | 115.80 us | 1.12x faster |
+| 1,000 / all | 347.55 us | 264.88 us | 1.31x faster |
+
+The sparse measurements have substantial scheduler/GC variance. An earlier
+matching-only probe found positional and ID keys within 1%, so the dense gains
+from avoiding map reconstruction are more persuasive than the small sparse
+differences.
+
+## Batch allocation
+
+For the checked-in 1,000-rule/eight-match batch fixture, positional addressing
+reduced measured allocation in the prepare-once path from 56.20 KB to 25.80 KB
+for 10 events and from 0.54 MB to 0.24 MB for 100 events: about 2.18-2.25x lower.
+Wall-clock results varied between runs, so they are not used to claim an
+additional positional batch speedup.
+
+## Snapshot representation
+
+Using the component model documented by the parent hardening note, removing the
+ID index and entry IDs reduced the already-compact modeled snapshot by another
+29-39%:
+
+| Rules / shape | ID-keyed parent | Positional child | Reduction |
+| --- | ---: | ---: | ---: |
+| 100 / 8 | 6,250 B | 4,207 B | 32.7% |
+| 100 / 1 | 6,936 B | 4,685 B | 32.5% |
+| 100 / all | 5,757 B | 3,519 B | 38.9% |
+| 1,000 / 8 | 65,572 B | 45,805 B | 30.1% |
+| 1,000 / 1 | 71,333 B | 50,581 B | 29.1% |
+| 1,000 / all | 58,385 B | 37,588 B | 35.6% |
+
+This is a representation model, not resident-process memory. It excludes
+Cachex/ETS table overhead and allocator fragmentation equally from both sides.
+
+## Commands
+
+```sh
+MIX_ENV=test ../bin/x mix run test/profiling/source_routing_bench.exs
+MIX_ENV=test ../bin/x mix run test/profiling/source_routing_batch_bench.exs
+MIX_ENV=test ../bin/x mix run /tmp/routing-base-footprint.exs
+```


### PR DESCRIPTION
## Review scope

> This stacked PR changes **only target addressing**. Its base, #3943, owns compact targets, batch reuse, missing-generation repair, byte-aware capacity, and lifecycle telemetry.

| Boundary | Revision |
| --- | --- |
| Current main used for the cumulative memory comparison | `fcb4c938` |
| ID-keyed base (#3943) | `6820c6ee` |
| This positional head | `4754419c` |

## What changes

The tree and ordered target tuple are built from the same sorted rule list. The tree then emits zero-based tuple positions instead of database rule IDs.

| ID-keyed #3943 | Positional #3946 |
| --- | --- |
| Tree emits rule ID | Tree emits tuple position |
| Binary-search ID index | Direct tuple access |
| Sparse lookup searches then reads ETS | Sparse lookup reads the ETS element directly |
| Dense lookup rebuilds an ID-keyed map | Dense lookup reads the target tuple directly |
| Snapshot stores IDs and targets | Snapshot stores targets only |

No cache lifecycle, batch API, recovery, telemetry, or capacity-policy changes remain in this PR.

### Correctness constraints

- The tree and target tuple use one query and one deterministic ordering.
- Every emitted position addresses the target from that same immutable generation.
- Replacement, eviction, restart fallback, and conditional repair retain #3943's consistency behavior.
- Missing, out-of-range, and nil targets remain rejected.

## Incremental effect of this PR

Same corrected fixtures and Linux / 6-core / Elixir 1.19.5 / OTP 27.3.4.6 environment as #3943. These are local microbenchmarks, not production-throughput claims.

One adjacent run per representation:

| Rules / matches | ID-keyed #3943 | Positional child | Approximate change |
| --- | ---: | ---: | ---: |
| 100 / 8 | 7.02 us | 5.92 us | 1.19x faster |
| 100 / 1 | 11.65 us | 10.60 us | 1.10x faster |
| 100 / all | 24.78 us | 19.11 us | 1.30x faster |
| 1,000 / 8 | 35.97 us | 33.92 us | 1.06x faster |
| 1,000 / 1 | 129.17 us | 115.80 us | 1.12x faster |
| 1,000 / all | 347.55 us | 264.88 us | 1.31x faster |

Sparse results have substantial scheduler/GC variance. An earlier matching-only probe found positional and ID keys within 1%; the dense gains from avoiding map reconstruction are more persuasive than the small sparse differences.

Additional positional effects:

- Prepare-once allocation for 1,000 rules / 8 matches fell from **56.20 KB to 25.80 KB** for 10 events and from **0.54 MB to 0.24 MB** for 100 events: **2.18-2.25x lower**.
- Removing the index and entry IDs reduced the already-compact modeled snapshot by another **29-39%**.
- Wall-clock batch results varied between runs, so no additional positional batch-speed claim is made.

Incremental commands and details: [`source_routing_followup_results.md`](test/profiling/source_routing_followup_results.md).

```sh
MIX_ENV=test ../bin/x mix run test/profiling/source_routing_bench.exs
MIX_ENV=test ../bin/x mix run test/profiling/source_routing_batch_bench.exs
```

## Cumulative final stack vs current main

A branch-neutral external harness used the same database-backed 100/1,000-rule fixtures and ran twice per revision in the same environment. Caches were warm before Benchee measurement; retained deltas and allocation results reproduced across both runs.

### Retained routing-cache memory

The ETS delta includes `Rules.Cache` and, on the final stack, the routing snapshot data/source/expiry tables:

| 1,000-rule cache state | Matches | Main | Final | Change |
| --- | ---: | ---: | ---: | ---: |
| One representative event | 1 | 119.9 KB | 158.8 KB | **32.5% higher** |
| One representative event | 8 | 99.7 KB | 128.9 KB | **29.2% higher** |
| One representative event | 1,000 | 1.80 MB | 121.2 KB | **93.2% lower / 14.8x** |
| All rules warmed | 1 | 1.90 MB | 158.8 KB | **91.7% lower / 12.0x** |
| All rules warmed | 8 | 1.55 MB | 128.9 KB | **91.7% lower / 12.1x** |
| All rules warmed | 1,000 | 1.84 MB | 121.2 KB | **93.4% lower / 15.2x** |

Interpretation:

- Main lazily caches only `%Rule{}` records that have matched; final stores all compact targets immediately. That gives final a **29-33% higher first-event floor** in the 1,000-rule sparse fixtures.
- Main retained memory grows as distinct rules are encountered, while final remains nearly flat.
- Once all main per-rule entries are warm, final uses **91-93% less ETS memory**. The same comparison at 100 rules was 91.1-92.8% lower.
- An externalized-term payload model, excluding ETS table overhead, was **96.1-97.2% lower** across fully warmed 100/1,000-rule fixtures.

### Per-batch allocation

Benchee allocation for 1,000 rules:

| Matches / events | Main | Final | Change |
| --- | ---: | ---: | ---: |
| 1 / 10 | 3.21 MB | 3.22 MB | comparable |
| 1 / 100 | 38.42 MB | 27.55 MB | **28.3% lower / 1.39x** |
| 8 / 10 | 875.42 KB | 112.48 KB | **87.2% lower / 7.78x** |
| 8 / 100 | 7.46 MB | 338.19 KB | **95.6% lower / 22.6x** |
| 1,000 / 10 | 28.03 MB | 5.98 MB | **78.7% lower / 4.69x** |
| 1,000 / 100 | 284.52 MB | 67.58 MB | **76.2% lower / 4.21x** |

These measurements are retained ETS deltas, externalized term sizes, and per-operation allocations—not total VM RSS.

## Validation

- [x] 90 focused snapshot/cache/tree/router tests, 0 failures, 1 existing excluded benchmark test.
- [x] 25 additional rules/context-cache/gossip/cache-buster/BigQuery consumer tests, 0 failures.
- [x] Formatter and `MIX_ENV=test mix compile` through project wrappers.
- [x] `MIX_ENV=test mix lint.all`; only 32 existing design suggestions.
- [x] `MIX_ENV=test mix test.typings`; 158 configured errors skipped, 10 existing unnecessary skips, task passed.
- [x] Two same-environment cumulative memory runs against current main.
- [x] Hosted Elixir CI and Playwright pass at `4754419c`.
- [ ] Production-shaped concurrent throughput was not run locally.
