### PR TITLE
chore: return a structured clickhouse insert error instead of a formatted string

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -938,7 +938,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   #{@insert_max_execution_time_seconds} seconds.
   """
   @spec insert_log_events(Backend.t(), [LogEvent.t()], TypeDetection.event_type(), keyword()) ::
-          :ok | {:error, String.t()}
+          :ok | {:error, term()}
   def insert_log_events(backend, events, event_type, opts \\ [])
 
   def insert_log_events(%Backend{}, [], _event_type, _opts), do: :ok
@@ -992,7 +992,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   defp handle_insert_result({:error, reason}, backend, event_type, async?) do
     Logger.warning("ClickHouse http insert error.",
       host: insert_host(backend.config, async?),
-      error_string: inspect(reason)
+      error_string: Ingester.error_message(reason)
     )
 
     emit_insert_telemetry(backend, event_type, async?, :error, Ingester.error_class(reason))

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -992,7 +992,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   defp handle_insert_result({:error, reason}, backend, event_type, async?) do
     Logger.warning("ClickHouse http insert error.",
       host: insert_host(backend.config, async?),
-      error_string: Ingester.error_message(reason)
+      error_string: Ingester.error_string(reason)
     )
 
     emit_insert_telemetry(backend, event_type, async?, :error, Ingester.error_class(reason))

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -30,6 +30,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
     :tls_alert
   ]
 
+  @type http_error :: {:http, status :: pos_integer(), body :: binary()}
+
   @type error_class ::
           :too_many_parts
           | :http_too_many_requests
@@ -59,7 +61,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
           TypeDetection.event_type(),
           opts :: keyword()
         ) ::
-          :ok | {:error, String.t()}
+          :ok | {:error, http_error() | term()}
   def insert(backend_or_conn_opts, table, log_events, event_type, opts \\ [])
 
   def insert(_backend_or_conn_opts, _table, [], _event_type, _opts), do: :ok
@@ -85,7 +87,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   end
 
   @spec do_insert(Keyword.t(), String.t(), TypeDetection.event_type(), iodata(), keyword()) ::
-          :ok | {:error, String.t()}
+          :ok | {:error, http_error() | term()}
   defp do_insert(connection_opts, table, event_type, request_body, opts) do
     async? = Keyword.get(opts, :async, false)
     settings = Keyword.delete(opts, :async)
@@ -97,7 +99,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
         :ok
 
       {:ok, %Tesla.Env{status: status, body: response_body}} ->
-        {:error, "HTTP #{status}: #{response_body}"}
+        {:error, {:http, status, response_body}}
 
       {:error, reason} ->
         {:error, reason}
@@ -106,6 +108,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
 
   @doc false
   @spec too_many_parts?(term()) :: boolean()
+  def too_many_parts?({:http, _status, body}), do: too_many_parts?(body)
+
   def too_many_parts?(reason) when is_binary(reason),
     do: String.contains?(reason, @too_many_parts_marker)
 
@@ -115,8 +119,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   Classifies an insert failure reason into a low-cardinality class suitable for metric tags.
   """
   @spec error_class(term()) :: error_class()
-  def error_class(reason) when is_binary(reason),
-    do: response_body_error_class(too_many_parts?(reason), reason)
+  def error_class({:http, status, body} = reason) when is_pos_integer(status),
+    do: http_error_class(too_many_parts?(reason), status, body)
 
   # %Finch.Error{} only ever comes from an HTTP/2 pool. Both ClickHouse ingest pools are
   # HTTP/1, where a pool checkout timeout arrives as :pool_timeout via FinchPoolTimeoutNormalizer.
@@ -124,20 +128,21 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   def error_class(%Mint.TransportError{reason: reason}), do: transport_error_class(reason)
   def error_class(reason), do: transport_error_class(reason)
 
-  @spec response_body_error_class(boolean(), String.t()) :: error_class()
-  defp response_body_error_class(true, _reason), do: :too_many_parts
-  defp response_body_error_class(false, reason), do: http_error_class(reason)
+  @spec http_error_class(boolean(), pos_integer(), term()) :: error_class()
+  defp http_error_class(true, _status, _body), do: :too_many_parts
+  defp http_error_class(false, 429, _body), do: :http_too_many_requests
+  defp http_error_class(false, status, _body) when status >= 500, do: :http_server_error
+  defp http_error_class(false, status, _body) when status >= 400, do: :http_client_error
+  defp http_error_class(false, _status, _body), do: :http_error
 
