### PR TITLE
chore: add connect/disconnect telemetry for ClickHouse read pools

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -47,7 +47,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @ch_slow_pool_checkout_ms 1_000
   @us_per_hour 3_600 * 1_000_000
   @default_max_event_age_hours 24
-  @default_read_cluster_tag "default"
+  @unlabeled_read_cluster_tag "(unlabeled)"
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
   defdelegate connection_pool_via(arg, label), to: ConnectionManager
@@ -556,11 +556,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @doc """
   Normalizes a read cluster label into a telemetry tag, mapping the legacy
-  unlabeled pool to a stable string.
+  unlabeled pool to `#{@unlabeled_read_cluster_tag}`.
+
+  The value is reserved: `read_only_urls` rejects it as a cluster label, so a
+  labeled pool can never share a tag with the unlabeled one.
   """
   @spec read_cluster_tag(String.t() | nil) :: String.t()
   def read_cluster_tag(label) when is_non_empty_binary(label), do: label
-  def read_cluster_tag(_label), do: @default_read_cluster_tag
+  def read_cluster_tag(_label), do: @unlabeled_read_cluster_tag
 
   @spec default_read_cluster_label(Backend.t()) :: String.t() | nil
   defp default_read_cluster_label(%Backend{config: config}) do
@@ -1268,6 +1271,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   end
 
   @spec validate_read_only_url_entry({String.t(), term()}, Changeset.t()) :: Changeset.t()
+  defp validate_read_only_url_entry({@unlabeled_read_cluster_tag = label, _url}, changeset) do
+    Changeset.add_error(
+      changeset,
+      :read_only_urls,
+      "read cluster label \"#{label}\" is reserved for the unlabeled read pool"
+    )
+  end
+
   defp validate_read_only_url_entry({label, url}, changeset) do
     if is_non_empty_binary(url) and Regex.match?(~r/https?\:\/\/.+/, url) do
       changeset

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -47,6 +47,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
   @ch_slow_pool_checkout_ms 1_000
   @us_per_hour 3_600 * 1_000_000
   @default_max_event_age_hours 24
+  @default_read_cluster_tag "default"
 
   defdelegate connection_pool_via(arg), to: ConnectionManager
   defdelegate connection_pool_via(arg, label), to: ConnectionManager
@@ -553,6 +554,14 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
     end
   end
 
+  @doc """
+  Normalizes a read cluster label into a telemetry tag, mapping the legacy
+  unlabeled pool to a stable string.
+  """
+  @spec read_cluster_tag(String.t() | nil) :: String.t()
+  def read_cluster_tag(label) when is_non_empty_binary(label), do: label
+  def read_cluster_tag(_label), do: @default_read_cluster_tag
+
   @spec default_read_cluster_label(Backend.t()) :: String.t() | nil
   defp default_read_cluster_label(%Backend{config: config}) do
     urls = Map.get(config, :read_only_urls) || %{}
@@ -676,7 +685,10 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
           {result, label}
       end
 
-    emit_query_error_telemetry(result, %{backend_id: backend.id, read_cluster: queried_label})
+    emit_query_error_telemetry(result, %{
+      backend_id: backend.id,
+      read_cluster: read_cluster_tag(queried_label)
+    })
 
     result
   end
@@ -760,7 +772,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
       :telemetry.execute(
         [:logflare, :clickhouse, :read_pool, :failover],
         %{count: 1},
-        %{backend_id: backend.id, read_cluster: label}
+        %{backend_id: backend.id, read_cluster: read_cluster_tag(label)}
       )
 
       {do_ch_query_on_label(backend, statement, params, default), default}
@@ -771,7 +783,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor do
 
   @spec handle_read_pool_log(DBConnection.LogEntry.t(), pos_integer(), String.t() | nil) :: :ok
   defp handle_read_pool_log(%DBConnection.LogEntry{} = entry, backend_id, label) do
-    metadata = %{backend_id: backend_id, read_cluster: label}
+    metadata = %{backend_id: backend_id, read_cluster: read_cluster_tag(label)}
 
     measurements =
       entry

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/connection_manager.ex
@@ -37,6 +37,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
   @ch_idle_interval :timer.seconds(3)
   @default_read_pool_size 50
   @default_labeled_read_pool_size 32
+  @telemetry_listener __MODULE__.TelemetryListener
 
   typedstruct do
     field :backend_id, pos_integer(), enforce: true
