### PR TITLE
fix: Exclude map keys from ingested byte accounting

### DIFF
--- a/lib/logflare/backends/ingest_event_queue.ex
+++ b/lib/logflare/backends/ingest_event_queue.ex
@@ -705,7 +705,7 @@ defmodule Logflare.Backends.IngestEventQueue do
       gen_event_id = make_ref()
 
       row =
-        {id, gen_tid, gen_event_id, :erlang.external_size(event.body), event.retries || 0,
+        {id, gen_tid, gen_event_id, LogEvent.body_byte_size(event.body), event.retries || 0,
          event.event_type, event.day_bucket}
 
       :ets.insert(gen_tid, {gen_event_id, event})

--- a/lib/logflare/logs/log_event.ex
+++ b/lib/logflare/logs/log_event.ex
@@ -415,6 +415,20 @@ defmodule Logflare.LogEvent do
     log_event.body["message"] || log_event.body["event_message"]
   end
 
+  @doc """
+  Size in bytes of an event body's values, excluding map keys.
+  """
+  @spec body_byte_size(term()) :: non_neg_integer()
+  def body_byte_size(value) when is_map(value) and not is_struct(value) do
+    Enum.reduce(value, 0, fn {_k, v}, acc -> acc + body_byte_size(v) end)
+  end
+
+  def body_byte_size(value) when is_list(value) do
+    Enum.reduce(value, 0, fn v, acc -> acc + body_byte_size(v) end)
+  end
+
+  def body_byte_size(value), do: :erlang.external_size(value)
+
   @spec query_json(map(), String.t()) :: String.t()
   defp query_json(metadata, query) do
     case Warpath.query(metadata, query) do

--- a/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
+++ b/test/logflare/backends/adaptor/clickhouse_adaptor/pipeline_test.exs
@@ -79,7 +79,7 @@ defmodule Logflare.Backends.Adaptor.ClickHouseAdaptor.PipelineTest do
       tid: gen_tid,
       gen_event_id: event.id,
       queue_tid: queue_tid || :ets.new(:test_pipeline_queue, [:set, :public]),
-      size: :erlang.external_size(event.body),
+      size: Logflare.LogEvent.body_byte_size(event.body),
       retries: event.retries || 0,
       event_type: event.event_type,
       day_bucket: event.day_bucket

--- a/test/logflare/backends/buffer_producer_test.exs
+++ b/test/logflare/backends/buffer_producer_test.exs
@@ -507,7 +507,7 @@ defmodule Logflare.Backends.BufferProducerTest do
              } = pointer
 
       assert event_id == le.id
-      assert size == :erlang.external_size(le.body)
+      assert size == Logflare.LogEvent.body_byte_size(le.body)
 
       # The claimed pointer row is already deleted (pop_pending_pointers/2 claims via
       # :ets.take/2), so the full event is resolved lazily via the pointer's own tid.

--- a/test/logflare/backends/ingest_event_queue_test.exs
+++ b/test/logflare/backends/ingest_event_queue_test.exs
@@ -670,7 +670,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       log_pointer = Map.fetch!(by_id, log_ev.id)
       assert log_pointer.event_type == :log
       assert log_pointer.day_bucket == 12_345
-      assert log_pointer.size == :erlang.external_size(log_ev.body)
+      assert log_pointer.size == Logflare.LogEvent.body_byte_size(log_ev.body)
 
       assert IngestEventQueue.lookup_event(log_pointer.tid, log_pointer.gen_event_id).id ==
                log_ev.id
@@ -802,7 +802,7 @@ defmodule Logflare.Backends.IngestEventQueueTest do
       assert {:ok, [pointer], tid} = IngestEventQueue.pop_pending_pointers(sbp, 1)
       assert tid != nil
       assert pointer.id == event.id
-      assert pointer.size == :erlang.external_size(event.body)
+      assert pointer.size == Logflare.LogEvent.body_byte_size(event.body)
       assert pointer.event_type == nil
       assert pointer.day_bucket == nil
       assert IngestEventQueue.total_pending(sbp) == 0


### PR DESCRIPTION
Log event size now sums only the bytes of body values, recursing into
nested maps and lists, instead of the external size of the whole body.

Does a full body iteration so it isn't the most performant, to be fixed in a follow-up. 