### PR TITLE
chore: improve ClickHouse insert outcome, drop, and circuit breaker telemetry

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -950,18 +950,9 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     async? = Keyword.get(opts, :async, false)
     insert_opts = [{:async, async?} | build_insert_opts(opts)]
 
-    case Ingester.insert(backend, table_name, events, event_type, insert_opts) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("ClickHouse http insert error.",
-          host: insert_host(backend.config, async?),
-          error_string: inspect(reason)
-        )
-
-        {:error, reason}
-    end
+    backend
+    |> Ingester.insert(table_name, events, event_type, insert_opts)
+    |> handle_insert_result(backend, event_type, async?)
   end
 
   @doc """
@@ -982,18 +973,52 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     async? = Keyword.get(opts, :async, false)
     insert_opts = [{:async, async?} | build_insert_opts(opts)]
 
-    case Ingester.insert_compressed(backend, table_name, event_type, compressed, insert_opts) do
-      :ok ->
-        :ok
+    backend
+    |> Ingester.insert_compressed(table_name, event_type, compressed, insert_opts)
+    |> handle_insert_result(backend, event_type, async?)
+  end
 
-      {:error, reason} ->
-        Logger.warning("ClickHouse http insert error.",
-          host: insert_host(backend.config, async?),
-          error_string: inspect(reason)
-        )
+  @spec handle_insert_result(
+          :ok | {:error, term()},
+          Backend.t(),
+          TypeDetection.event_type(),
+          boolean()
+        ) :: :ok | {:error, term()}
+  defp handle_insert_result(:ok, backend, event_type, async?) do
+    emit_insert_telemetry(backend, event_type, async?, :ok, :none)
+    :ok
+  end
 
-        {:error, reason}
-    end
+  defp handle_insert_result({:error, reason}, backend, event_type, async?) do
+    Logger.warning("ClickHouse http insert error.",
+      host: insert_host(backend.config, async?),
+      error_string: inspect(reason)
+    )
+
+    emit_insert_telemetry(backend, event_type, async?, :error, Ingester.error_class(reason))
+
+    {:error, reason}
+  end
+
+  @spec emit_insert_telemetry(
+          Backend.t(),
+          TypeDetection.event_type(),
+          boolean(),
+          :ok | :error,
+          Ingester.error_class() | :none
+        ) :: :ok
+  defp emit_insert_telemetry(backend, event_type, async?, result, error_class) do
+    :telemetry.execute(
+      [:logflare, :clickhouse, :insert, :result],
+      %{count: 1},
+      %{
+        backend_id: backend.id,
+        event_type: event_type,
+        async: async?,
+        result: result,
+        error_class: error_class
+      }
+    )
   end
 
   @spec build_insert_opts(keyword()) :: keyword()

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer.ex
@@ -1,0 +1,46 @@
+defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.FinchPoolTimeoutNormalizer do
+  @moduledoc """
+  Tesla middleware that turns a Finch HTTP/1 pool checkout timeout into `{:error, :pool_timeout}`.
+
+  Finch only returns `%Finch.Error{reason: :pool_timeout}` for HTTP/2 pools. On an
+  HTTP/1 pool — which both ClickHouse ingest pools are — a checkout timeout surfaces
+  as a `NimblePool` exit that `Finch.HTTP1.Pool` catches and re-raises as a
+  `RuntimeError`. An exception is invisible to `Tesla.Middleware.Retry`, which only
+  inspects the return value of the stack below it, so a saturated pool would neither
+  be retried nor counted as an insert failure.
+
+  Must sit *after* `Tesla.Middleware.Retry` in the middleware list so it runs inside
+  the retry loop and its `{:error, :pool_timeout}` is visible to `should_retry`.
+
+  Finch gives no structured way to tell this exception apart from any other
+  `RuntimeError`, so it is matched on a stable fragment of the message and anything
+  else is re-raised untouched. `FinchPoolTimeoutNormalizerTest` saturates a real
+  single-connection HTTP/1 pool, so a Finch upgrade that changes the wording fails
+  there rather than silently restoring the old behaviour.
+  """
+
+  @behaviour Tesla.Middleware
+
+  import Logflare.Utils.Guards
+
+  @pool_timeout_marker "unable to provide a connection within the timeout"
+
+  @impl Tesla.Middleware
+  def call(env, next, _opts) do
+    Tesla.run(env, next)
+  rescue
+    error in RuntimeError ->
+      normalize(pool_timeout?(error), error, __STACKTRACE__)
+  end
+
+  @spec pool_timeout?(RuntimeError.t()) :: boolean()
+  defp pool_timeout?(%RuntimeError{message: message}) when is_non_empty_binary(message),
+    do: String.contains?(message, @pool_timeout_marker)
+
+  defp pool_timeout?(_error), do: false
+
+  @spec normalize(boolean(), RuntimeError.t(), Exception.stacktrace()) ::
+          {:error, :pool_timeout} | no_return()
+  defp normalize(true, _error, _stacktrace), do: {:error, :pool_timeout}
+  defp normalize(false, error, stacktrace), do: reraise(error, stacktrace)
+end

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer.ex
@@ -33,13 +33,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.FinchPoolTimeoutNormalizer
       normalize(pool_timeout?(error), error, __STACKTRACE__)
   end
 
-  @spec pool_timeout?(RuntimeError.t()) :: boolean()
+  @spec pool_timeout?(%RuntimeError{}) :: boolean()
   defp pool_timeout?(%RuntimeError{message: message}) when is_non_empty_binary(message),
     do: String.contains?(message, @pool_timeout_marker)
 
   defp pool_timeout?(_error), do: false
 
-  @spec normalize(boolean(), RuntimeError.t(), Exception.stacktrace()) ::
+  @spec normalize(boolean(), %RuntimeError{}, Exception.stacktrace()) ::
           {:error, :pool_timeout} | no_return()
   defp normalize(true, _error, _stacktrace), do: {:error, :pool_timeout}
   defp normalize(false, error, stacktrace), do: reraise(error, stacktrace)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -20,6 +20,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   @pool_timeout 8_000
   @receive_timeout 15_000
   @too_many_parts_marker "Code: 252."
+  @retriable_error_classes [
+    :pool_timeout,
+    :timeout,
+    :connection_refused,
+    :connection_reset,
+    :connection_closed,
+    :tls_alert
+  ]
 
   @type error_class ::
           :too_many_parts
@@ -175,11 +183,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   defp retriable?({:ok, %Tesla.Env{status: 429}}), do: true
   defp retriable?({:ok, _env}), do: false
 
-  defp retriable?({:error, reason})
-       when reason in [:timeout, :econnrefused, :econnreset, :closed],
-       do: true
-
-  defp retriable?({:error, _reason}), do: false
+  defp retriable?({:error, reason}), do: error_class(reason) in @retriable_error_classes
 
   @doc """
   Inserts a pre-gzipped RowBinary payload directly into ClickHouse.

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -21,6 +21,21 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   @receive_timeout 15_000
   @too_many_parts_marker "Code: 252."
 
