### PR TITLE
test(log-event): exclude reserved custom message keys

### DIFF
--- a/test/logflare/log_event_test.exs
+++ b/test/logflare/log_event_test.exs
@@ -866,6 +866,7 @@ defmodule Logflare.LogEventTest do
     end
 
     @alphas [?a..?z, ?A..?Z]
+    @reserved_message_keys ~w[id message event_message]
 
     property "`m.` can be used as an alias for `metadata.`" do
       check all key <- string(@alphas, min_length: 1),
@@ -878,17 +879,13 @@ defmodule Logflare.LogEventTest do
     end
 
     property "top keys are reachable" do
-      check all metadata <-
-                  map_of(
-                    string(@alphas, min_length: 1),
-                    string(:printable),
-                    min_length: 1
-                  ) do
-        key = Enum.random(Map.keys(metadata))
+      check all key <-
+                  string(@alphas, min_length: 1)
+                  |> filter(&(&1 not in @reserved_message_keys)),
+                value <- string(:printable) do
+        le = event_with_message(key, %{key => value})
 
-        le = event_with_message(key, metadata)
-
-        assert Jason.encode!(metadata[key]) == le.body["event_message"]
+        assert Jason.encode!(value) == le.body["event_message"]
       end
     end
 


### PR DESCRIPTION
The `make_message/2` top-key property could select `id`, `message`, or `event_message`, even though those names intentionally have special selector behavior. CI seed `859784` selected `id`, so the property expected the metadata value while production correctly returned the event ID.

## Change

- Generates the selected top-level key directly instead of choosing one with `Enum.random/1` from a generated map.
- Excludes the three reserved custom-message selectors.
- Keeps the existing dedicated examples that cover `id`, `message`, and `event_message` behavior.

This is a test-only change; production `LogEvent` behavior is unchanged.

## Validation

- Exact failing property with seed `859784`: **1 property, 0 failures**
- Full `test/logflare/log_event_test.exs` with seed `859784`: **6 properties, 66 tests, 0 failures**
- Full test file with a fresh seed: **6 properties, 66 tests, 0 failures**
- Formatting passes.
- `mix lint.all` passes with 32 pre-existing software-design suggestions.

Original failure: https://github.com/Logflare/logflare/actions/runs/34368651783