@@ -68,6 +69,16 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
       start: {__MODULE__, :start_link, [backend, label]}
     }
   end
+
+  @doc """
+  Registered name of the `DBConnection.TelemetryListener` that read pools report
+  connect and disconnect events to.
+
+  The listener is supervised by `QueryConnectionSup` so that it outlives the pools,
+  which are stopped and restarted on config refresh, inactivity, and recycle.
+  """
+  @spec telemetry_listener_name() :: atom()
+  def telemetry_listener_name, do: @telemetry_listener
 
   @doc """
   Generates a unique ClickHouse connection pool via tuple based on a `Backend` and
@@ -509,7 +520,8 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManager do
         timeout: @ch_query_conn_timeout,
         queue_target: @ch_queue_target,
         idle_interval: @ch_idle_interval,
-        idle_limit: pool_size
+        idle_limit: pool_size,
+        connection_listeners: {[@telemetry_listener], {backend.id, label}}
       ]
 
       {:ok, ch_opts}

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/query_connection_sup.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/query_connection_sup.ex
@@ -10,6 +10,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryConnectionSup do
   ```
   Logflare.Backends.Supervisor
   └── QueryConnectionSup (this module)
+      ├── DBConnection.TelemetryListener (read pool connect/disconnect events)
       └── DynamicSupervisor
           └── ConnectionManager (one per backend, lazily started)
   ```
@@ -67,6 +68,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryConnectionSup do
   @impl true
   def init(_args) do
     children = [
+      {DBConnection.TelemetryListener, name: ConnectionManager.telemetry_listener_name()},
       {DynamicSupervisor, strategy: :one_for_one, name: @dynamic_sup_name}
     ]
 

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -5,6 +5,8 @@ defmodule Logflare.Telemetry do
   import Logflare.Utils, only: [ets_info: 1]
   import Logflare.Utils.Guards, only: [is_non_empty_binary: 1, is_pos_integer: 1]
 
+  alias Logflare.Backends.Adaptor.ClickHouseAdaptor
+
   def start_link(arg), do: Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
 
   context_caches_with_metrics = Logflare.ContextCache.Supervisor.list_caches_with_metrics()
@@ -391,6 +393,24 @@ defmodule Logflare.Telemetry do
         tags: [:backend_id, :read_cluster],
         description:
           "Read queries that failed over to the default read cluster, tagged with the unhealthy cluster failed over from"
+      ),
+      sum("logflare.clickhouse.read_pool.connected.count",
+        event_name: [:db_connection, :connected],
+        measurement: :count,
+        tags: [:backend_id, :read_cluster],
+        tag_values: &ch_read_pool_connection_tags/1,
+        keep: &ch_read_pool_connection_event?/1,
+        description:
+          "ClickHouse read pool connections established, per backend and read cluster. Only pools started after deploy are counted"
+      ),
+      sum("logflare.clickhouse.read_pool.disconnected.count",
+        event_name: [:db_connection, :disconnected],
+        measurement: :count,
+        tags: [:backend_id, :read_cluster],
+        tag_values: &ch_read_pool_connection_tags/1,
+        keep: &ch_read_pool_connection_event?/1,
+        description:
+          "ClickHouse read pool connections lost or recycled, per backend and read cluster. Paired with `connected`, this is the pool's connection churn rate"
       ),
       sum("logflare.clickhouse.insert.result.count",
         event_name: [:logflare, :clickhouse, :insert, :result],
@@ -805,6 +825,16 @@ defmodule Logflare.Telemetry do
 
   defp backend_scoped_drop?(%{backend_id: _, backend_type: _}), do: true
   defp backend_scoped_drop?(_metadata), do: false
+
+  defp ch_read_pool_connection_event?(%{tag: {backend_id, label}})
+       when is_pos_integer(backend_id) and (is_binary(label) or is_nil(label)),
+       do: true
+
+  defp ch_read_pool_connection_event?(_metadata), do: false
+
+  defp ch_read_pool_connection_tags(%{tag: {backend_id, label}}) do
+    %{backend_id: backend_id, read_cluster: ClickHouseAdaptor.read_cluster_tag(label)}
+  end
 
   defp batch_size_reporter_opts do
     [buckets: [0, 1, 50, 100, 250, 500, 1_000, 5_000, 10_000, 20_000, 50_000]]

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/connection_manager_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/connection_manager_test.exs
@@ -354,7 +354,65 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManagerTest do
     end
   end
 
+  describe "connection listeners" do
+    test "tags the legacy pool with the backend id and a nil label", %{backend: backend} do
+      opts = capture_ch_opts(backend, nil)
+
+      assert {[listener], {backend_id, nil}} = Keyword.fetch!(opts, :connection_listeners)
+      assert listener == ConnectionManager.telemetry_listener_name()
+      assert backend_id == backend.id
+    end
+
+    test "tags a labeled pool with its read cluster", %{backend: backend} do
+      opts = capture_ch_opts(backend, "api_free")
+
+      assert {[_listener], {_backend_id, "api_free"}} =
+               Keyword.fetch!(opts, :connection_listeners)
+    end
+
+    test "a started pool emits tagged connect telemetry", %{backend: backend} do
+      TestUtils.attach_forwarder([:db_connection, :connected])
+
+      {:ok, _manager_pid} = ConnectionManager.start_link(backend)
+      assert :ok == ConnectionManager.ensure_pool_started(backend)
+
+      assert_receive {:telemetry_event, [:db_connection, :connected], %{count: 1},
+                      %{tag: {backend_id, nil}}},
+                     @timeout_interval
+
+      assert backend_id == backend.id
+    end
+
+    test "a recycled pool emits tagged disconnect telemetry", %{backend: backend} do
+      config = Application.get_env(:logflare, ConnectionManager)
+      on_exit(fn -> Application.put_env(:logflare, ConnectionManager, config) end)
+      Application.put_env(:logflare, ConnectionManager, recycle_spread: 1)
+
+      {:ok, _manager_pid} = ConnectionManager.start_link(backend)
+      assert :ok == ConnectionManager.ensure_pool_started(backend)
+      assert {:ok, _} = ClickHouseAdaptor.execute_ch_query(backend, "SELECT 1 as test")
+
+      TestUtils.attach_forwarder([:db_connection, :disconnected])
+
+      assert :ok == ConnectionManager.recycle_pool(backend)
+
+      assert {:ok, _} = ClickHouseAdaptor.execute_ch_query(backend, "SELECT 2 as test")
+
+      assert_receive {:telemetry_event, [:db_connection, :disconnected], %{count: 1},
+                      %{tag: {backend_id, nil}}},
+                     @timeout_interval
+
+      assert backend_id == backend.id
+    end
+  end
+
   defp start_pool_credentials(backend) do
+    opts = capture_ch_opts(backend, nil)
+
+    {Keyword.fetch!(opts, :username), Keyword.fetch!(opts, :password)}
+  end
+
+  defp capture_ch_opts(backend, label) do
     test_pid = self()
 
     stub(Ch, :start_link, fn opts ->
@@ -362,11 +420,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.ConnectionManagerTest do
       Agent.start_link(fn -> :ok end)
     end)
 
-    {:ok, _manager_pid} = ConnectionManager.start_link(backend)
-    assert :ok == ConnectionManager.ensure_pool_started(backend)
+    {:ok, _manager_pid} = ConnectionManager.start_link(backend, label)
+    assert :ok == ConnectionManager.ensure_pool_started(backend, label)
 
     assert_receive {:ch_opts, opts}
 
-    {Keyword.fetch!(opts, :username), Keyword.fetch!(opts, :password)}
+    opts
   end
 end

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/query_connection_sup_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/query_connection_sup_test.exs
@@ -42,6 +42,20 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.QueryConnectionSupTest do
     end
   end
 
+  describe "telemetry listener" do
+    test "supervises a named DBConnection telemetry listener" do
+      listener_pid = Process.whereis(ConnectionManager.telemetry_listener_name())
+
+      assert is_pid(listener_pid)
+      assert Process.alive?(listener_pid)
+
+      assert Enum.any?(Supervisor.which_children(QueryConnectionSup), fn
+               {DBConnection.TelemetryListener, ^listener_pid, _type, _modules} -> true
+               _child -> false
+             end)
+    end
+  end
+
   describe "recycle_backend_local/1" do
     test "returns an error when no manager is running for the backend", %{backend: backend} do
       assert {:error, :no_manager} == QueryConnectionSup.recycle_backend_local(backend.id)

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -192,7 +192,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert is_integer(measurements.connection_time)
       assert measurements.connection_time > System.convert_time_unit(10, :microsecond, :native)
       assert metadata.backend_id == backend.id
-      assert metadata.read_cluster == "default"
+      assert metadata.read_cluster == "(unlabeled)"
     end
 
     test "emits a plausible idle_time on a checked-in connection", %{backend: backend} do
@@ -228,7 +228,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
                       %{count: 1}, metadata}
 
       assert metadata.backend_id == backend.id
-      assert metadata.read_cluster == "default"
+      assert metadata.read_cluster == "(unlabeled)"
       assert metadata.error_kind == :connection_error
     end
 
@@ -460,6 +460,26 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
 
       refute changeset.valid?
       assert Keyword.has_key?(changeset.errors, :read_only_urls)
+    end
+
+    test "rejects the read cluster label reserved for the unlabeled pool" do
+      changeset =
+        cast_and_validate_config(
+          read_only_urls: %{"(unlabeled)" => "http://logs-read.local:8123"}
+        )
+
+      refute changeset.valid?
+      assert {message, _opts} = changeset.errors[:read_only_urls]
+      assert message =~ "reserved"
+    end
+
+    test "accepts a read cluster labeled \"default\"" do
+      urls = %{"default" => "http://logs-read.local:8123"}
+
+      changeset = cast_and_validate_config(read_only_urls: urls)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :read_only_urls) == urls
     end
 
     test "strips basic auth credentials from every URL config field" do
@@ -946,8 +966,25 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
     end
 
     test "returns a stable tag for the legacy pool" do
-      assert ClickHouseAdaptor.read_cluster_tag(nil) == "default"
-      assert ClickHouseAdaptor.read_cluster_tag("") == "default"
+      assert ClickHouseAdaptor.read_cluster_tag(nil) == "(unlabeled)"
+      assert ClickHouseAdaptor.read_cluster_tag("") == "(unlabeled)"
+    end
+
+    test "keeps the legacy pool distinct from a cluster labeled \"default\"" do
+      config = %{
+        url: "http://ingest.local:8123",
+        read_only_url: "http://legacy-read.local:8123",
+        read_only_urls: %{"default" => "http://named-default-read.local:8123"}
+      }
+
+      legacy_label = ClickHouseAdaptor.resolve_read_cluster_label(config, nil)
+      named_label = ClickHouseAdaptor.resolve_read_cluster_label(config, "default")
+
+      assert legacy_label == nil
+      assert named_label == "default"
+
+      refute ClickHouseAdaptor.read_cluster_tag(legacy_label) ==
+               ClickHouseAdaptor.read_cluster_tag(named_label)
     end
   end
 

--- a/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor_test.exs
@@ -192,7 +192,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       assert is_integer(measurements.connection_time)
       assert measurements.connection_time > System.convert_time_unit(10, :microsecond, :native)
       assert metadata.backend_id == backend.id
-      assert metadata.read_cluster == nil
+      assert metadata.read_cluster == "default"
     end
 
     test "emits a plausible idle_time on a checked-in connection", %{backend: backend} do
@@ -228,7 +228,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
                       %{count: 1}, metadata}
 
       assert metadata.backend_id == backend.id
-      assert metadata.read_cluster == nil
+      assert metadata.read_cluster == "default"
       assert metadata.error_kind == :connection_error
     end
 
@@ -937,6 +937,17 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptorTest do
       backend = %Backend{config: config}
 
       assert ClickHouseAdaptor.resolve_read_cluster_label(backend, "api") == "api"
+    end
+  end
+
+  describe "read_cluster_tag/1" do
+    test "returns a configured label unchanged" do
+      assert ClickHouseAdaptor.read_cluster_tag("api") == "api"
+    end
+
+    test "returns a stable tag for the legacy pool" do
+      assert ClickHouseAdaptor.read_cluster_tag(nil) == "default"
+      assert ClickHouseAdaptor.read_cluster_tag("") == "default"
     end
   end
 

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -247,6 +247,35 @@ defmodule Logflare.TelemetryTest do
       assert failover.tags == [:backend_id, :read_cluster]
     end
 
+    test "defines ClickHouse read pool connection lifecycle counts" do
+      connected = read_pool_metric([:logflare, :clickhouse, :read_pool, :connected, :count])
+      disconnected = read_pool_metric([:logflare, :clickhouse, :read_pool, :disconnected, :count])
+
+      assert connected.event_name == [:db_connection, :connected]
+      assert disconnected.event_name == [:db_connection, :disconnected]
+
+      for metric <- [connected, disconnected] do
+        assert to_string(metric.__struct__) == "Elixir.Telemetry.Metrics.Sum"
+        assert metric.measurement == :count
+        assert metric.tags == [:backend_id, :read_cluster]
+
+        assert metric.keep.(%{tag: {123, "api_free"}})
+        assert metric.keep.(%{tag: {123, nil}})
+        refute metric.keep.(%{tag: Logflare.Repo})
+        refute metric.keep.(%{})
+
+        assert metric.tag_values.(%{tag: {123, "api_free"}}) == %{
+                 backend_id: 123,
+                 read_cluster: "api_free"
+               }
+
+        assert metric.tag_values.(%{tag: {123, nil}}) == %{
+                 backend_id: 123,
+                 read_cluster: "default"
+               }
+      end
+    end
+
     test "honors configured Broadway processor message duration sampling" do
       denominator = Application.fetch_env!(:logflare, :broadway_message_sample_denominator)
 

--- a/test/logflare/telemetry_test.exs
+++ b/test/logflare/telemetry_test.exs
@@ -271,8 +271,11 @@ defmodule Logflare.TelemetryTest do
 
         assert metric.tag_values.(%{tag: {123, nil}}) == %{
                  backend_id: 123,
-                 read_cluster: "default"
+                 read_cluster: "(unlabeled)"
                }
+
+        refute metric.tag_values.(%{tag: {123, "default"}}) ==
+                 metric.tag_values.(%{tag: {123, nil}})
       end
     end
 


### PR DESCRIPTION
## Overview

We have no direct measurement of read pool connection lifecycle. Reconnect storms, recycle behavior, and idle socket death can only be inferred from server-side ClickHouse metrics, which the proxy layer obscures anyway. `DBConnection.TelemetryListener` emits per-connection `[:db_connection, :connected]` and `[:db_connection, :disconnected]` events — the measurement itself rather than an inference from it.

Pairs with the checkout timing metrics already in place (#3896): a disconnect/reconnect rate baseline per pool means a spike at recycle time, or one synchronized across pools, discriminates between the slow-checkout mechanisms directly.

### Key Changes

- `QueryConnectionSup` supervises a named `DBConnection.TelemetryListener` ahead of the pools' `DynamicSupervisor`, so it outlives the pools — which are hard-stopped on config refresh, idle-stopped after 5 minutes, and recycled every ~10 mins
- `build_ch_opts/2` passes `connection_listeners: {[listener], {backend_id, label}}`. The tag is computed at pool start, so dynamically-created labeled pools self-identify
- `logflare.clickhouse.read_pool.connected.count` and `.disconnected.count` tag `backend_id` and `read_cluster`, unpacking the pool tag in `tag_values`. A `keep` guard restricts them to our tag shape, since `[:db_connection, :connected]` is a globally-named event any future `DBConnection` listener would land on
- New `ClickHouseAdaptor.read_cluster_tag/1` maps the legacy unlabeled pool to a stable `"default"`, and is applied to the existing checkout, `query_error`, and `failover` tags as well, so every read pool metric family joins on `read_cluster`
- Two of the new tests run against a real pool end to end, asserting tagged connect and disconnect events rather than just the opts we hand to `Ch.start_link/1`


### Risks / Considerations

- **Dashboard impact.** The legacy pool's `read_cluster` changes from empty to `"(unlabeled)"` on already-shipped read pool metrics.
- **Disconnects are lazy, not instantaneous.** `DBConnection.disconnect_all/2` — what `recycle_pool/1` calls — only stamps the pool; connections drop at their next checkin or idle-scan pass. Recycle-driven disconnects smear across the 60s `recycle_spread` on a busy pool, and an idle pool registers none until traffic touches it. Panel descriptions should say so rather than imply a sawtooth
- The listener is a singleton keyed by name. If it crashes, in-flight monitors are lost and disconnects for existing connections go uncounted until those connections cycle — bounded and self-healing, but it makes the counters lower bounds, not exact
- `Ch.start_link/1` forwards opts untouched to `DBConnection.start_link/2` (_ch 0.5.6, db_connection 2.9.0_), so no adapter change was needed