### PR TITLE
fix: update clickhouse mapping configuration to ensure `metadata.source` does not get lost

### DIFF
--- a/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults.ex
@@ -24,6 +24,19 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
   This trade-off is deliberate: downstream queries get a stable, predictable key set
   rather than having to reconcile aliases and duplicate keys per row.
 
+  ## Root-level `source` contract
+
+  Every attribute map (`log_attributes`, `attributes`, `span_attributes`) excludes the
+  root-level `source` key. Ingest resolves the target source from `params["source"]`, and
+  `Plug.Parsers` merges the parsed request body into `conn.params`, so a caller may pass
+  the source token in the JSON body rather than the query string. The ingest controller
+  drops only `timestamp` and `id` from that body, so a body-supplied token survives into
+  the event body as a source UUID under `$.source`.
+
+  Because `:exclude_keys` is applied before `:elevate_keys`, dropping the key lets a
+  caller-supplied `metadata.source` elevate into `source` instead of being overwritten by
+  the UUID.
+
   ## `severity_number` contract
 
   A supplied `severity_number` is stored only when it is an integer (or a string holding
@@ -40,9 +53,11 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
   alias Logflare.Mapper.MappingConfig.InferRule
   alias Logflare.Mapper.MappingConfig.OutputFormat
 
-  @log_config_id "00000000-0000-0000-0001-000000000004"
-  @metric_config_id "00000000-0000-0000-0002-000000000004"
-  @trace_config_id "00000000-0000-0000-0003-000000000005"
+  @log_config_id "00000000-0000-0000-0001-000000000005"
+  @metric_config_id "00000000-0000-0000-0002-000000000005"
+  @trace_config_id "00000000-0000-0000-0003-000000000006"
+
+  @attributes_exclude_keys ["id", "event_message", "source", "timestamp"]
 
   @spec config_id(TypeDetection.event_type()) :: String.t()
   def config_id(:log), do: @log_config_id
@@ -158,7 +173,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("log_attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp", "resource", "scope"],
+        exclude_keys: @attributes_exclude_keys ++ ["resource", "scope"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.datetime64("timestamp", path: "$.timestamp", precision: 9)
@@ -267,7 +282,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       ),
       Field.flat_map("attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp", "resource", "scope"],
+        exclude_keys: @attributes_exclude_keys ++ ["resource", "scope"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.string("aggregation_temporality",
@@ -503,7 +518,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaults do
       # scope.attributes.*. Adding "scope" here would drop them entirely.
       Field.flat_map("span_attributes",
         path: "$",
-        exclude_keys: ["id", "event_message", "timestamp", "resource"],
+        exclude_keys: @attributes_exclude_keys ++ ["resource"],
         elevate_keys: ["metadata", "attributes"]
       ),
       Field.array_datetime64("events.timestamp",

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/mapping_defaults_test.exs
@@ -175,6 +175,29 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.MappingDefaultsTest do
       end
     end
 
+    test "a metadata.source child is not shadowed by the root-level source token", %{
+      log: log,
+      metric: metric,
+      trace: trace
+    } do
+      payload = %{
+        "source" => "9a1c7e40-3b62-4f18-8d5a-1c0b4e7f2a96",
+        "event_message" => "worker ingress request",
+        "metadata" => %{"source" => "worker_ingress_logs", "level" => "info"},
+        "timestamp" => 1_775_591_051_937_363
+      }
+
+      for {compiled, field} <- [
+            {log, "log_attributes"},
+            {metric, "attributes"},
+            {trace, "span_attributes"}
+          ] do
+        attrs = Mapper.map(payload, compiled)[field]
+
+        assert attrs["source"] == "worker_ingress_logs", "#{field} lost metadata.source"
+      end
+    end
+
     test "a non-map attributes value is preserved as a literal key", %{
       log: log,
       metric: metric,


### PR DESCRIPTION
The mapping behavior for `log_attributes` (logs), `attributes` (metrics), and `span_attributes` (traces) is configured to elevate keys within `metadata` as well as include all root-level attributes not listed in their respective `exclude_keys` property.

The problem is that a new source coming online with a `metadata.source` attribute would be lost to a root-level `source` property in the existing configuration despite us not leveraging the `$.source` attribute for anything as it already exists as `source_uuid` in ClickHouse.

This PR adds `source` to `exclude_keys` for all three types to ensure the root level `source` attribute is excluded prior to elevating the attributes within `metadata`. Worth noting that `exclude_keys` is applied _before_ `elevate_keys`, which is what makes this work properly. 