### PR TITLE
chore: mapper / mapping configuration follow-ups

### DIFF
--- a/bench/clickhouse_mapper_rowbinary_fusion.exs
+++ b/bench/clickhouse_mapper_rowbinary_fusion.exs
@@ -92,6 +92,13 @@ defmodule Logflare.Bench.ClickHouseMapperRowBinaryFusion do
     end)
   end
 
+  @spec with_out_of_range_severity([LogEvent.t()], atom()) :: [LogEvent.t()]
+  def with_out_of_range_severity(events, :log) do
+    Enum.map(events, &%{&1 | body: Map.put(&1.body, "severity_number", 25)})
+  end
+
+  def with_out_of_range_severity(events, _type), do: events
+
   defp maybe_compute_duration(
          %{"start_time" => start_time, "end_time" => end_time, "duration" => 0} = body,
          :trace
@@ -103,7 +110,7 @@ defmodule Logflare.Bench.ClickHouseMapperRowBinaryFusion do
   defp maybe_compute_duration(body, _type), do: body
 
   defp resolve_severity_number(%{"severity_number_alt" => alt} = body, :log)
-       when is_integer(alt) and alt > 0 do
+       when is_integer(alt) and alt in 1..24 do
     %{body | "severity_number" => alt}
   end
 
@@ -140,6 +147,13 @@ inputs =
 
     if actual != expected do
       raise "fused RowBinary differs for #{type}/batch=#{batch_size}"
+    end
+
+    out_of_range = Fusion.with_out_of_range_severity(events, type)
+
+    if Fusion.encode_fused(out_of_range, type, output_compiled, mapping_config_id) !=
+         Fusion.encode_separate(out_of_range, type, map_compiled, mapping_config_id) do
+      raise "fused RowBinary differs for #{type}/batch=#{batch_size} with an out-of-range severity"
     end
 
     IO.puts("#{type}/batch=#{batch_size}: validation=ok bytes=#{byte_size(expected)}")

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -151,69 +151,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.string("resource_schema_url",
         paths: ["$.resource.schema_url"]
       ),
-      Field.flat_map("resource_attributes",
-        paths: ["$.resource"],
-        exclude_keys: ["_project_region", "_service_name"],
-        pick_mode: :merge,
-        pick: [
-          {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
-          {"application_name",
-           [
-             "$.metadata.context.application",
-             "$.app_name",
-             "$.application_name",
-             "$.metadata.app_name",
-             "$.metadata.parsed.application_name"
-           ]},
-          {"cluster",
-           [
-             "$.metadata.cluster",
-             "$.metadata.context.cluster",
-             "$.cluster",
-             "$.resource.cluster"
-           ]},
-          {"environment",
-           [
-             "$.metadata.environment",
-             "$.metadata.context.environment",
-             "$.environment",
-             "$.resource.environment"
-           ]},
-          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
-          {"instance_id", ["$.metadata.instance_id"]},
-          {"machine_id", ["$.machine_id"]},
-          {"node",
-           [
-             "$.metadata.node",
-             "$.metadata.context.vm.node",
-             "$.node",
-             "$.resource.node"
-           ]},
-          {"organization_id", ["$.organization_id", "$.org_id"]},
-          {"organization_slug", ["$.organization_slug"]},
-          {"project",
-           [
-             "$.project",
-             "$.project_ref",
-             "$.project_id",
-             "$.metadata.project",
-             "$.metadata.tenant",
-             "$.metadata.tenantId"
-           ]},
-          {"region",
-           [
-             "$.metadata.region",
-             "$.region",
-             "$.resource.region",
-             "$.resource._project_region"
-           ]},
-          {"service_name",
-           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
-          {"vector_file", ["$.metadata.vector_file"]},
-          {"vector_host", ["$.metadata.vector_host"]}
-        ],
-        default: %{}
-      ),
+      resource_attributes_field(:log),
       Field.flat_map("scope_attributes",
         paths: ["$.scope.attributes", "$.scope"],
         default: %{}
@@ -322,69 +260,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       Field.string("resource_schema_url",
         paths: ["$.resource.schema_url"]
       ),
-      Field.flat_map("resource_attributes",
-        paths: ["$.resource"],
-        exclude_keys: ["_project_region", "_service_name"],
-        pick_mode: :merge,
-        pick: [
-          {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
-          {"application",
-           [
-             "$.metadata.context.application",
-             "$.app_name",
-             "$.application_name",
-             "$.metadata.app_name",
-             "$.metadata.parsed.application_name"
-           ]},
-          {"cluster",
-           [
-             "$.metadata.cluster",
-             "$.metadata.context.cluster",
-             "$.cluster",
-             "$.resource.cluster"
-           ]},
-          {"environment",
-           [
-             "$.metadata.environment",
-             "$.metadata.context.environment",
-             "$.environment",
-             "$.resource.environment"
-           ]},
-          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
-          {"instance_id", ["$.metadata.instance_id"]},
-          {"machine_id", ["$.machine_id"]},
-          {"node",
-           [
-             "$.metadata.node",
-             "$.metadata.context.vm.node",
-             "$.node",
-             "$.resource.node"
-           ]},
-          {"organization_id", ["$.organization_id", "$.org_id"]},
-          {"organization_slug", ["$.organization_slug"]},
-          {"project",
-           [
-             "$.project",
-             "$.project_ref",
-             "$.project_id",
-             "$.metadata.project",
-             "$.metadata.tenant",
-             "$.metadata.tenantId"
-           ]},
-          {"region",
-           [
-             "$.metadata.region",
-             "$.region",
-             "$.resource.region",
-             "$.resource._project_region"
-           ]},
-          {"service_name",
-           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
-          {"vector_file", ["$.metadata.vector_file"]},
-          {"vector_host", ["$.metadata.vector_host"]}
-        ],
-        default: %{}
-      ),
+      resource_attributes_field(:metric),
       Field.flat_map("scope_attributes",
         paths: ["$.scope.attributes", "$.scope"],
         default: %{}
@@ -620,69 +496,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
           "$.instrumentation_library.version"
         ]
       ),
-      Field.flat_map("resource_attributes",
-        paths: ["$.resource"],
-        exclude_keys: ["_project_region", "_service_name"],
-        pick_mode: :merge,
-        pick: [
-          {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
-          {"application",
-           [
-             "$.metadata.context.application",
-             "$.app_name",
-             "$.application_name",
-             "$.metadata.app_name",
-             "$.metadata.parsed.application_name"
-           ]},
-          {"cluster",
-           [
-             "$.metadata.cluster",
-             "$.metadata.context.cluster",
-             "$.cluster",
-             "$.resource.cluster"
-           ]},
-          {"environment",
-           [
-             "$.metadata.environment",
-             "$.metadata.context.environment",
-             "$.environment",
-             "$.resource.environment"
-           ]},
-          {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
-          {"instance_id", ["$.metadata.instance_id"]},
-          {"machine_id", ["$.machine_id"]},
-          {"node",
-           [
-             "$.metadata.node",
-             "$.metadata.context.vm.node",
-             "$.node",
-             "$.resource.node"
-           ]},
-          {"organization_id", ["$.organization_id", "$.org_id"]},
-          {"organization_slug", ["$.organization_slug"]},
-          {"project",
-           [
-             "$.project",
-             "$.project_ref",
-             "$.project_id",
-             "$.metadata.project",
-             "$.metadata.tenant",
-             "$.metadata.tenantId"
-           ]},
-          {"region",
-           [
-             "$.metadata.region",
-             "$.region",
-             "$.resource.region",
-             "$.resource._project_region"
-           ]},
-          {"service_name",
-           ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
-          {"vector_file", ["$.metadata.vector_file"]},
-          {"vector_host", ["$.metadata.vector_host"]}
-        ],
-        default: %{}
-      ),
+      resource_attributes_field(:trace),
       # `scope` is deliberately not excluded here and must stay that way.
       # otel_traces has no scope_attributes column and will not be getting one,
       # so span_attributes is the permanent home for scope.schema_url and
@@ -719,4 +533,79 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
 
     MappingConfig.new(fields, output: OutputFormat.clickhouse_row_binary(:trace))
   end
+
+  @spec resource_attributes_field(TypeDetection.event_type()) :: Field.t()
+  defp resource_attributes_field(event_type) do
+    Field.flat_map("resource_attributes",
+      paths: ["$.resource"],
+      exclude_keys: ["_project_region", "_service_name"],
+      pick_mode: :merge,
+      pick: resource_attributes_pick(event_type),
+      default: %{}
+    )
+  end
+
+  @spec resource_attributes_pick(TypeDetection.event_type()) :: [{String.t(), [String.t()]}]
+  defp resource_attributes_pick(event_type) do
+    [
+      {"application_id", ["$.app_id", "$.application_id", "$.metadata.app_id"]},
+      {application_key(event_type),
+       [
+         "$.metadata.context.application",
+         "$.app_name",
+         "$.application_name",
+         "$.metadata.app_name",
+         "$.metadata.parsed.application_name"
+       ]},
+      {"cluster",
+       [
+         "$.metadata.cluster",
+         "$.metadata.context.cluster",
+         "$.cluster",
+         "$.resource.cluster"
+       ]},
+      {"environment",
+       [
+         "$.metadata.environment",
+         "$.metadata.context.environment",
+         "$.environment",
+         "$.resource.environment"
+       ]},
+      {"host", ["$.metadata.host", "$.metadata.context.host", "$.host", "$.resource.host"]},
+      {"instance_id", ["$.metadata.instance_id"]},
+      {"machine_id", ["$.machine_id"]},
+      {"node",
+       [
+         "$.metadata.node",
+         "$.metadata.context.vm.node",
+         "$.node",
+         "$.resource.node"
+       ]},
+      {"organization_id", ["$.organization_id", "$.org_id"]},
+      {"organization_slug", ["$.organization_slug"]},
+      {"project",
+       [
+         "$.project",
+         "$.project_ref",
+         "$.project_id",
+         "$.metadata.project",
+         "$.metadata.tenant",
+         "$.metadata.tenantId"
+       ]},
+      {"region",
+       [
+         "$.metadata.region",
+         "$.region",
+         "$.resource.region",
+         "$.resource._project_region"
+       ]},
+      {"service_name", ["$.resource.service.name", "$.resource._service_name", "$.service_name"]},
+      {"vector_file", ["$.metadata.vector_file"]},
+      {"vector_host", ["$.metadata.vector_host"]}
+    ]
+  end
+
+  @spec application_key(TypeDetection.event_type()) :: String.t()
+  defp application_key(:log), do: "application_name"
+  defp application_key(_event_type), do: "application"
 end

--- a/lib/logflare/mapper/mapping_config/field_config.ex
+++ b/lib/logflare/mapper/mapping_config/field_config.ex
@@ -233,6 +233,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   @valid_transforms ~w(upcase downcase)
   @valid_value_types ~w(string)
   @valid_coercions ~w(lenient strict)
+  @default_datetime_precision 9
   @length_filters ~w(len_eq len_gt len_gte len_lt len_lte)
   @char_classes ~w(alpha numeric alphanumeric)
 
@@ -353,7 +354,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   @spec datetime64(String.t(), keyword()) :: t()
   def datetime64(name, opts \\ []) do
     base = build(name, "datetime64", opts)
-    %{base | precision: opts[:precision] || 9}
+    %{base | precision: Keyword.get(opts, :precision, @default_datetime_precision)}
   end
 
   @spec json(String.t(), keyword()) :: t()
@@ -383,7 +384,7 @@ defmodule Logflare.Mapper.MappingConfig.FieldConfig do
   @spec array_datetime64(String.t(), keyword()) :: t()
   def array_datetime64(name, opts \\ []) do
     base = build(name, "array_datetime64", opts, [:filter_nil])
-    %{base | precision: opts[:precision] || 9}
+    %{base | precision: Keyword.get(opts, :precision, @default_datetime_precision)}
   end
 
   @spec array_json(String.t(), keyword()) :: t()

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -674,6 +674,27 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       end
     end
 
+    test "the field config is shared across types, differing only by the application key" do
+      [log, metric, trace] =
+        for event_type <- [:log, :metric, :trace] do
+          Enum.find(
+            MappingDefaults.for_type(event_type).fields,
+            &(&1.name == "resource_attributes")
+          )
+        end
+
+      assert metric == trace
+      assert %{log | pick: nil} == %{metric | pick: nil}
+
+      renamed =
+        Enum.map(log.pick, fn
+          %{key: "application_name"} = entry -> %{entry | key: "application"}
+          entry -> entry
+        end)
+
+      assert renamed == metric.pick
+    end
+
     test "project resolves from metadata.tenantId in every type", %{
       log: log,
       metric: metric,

--- a/test/logflare/mapper/mapping_config_test.exs
+++ b/test/logflare/mapper/mapping_config_test.exs
@@ -96,6 +96,11 @@ defmodule Logflare.Mapper.MappingConfigTest do
       assert field.precision == 9
     end
 
+    test "datetime64 constructors preserve an explicitly supplied invalid precision" do
+      assert Field.datetime64("ts", path: "$.ts", precision: false).precision == false
+      assert Field.array_datetime64("ts", path: "$.ts[*]", precision: false).precision == false
+    end
+
     test "datetime64/2 with custom precision" do
       field = Field.datetime64("timestamp", path: "$.timestamp", precision: 6)
 

--- a/test/logflare/mapper_test.exs
+++ b/test/logflare/mapper_test.exs
@@ -1894,6 +1894,18 @@ defmodule Logflare.MapperTest do
       assert reason =~ "precision must be between 0 and 9"
     end
 
+    test "rejects an explicit precision of false on both datetime64 constructors" do
+      for field <- [
+            Field.datetime64("ts", path: "$.ts", precision: false),
+            Field.array_datetime64("ts", path: "$.ts[*]", precision: false)
+          ] do
+        assert {:error, reason} = Mapper.compile(MappingConfig.new([field])),
+               "#{field.type} accepted precision: false"
+
+        assert reason =~ "'precision' must be an integer"
+      end
+    end
+
     test "rejects a datetime64 precision that is not a 64-bit integer" do
       for precision <- [Integer.pow(2, 100), 3.0, "3"] do
         config = MappingConfig.new([Field.datetime64("ts", path: "$.ts", precision: precision)])


### PR DESCRIPTION
## Overview

Minor follow-ups from the earlier mapper stack (_#3927–#3936_). None of these change production behavior.

### Key Changes

- `resource_attributes` mapping configuration is built from a shared definition across log, metric, and trace. Big reduction in configuration lines. Raised by @Ziinc on #3927
- The fusion benchmark severity collapse rule now matches production and the other three harness copies (`alt in 1..24`). Parity validation additionally runs an out-of-range copy of each log batch, which fails against the old guard. Raised on #3936
- `datetime64/2` and `array_datetime64/2` pass an explicitly supplied `precision` through instead of normalizing `false` to 9, so the compile-time check from #3931 can reject it.