+  @type error_class ::
+          :too_many_parts
+          | :http_too_many_requests
+          | :http_client_error
+          | :http_server_error
+          | :http_error
+          | :pool_timeout
+          | :timeout
+          | :connection_refused
+          | :connection_reset
+          | :connection_closed
+          | :dns_error
+          | :tls_alert
+          | :unknown
+
   @doc """
   Inserts a list of `LogEvent` structs into ClickHouse.
 
@@ -86,6 +101,42 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
     do: String.contains?(reason, @too_many_parts_marker)
 
   def too_many_parts?(_reason), do: false
+
+  @doc """
+  Classifies an insert failure reason into a low-cardinality class suitable for metric tags.
+  """
+  @spec error_class(term()) :: error_class()
+  def error_class(reason) when is_binary(reason),
+    do: response_body_error_class(too_many_parts?(reason), reason)
+
+  def error_class(%Finch.Error{reason: reason}), do: transport_error_class(reason)
+  def error_class(%Mint.TransportError{reason: reason}), do: transport_error_class(reason)
+  def error_class(reason), do: transport_error_class(reason)
+
+  @spec response_body_error_class(boolean(), String.t()) :: error_class()
+  defp response_body_error_class(true, _reason), do: :too_many_parts
+  defp response_body_error_class(false, reason), do: http_error_class(reason)
+
+  @spec http_error_class(String.t()) :: error_class()
+  defp http_error_class("HTTP " <> rest), do: http_status_class(Integer.parse(rest))
+  defp http_error_class(_reason), do: :unknown
+
+  @spec http_status_class({integer(), String.t()} | :error) :: error_class()
+  defp http_status_class({429, _rest}), do: :http_too_many_requests
+  defp http_status_class({status, _rest}) when status >= 500, do: :http_server_error
+  defp http_status_class({status, _rest}) when status >= 400, do: :http_client_error
+  defp http_status_class({_status, _rest}), do: :http_error
+  defp http_status_class(:error), do: :unknown
+
+  @spec transport_error_class(term()) :: error_class()
+  defp transport_error_class(:pool_timeout), do: :pool_timeout
+  defp transport_error_class(:timeout), do: :timeout
+  defp transport_error_class(:econnrefused), do: :connection_refused
+  defp transport_error_class(:econnreset), do: :connection_reset
+  defp transport_error_class(:closed), do: :connection_closed
+  defp transport_error_class(:nxdomain), do: :dns_error
+  defp transport_error_class({:tls_alert, _alert}), do: :tls_alert
+  defp transport_error_class(_reason), do: :unknown
 
   @spec build_client(Keyword.t(), boolean()) :: Tesla.Client.t()
   defp build_client(connection_opts, async?) do

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -6,6 +6,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   import Logflare.Utils.Guards
 
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.EndpointUtils
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.FinchPoolTimeoutNormalizer
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryTemplates
   alias Logflare.Backends.Adaptor.ClickHouseAdaptor.RowBinaryEncoder
   alias Logflare.Backends.Backend
@@ -117,6 +118,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   def error_class(reason) when is_binary(reason),
     do: response_body_error_class(too_many_parts?(reason), reason)
 
+  # %Finch.Error{} only ever comes from an HTTP/2 pool. Both ClickHouse ingest pools are
+  # HTTP/1, where a pool checkout timeout arrives as :pool_timeout via FinchPoolTimeoutNormalizer.
   def error_class(%Finch.Error{reason: reason}), do: transport_error_class(reason)
   def error_class(%Mint.TransportError{reason: reason}), do: transport_error_class(reason)
   def error_class(reason), do: transport_error_class(reason)
@@ -160,7 +163,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
        delay: @initial_delay,
        max_retries: @max_retries,
        max_delay: @max_delay,
-       should_retry: &retriable?/1}
+       should_retry: &retriable?/1},
+      FinchPoolTimeoutNormalizer
     ]
 
     adapter =

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -645,7 +645,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     )
 
     :telemetry.execute(
-      [:logflare, :ingest_event_queue, :not_initialized, :dropped],
+      [:logflare, :ingest_event_queue, :requeue_queue_unavailable],
       %{count: dropped_count},
       %{backend_type: :clickhouse, backend_id: backend_id}
     )

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/pipeline.ex
@@ -516,7 +516,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
     {retriable, exhausted} =
       Enum.split_with(payloads, &(message_pointer(&1).retries < @max_retries))
 
-    drop_failed(exhausted, backend_id, "exhausted #{@max_retries} retries")
+    drop_failed(exhausted, backend_id, :retries_exhausted)
 
     requeue_or_shed(backend_id, retriable)
   end
@@ -533,11 +533,13 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
         requeue_retriable(backend_id, retriable)
 
       {:error, :circuit_open, _blocked_until} ->
-        drop_failed(retriable, backend_id, "circuit breaker open")
+        drop_failed(retriable, backend_id, :circuit_breaker_open)
     end
   end
 
   @typep requeue_result :: :requeued | :deduplicated | :lookup_miss | :queue_unavailable
+
+  @typep drop_reason :: :retries_exhausted | :circuit_breaker_open
 
   @spec requeue_retriable(
           backend_id :: pos_integer(),
@@ -654,14 +656,22 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
   @spec drop_failed(
           payloads :: [EncodedRow.t() | LogEventPointer.t()],
           backend_id :: pos_integer(),
-          reason :: String.t()
+          reason :: drop_reason()
         ) :: :ok
   defp drop_failed([], _backend_id, _reason), do: :ok
 
   defp drop_failed(payloads, backend_id, reason) do
+    dropped_count = length(payloads)
+
     Logger.warning(
-      "Dropping #{length(payloads)} ClickHouse events: #{reason}",
+      "Dropping #{dropped_count} ClickHouse events: #{drop_reason_message(reason)}",
       backend_id: backend_id
+    )
+
+    :telemetry.execute(
+      [:logflare, :ingest_event_queue, :retry_dropped],
+      %{count: dropped_count},
+      %{backend_type: :clickhouse, backend_id: backend_id, reason: reason}
     )
 
     Enum.each(payloads, fn payload ->
@@ -669,6 +679,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Pipeline do
       IngestEventQueue.delete_id(pointer.tid, pointer.gen_event_id)
     end)
   end
+
+  @spec drop_reason_message(drop_reason()) :: String.t()
+  defp drop_reason_message(:retries_exhausted), do: "exhausted #{@max_retries} retries"
+  defp drop_reason_message(:circuit_breaker_open), do: "circuit breaker open"
 
   @spec message_pointer(Message.t() | EncodedRow.t() | LogEventPointer.t()) :: LogEventPointer.t()
   defp message_pointer(%Message{data: data}), do: message_pointer(data)

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -583,6 +583,13 @@ defmodule Logflare.Telemetry do
         description:
           "Count of retriable events whose generation-store row was already gone by requeue lookup time"
       ),
+      sum("logflare.ingest_event_queue.retry_dropped.count",
+        event_name: [:logflare, :ingest_event_queue, :retry_dropped],
+        measurement: :count,
+        tags: [:backend_id, :reason],
+        description:
+          "Count of ClickHouse events dropped outright after an insert failure, tagged `:retries_exhausted` when the payload ran out of retries or `:circuit_breaker_open` when the breaker shed the retry. This is realized ingest data loss"
+      ),
       sum("logflare.ingest_event_queue.requeue_queue_unavailable.count",
         event_name: [:logflare, :ingest_event_queue, :requeue_queue_unavailable],
         measurement: :count,

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -392,6 +392,13 @@ defmodule Logflare.Telemetry do
         description:
           "Read queries that failed over to the default read cluster, tagged with the unhealthy cluster failed over from"
       ),
+      sum("logflare.clickhouse.insert.result.count",
+        event_name: [:logflare, :clickhouse, :insert, :result],
+        measurement: :count,
+        tags: [:backend_id, :event_type, :async, :result, :error_class],
+        description:
+          "ClickHouse inserts by outcome, counted once per batch after any HTTP retry. `result` provides the insert error rate numerator and denominator, and `error_class` is `:none` on success"
+      ),
       sum("logflare.logs.ingest_logs.drop_future",
         event_name: [:logflare, :logs, :ingest_logs, :drop_future],
         measurement: :count,

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -583,6 +583,13 @@ defmodule Logflare.Telemetry do
         description:
           "Count of retriable events whose generation-store row was already gone by requeue lookup time"
       ),
+      sum("logflare.ingest_event_queue.requeue_queue_unavailable.count",
+        event_name: [:logflare, :ingest_event_queue, :requeue_queue_unavailable],
+        measurement: :count,
+        tags: [:backend_id],
+        description:
+          "Count of retriable ClickHouse events dropped because no retry queue remained available to requeue them into"
+      ),
       sum("logflare.ingest_event_queue.requeue_deduplicated.count",
         event_name: [:logflare, :ingest_event_queue, :requeue_deduplicated],
         measurement: :count,

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -399,6 +399,13 @@ defmodule Logflare.Telemetry do
         description:
           "ClickHouse inserts by outcome, counted once per batch after any HTTP retry. `result` provides the insert error rate numerator and denominator, and `error_class` is `:none` on success"
       ),
+      counter("logflare.clickhouse.circuit_breaker.open.count",
+        event_name: [:logflare, :clickhouse, :circuit_breaker, :open],
+        measurement: :failures,
+        tags: [:backend_id, :reason],
+        description:
+          "Times a backend's ClickHouse insert circuit breaker opened, tagged `:threshold` when the failure count in the window was reached or `:forced` when opened immediately by a TOO_MANY_PARTS response"
+      ),
       sum("logflare.logs.ingest_logs.drop_future",
         event_name: [:logflare, :logs, :ingest_logs, :drop_future],
         measurement: :count,

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/circuit_breaker_test.exs
@@ -90,6 +90,50 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.CircuitBreakerTest do
     end
   end
 
+  describe "open telemetry" do
+    setup do
+      TestUtils.attach_forwarder([:logflare, :clickhouse, :circuit_breaker, :open])
+
+      :ok
+    end
+
+    test "emits the failure count and :threshold reason when tripped by the threshold", %{
+      backend: backend
+    } do
+      start_supervised!({CircuitBreaker, backend})
+
+      record_failures(backend, 3)
+      CircuitBreaker.get_state(backend)
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :circuit_breaker, :open],
+                      %{failures: 3}, metadata}
+
+      assert metadata.backend_id == backend.id
+      assert metadata.reason == :threshold
+    end
+
+    test "emits a :forced reason when opened by trip/1", %{backend: backend} do
+      start_supervised!({CircuitBreaker, backend})
+
+      assert :ok = CircuitBreaker.trip(backend)
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :circuit_breaker, :open],
+                      %{failures: 0}, metadata}
+
+      assert metadata.backend_id == backend.id
+      assert metadata.reason == :forced
+    end
+
+    test "does not emit while the breaker stays closed", %{backend: backend} do
+      start_supervised!({CircuitBreaker, backend})
+
+      record_failures(backend, 2)
+      CircuitBreaker.get_state(backend)
+
+      refute_received {:telemetry_event, [:logflare, :clickhouse, :circuit_breaker, :open], _, _}
+    end
+  end
+
   describe "fail-safe on process death" do
     test "reads as closed after the breaker process crashes", %{backend: backend} do
       pid = start_supervised!({CircuitBreaker, backend})

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/finch_pool_timeout_normalizer_test.exs
@@ -1,0 +1,120 @@
+defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.FinchPoolTimeoutNormalizerTest do
+  use ExUnit.Case, async: false
+
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor.FinchPoolTimeoutNormalizer
+
+  @pool __MODULE__.Pool
+
+  describe "call/3 against a saturated HTTP/1 pool" do
+    setup do
+      start_supervised!(
+        {Finch, name: @pool, pools: %{default: [protocols: [:http1], size: 1, count: 1]}}
+      )
+
+      {:ok, listen_socket} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+      {:ok, port} = :inet.port(listen_socket)
+      spawn_link(fn -> accept_loop(listen_socket) end)
+
+      url = "http://127.0.0.1:#{port}/"
+
+      # Occupies the pool's only connection for longer than the checkout timeout below,
+      # so the request under test has to wait for a connection that never frees up.
+      # A bare process rather than a Task: on_exit runs outside the owner, and Task
+      # shutdown is only legal from the owning process.
+      holder =
+        spawn(fn ->
+          Finch.build(:get, url) |> Finch.request(@pool, receive_timeout: 5_000)
+        end)
+
+      on_exit(fn -> Process.exit(holder, :kill) end)
+
+      wait_until_pool_busy(url)
+
+      [url: url]
+    end
+
+    test "returns a tagged error instead of raising", %{url: url} do
+      {client, _retry_calls} = client_with_retry_counter(0)
+
+      assert {:error, :pool_timeout} = Tesla.get(client, url)
+    end
+
+    test "surfaces the timeout to the retry middleware", %{url: url} do
+      {client, retry_calls} = client_with_retry_counter(1)
+
+      assert {:error, :pool_timeout} = Tesla.get(client, url)
+
+      # The point of normalizing at all: a raise never reaches should_retry, so before
+      # this middleware existed the pool timeout was unretriable by construction.
+      assert :counters.get(retry_calls, 1) >= 1
+    end
+  end
+
+  describe "call/3 with an unrelated failure" do
+    test "re-raises a RuntimeError it does not recognize" do
+      client = Tesla.client([FinchPoolTimeoutNormalizer], fn _env -> raise "unrelated boom" end)
+
+      assert_raise RuntimeError, "unrelated boom", fn -> Tesla.get(client, "/") end
+    end
+
+    test "leaves an ordinary error response untouched" do
+      client = Tesla.client([FinchPoolTimeoutNormalizer], fn _env -> {:error, :econnrefused} end)
+
+      assert {:error, :econnrefused} = Tesla.get(client, "/")
+    end
+  end
+
+  defp client_with_retry_counter(max_retries) do
+    retry_calls = :counters.new(1, [])
+
+    middleware = [
+      {Tesla.Middleware.Retry,
+       delay: 10,
+       max_retries: max_retries,
+       should_retry: fn result ->
+         :counters.add(retry_calls, 1, 1)
+         match?({:error, _reason}, result)
+       end},
+      FinchPoolTimeoutNormalizer
+    ]
+
+    adapter = {Tesla.Adapter.Finch, name: @pool, pool_timeout: 100, receive_timeout: 5_000}
+
+    {Tesla.client(middleware, adapter), retry_calls}
+  end
+
+  defp accept_loop(listen_socket) do
+    {:ok, socket} = :gen_tcp.accept(listen_socket)
+
+    spawn(fn ->
+      :gen_tcp.recv(socket, 0, 5_000)
+      Process.sleep(3_000)
+      :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+      :gen_tcp.close(socket)
+    end)
+
+    accept_loop(listen_socket)
+  end
+
+  # The holder task has to actually check the connection out before the pool is
+  # saturated; polling for the timeout beats sleeping on a guessed interval.
+  defp wait_until_pool_busy(url, attempts \\ 50) do
+    client =
+      Tesla.client(
+        [FinchPoolTimeoutNormalizer],
+        {Tesla.Adapter.Finch, name: @pool, pool_timeout: 50, receive_timeout: 5_000}
+      )
+
+    case {Tesla.get(client, url), attempts} do
+      {{:error, :pool_timeout}, _attempts} ->
+        :ok
+
+      {_other, 0} ->
+        flunk("pool never became saturated")
+
+      {_other, attempts} ->
+        Process.sleep(20)
+        wait_until_pool_busy(url, attempts - 1)
+    end
+  end
+end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -410,6 +410,47 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
                Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
     end
 
+    test "retries a Finch pool checkout timeout", %{
+      backend: backend,
+      table_name: table_name
+    } do
+      Finch
+      |> expect(:request, 2, fn _request, _pool, _opts ->
+        {:error, %Finch.Error{reason: :pool_timeout}}
+      end)
+
+      assert {:error, %Finch.Error{reason: :pool_timeout}} =
+               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+    end
+
+    test "retries a TLS alert transport error", %{
+      backend: backend,
+      table_name: table_name
+    } do
+      tls_alert = {:tls_alert, {:bad_record_mac, "decryption failed"}}
+
+      Finch
+      |> expect(:request, 2, fn _request, _pool, _opts ->
+        {:error, tls_alert}
+      end)
+
+      assert {:error, ^tls_alert} =
+               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+    end
+
+    test "does not retry an unrecognized transport error", %{
+      backend: backend,
+      table_name: table_name
+    } do
+      Finch
+      |> expect(:request, fn _request, _pool, _opts ->
+        {:error, :ehostunreach}
+      end)
+
+      assert {:error, :ehostunreach} =
+               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+    end
+
     test "includes column list in INSERT query", %{
       backend: backend,
       table_name: table_name,

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -322,6 +322,42 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
     end
   end
 
+  describe "error_class/1" do
+    test "classifies a too-many-parts response body ahead of its HTTP status" do
+      assert Ingester.error_class("HTTP 500: Code: 252. DB::Exception: Too many parts") ==
+               :too_many_parts
+    end
+
+    test "classifies HTTP status ranges" do
+      assert Ingester.error_class("HTTP 429: slow down") == :http_too_many_requests
+      assert Ingester.error_class("HTTP 503: unavailable") == :http_server_error
+      assert Ingester.error_class("HTTP 400: bad request") == :http_client_error
+      assert Ingester.error_class("HTTP 302: moved") == :http_error
+    end
+
+    test "classifies wrapped Finch and Mint transport errors" do
+      assert Ingester.error_class(%Finch.Error{reason: :pool_timeout}) == :pool_timeout
+      assert Ingester.error_class(%Mint.TransportError{reason: :closed}) == :connection_closed
+
+      assert Ingester.error_class(%Mint.TransportError{
+               reason: {:tls_alert, {:bad_record_mac, "handshake failure"}}
+             }) == :tls_alert
+    end
+
+    test "classifies bare transport atoms" do
+      assert Ingester.error_class(:timeout) == :timeout
+      assert Ingester.error_class(:econnrefused) == :connection_refused
+      assert Ingester.error_class(:econnreset) == :connection_reset
+      assert Ingester.error_class(:nxdomain) == :dns_error
+    end
+
+    test "falls back to :unknown for unrecognized shapes" do
+      assert Ingester.error_class("something unstructured") == :unknown
+      assert Ingester.error_class({:weird, :shape}) == :unknown
+      assert Ingester.error_class(:some_unmapped_atom) == :unknown
+    end
+  end
+
   describe "insert/4" do
     setup do
       insert(:plan, name: "Free")

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -410,17 +410,34 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
                Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
     end
 
-    test "retries a Finch pool checkout timeout", %{
+    test "normalizes and retries a Finch pool checkout timeout", %{
+      backend: backend,
+      table_name: table_name
+    } do
+      # The real failure shape for an HTTP/1 pool: Finch.HTTP1.Pool catches NimblePool's
+      # checkout exit and re-raises it, so this arrives as an exception rather than an
+      # {:error, _} tuple. Two calls asserts the retry still happens after normalizing.
+      Finch
+      |> expect(:request, 2, fn _request, _pool, _opts ->
+        raise """
+        Finch was unable to provide a connection within the timeout due to excess queuing         for connections. Consider adjusting the pool size, count, timeout or reducing the         rate of requests if it is possible that the downstream service is unable to keep up         with the current rate.
+        """
+      end)
+
+      assert {:error, :pool_timeout} =
+               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+    end
+
+    test "does not swallow an unrelated exception from the adapter", %{
       backend: backend,
       table_name: table_name
     } do
       Finch
-      |> expect(:request, 2, fn _request, _pool, _opts ->
-        {:error, %Finch.Error{reason: :pool_timeout}}
-      end)
+      |> expect(:request, fn _request, _pool, _opts -> raise "unrelated boom" end)
 
-      assert {:error, %Finch.Error{reason: :pool_timeout}} =
-               Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+      assert_raise RuntimeError, "unrelated boom", fn ->
+        Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
+      end
     end
 
     test "retries a TLS alert transport error", %{

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1491,9 +1491,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
                  IngestEventQueue.lookup_event(retry_pointer.tid, retry_pointer.gen_event_id)
       end
 
-      test "reports a queue-unavailable drop separately from a generation lookup miss", %{
-        source: source
-      } do
+      test "reports a queue-unavailable drop under its own event, separately from a generation lookup miss",
+           %{source: source} do
         retry_backend_id = System.unique_integer([:positive])
         stale_queue_tid = :ets.new(:test_pipeline_stale_retry_queue, [:set, :public])
         :ets.delete(stale_queue_tid)
@@ -1510,11 +1509,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
           status: {:failed, "connection error"}
         }
 
-        dropped_event = [:logflare, :ingest_event_queue, :not_initialized, :dropped]
+        dropped_event = [:logflare, :ingest_event_queue, :requeue_queue_unavailable]
+        not_initialized_event = [:logflare, :ingest_event_queue, :not_initialized, :dropped]
         lookup_miss_event = [:logflare, :ingest_event_queue, :requeue_lookup_miss]
 
         ref =
-          :telemetry_test.attach_event_handlers(self(), [dropped_event, lookup_miss_event])
+          :telemetry_test.attach_event_handlers(self(), [
+            dropped_event,
+            not_initialized_event,
+            lookup_miss_event
+          ])
 
         on_exit(fn -> :telemetry.detach(ref) end)
         Mimic.stub(CircuitBreaker, :check, fn ^retry_backend_id -> :ok end)
@@ -1525,6 +1529,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         assert metadata.backend_type == :clickhouse
         assert metadata.backend_id == retry_backend_id
         refute_receive {^lookup_miss_event, ^ref, _, _}
+        refute_receive {^not_initialized_event, ^ref, _, _}
         assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
       end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1239,6 +1239,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         status: {:failed, "connection error"}
       }
 
+      dropped_event = [:logflare, :ingest_event_queue, :retry_dropped]
+      ref = :telemetry_test.attach_event_handlers(self(), [dropped_event])
+      on_exit(fn -> :telemetry.detach(ref) end)
+
       log =
         capture_log(fn ->
           Pipeline.ack(:ack_ref, [], [failed_message])
@@ -1246,6 +1250,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
 
       assert log =~ "Dropping 1 ClickHouse events: exhausted #{max_retries} retries"
       assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+      assert_receive {^dropped_event, ^ref, %{count: 1}, metadata}
+      assert metadata.reason == :retries_exhausted
+      assert metadata.backend_id == backend.id
+      assert metadata.backend_type == :clickhouse
     end
   end
 
@@ -1884,10 +1893,18 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
         status: {:failed, "boom"}
       }
 
+      dropped_event = [:logflare, :ingest_event_queue, :retry_dropped]
+      ref = :telemetry_test.attach_event_handlers(self(), [dropped_event])
+      on_exit(fn -> :telemetry.detach(ref) end)
+
       log = capture_log(fn -> Pipeline.ack(:ack_ref, [], [failed_message]) end)
 
       assert log =~ "circuit breaker open"
       assert IngestEventQueue.lookup_event(gen_tid, event.id) == nil
+
+      assert_receive {^dropped_event, ^ref, %{count: 1}, metadata}
+      assert metadata.reason == :circuit_breaker_open
+      assert metadata.backend_id == backend.id
     end
 
     test "requeues encoded rows when the breaker is closed", %{

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -1699,6 +1699,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert metadata.error_class == :http_client_error
     end
 
+    test "counts a pool checkout timeout as :pool_timeout", %{backend: backend} do
+      # Raised, not returned — the real HTTP/1 pool behaviour. Before FinchPoolTimeoutNormalizer
+      # normalized it, this exception escaped handle_insert_result/4 entirely and the
+      # insert never appeared in this metric at all.
+      Mimic.stub(Finch, :request, fn _request, _pool, _opts ->
+        raise """
+        Finch was unable to provide a connection within the timeout due to excess queuing         for connections. Consider adjusting the pool size, count, timeout or reducing the         rate of requests if it is possible that the downstream service is unable to keep up         with the current rate.
+        """
+      end)
+
+      assert {:error, :pool_timeout} =
+               ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.result == :error
+      assert metadata.error_class == :pool_timeout
+    end
+
     test "distinguishes too-many-parts rejections", %{backend: backend} do
       Mimic.stub(Finch, :request, fn _request, _pool, _opts ->
         {:ok, %Finch.Response{status: 500, body: "Code: 252. DB::Exception: Too many parts"}}

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -1657,6 +1657,98 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
   end
 
+  describe "insert outcome telemetry" do
+    setup do
+      insert(:plan, name: "Free")
+      {_source, backend} = setup_clickhouse_test()
+
+      TestUtils.attach_forwarder([:logflare, :clickhouse, :insert, :result])
+
+      [backend: backend]
+    end
+
+    test "emits an :ok result for a successful insert", %{backend: backend} do
+      Mimic.expect(Finch, :request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 200, body: ""}}
+      end)
+
+      assert :ok = ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.backend_id == backend.id
+      assert metadata.event_type == :log
+      assert metadata.async == false
+      assert metadata.result == :ok
+      assert metadata.error_class == :none
+    end
+
+    test "tags the error class for a failed insert", %{backend: backend} do
+      Mimic.expect(Finch, :request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 400, body: "boom"}}
+      end)
+
+      assert {:error, _reason} =
+               ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.result == :error
+      assert metadata.error_class == :http_client_error
+    end
+
+    test "distinguishes too-many-parts rejections", %{backend: backend} do
+      Mimic.stub(Finch, :request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 500, body: "Code: 252. DB::Exception: Too many parts"}}
+      end)
+
+      assert {:error, _reason} =
+               ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.error_class == :too_many_parts
+    end
+
+    test "counts a retried insert once", %{backend: backend} do
+      Mimic.stub(Finch, :request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 503, body: "unavailable"}}
+      end)
+
+      assert {:error, _reason} =
+               ClickHouseAdaptor.insert_log_events_compressed(backend, :log, :zlib.gzip(""))
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.error_class == :http_server_error
+
+      refute_received {:telemetry_event, [:logflare, :clickhouse, :insert, :result], _, _}
+    end
+
+    test "flags async inserts", %{backend: backend} do
+      Mimic.expect(Finch, :request, fn _request, _pool, _opts ->
+        {:ok, %Finch.Response{status: 200, body: ""}}
+      end)
+
+      assert :ok =
+               ClickHouseAdaptor.insert_log_events_compressed(
+                 backend,
+                 :log,
+                 :zlib.gzip(""),
+                 async: true
+               )
+
+      assert_receive {:telemetry_event, [:logflare, :clickhouse, :insert, :result], %{count: 1},
+                      metadata}
+
+      assert metadata.async == true
+    end
+  end
+
   describe "log event insertion and retrieval" do
     setup do
       insert(:plan, name: "Free")

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -168,6 +168,14 @@ defmodule Logflare.TelemetryTest do
       assert not_initialized.tags == [:backend_type]
     end
 
+    test "defines realized retry drops as a reason-tagged loss counter" do
+      metric = ch_metric([:logflare, :ingest_event_queue, :retry_dropped, :count])
+
+      assert metric.event_name == [:logflare, :ingest_event_queue, :retry_dropped]
+      assert metric.measurement == :count
+      assert metric.tags == [:backend_id, :reason]
+    end
+
     test "defines ClickHouse batch distribution and throughput metrics" do
       metrics = clickhouse_batch_metrics()
 

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -129,6 +129,22 @@ defmodule Logflare.TelemetryTest do
       assert metric.tags == [:backend_type]
     end
 
+    test "defines the ClickHouse insert outcome and circuit breaker metrics" do
+      insert_result = ch_metric([:logflare, :clickhouse, :insert, :result, :count])
+
+      assert to_string(insert_result.__struct__) == "Elixir.Telemetry.Metrics.Sum"
+      assert insert_result.event_name == [:logflare, :clickhouse, :insert, :result]
+      assert insert_result.measurement == :count
+      assert insert_result.tags == [:backend_id, :event_type, :async, :result, :error_class]
+
+      circuit_breaker = ch_metric([:logflare, :clickhouse, :circuit_breaker, :open, :count])
+
+      assert to_string(circuit_breaker.__struct__) == "Elixir.Telemetry.Metrics.Counter"
+      assert circuit_breaker.event_name == [:logflare, :clickhouse, :circuit_breaker, :open]
+      assert circuit_breaker.measurement == :failures
+      assert circuit_breaker.tags == [:backend_id, :reason]
+    end
+
     test "defines ClickHouse batch distribution and throughput metrics" do
       metrics = clickhouse_batch_metrics()
 
@@ -629,6 +645,11 @@ defmodule Logflare.TelemetryTest do
 
   defp requeue_deduplicated_metrics do
     Enum.filter(Telemetry.metrics(), &(&1.name == @requeue_deduplicated_metric_name))
+  end
+
+  defp ch_metric(name) do
+    [metric] = Enum.filter(Telemetry.metrics(), &(&1.name == name))
+    metric
   end
 
   defp read_pool_metric(name) do

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -145,6 +145,29 @@ defmodule Logflare.TelemetryTest do
       assert circuit_breaker.tags == [:backend_id, :reason]
     end
 
+    test "defines queue-unavailable retry drops separately from not-initialized drops" do
+      queue_unavailable =
+        ch_metric([:logflare, :ingest_event_queue, :requeue_queue_unavailable, :count])
+
+      assert queue_unavailable.event_name ==
+               [:logflare, :ingest_event_queue, :requeue_queue_unavailable]
+
+      assert queue_unavailable.measurement == :count
+      assert queue_unavailable.tags == [:backend_id]
+
+      not_initialized =
+        ch_metric([:logflare, :ingest_event_queue, :not_initialized, :dropped, :count])
+
+      assert not_initialized.event_name == [
+               :logflare,
+               :ingest_event_queue,
+               :not_initialized,
+               :dropped
+             ]
+
+      assert not_initialized.tags == [:backend_type]
+    end
+
     test "defines ClickHouse batch distribution and throughput metrics" do
       metrics = clickhouse_batch_metrics()
 


### PR DESCRIPTION
## Overview

Closes a known insert-layer observability gap. Finch latency/churn metrics were isolable by pool name, but nothing counted insert outcomes, so there was no error rate, no error breakdown, and no count of events actually lost.

The ClickHouse-side alert from `O11Y-2022` only sees requests that reach the server and is blind to pool checkout timeouts, connect timeouts, TLS failures, and circuit-breaker fast-fails. These metrics are emitted client-side, so they cover exactly those.


### Key Changes

- `logflare.clickhouse.insert.result.count` counts one event per batch tagged `backend_id`, `event_type`, `async`, `result`, and `error_class`
- `Ingester.error_class/1` turns a failure reason into a short atom safe to use as a metric tag
- `logflare.clickhouse.circuit_breaker.open.count` registers the breaker's existing `:open` event, which was emitted but never exported
- `logflare.ingest_event_queue.retry_dropped.count` counts events lost outright after an insert failure, tagged `:retries_exhausted` or `:circuit_breaker_open`
- The retry-requeue path emits its own `requeue_queue_unavailable` event instead of borrowing `not_initialized.dropped`, which had two unrelated emitters
- `retriable?/1` treats pool checkout timeouts and TLS alerts as retriable, and reuses `error_class/1` so retries and metrics stay in sync


### Risks

- **Dashboard impact.** Any panel reading `logflare.ingest_event_queue.not_initialized.dropped.count` for a ClickHouse backend loses the requeue-path contribution and needs the new series added. Three live queries in `o11y-team-tools` are affected (_tracked in `O11Y-2477`, to land before this reaches prod_)
- **Retry behavior change.** Pool checkout timeouts and TLS alerts now get one additional attempt (`@max_retries 1`) where they previously failed immediately.
- **Coupling.** Since `retriable?/1` reuses `error_class/1`, changing how errors are classified changes what gets retried. Both are pinned by tests
- `error_class/1` recovers the HTTP status by re-parsing the string `do_insert/5` formats two lines earlier. Contained, but fragile — the structured-error refactor is tracked separately in `O11Y-2478`