-  @spec http_error_class(String.t()) :: error_class()
-  defp http_error_class("HTTP " <> rest), do: http_status_class(Integer.parse(rest))
-  defp http_error_class(_reason), do: :unknown
+  @doc """
+  Renders an insert failure reason as a log-friendly string.
+  """
+  @spec error_message(term()) :: String.t()
+  def error_message({:http, status, body}) when is_pos_integer(status),
+    do: "HTTP #{status}: #{body}"
 
-  @spec http_status_class({integer(), String.t()} | :error) :: error_class()
-  defp http_status_class({429, _rest}), do: :http_too_many_requests
-  defp http_status_class({status, _rest}) when status >= 500, do: :http_server_error
-  defp http_status_class({status, _rest}) when status >= 400, do: :http_client_error
-  defp http_status_class({_status, _rest}), do: :http_error
-  defp http_status_class(:error), do: :unknown
+  def error_message(reason), do: inspect(reason)
 
   @spec transport_error_class(term()) :: error_class()
   defp transport_error_class(:pool_timeout), do: :pool_timeout
@@ -201,7 +206,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
           TypeDetection.event_type(),
           compressed :: binary(),
           opts :: keyword()
-        ) :: :ok | {:error, String.t()}
+        ) :: :ok | {:error, http_error() | term()}
   def insert_compressed(backend_or_conn_opts, table, event_type, compressed, opts \\ [])
 
   def insert_compressed(%Backend{} = backend, table, event_type, compressed, opts)

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/ingester.ex
@@ -136,13 +136,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.Ingester do
   defp http_error_class(false, _status, _body), do: :http_error
 
   @doc """
-  Renders an insert failure reason as a log-friendly string.
+  Renders an insert failure reason for the `error_string` log metadata. The `inspect/1`
+  keeps a multiline or oversized response body from breaking the log entry.
   """
-  @spec error_message(term()) :: String.t()
-  def error_message({:http, status, body}) when is_pos_integer(status),
-    do: "HTTP #{status}: #{body}"
+  @spec error_string(term()) :: String.t()
+  def error_string({:http, status, body}) when is_pos_integer(status),
+    do: inspect("HTTP #{status}: #{body}")
 
-  def error_message(reason), do: inspect(reason)
+  def error_string(reason), do: inspect(reason)
 
   @spec transport_error_class(term()) :: error_class()
   defp transport_error_class(:pool_timeout), do: :pool_timeout

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -324,15 +324,15 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
 
   describe "error_class/1" do
     test "classifies a too-many-parts response body ahead of its HTTP status" do
-      assert Ingester.error_class("HTTP 500: Code: 252. DB::Exception: Too many parts") ==
+      assert Ingester.error_class({:http, 500, "Code: 252. DB::Exception: Too many parts"}) ==
                :too_many_parts
     end
 
     test "classifies HTTP status ranges" do
-      assert Ingester.error_class("HTTP 429: slow down") == :http_too_many_requests
-      assert Ingester.error_class("HTTP 503: unavailable") == :http_server_error
-      assert Ingester.error_class("HTTP 400: bad request") == :http_client_error
-      assert Ingester.error_class("HTTP 302: moved") == :http_error
+      assert Ingester.error_class({:http, 429, "slow down"}) == :http_too_many_requests
+      assert Ingester.error_class({:http, 503, "unavailable"}) == :http_server_error
+      assert Ingester.error_class({:http, 400, "bad request"}) == :http_client_error
+      assert Ingester.error_class({:http, 302, "moved"}) == :http_error
     end
 
     test "classifies wrapped Finch and Mint transport errors" do
@@ -355,6 +355,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
       assert Ingester.error_class("something unstructured") == :unknown
       assert Ingester.error_class({:weird, :shape}) == :unknown
       assert Ingester.error_class(:some_unmapped_atom) == :unknown
+    end
+  end
+
+  describe "error_message/1" do
+    test "renders a structured HTTP error the way it reads in logs" do
+      assert Ingester.error_message({:http, 400, "boom"}) == "HTTP 400: boom"
+    end
+
+    test "inspects any other reason" do
+      assert Ingester.error_message(%Finch.Error{reason: :pool_timeout}) ==
+               inspect(%Finch.Error{reason: :pool_timeout})
+
+      assert Ingester.error_message(:closed) == ":closed"
     end
   end
 
