### PR TITLE
feat(helm): allow per-path backends and extra Ingress objects

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/README.md
+++ b/helm/README.md
@@ -190,6 +190,100 @@ externalSecrets:
 
 Per-entry `refreshInterval` and `creationPolicy` overrides are also supported; see `values.yaml` for the full set of fields. This block is ESO-specific by design, so support for other providers (for example a HashiCorp Vault Agent integration) can be added as a sibling block without disturbing it.
 
+## Ingress
+
+`ingress` renders one Ingress in front of the release's Service, with `annotations` passed through
+verbatim so any controller's conventions work.
+
+A path can name its own backend. Leave `serviceName` and `servicePortName` empty and the path is
+backed by the release's own Service on `service.port`, which is the default. `serviceName` points
+the path at another Service in the release's namespace, and `servicePortName` selects a port by
+name rather than by number:
+
+```yaml
+ingress:
+  enabled: true
+  hosts:
+    - host: logflare.example.com
+      paths:
+        # The release's own Service on service.port.
+        - path: /
+          pathType: Prefix
+        # The Rollout's preview Service, so an incoming version can be reached by path.
+        - path: /preview
+          pathType: Prefix
+          serviceName: logflare-preview
+        # The chart's named gRPC port instead of service.port.
+        - path: /opentelemetry.proto.collector
+          pathType: Prefix
+          servicePortName: grpc
+```
+
+`extraIngresses` renders further Ingress objects, each taking the same shape as `ingress` plus a
+required `nameSuffix`. Reach for it when a release's routes cannot share one object, either because
+they belong on different ingress classes or because an annotation applies per Ingress rather than
+per rule. gRPC needs the second: a backend protocol version set on a Service covers every port that
+Service serves, including its HTTP one.
+
+```yaml
+extraIngresses:
+  - nameSuffix: grpc
+    className: alb
+    annotations:
+      alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+    hosts:
+      - host: otel.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+            servicePortName: grpc
+```
+
+`ingress.enabled` does not gate these. An entry present in the list is rendered.
+
+### Several releases behind one load balancer
+
+One cluster often runs several releases with distinct jobs, one serving the query UI and one or
+more taking ingest, so that each updates on its own schedule. Where the ingress controller merges
+Ingresses onto a single load balancer, values describe that whole topology one release at a time.
+
+With the [AWS Load Balancer
+Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/) the merge is an
+IngressGroup. Every release names the same group and sets an explicit evaluation order. The
+controller evaluates rules in that order rather than by path specificity, so without one a `/` rule
+swallows a more specific sibling from another release.
+
+The ingest release:
+
+```yaml
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/group.name: logflare.public
+    alb.ingress.kubernetes.io/group.order: "10"
+  hosts:
+    - host: logflare.example.com
+      paths:
+        - path: /logs
+          pathType: Prefix
+```
+
+The query release, evaluated after it:
+
+```yaml
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/group.name: logflare.public
+    alb.ingress.kubernetes.io/group.order: "100"
+  hosts:
+    - host: logflare.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+A rule only names a Service in its own Ingress's namespace, so each release owns the rules that
+reach it and no release describes another's routes.
+
 ## Progressive delivery with Argo Rollouts
 
 Set `rollout.enabled` and the chart renders an [Argo Rollouts](https://argo-rollouts.readthedocs.io/)
@@ -223,6 +317,48 @@ kubectl argo rollouts promote logflare
 
 A canary strategy goes in the same place. If you route canary traffic through an ingress controller
 or a service mesh, add the matching `trafficRouting` block and the Services it names.
+
+Some traffic routers take the backend from an annotation the controller writes rather than from the
+rule itself, which is what `servicePortName` is for. Argo Rollouts' ALB router is one: it rewrites
+an `alb.ingress.kubernetes.io/actions.<service>` annotation on each step, and the rule has to defer
+to it.
+
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    # Seeded so the rule resolves before the first rollout, then owned by Argo Rollouts.
+    alb.ingress.kubernetes.io/actions.logflare: >
+      {"type":"forward","forwardConfig":{"targetGroups":[
+        {"serviceName":"logflare","servicePort":"4000","weight":100}]}}
+  hosts:
+    - host: logflare.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePortName: use-annotation
+
+rollout:
+  enabled: true
+  strategy:
+    canary:
+      stableService: logflare
+      canaryService: logflare-preview
+      trafficRouting:
+        alb:
+          ingress: logflare
+          servicePort: 4000
+      steps:
+        - setWeight: 5
+        - pause: {}
+```
+
+Two things to check when the Rollout is reconciled by a GitOps controller. It must not revert the
+action annotation mid step, so exclude that annotation from drift detection. And a strategy that
+sizes the canary from the traffic weight can land on a single pod, which is below
+`LOGFLARE_MIN_CLUSTER_SIZE` once `RELEASE_COOKIE` is bound per ReplicaSet (see [Configuration that
+differs per version](#configuration-that-differs-per-version)), so set `minPodsPerReplicaSet` to at
+least that.
 
 When `autoscaling.enabled` is also set, the HorizontalPodAutoscaler targets the `Rollout` rather
 than the `Deployment` automatically.
@@ -289,6 +425,9 @@ empty string, so the same values stay safe with the `Deployment`.
 | `deploymentAnnotations` | — | Annotations on the Deployment object. Set `reloader.stakater.com/auto: "true"` to roll pods on ConfigMap/Secret changes (requires Stakater Reloader) |
 | `logflare.extraConfig` | (any) | Map of non-secret env vars rendered verbatim into the ConfigMap |
 | `extraEnv` | (any) | Env vars appended to the container, rendered verbatim so `valueFrom` works. For values that must differ per version rather than per release. See [Progressive delivery](#progressive-delivery-with-argo-rollouts) |
+| `ingress.hosts[].paths[].serviceName` | — | Service this path routes to, in the release's namespace. Defaults to the release's own Service. See [Ingress](#ingress) |
+| `ingress.hosts[].paths[].servicePortName` | — | Port name on that Service, instead of the `service.port` number. See [Ingress](#ingress) |
+| `extraIngresses` | — | Further Ingress objects, each shaped like `ingress` plus a required `nameSuffix`. See [Ingress](#ingress) |
 | `rollout.enabled` | — | Render an Argo Rollouts `Rollout` in place of the `Deployment`, plus a `<fullname>-preview` Service |
 | `rollout.strategy` | — | Passed to the `Rollout` verbatim. Required when `rollout.enabled` is set |
 | `rollout.progressDeadlineSeconds` | — | Must cover a full pod start, which `startupProbe` alone allows `failureThreshold` x `periodSeconds` seconds for |

--- a/helm/ingress_test.yaml
+++ b/helm/ingress_test.yaml
@@ -1,0 +1,120 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should render nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should back every path with the release's own Service and port by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logflare
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-logflare
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 4000
+      - notExists:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+
+  - it: should route a path to another Service when serviceName is set
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: chart-example.local
+          paths:
+            - path: /
+              pathType: Prefix
+              serviceName: RELEASE-NAME-logflare-preview
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-logflare-preview
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 4000
+
+  - it: should reference the port by name when servicePortName is set
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: chart-example.local
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePortName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: use-annotation
+      - notExists:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+
+  - it: should render one document per extraIngresses entry, suffixing each name
+    set:
+      ingress.enabled: true
+      extraIngresses:
+        - nameSuffix: grpc
+          className: alb
+          annotations:
+            alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+          hosts:
+            - host: otel.chart-example.local
+              paths:
+                - path: /
+                  pathType: Prefix
+                  servicePortName: grpc
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logflare
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logflare-grpc
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/backend-protocol-version"]
+          value: GRPC
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: grpc
+        documentIndex: 1
+
+  - it: should render extraIngresses even when ingress.enabled is false
+    set:
+      ingress.enabled: false
+      extraIngresses:
+        - nameSuffix: internal
+          hosts:
+            - host: chart-example.internal
+              paths:
+                - path: /
+                  pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logflare-internal
+
+  - it: should fail when an extraIngresses entry has no nameSuffix
+    set:
+      extraIngresses:
+        - hosts:
+            - host: chart-example.internal
+              paths:
+                - path: /
+                  pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "extraIngresses[0] has no nameSuffix: each extra Ingress needs one so its name stays distinct from the chart's own Ingress"

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,21 +1,27 @@
-{{- if .Values.ingress.enabled -}}
+{{/*
+One Ingress object, rendered once for `ingress` and once per `extraIngresses` entry. Both take
+the same shape, so a release needing several Ingresses describes each of them identically.
+*/}}
+{{- define "logflare.ingressObject" -}}
+{{- $root := .root -}}
+{{- $ingress := .ingress -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "logflare.fullname" . }}
+  name: {{ include "logflare.fullname" $root }}{{ with $ingress.nameSuffix }}-{{ . }}{{ end }}
   labels:
-    {{- include "logflare.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "logflare.labels" $root | nindent 4 }}
+  {{- with $ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with $ingress.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if $ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range $ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -24,7 +30,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range $ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -35,9 +41,23 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "logflare.fullname" $ }}
+                name: {{ .serviceName | default (include "logflare.fullname" $root) }}
                 port:
-                  number: {{ $.Values.service.port }}
+                  {{- if .servicePortName }}
+                  name: {{ .servicePortName }}
+                  {{- else }}
+                  number: {{ $root.Values.service.port }}
+                  {{- end }}
           {{- end }}
     {{- end }}
+{{- end }}
+{{- if .Values.ingress.enabled }}
+{{ include "logflare.ingressObject" (dict "root" $ "ingress" .Values.ingress) }}
+{{- end }}
+{{- range $index, $extra := .Values.extraIngresses }}
+{{- if not $extra.nameSuffix }}
+{{- fail (printf "extraIngresses[%d] has no nameSuffix: each extra Ingress needs one so its name stays distinct from the chart's own Ingress" $index) }}
+{{- end }}
+---
+{{ include "logflare.ingressObject" (dict "root" $ "ingress" $extra) }}
 {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -53,6 +53,9 @@
         "extraEnv": {
             "type": "array"
         },
+        "extraIngresses": {
+            "type": "array"
+        },
         "fullnameOverride": {
             "type": "string"
         },
@@ -160,6 +163,12 @@
                                             "type": "string"
                                         },
                                         "pathType": {
+                                            "type": "string"
+                                        },
+                                        "serviceName": {
+                                            "type": "string"
+                                        },
+                                        "servicePortName": {
                                             "type": "string"
                                         }
                                     }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -227,10 +227,31 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+          # Backend for this path. Both empty routes it to the release's own Service on
+          # `service.port`. `serviceName` names another Service in the release's namespace,
+          # `servicePortName` a port on it by name. See README.md#ingress.
+          serviceName: ""
+          servicePortName: ""
   tls: []
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
+
+# Further Ingress objects, each taking the same shape as `ingress` above plus a required
+# `nameSuffix` that keeps its name distinct from `<fullname>`. For routes that cannot share one
+# Ingress, because they belong on different ingress classes or because an annotation applies per
+# Ingress rather than per rule. `ingress.enabled` does not gate these. See README.md#ingress.
+extraIngresses: []
+  # - nameSuffix: grpc
+  #   className: alb
+  #   annotations:
+  #     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+  #   hosts:
+  #     - host: otel.chart-example.local
+  #       paths:
+  #         - path: /
+  #           pathType: Prefix
+  #           servicePortName: grpc
 
 # -- Expose the service via gateway-api HTTPRoute
 # Requires Gateway API resources and suitable controller installed within the cluster


### PR DESCRIPTION
The chart rendered one Ingress whose every path pointed at the release's own Service on service.port, so nothing could route a path to a preview Service, to a named port, or to a controller annotation, which is how Argo Rollouts splits canary traffic on an ALB. Paths now take optional serviceName and servicePortName, and extraIngresses renders further Ingress objects for routes that cannot share one.