### PR TITLE
fix: bound the ClickHouse ingest pool send path with `send_timeout`

### DIFF
--- a/lib/logflare/networking.ex
+++ b/lib/logflare/networking.ex
@@ -5,6 +5,15 @@ defmodule Logflare.Networking do
   alias Logflare.Backends.Adaptor.DatadogAdaptor
   alias Logflare.SingleTenant
 
+  # Finch bounds only connect and receive. Without `send_timeout` a peer that accepts
+  # the connection and then stops reading blocks the insert inside `:gen_tcp.send`
+  # forever, wedging a batcher and leaking the connection out of the pool.
+  @clickhouse_transport_opts [
+    timeout: :timer.seconds(10),
+    send_timeout: :timer.seconds(15),
+    send_timeout_close: true
+  ]
+
   def pools do
     if SingleTenant.postgres_backend?() do
       finch_pools(true)
@@ -89,7 +98,7 @@ defmodule Logflare.Networking do
            conn_max_idle_time: 5_000,
            start_pool_metrics?: true,
            conn_opts: [
-             transport_opts: [timeout: 10_000]
+             transport_opts: @clickhouse_transport_opts
            ]
          ]
        }},
@@ -107,7 +116,7 @@ defmodule Logflare.Networking do
            conn_max_idle_time: 5_000,
            start_pool_metrics?: true,
            conn_opts: [
-             transport_opts: [timeout: 10_000]
+             transport_opts: @clickhouse_transport_opts
            ]
          ]
        }}

--- a/test/logflare/networking_test.exs
+++ b/test/logflare/networking_test.exs
@@ -61,4 +61,27 @@ defmodule Logflare.NetworkingTest do
       assert datadog_pools == expected_datadog_pools
     end
   end
+
+  describe "ClickHouse ingest pools" do
+    test "bound the request send path in addition to connect" do
+      for name <- [Logflare.FinchClickHouseIngest, Logflare.FinchClickHouseAsyncIngest] do
+        assert {Finch, opts} =
+                 Enum.find(Networking.pools(), fn
+                   {Finch, opts} -> Keyword.get(opts, :name) == name
+                   _ -> false
+                 end)
+
+        transport_opts =
+          opts
+          |> Keyword.fetch!(:pools)
+          |> Map.fetch!(:default)
+          |> Keyword.fetch!(:conn_opts)
+          |> Keyword.fetch!(:transport_opts)
+
+        assert Keyword.fetch!(transport_opts, :timeout) == :timer.seconds(10)
+        assert Keyword.fetch!(transport_opts, :send_timeout) == :timer.seconds(15)
+        assert Keyword.fetch!(transport_opts, :send_timeout_close) == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Overview

Both ClickHouse ingest pools bounded connect and receive, but nothing bounded the request send. Finch passes `receive_timeout`/`request_timeout` only to `receive_response/8` — the `Mint.HTTP.request/5` call that writes the body is a blocking `:gen_tcp.send` with no deadline. A peer that accepts the connection and then stops reading (TCP zero-window, half-dead node) blocks the insert indefinitely, wedging one of the four batchers and leaking the connection out of the pool.

Surfaced while reviewing the same gap on the S3 pool in #3944.

### Key Changes

- Both `FinchClickHouseIngest` and `FinchClickHouseAsyncIngest` get `send_timeout: 15s` and `send_timeout_close: true`
- Shared `@clickhouse_transport_opts`, since both pools already carried identical `transport_opts`

### Risks / Considerations

- `send_timeout` matches `Ingester`'s `@receive_timeout`, so both halves of the request are bounded the same. A 60k-event gzipped RowBinary batch has no business taking 15s on a healthy socket
- Failures arrive as `%Mint.TransportError{reason: :timeout}`, which `error_class/1` already maps to `:timeout` — a retriable class. No adaptor changes needed, and the existing telemetry picks it up
- `send_timeout_close: true` discards the socket rather than returning a half-written connection to the pool
- Verified the keys actually reach the socket: Mint merges caller `transport_opts` into the connect call dropping only `:timeout/:inet4/:inet6`, and Finch's `maybe_drop_tls_options/2` strips only TLS opts, so this holds on plaintext endpoints too