@@ -406,7 +419,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
         {:ok, %Finch.Response{status: 500, body: response_body}}
       end)
 
-      assert {:error, "HTTP 500: " <> ^response_body} =
+      assert {:error, {:http, 500, ^response_body}} =
                Ingester.insert_compressed(backend, table_name, :log, :zlib.gzip(""))
     end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/ingester_test.exs
@@ -358,16 +358,29 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.IngesterTest do
     end
   end
 
-  describe "error_message/1" do
-    test "renders a structured HTTP error the way it reads in logs" do
-      assert Ingester.error_message({:http, 400, "boom"}) == "HTTP 400: boom"
+  describe "error_string/1" do
+    test "renders a structured HTTP error exactly as the call site logged it before" do
+      assert Ingester.error_string({:http, 400, "boom"}) == inspect("HTTP 400: boom")
+    end
+
+    test "escapes a multiline response body so the log entry stays on one line" do
+      rendered = Ingester.error_string({:http, 500, "line one\nline two"})
+
+      assert rendered == inspect("HTTP 500: line one\nline two")
+      refute rendered =~ "\n"
+    end
+
+    test "bounds an oversized response body" do
+      body = String.duplicate("x", 9_000)
+
+      assert String.length(Ingester.error_string({:http, 500, body})) < String.length(body)
     end
 
     test "inspects any other reason" do
-      assert Ingester.error_message(%Finch.Error{reason: :pool_timeout}) ==
+      assert Ingester.error_string(%Finch.Error{reason: :pool_timeout}) ==
                inspect(%Finch.Error{reason: :pool_timeout})
 
-      assert Ingester.error_message(:closed) == ":closed"
+      assert Ingester.error_string(:closed) == ":closed"
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -1804,7 +1804,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       expected_backend_id = backend.id
 
       too_many_parts_error =
-        "HTTP 500: Code: 252. DB::Exception: Too many parts (600 with average size of 1.00 MiB) in table."
+        {:http, 500,
+         "Code: 252. DB::Exception: Too many parts (600 with average size of 1.00 MiB) in table."}
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,
@@ -1845,7 +1846,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       source: source,
       backend: backend
     } do
-      too_many_parts_error = "HTTP 500: Code: 252. DB::Exception: Too many parts in table."
+      too_many_parts_error = {:http, 500, "Code: 252. DB::Exception: Too many parts in table."}
 
       Mimic.expect(ClickHouseAdaptor, :insert_log_events_compressed, fn _backend,
                                                                         _event_type,


### PR DESCRIPTION
## Overview

Follow-up to #3950.

`do_insert/5` flattened a non-200 ClickHouse response into `"HTTP #{status}: #{body}"`, and the two consumers that needed the status then parsed it back out of that sentence. Reformatting the message would have silently broken classification, sending the new insert error-rate metric to `:unknown` with no test failure.

Behavior-preserving — same classes for the same failures, same log output, no metric or telemetry changes.


### Key Changes

- `do_insert/5` returns `{:error, {:http, status, body}}` instead of a formatted string
- `error_class/1` matches the status directly, dropping the `"HTTP "` prefix match and `Integer.parse` round trip
- `too_many_parts?/1` accepts the structured shape, keeping its binary clause since `retriable?/1` calls it with the raw response body
- New `Ingester.error_string/1` renders the reason for the log line, wrapping the formatted string in `inspect/1` so the logged `error_string` is the same as before
- Specs move from `{:error, String.t()}` to `{:error, http_error() | term()}`


### Risks / Considerations

- **Stacked on #3950** — _needs a rebase once that PR merges_
- The `inspect/1` in `error_string/1` is required, not stylistic. Without it a multiline ClickHouse response body splits the log entry across lines, and an oversized one writes unbounded — a 9000-byte body goes from 4105 chars to 9010. Both cases are tested
- `Message.failed/2` in `pipeline.ex:485` now carries a tuple rather than a string as the Broadway failure reason. Nothing matches on its shape, and it is only ever inspected
- `retriable?/1` is unaffected: Tesla's `should_retry` sees the raw adapter result, and the tuple is built after retries are exhausted
- Four tests pinned the old string shape and were updated. Two of them (`pipeline_test.exs:1807`, `:1848`) were stubbing the adaptor with a string the real code no longer produces